### PR TITLE
feat: Guild Progression Level 100

### DIFF
--- a/docs/GUILD_INVITATIONS_COMPLETE.md
+++ b/docs/GUILD_INVITATIONS_COMPLETE.md
@@ -1,0 +1,189 @@
+# Guild Invitations System - Implementation Complete
+
+## Summary
+
+The guild invitations system has been fully implemented with commands, database persistence, and sound effects.
+
+## What Was Implemented
+
+### 1. Repository Layer (Already Existed)
+- **`GuildInvitationRepository`** interface - defines invitation persistence operations
+- **`GuildInvitationRepositorySQLite`** - SQLite implementation with in-memory caching
+- **Database Schema** - `guild_invitations` table in `schema-sqlite.sql`
+
+### 2. Service Layer (Already Existed)
+- **`InvitationService`** interface - defines invitation business logic
+- **`HytaleInvitationService`** - Hytale implementation with full validation
+
+### 3. Commands (NEW - Implemented Now)
+All commands are subcommands of `/guild`:
+
+#### `/guild invite <player>`
+- Sends an invitation to a player to join your guild
+- Validates that inviter is in a guild
+- Checks for duplicate invitations
+- Plays "invitation sent" sound effect
+- **Note**: Currently requires UUID format (player lookup by name not yet implemented)
+
+#### `/guild accept <guild>`
+- Accepts a pending guild invitation by guild name
+- Adds player to guild with default rank
+- Removes the invitation after acceptance
+- Plays "invitation accepted" sound effect
+
+#### `/guild decline <guild>`
+- Declines a pending guild invitation by guild name
+- Removes the invitation
+- Plays "invitation declined" sound effect
+
+#### `/guild invites`
+- Lists all pending guild invitations for the player
+- Shows guild name and inviter name for each invitation
+- Provides helpful usage hints for accept/decline commands
+
+### 4. Sound Effects (NEW - Implemented Now)
+Created **`GuildSounds.kt`** with the following sounds:
+
+- **INVITATION_SENT**: `SFX/UI/Discovery/SFX_Discovery_Z1_Medium` (volume 0.7, pitch 1.0)
+- **INVITATION_RECEIVED**: `SFX/UI/Interactions/Benches/SFX_Workbench_Craft` (volume 0.8, pitch 1.2)
+- **INVITATION_ACCEPTED**: `SFX/Crafting/SFX_Workbench_Upgrade_Complete_Default` (volume 0.8, pitch 1.0)
+- **INVITATION_DECLINED**: `SFX/UI/Interactions/Benches/SFX_Furnace_Bench_Processing_Failed` (volume 0.5, pitch 0.9)
+- **GUILD_CREATED**: `SFX/UI/Discovery/SFX_Discovery_Z1_Medium` (volume 0.9, pitch 1.0)
+
+All sounds are initialized on plugin startup via `GuildSounds.initialize()`.
+
+### 5. Plugin Integration
+- **`LumaGuildsHytale.kt`** - Added `GuildSounds.initialize()` in `start()` method
+- **`GuildCommand.kt`** - Registered all 4 new invitation commands
+- **Koin DI** - `InvitationService` already registered in `HytaleModules.kt`
+
+## Database Schema
+
+```sql
+CREATE TABLE IF NOT EXISTS guild_invitations (
+    guild_id TEXT NOT NULL,
+    guild_name TEXT NOT NULL,
+    invited_player_id TEXT NOT NULL,
+    inviter_player_id TEXT NOT NULL,
+    inviter_name TEXT NOT NULL,
+    invited_at TEXT NOT NULL,
+    PRIMARY KEY (guild_id, invited_player_id),
+    FOREIGN KEY (guild_id) REFERENCES guilds(id) ON DELETE CASCADE
+);
+```
+
+## Service Logic Highlights
+
+### sendInvitation()
+1. Validates inviter is a guild member
+2. Checks target player is not already in the guild
+3. Checks for existing invitation (prevents duplicates)
+4. Retrieves inviter name from PlayerService
+5. Creates and stores invitation with timestamp
+
+### acceptInvitation()
+1. Retrieves the invitation
+2. Validates player is not already in another guild
+3. Gets default rank for new members
+4. Adds player to guild as a member
+5. Removes the invitation
+
+### declineInvitation()
+1. Simply removes the invitation from storage
+
+### getPlayerInvitations()
+1. Returns all pending invitations for a player
+2. Results are sorted by timestamp (oldest first)
+
+## Files Modified/Created
+
+### New Files
+- `src/main/kotlin/net/lumalyte/lg/infrastructure/hytale/sounds/GuildSounds.kt`
+- `docs/GUILD_INVITATIONS_COMPLETE.md` (this file)
+
+### Modified Files
+- `src/main/kotlin/net/lumalyte/lg/infrastructure/hytale/commands/GuildCommand.kt`
+  - Added import for `GuildSounds`
+  - Added import for `InvitationService`
+  - Registered 4 new invitation commands
+  - Added sound playback to `/guild create`
+  - Created `GuildInviteCommand` class
+  - Created `GuildAcceptCommand` class
+  - Created `GuildDeclineCommand` class
+  - Created `GuildInvitesCommand` class
+
+- `src/main/kotlin/net/lumalyte/lg/infrastructure/hytale/LumaGuildsHytale.kt`
+  - Added import for `GuildSounds`
+  - Added `GuildSounds.initialize()` call in `start()`
+
+- `src/main/kotlin/net/lumalyte/lg/infrastructure/persistence/guilds/GuildInvitationRepositorySQLite.kt`
+  - Fixed field name from `timestamp` to `invited_at` to match schema
+  - Fixed SQL INSERT statement column name
+  - Fixed SQL DELETE WHERE clause column name
+
+## Known Limitations
+
+### Player Lookup by Name
+Currently, `/guild invite` requires a UUID instead of a player name:
+```
+/guild invite 550e8400-e29b-41d4-a716-446655440000
+```
+
+This is because we don't yet have a player name → UUID lookup service. Future enhancement:
+- Add `PlayerService.getPlayerIdByName(name: String): UUID?` method
+- Update `GuildInviteCommand` to use name lookup
+
+### Permission System
+Currently, any guild member can send invitations. Future enhancement:
+- Check rank permissions before allowing invites
+- Add `CAN_INVITE` flag to rank permissions
+- Validate inviter has permission in `sendInvitation()`
+
+### Invitation Expiration
+The system supports expiration via `removeOlderThan()` but it's not automatically scheduled. Future enhancement:
+- Schedule a task to clean up old invitations (e.g., every hour)
+- Make expiration time configurable (default 24 hours)
+
+### Notification System
+When a player receives an invitation, they are not notified in real-time. Future enhancement:
+- Send a notification message when online player receives invite
+- Show pending invitation count on join
+- Add configurable notification sounds for recipients
+
+## Testing Checklist
+
+Once the plugin is running in Hytale, test these scenarios:
+
+- [ ] Create a guild with `/guild create TestGuild`
+- [ ] Get your UUID and a friend's UUID
+- [ ] Send invitation: `/guild invite <friend-uuid>`
+- [ ] Check invitations: `/guild invites`
+- [ ] Accept invitation: `/guild accept TestGuild`
+- [ ] Verify player joined guild with `/guild info`
+- [ ] Send another invite, then decline: `/guild decline TestGuild`
+- [ ] Verify sound effects play for each action
+- [ ] Test duplicate invitation prevention
+- [ ] Test accepting invite when already in guild (should fail)
+
+## Integration with Existing Systems
+
+### Dependencies
+The invitation system properly integrates with:
+- **GuildRepository** - Validates guild exists, gets guild name
+- **MemberRepository** - Checks membership, adds new members
+- **RankRepository** - Gets default rank for new members
+- **PlayerService** - Gets player names for display
+
+### Sound System
+Follows the same pattern as `ClaimSounds.kt`:
+- Static object with lazy initialization
+- `SoundEvent.getAssetMap()` for ID resolution
+- `PlaySoundEvent2D` for UI feedback
+- `PlayerRef.getPacketHandler().write()` for playback
+
+## Next Steps
+
+As mentioned in the user's request, the next action is:
+> "check the main branch features to see what else we need to have complete feature parity with the minecraft version of the plugin"
+
+The guild invitations system is now complete and ready for testing in-game!

--- a/docs/PLAYER_LOOKUP_IMPLEMENTATION.md
+++ b/docs/PLAYER_LOOKUP_IMPLEMENTATION.md
@@ -1,0 +1,231 @@
+# Player Lookup Implementation - Complete
+
+## Problem Solved
+
+The `/guild invite` command previously required a player's UUID instead of their username, making it difficult to use:
+```
+/guild invite 550e8400-e29b-41d4-a716-446655440000  ❌ Hard to remember
+```
+
+## Solution Implemented
+
+Players can now use usernames directly:
+```
+/guild invite PlayerName  ✅ Easy to use
+```
+
+---
+
+## Implementation Details
+
+### API Discovery
+
+Found the correct Hytale API through exploration of decompiled server code:
+
+**Class**: `com.hypixel.hytale.server.core.universe.Universe`
+
+**Method**:
+```kotlin
+fun getPlayerByUsername(
+    playerName: String,
+    nameMatching: com.hypixel.hytale.server.core.NameMatching
+): PlayerRef?
+```
+
+**NameMatching Options**:
+- `EXACT_IGNORE_CASE` - Case-insensitive exact match (used in implementation)
+
+### Code Changes
+
+**File**: `src/main/kotlin/net/lumalyte/lg/infrastructure/hytale/commands/GuildCommand.kt`
+
+**Lines**: 311-332
+
+**Implementation**:
+```kotlin
+// Look up target player by username
+val targetPlayerRef = universe.getPlayerByUsername(
+    targetPlayerName,
+    com.hypixel.hytale.server.core.NameMatching.EXACT_IGNORE_CASE
+)
+
+if (targetPlayerRef == null) {
+    context.sendMessage(
+        Message.raw("Player '$targetPlayerName' not found or is not online!")
+            .color("red")
+    )
+    return
+}
+
+val targetPlayerId = targetPlayerRef.getUuid()!!  // Safe: PlayerRef always has UUID
+```
+
+---
+
+## Universe API Reference
+
+### Player Lookup Methods
+
+```kotlin
+// Get player by UUID
+fun getPlayer(playerId: UUID): PlayerRef?
+
+// Get player by username
+fun getPlayerByUsername(
+    playerName: String,
+    nameMatching: NameMatching
+): PlayerRef?
+
+// Get all online players
+val players: List<PlayerRef>
+
+// Get world by UUID
+fun getWorld(worldUuid: UUID): World?
+```
+
+### PlayerRef Properties
+
+```kotlin
+val username: String              // Player's username
+val uuid: UUID                    // Player's UUID
+val language: String?             // Player's language preference
+val reference: Ref<EntityStore>?  // Entity reference in ECS
+```
+
+### PlayerRef Methods
+
+```kotlin
+fun getUuid(): UUID?              // Get player UUID (always non-null)
+fun getWorldUuid(): UUID?         // Get current world UUID
+fun getTransform(): Transform     // Get player's position/rotation
+fun sendMessage(message: Message) // Send message to player
+fun getPacketHandler(): PacketHandler  // Get packet handler for custom packets
+```
+
+---
+
+## External Player Lookup Options (Not Used)
+
+During research, several external APIs were found but not needed:
+
+### 1. PlayerDB API (HytaleID.com)
+```
+GET https://playerdb.co/api/player/minecraft/username
+```
+Returns player info including UUID and avatar.
+
+**Not Used**: Requires external HTTP requests, adds latency, requires internet connection.
+
+### 2. Nitrado Query Plugin
+Provides HTTP endpoint for connected players.
+
+**Not Used**: Only returns currently connected players, requires additional plugin.
+
+### 3. Official Authentication APIs
+Server provider authentication endpoints.
+
+**Not Used**: Requires authentication setup, designed for server hosting providers.
+
+**Decision**: Use Hytale's built-in `Universe` API - faster, more reliable, no external dependencies.
+
+---
+
+## Testing Checklist
+
+Once the plugin is deployed to a Hytale server:
+
+### Basic Functionality
+- [ ] `/guild invite ValidUsername` - Should work
+- [ ] `/guild invite InvalidUsername` - Should show error
+- [ ] `/guild invite UPPERCASE` - Should work (case-insensitive)
+- [ ] `/guild invite lowercase` - Should work (case-insensitive)
+- [ ] `/guild invite OfflinePlayer` - Should show "not online" error
+
+### Edge Cases
+- [ ] Invite player already in guild - Should fail gracefully
+- [ ] Invite self - Should handle appropriately
+- [ ] Invite with duplicate pending invitation - Should detect and warn
+- [ ] Invite from non-guild member - Should reject
+
+### Sound Effects
+- [ ] Successful invitation - Should play "invitation sent" sound
+- [ ] Failed invitation - Should not play sound
+
+---
+
+## Related Files
+
+### Modified Files
+- `src/main/kotlin/net/lumalyte/lg/infrastructure/hytale/commands/GuildCommand.kt`
+  - Lines 311-332: Player lookup implementation
+  - Lines 324-331: Error handling for not found/offline players
+
+### Reference Files (Existing Usage)
+- `src/main/kotlin/net/lumalyte/lg/infrastructure/hytale/commands/ClaimCommand.kt`
+  - Lines 457, 575: Uses `getPlayerByUsername()` for trust/untrust commands
+
+- `src/main/kotlin/net/lumalyte/lg/infrastructure/hytale/services/HytalePlayerService.kt`
+  - Line 38: Uses `getPlayer(UUID)` for UUID lookup
+  - Line 77: Uses `universe.players` for online player list
+
+---
+
+## Benefits
+
+### User Experience
+- ✅ Easier to remember player names than UUIDs
+- ✅ Consistent with other commands (`/claim trust PlayerName`)
+- ✅ Natural command syntax
+- ✅ Clear error messages when player not found
+
+### Technical
+- ✅ No external API dependencies
+- ✅ Fast local lookup
+- ✅ Works offline (server-local)
+- ✅ Consistent with Hytale's API patterns
+- ✅ Case-insensitive matching for convenience
+
+---
+
+## Future Enhancements
+
+### Autocomplete Support
+Consider adding tab completion for player names:
+```kotlin
+override fun getSuggestions(context: CommandContext): List<String> {
+    val universe = Universe.get()
+    return universe.players.map { it.username }
+}
+```
+
+### Offline Player Support
+Currently only works for online players. To support offline players:
+- Option 1: Maintain player name cache in database
+- Option 2: Use external PlayerDB API as fallback
+- Option 3: Accept UUIDs as fallback (current behavior if name parsing fails)
+
+**Decision**: Current online-only approach is acceptable for invitations (inviter and invitee both need to be online for real-time interaction).
+
+---
+
+## API Documentation Sources
+
+- **Web Search**: Found community resources at HytaleID.com, Nitrado Query Plugin
+- **Hytale Docs**: https://hytale-docs.com/docs (limited API coverage)
+- **Decompiled Source**: Located methods in `com.hypixel.hytale.server.core.universe.Universe`
+- **Existing Usage**: Found usage examples in ClaimCommand.kt and HytalePlayerService.kt
+
+### Sources Referenced
+- [Lookup Hytale Player UUIDs with HytaleID.com](https://nodecraft.com/blog/service-updates/lookup-hytale-player-uuids-with-hytaleid-com)
+- [Hytale Server Manual](https://support.hytale.com/hc/en-us/articles/45326769420827-Hytale-Server-Manual)
+- [GitHub - nitrado/hytale-plugin-query](https://github.com/nitrado/hytale-plugin-query)
+
+---
+
+## Conclusion
+
+The player lookup feature is now fully implemented using Hytale's native `Universe.getPlayerByUsername()` API. This provides a seamless user experience for guild invitations without requiring external dependencies or complex workarounds.
+
+**Status**: ✅ Complete and ready for testing
+**Build**: ✅ Compiles successfully
+**Next Step**: Test in-game with real players

--- a/src/main/kotlin/net/lumalyte/lg/LumaGuilds.kt
+++ b/src/main/kotlin/net/lumalyte/lg/LumaGuilds.kt
@@ -743,7 +743,14 @@ class LumaGuilds : JavaPlugin() {
         getCommand("removevault")?.setExecutor(removeVaultCommand)
         getCommand("removevault")?.tabCompleter = removeVaultCommand
 
-        logColored("✓ Admin commands registered (/lumaguilds, /bellclaims, /vaultrollback, /bankcredit, /removevault)")
+        // Register Custom Emoji admin command
+        val customEmojiCommand = net.lumalyte.lg.interaction.commands.admin.CustomEmojiCommand(
+            get().get()
+        )
+        getCommand("customemoji")?.setExecutor(customEmojiCommand)
+        getCommand("customemoji")?.tabCompleter = customEmojiCommand
+
+        logColored("✓ Admin commands registered (/lumaguilds, /bellclaims, /vaultrollback, /bankcredit, /removevault, /customemoji)")
         logColored("✓ Bedrock cache stats command registered (/bedrockcachestats)")
     }
 

--- a/src/main/kotlin/net/lumalyte/lg/application/persistence/AnnouncementRepository.kt
+++ b/src/main/kotlin/net/lumalyte/lg/application/persistence/AnnouncementRepository.kt
@@ -1,0 +1,91 @@
+package net.lumalyte.lg.application.persistence
+
+import net.lumalyte.lg.domain.entities.Announcement
+import java.util.UUID
+
+/**
+ * Repository for managing guild announcement persistence.
+ */
+interface AnnouncementRepository {
+    /**
+     * Gets all announcements for a guild.
+     *
+     * @param guildId The ID of the guild.
+     * @param includeExpired Whether to include expired announcements.
+     * @return List of announcements.
+     */
+    fun getByGuild(guildId: UUID, includeExpired: Boolean = false): List<Announcement>
+
+    /**
+     * Gets a specific announcement by ID.
+     *
+     * @param id The ID of the announcement.
+     * @return The announcement if found, null otherwise.
+     */
+    fun getById(id: UUID): Announcement?
+
+    /**
+     * Gets all pinned announcements for a guild.
+     *
+     * @param guildId The ID of the guild.
+     * @return List of pinned announcements.
+     */
+    fun getPinnedByGuild(guildId: UUID): List<Announcement>
+
+    /**
+     * Creates a new announcement.
+     *
+     * @param announcement The announcement to create.
+     * @return true if successful, false otherwise.
+     */
+    fun add(announcement: Announcement): Boolean
+
+    /**
+     * Updates an existing announcement.
+     *
+     * @param announcement The announcement to update.
+     * @return true if successful, false otherwise.
+     */
+    fun update(announcement: Announcement): Boolean
+
+    /**
+     * Deletes an announcement.
+     *
+     * @param id The ID of the announcement to delete.
+     * @return true if successful, false otherwise.
+     */
+    fun delete(id: UUID): Boolean
+
+    /**
+     * Deletes all announcements for a guild.
+     *
+     * @param guildId The ID of the guild.
+     * @return true if successful, false otherwise.
+     */
+    fun deleteByGuild(guildId: UUID): Boolean
+
+    /**
+     * Pins or unpins an announcement.
+     *
+     * @param id The ID of the announcement.
+     * @param isPinned Whether to pin or unpin.
+     * @return true if successful, false otherwise.
+     */
+    fun setPinned(id: UUID, isPinned: Boolean): Boolean
+
+    /**
+     * Gets the count of announcements for a guild.
+     *
+     * @param guildId The ID of the guild.
+     * @param includeExpired Whether to include expired announcements.
+     * @return The count of announcements.
+     */
+    fun getCountByGuild(guildId: UUID, includeExpired: Boolean = false): Int
+
+    /**
+     * Deletes expired announcements.
+     *
+     * @return The number of announcements deleted.
+     */
+    fun deleteExpired(): Int
+}

--- a/src/main/kotlin/net/lumalyte/lg/application/services/AnnouncementService.kt
+++ b/src/main/kotlin/net/lumalyte/lg/application/services/AnnouncementService.kt
@@ -1,0 +1,123 @@
+package net.lumalyte.lg.application.services
+
+import net.lumalyte.lg.domain.entities.Announcement
+import java.time.Instant
+import java.util.UUID
+
+/**
+ * Service interface for managing guild announcements.
+ */
+interface AnnouncementService {
+    /**
+     * Creates a new guild announcement.
+     *
+     * @param guildId The ID of the guild.
+     * @param authorId The ID of the author.
+     * @param title The announcement title.
+     * @param message The announcement message.
+     * @param isPinned Whether to pin the announcement.
+     * @param expiresAt Optional expiration time.
+     * @return The created announcement if successful, null otherwise.
+     */
+    fun createAnnouncement(
+        guildId: UUID,
+        authorId: UUID,
+        title: String,
+        message: String,
+        isPinned: Boolean = false,
+        expiresAt: Instant? = null
+    ): Announcement?
+
+    /**
+     * Gets all announcements for a guild.
+     *
+     * @param guildId The ID of the guild.
+     * @param includeExpired Whether to include expired announcements.
+     * @return List of announcements sorted by creation date (newest first).
+     */
+    fun getAnnouncements(guildId: UUID, includeExpired: Boolean = false): List<Announcement>
+
+    /**
+     * Gets pinned announcements for a guild.
+     *
+     * @param guildId The ID of the guild.
+     * @return List of pinned announcements.
+     */
+    fun getPinnedAnnouncements(guildId: UUID): List<Announcement>
+
+    /**
+     * Gets a specific announcement by ID.
+     *
+     * @param announcementId The ID of the announcement.
+     * @return The announcement if found, null otherwise.
+     */
+    fun getAnnouncement(announcementId: UUID): Announcement?
+
+    /**
+     * Updates an announcement.
+     *
+     * @param announcementId The ID of the announcement.
+     * @param title The new title.
+     * @param message The new message.
+     * @param actorId The ID of the player performing the action.
+     * @return true if successful, false otherwise.
+     */
+    fun updateAnnouncement(
+        announcementId: UUID,
+        title: String,
+        message: String,
+        actorId: UUID
+    ): Boolean
+
+    /**
+     * Deletes an announcement.
+     *
+     * @param announcementId The ID of the announcement.
+     * @param actorId The ID of the player performing the action.
+     * @return true if successful, false otherwise.
+     */
+    fun deleteAnnouncement(announcementId: UUID, actorId: UUID): Boolean
+
+    /**
+     * Pins or unpins an announcement.
+     *
+     * @param announcementId The ID of the announcement.
+     * @param isPinned Whether to pin or unpin.
+     * @param actorId The ID of the player performing the action.
+     * @return true if successful, false otherwise.
+     */
+    fun setPinned(announcementId: UUID, isPinned: Boolean, actorId: UUID): Boolean
+
+    /**
+     * Checks if a player can create announcements in a guild.
+     *
+     * @param playerId The ID of the player.
+     * @param guildId The ID of the guild.
+     * @return true if the player has permission, false otherwise.
+     */
+    fun canCreateAnnouncement(playerId: UUID, guildId: UUID): Boolean
+
+    /**
+     * Checks if a player can manage (edit/delete) an announcement.
+     *
+     * @param playerId The ID of the player.
+     * @param announcementId The ID of the announcement.
+     * @return true if the player has permission, false otherwise.
+     */
+    fun canManageAnnouncement(playerId: UUID, announcementId: UUID): Boolean
+
+    /**
+     * Gets the count of announcements for a guild.
+     *
+     * @param guildId The ID of the guild.
+     * @return The count of active announcements.
+     */
+    fun getAnnouncementCount(guildId: UUID): Int
+
+    /**
+     * Cleans up expired announcements.
+     *
+     * @return The number of announcements deleted.
+     */
+    fun cleanupExpired(): Int
+}

--- a/src/main/kotlin/net/lumalyte/lg/application/services/GuildService.kt
+++ b/src/main/kotlin/net/lumalyte/lg/application/services/GuildService.kt
@@ -176,6 +176,9 @@ interface GuildService {
     /** Checks if a player can access a guild's ally home (must be in an allied guild). */
     fun canAccessAllyHome(actorId: UUID, hostGuildId: UUID): Boolean
 
+    /** Admin override — sets emoji without rank permission check. */
+    fun setEmojiAdmin(guildId: UUID, emoji: String?): Boolean
+
     /**
      * Sets the mode for a guild (Peaceful/Hostile).
      *

--- a/src/main/kotlin/net/lumalyte/lg/application/services/GuildService.kt
+++ b/src/main/kotlin/net/lumalyte/lg/application/services/GuildService.kt
@@ -167,6 +167,15 @@ interface GuildService {
      */
     fun removeHome(guildId: UUID, actorId: UUID): Boolean
 
+    /** Sets the ally home location for a guild. Requires L25. */
+    fun setAllyHome(guildId: UUID, location: org.bukkit.Location?, actorId: UUID): Boolean
+
+    /** Gets the ally home for a guild. */
+    fun getAllyHome(guildId: UUID): GuildHome?
+
+    /** Checks if a player can access a guild's ally home (must be in an allied guild). */
+    fun canAccessAllyHome(actorId: UUID, hostGuildId: UUID): Boolean
+
     /**
      * Sets the mode for a guild (Peaceful/Hostile).
      *

--- a/src/main/kotlin/net/lumalyte/lg/application/services/InvitationService.kt
+++ b/src/main/kotlin/net/lumalyte/lg/application/services/InvitationService.kt
@@ -1,0 +1,64 @@
+package net.lumalyte.lg.application.services
+
+import net.lumalyte.lg.domain.entities.GuildInvitation
+import java.util.UUID
+
+/**
+ * Service for managing guild invitations.
+ */
+interface InvitationService {
+    /**
+     * Sends a guild invitation to a player.
+     *
+     * @param guildId The ID of the guild.
+     * @param invitedPlayerId The ID of the player being invited.
+     * @param inviterPlayerId The ID of the player sending the invitation.
+     * @return true if the invitation was sent successfully, false otherwise.
+     */
+    fun sendInvitation(guildId: UUID, invitedPlayerId: UUID, inviterPlayerId: UUID): Boolean
+
+    /**
+     * Accepts a guild invitation.
+     *
+     * @param playerId The ID of the player accepting the invitation.
+     * @param guildId The ID of the guild.
+     * @return true if the invitation was accepted successfully, false otherwise.
+     */
+    fun acceptInvitation(playerId: UUID, guildId: UUID): Boolean
+
+    /**
+     * Declines a guild invitation.
+     *
+     * @param playerId The ID of the player declining the invitation.
+     * @param guildId The ID of the guild.
+     * @return true if the invitation was declined successfully, false otherwise.
+     */
+    fun declineInvitation(playerId: UUID, guildId: UUID): Boolean
+
+    /**
+     * Gets all pending invitations for a player.
+     *
+     * @param playerId The ID of the player.
+     * @return A list of pending invitations.
+     */
+    fun getPlayerInvitations(playerId: UUID): List<GuildInvitation>
+
+    /**
+     * Cancels a pending invitation.
+     *
+     * @param playerId The ID of the invited player.
+     * @param guildId The ID of the guild.
+     * @param cancellerPlayerId The ID of the player cancelling the invitation.
+     * @return true if the invitation was cancelled successfully, false otherwise.
+     */
+    fun cancelInvitation(playerId: UUID, guildId: UUID, cancellerPlayerId: UUID): Boolean
+
+    /**
+     * Checks if a player has a pending invitation from a guild.
+     *
+     * @param playerId The ID of the player.
+     * @param guildId The ID of the guild.
+     * @return true if the player has a pending invitation, false otherwise.
+     */
+    fun hasInvitation(playerId: UUID, guildId: UUID): Boolean
+}

--- a/src/main/kotlin/net/lumalyte/lg/application/services/ProgressionService.kt
+++ b/src/main/kotlin/net/lumalyte/lg/application/services/ProgressionService.kt
@@ -192,6 +192,9 @@ interface ProgressionService {
     /** Returns true if the guild has reached Level 15 for Market Stall access. */
     fun hasMarketStallAccess(guildId: UUID): Boolean
 
+    /** Returns the guild's authoritative current level from GuildProgression (never stale). */
+    fun getGuildLevel(guildId: UUID): Int
+
     fun processLevelUp(guildId: UUID, newLevel: Int): List<PerkType>
 }
 

--- a/src/main/kotlin/net/lumalyte/lg/application/services/ProgressionService.kt
+++ b/src/main/kotlin/net/lumalyte/lg/application/services/ProgressionService.kt
@@ -249,8 +249,17 @@ enum class PerkType {
     ANNOUNCEMENT_SOUND_EFFECTS,
     WAR_DECLARATION_SOUND_EFFECTS,
 
-    // System perks
-    // (No system perks currently defined)
+    // Diplomacy perks (level-gated)
+    DECLARE_ENEMIES,       // Unlocked at Level 5
+    FORM_ALLIANCES,        // Unlocked at Level 10
+    DECLARE_WAR,           // Unlocked at Level 20
+
+    // Economic perks
+    MARKET_STALL_ACCESS,   // Unlocked at Level 15 — read by Guild-ARM integration
+
+    // Social perks
+    ALLY_HOME,             // Unlocked at Level 25
+    CUSTOM_EMOJI,          // Unlocked at Level 100
 }
 
 /**

--- a/src/main/kotlin/net/lumalyte/lg/application/services/ProgressionService.kt
+++ b/src/main/kotlin/net/lumalyte/lg/application/services/ProgressionService.kt
@@ -189,6 +189,9 @@ interface ProgressionService {
      * @param newLevel The new level achieved.
      * @return List of newly unlocked perks.
      */
+    /** Returns true if the guild has reached Level 15 for Market Stall access. */
+    fun hasMarketStallAccess(guildId: UUID): Boolean
+
     fun processLevelUp(guildId: UUID, newLevel: Int): List<PerkType>
 }
 

--- a/src/main/kotlin/net/lumalyte/lg/di/Modules.kt
+++ b/src/main/kotlin/net/lumalyte/lg/di/Modules.kt
@@ -398,7 +398,7 @@ fun guildsModule() = module {
     single<GuildService> { GuildServiceBukkit(get(), get(), get(), get(), get(), get(), get(), get(), get(), get()) }
     single<RankService> { RankServiceBukkit(get(), get(), get(), get()) }
     single<MemberService> { MemberServiceBukkit(get(), get(), get(), get(), get(), get()) }
-    single<RelationService> { RelationServiceBukkit(get(), get()) }
+    single<RelationService> { RelationServiceBukkit(get(), get(), get()) }
     single<LfgService> { LfgServiceBukkit(get(), get(), get(), get(), get(), get(), get(), get()) }
     single<GuildBannerService> { GuildBannerServiceBukkit() }
     single<AuditService> { AuditServiceBukkit() }

--- a/src/main/kotlin/net/lumalyte/lg/domain/entities/Announcement.kt
+++ b/src/main/kotlin/net/lumalyte/lg/domain/entities/Announcement.kt
@@ -1,0 +1,54 @@
+package net.lumalyte.lg.domain.entities
+
+import java.time.Instant
+import java.util.UUID
+
+/**
+ * Represents a guild announcement.
+ *
+ * @property id The unique identifier for the announcement.
+ * @property guildId The ID of the guild this announcement belongs to.
+ * @property authorId The ID of the player who created the announcement.
+ * @property authorName The name of the author (cached for display).
+ * @property title The title of the announcement.
+ * @property message The announcement message content.
+ * @property isPinned Whether this announcement is pinned to the top.
+ * @property createdAt When the announcement was created.
+ * @property expiresAt Optional expiration time for the announcement.
+ */
+data class Announcement(
+    val id: UUID = UUID.randomUUID(),
+    val guildId: UUID,
+    val authorId: UUID,
+    val authorName: String,
+    val title: String,
+    val message: String,
+    val isPinned: Boolean = false,
+    val createdAt: Instant = Instant.now(),
+    val expiresAt: Instant? = null
+) {
+    init {
+        require(title.isNotBlank()) { "Announcement title cannot be blank" }
+        require(title.length <= 100) { "Announcement title must be 100 characters or less" }
+        require(message.isNotBlank()) { "Announcement message cannot be blank" }
+        require(message.length <= 500) { "Announcement message must be 500 characters or less" }
+
+        expiresAt?.let { expiry ->
+            require(expiry.isAfter(createdAt)) { "Expiration time must be after creation time" }
+        }
+    }
+
+    /**
+     * Checks if this announcement has expired.
+     */
+    fun isExpired(): Boolean {
+        return expiresAt?.let { it.isBefore(Instant.now()) } ?: false
+    }
+
+    /**
+     * Checks if this announcement is currently active (not expired).
+     */
+    fun isActive(): Boolean {
+        return !isExpired()
+    }
+}

--- a/src/main/kotlin/net/lumalyte/lg/domain/entities/Guild.kt
+++ b/src/main/kotlin/net/lumalyte/lg/domain/entities/Guild.kt
@@ -47,7 +47,8 @@ data class Guild(
     val joinFeeEnabled: Boolean = false,
     val joinFeeAmount: Int = 0,
     val trackingEnabled: Boolean = true,
-    val bankFrozen: Boolean = false
+    val bankFrozen: Boolean = false,
+    val allyHomeLocation: GuildHome? = null
 ) {
     init {
         require(name.length in 1..32) { "Guild name must be between 1 and 32 characters." }

--- a/src/main/kotlin/net/lumalyte/lg/infrastructure/persistence/announcements/AnnouncementRepositoryMemory.kt
+++ b/src/main/kotlin/net/lumalyte/lg/infrastructure/persistence/announcements/AnnouncementRepositoryMemory.kt
@@ -1,0 +1,70 @@
+package net.lumalyte.lg.infrastructure.persistence.announcements
+
+import net.lumalyte.lg.application.persistence.AnnouncementRepository
+import net.lumalyte.lg.domain.entities.Announcement
+import java.util.UUID
+import java.util.concurrent.ConcurrentHashMap
+
+/**
+ * In-memory implementation of AnnouncementRepository.
+ * Suitable for announcements that don't need to persist across server restarts.
+ */
+class AnnouncementRepositoryMemory : AnnouncementRepository {
+    private val announcements = ConcurrentHashMap<UUID, Announcement>()
+
+    override fun getByGuild(guildId: UUID, includeExpired: Boolean): List<Announcement> {
+        return announcements.values
+            .filter { it.guildId == guildId }
+            .filter { includeExpired || it.isActive() }
+            .sortedByDescending { it.createdAt }
+    }
+
+    override fun getById(id: UUID): Announcement? {
+        return announcements[id]
+    }
+
+    override fun getPinnedByGuild(guildId: UUID): List<Announcement> {
+        return announcements.values
+            .filter { it.guildId == guildId && it.isPinned && it.isActive() }
+            .sortedByDescending { it.createdAt }
+    }
+
+    override fun add(announcement: Announcement): Boolean {
+        announcements[announcement.id] = announcement
+        return true
+    }
+
+    override fun update(announcement: Announcement): Boolean {
+        if (!announcements.containsKey(announcement.id)) {
+            return false
+        }
+        announcements[announcement.id] = announcement
+        return true
+    }
+
+    override fun delete(id: UUID): Boolean {
+        return announcements.remove(id) != null
+    }
+
+    override fun deleteByGuild(guildId: UUID): Boolean {
+        val toDelete = announcements.values.filter { it.guildId == guildId }.map { it.id }
+        toDelete.forEach { announcements.remove(it) }
+        return true
+    }
+
+    override fun setPinned(id: UUID, isPinned: Boolean): Boolean {
+        val announcement = announcements[id] ?: return false
+        announcements[id] = announcement.copy(isPinned = isPinned)
+        return true
+    }
+
+    override fun getCountByGuild(guildId: UUID, includeExpired: Boolean): Int {
+        return getByGuild(guildId, includeExpired).size
+    }
+
+    override fun deleteExpired(): Int {
+        val expired = announcements.values.filter { it.isExpired() }.map { it.id }
+        expired.forEach { announcements.remove(it) }
+        return expired.size
+    }
+}

--- a/src/main/kotlin/net/lumalyte/lg/infrastructure/persistence/guilds/GuildRepositorySQLite.kt
+++ b/src/main/kotlin/net/lumalyte/lg/infrastructure/persistence/guilds/GuildRepositorySQLite.kt
@@ -246,6 +246,23 @@ class GuildRepositorySQLite(private val storage: Storage<Database>) : GuildRepos
             false
         }
 
+        // Parse ally home location
+        val allyHomeLocation = try {
+            val allyWorldStr = rs.getString("ally_home_world")
+            if (allyWorldStr != null) {
+                GuildHome(
+                    worldId = UUID.fromString(allyWorldStr),
+                    position = net.lumalyte.lg.domain.values.Position3D(
+                        rs.getInt("ally_home_x"),
+                        rs.getInt("ally_home_y"),
+                        rs.getInt("ally_home_z")
+                    )
+                )
+            } else null
+        } catch (e: Exception) {
+            null
+        }
+
         // Debug logging for vault data loading
         println("DEBUG [GuildRepositorySQLite] Loading guild '$name'")
         println("  vault_status from DB: '$vaultStatusStr' -> $vaultStatus")
@@ -270,7 +287,8 @@ class GuildRepositorySQLite(private val storage: Storage<Database>) : GuildRepos
             joinFeeEnabled = joinFeeEnabled,
             joinFeeAmount = joinFeeAmount,
             trackingEnabled = trackingEnabled,
-            bankFrozen = bankFrozen
+            bankFrozen = bankFrozen,
+            allyHomeLocation = allyHomeLocation
         )
     }
 
@@ -641,4 +659,24 @@ class GuildRepositorySQLite(private val storage: Storage<Database>) : GuildRepos
     override fun isNameTaken(name: String): Boolean = getByName(name) != null
     
     override fun getCount(): Int = guilds.size
+    fun updateAllyHome(guildId: UUID, allyHome: GuildHome?): Boolean {
+        val sql = "UPDATE guilds SET ally_home_world = ?, ally_home_x = ?, ally_home_y = ?, ally_home_z = ? WHERE id = ?"
+        return try {
+            val rowsAffected = storage.connection.executeUpdate(sql,
+                allyHome?.worldId?.toString(),
+                allyHome?.position?.x,
+                allyHome?.position?.y,
+                allyHome?.position?.z,
+                guildId.toString()
+            )
+            // Update cache
+            guilds[guildId]?.let { guild ->
+                guilds[guildId] = guild.copy(allyHomeLocation = allyHome)
+            }
+            rowsAffected > 0
+        } catch (e: java.sql.SQLException) {
+            false
+        }
+    }
+
 }

--- a/src/main/kotlin/net/lumalyte/lg/infrastructure/persistence/invitations/GuildInvitationRepositorySQLite.kt
+++ b/src/main/kotlin/net/lumalyte/lg/infrastructure/persistence/invitations/GuildInvitationRepositorySQLite.kt
@@ -1,0 +1,196 @@
+package net.lumalyte.lg.infrastructure.persistence.invitations
+
+import co.aikar.idb.Database
+import net.lumalyte.lg.application.persistence.GuildInvitationRepository
+import net.lumalyte.lg.domain.entities.GuildInvitation
+import org.slf4j.LoggerFactory
+import java.time.Instant
+import java.util.UUID
+
+/**
+ * SQLite implementation of GuildInvitationRepository.
+ */
+class GuildInvitationRepositorySQLite(private val database: Database) : GuildInvitationRepository {
+
+    private val log = LoggerFactory.getLogger(GuildInvitationRepositorySQLite::class.java)
+
+    override fun getByPlayer(playerId: UUID): List<GuildInvitation> {
+        return try {
+            val results = database.getResults(
+                """
+                SELECT guild_id, guild_name, invited_player_id, inviter_player_id, inviter_name, invited_at
+                FROM guild_invitations
+                WHERE invited_player_id = ?
+                ORDER BY invited_at DESC
+                """.trimIndent(),
+                playerId.toString()
+            )
+
+            results.mapNotNull { row ->
+                try {
+                    GuildInvitation(
+                        guildId = UUID.fromString(row.getString("guild_id")),
+                        guildName = row.getString("guild_name"),
+                        invitedPlayerId = UUID.fromString(row.getString("invited_player_id")),
+                        inviterPlayerId = UUID.fromString(row.getString("inviter_player_id")),
+                        inviterName = row.getString("inviter_name"),
+                        timestamp = Instant.parse(row.getString("invited_at"))
+                    )
+                } catch (e: Exception) {
+                    log.error("Failed to parse invitation row", e)
+                    null
+                }
+            }
+        } catch (e: Exception) {
+            log.error("Failed to get invitations for player $playerId", e)
+            emptyList()
+        }
+    }
+
+    override fun getByPlayerAndGuild(playerId: UUID, guildId: UUID): GuildInvitation? {
+        return try {
+            val row = database.getFirstRow(
+                """
+                SELECT guild_id, guild_name, invited_player_id, inviter_player_id, inviter_name, invited_at
+                FROM guild_invitations
+                WHERE invited_player_id = ? AND guild_id = ?
+                """.trimIndent(),
+                playerId.toString(),
+                guildId.toString()
+            ) ?: return null
+
+            GuildInvitation(
+                guildId = UUID.fromString(row.getString("guild_id")),
+                guildName = row.getString("guild_name"),
+                invitedPlayerId = UUID.fromString(row.getString("invited_player_id")),
+                inviterPlayerId = UUID.fromString(row.getString("inviter_player_id")),
+                inviterName = row.getString("inviter_name"),
+                timestamp = Instant.parse(row.getString("invited_at"))
+            )
+        } catch (e: Exception) {
+            log.error("Failed to get invitation for player $playerId and guild $guildId", e)
+            null
+        }
+    }
+
+    override fun add(invitation: GuildInvitation): Boolean {
+        return try {
+            database.executeUpdate(
+                """
+                INSERT INTO guild_invitations (
+                    guild_id, guild_name, invited_player_id, inviter_player_id, inviter_name, invited_at
+                ) VALUES (?, ?, ?, ?, ?, ?)
+                """.trimIndent(),
+                invitation.guildId.toString(),
+                invitation.guildName,
+                invitation.invitedPlayerId.toString(),
+                invitation.inviterPlayerId.toString(),
+                invitation.inviterName,
+                invitation.timestamp.toString()
+            )
+            true
+        } catch (e: Exception) {
+            log.error("Failed to create invitation for player ${invitation.invitedPlayerId} to guild ${invitation.guildId}", e)
+            false
+        }
+    }
+
+    override fun remove(playerId: UUID, guildId: UUID): Boolean {
+        return try {
+            val rowsAffected = database.executeUpdate(
+                """
+                DELETE FROM guild_invitations
+                WHERE invited_player_id = ? AND guild_id = ?
+                """.trimIndent(),
+                playerId.toString(),
+                guildId.toString()
+            )
+            rowsAffected > 0
+        } catch (e: Exception) {
+            log.error("Failed to delete invitation for player $playerId and guild $guildId", e)
+            false
+        }
+    }
+
+    override fun removeAllForPlayer(playerId: UUID): Boolean {
+        return try {
+            database.executeUpdate(
+                """
+                DELETE FROM guild_invitations
+                WHERE invited_player_id = ?
+                """.trimIndent(),
+                playerId.toString()
+            )
+            true
+        } catch (e: Exception) {
+            log.error("Failed to delete all invitations for player $playerId", e)
+            false
+        }
+    }
+
+    override fun removeAllForGuild(guildId: UUID): Boolean {
+        return try {
+            database.executeUpdate(
+                """
+                DELETE FROM guild_invitations
+                WHERE guild_id = ?
+                """.trimIndent(),
+                guildId.toString()
+            )
+            true
+        } catch (e: Exception) {
+            log.error("Failed to delete all invitations for guild $guildId", e)
+            false
+        }
+    }
+
+    override fun hasInvitation(playerId: UUID, guildId: UUID): Boolean {
+        return try {
+            val row = database.getFirstRow(
+                """
+                SELECT 1 FROM guild_invitations
+                WHERE invited_player_id = ? AND guild_id = ?
+                """.trimIndent(),
+                playerId.toString(),
+                guildId.toString()
+            )
+            row != null
+        } catch (e: Exception) {
+            log.error("Failed to check invitation existence for player $playerId and guild $guildId", e)
+            false
+        }
+    }
+
+    override fun getInvitationCount(playerId: UUID): Int {
+        return try {
+            val row = database.getFirstRow(
+                """
+                SELECT COUNT(*) as count FROM guild_invitations
+                WHERE invited_player_id = ?
+                """.trimIndent(),
+                playerId.toString()
+            )
+            row?.getInt("count") ?: 0
+        } catch (e: Exception) {
+            log.error("Failed to count invitations for player $playerId", e)
+            0
+        }
+    }
+
+    override fun removeOlderThan(olderThan: Long): Int {
+        return try {
+            val cutoffTime = Instant.ofEpochSecond(olderThan)
+
+            database.executeUpdate(
+                """
+                DELETE FROM guild_invitations
+                WHERE invited_at < ?
+                """.trimIndent(),
+                cutoffTime.toString()
+            )
+        } catch (e: Exception) {
+            log.error("Failed to delete old invitations", e)
+            0
+        }
+    }
+}

--- a/src/main/kotlin/net/lumalyte/lg/infrastructure/persistence/migrations/SQLiteMigrations.kt
+++ b/src/main/kotlin/net/lumalyte/lg/infrastructure/persistence/migrations/SQLiteMigrations.kt
@@ -109,6 +109,11 @@ class SQLiteMigrations(private val plugin: JavaPlugin, private val connection: C
                 updateDatabaseVersion(18)
                 dbVersion = 18
             }
+            if (dbVersion < 19) {
+                migrateToVersion19()
+                updateDatabaseVersion(19)
+                dbVersion = 19
+            }
 
             // Validate that all required tables exist, recreate if missing
             validateAndRepairSchema()
@@ -1323,4 +1328,24 @@ class SQLiteMigrations(private val plugin: JavaPlugin, private val connection: C
             componentLogger.warn(Component.text("  Vault will use rollback journal mode (less crash-resistant)"))
         }
     }
+    private fun migrateToVersion19() {
+        componentLogger.info(Component.text("Migrating to version 19: Adding ally home columns to guilds table..."))
+
+        val columns = mapOf(
+            "ally_home_world" to "TEXT",
+            "ally_home_x" to "INTEGER",
+            "ally_home_y" to "INTEGER",
+            "ally_home_z" to "INTEGER"
+        )
+
+        for ((colName, colType) in columns) {
+            if (!columnExists("guilds", colName)) {
+                connection.createStatement().use { stmt ->
+                    stmt.execute("ALTER TABLE guilds ADD COLUMN $colName $colType")
+                }
+                componentLogger.info(Component.text("  Added column guilds.$colName ($colType)"))
+            }
+        }
+    }
+
 }

--- a/src/main/kotlin/net/lumalyte/lg/infrastructure/services/GuildServiceBukkit.kt
+++ b/src/main/kotlin/net/lumalyte/lg/infrastructure/services/GuildServiceBukkit.kt
@@ -444,7 +444,13 @@ class GuildServiceBukkit(
         }
     }
 
-        override fun setMode(guildId: UUID, mode: GuildMode, actorId: UUID): Boolean {
+        override fun setEmojiAdmin(guildId: UUID, emoji: String?): Boolean {
+        val guild = guildRepository.getById(guildId) ?: return false
+        if (emoji != null && !nexoEmojiService.isValidEmojiFormat(emoji)) return false
+        return guildRepository.update(guild.copy(emoji = emoji))
+    }
+
+    override fun setMode(guildId: UUID, mode: GuildMode, actorId: UUID): Boolean {
         val guild = guildRepository.getById(guildId) ?: return false
         
         // Check if actor has permission to change mode

--- a/src/main/kotlin/net/lumalyte/lg/infrastructure/services/GuildServiceBukkit.kt
+++ b/src/main/kotlin/net/lumalyte/lg/infrastructure/services/GuildServiceBukkit.kt
@@ -420,7 +420,31 @@ class GuildServiceBukkit(
         }
     }
     
-    override fun setMode(guildId: UUID, mode: GuildMode, actorId: UUID): Boolean {
+    override fun setAllyHome(guildId: UUID, location: org.bukkit.Location?, actorId: UUID): Boolean {
+        val guild = guildRepository.getById(guildId) ?: return false
+        if (!hasPermission(actorId, guildId, RankPermission.MANAGE_HOME)) return false
+        if (guild.level < 25) return false
+
+        val home = location?.let {
+            GuildHome(it.world.uid, net.lumalyte.lg.domain.values.Position3D(it.blockX, it.blockY, it.blockZ))
+        }
+        return (guildRepository as? net.lumalyte.lg.infrastructure.persistence.guilds.GuildRepositorySQLite)
+            ?.updateAllyHome(guildId, home) ?: guildRepository.update(guild.copy(allyHomeLocation = home))
+    }
+
+    override fun getAllyHome(guildId: UUID): GuildHome? {
+        return guildRepository.getById(guildId)?.allyHomeLocation
+    }
+
+    override fun canAccessAllyHome(actorId: UUID, hostGuildId: UUID): Boolean {
+        val playerGuilds = memberRepository.getGuildsByPlayer(actorId)
+        return playerGuilds.any { playerGuildId ->
+            playerGuildId != hostGuildId &&
+            relationRepository.hasRelationType(playerGuildId, hostGuildId, net.lumalyte.lg.domain.entities.RelationType.ALLY)
+        }
+    }
+
+        override fun setMode(guildId: UUID, mode: GuildMode, actorId: UUID): Boolean {
         val guild = guildRepository.getById(guildId) ?: return false
         
         // Check if actor has permission to change mode

--- a/src/main/kotlin/net/lumalyte/lg/infrastructure/services/GuildServiceBukkit.kt
+++ b/src/main/kotlin/net/lumalyte/lg/infrastructure/services/GuildServiceBukkit.kt
@@ -353,25 +353,11 @@ class GuildServiceBukkit(
     }
 
     override fun getAvailableHomeSlots(guildId: UUID): Int {
-        try {
-            val guild = guildRepository.getById(guildId) ?: return 1 // Default to 1 slot if guild not found
-
-            // Get progression service to check for ADDITIONAL_HOMES perk
-            // For now, use a simple calculation based on guild level
-            // This can be enhanced later to use the actual perk system
-            val baseSlots = 1
-            val additionalSlots = when {
-                guild.level >= 30 -> 5  // Level 30: 5 additional homes
-                guild.level >= 20 -> 3  // Level 20: 3 additional homes
-                guild.level >= 15 -> 2  // Level 15: 2 additional homes
-                guild.level >= 7 -> 1   // Level 7: 1 additional home
-                else -> 0
-            }
-            return baseSlots + additionalSlots
-        } catch (e: Exception) {
-            // Non-critical operation - catching all exceptions to prevent service failure
-            logger.error("Error calculating available home slots for guild $guildId", e)
-            return 1 // Default fallback
+        val guild = guildRepository.getById(guildId) ?: return 1
+        return when {
+            guild.level >= 70 -> 3  // Level 70: 3rd home unlocked
+            guild.level >= 40 -> 2  // Level 40: 2nd home unlocked
+            else -> 1               // Default: 1 home from creation
         }
     }
 

--- a/src/main/kotlin/net/lumalyte/lg/infrastructure/services/ProgressionServiceBukkit.kt
+++ b/src/main/kotlin/net/lumalyte/lg/infrastructure/services/ProgressionServiceBukkit.kt
@@ -362,8 +362,11 @@ class ProgressionServiceBukkit(
     }
 
     override fun hasMarketStallAccess(guildId: UUID): Boolean {
-        val guild = guildRepository.getById(guildId) ?: return false
-        return guild.level >= 15
+        return getGuildLevel(guildId) >= 15
+    }
+
+    override fun getGuildLevel(guildId: UUID): Int {
+        return progressionRepository.getGuildProgression(guildId)?.currentLevel ?: 1
     }
 
     override fun processLevelUp(guildId: UUID, newLevel: Int): List<PerkType> {
@@ -375,9 +378,10 @@ class ProgressionServiceBukkit(
         // Apply any immediate effects of new perks
         applyPerkEffects(guildId, newPerks)
         
-        // Sync Guild.level with authoritative GuildProgression level
+        // Sync Guild.level with authoritative GuildProgression level.
+        // Use < (not !=) so a slow concurrent write can never downgrade the stored level.
         val currentGuild = guildRepository.getById(guildId)
-        if (currentGuild != null && currentGuild.level != newLevel) {
+        if (currentGuild != null && currentGuild.level < newLevel) {
             guildRepository.update(currentGuild.copy(level = newLevel))
         }
 

--- a/src/main/kotlin/net/lumalyte/lg/infrastructure/services/ProgressionServiceBukkit.kt
+++ b/src/main/kotlin/net/lumalyte/lg/infrastructure/services/ProgressionServiceBukkit.kt
@@ -361,6 +361,11 @@ class ProgressionServiceBukkit(
         return maxWars
     }
 
+    override fun hasMarketStallAccess(guildId: UUID): Boolean {
+        val guild = guildRepository.getById(guildId) ?: return false
+        return guild.level >= 15
+    }
+
     override fun processLevelUp(guildId: UUID, newLevel: Int): List<PerkType> {
         val newPerks = getPerksForLevel(newLevel)
         

--- a/src/main/kotlin/net/lumalyte/lg/infrastructure/services/ProgressionServiceBukkit.kt
+++ b/src/main/kotlin/net/lumalyte/lg/infrastructure/services/ProgressionServiceBukkit.kt
@@ -370,6 +370,12 @@ class ProgressionServiceBukkit(
         // Apply any immediate effects of new perks
         applyPerkEffects(guildId, newPerks)
         
+        // Sync Guild.level with authoritative GuildProgression level
+        val currentGuild = guildRepository.getById(guildId)
+        if (currentGuild != null && currentGuild.level != newLevel) {
+            guildRepository.update(currentGuild.copy(level = newLevel))
+        }
+
         return newPerks
     }
 

--- a/src/main/kotlin/net/lumalyte/lg/infrastructure/services/ProgressionServiceBukkit.kt
+++ b/src/main/kotlin/net/lumalyte/lg/infrastructure/services/ProgressionServiceBukkit.kt
@@ -492,6 +492,12 @@ class ProgressionServiceBukkit(
             PerkType.FASTER_CLAIM_REGEN -> "Faster Claim Regeneration"
             PerkType.CUSTOM_BANNER_COLORS -> "Custom Banner Colors"
             PerkType.ANIMATED_EMOJIS -> "Animated Emojis"
+            PerkType.DECLARE_ENEMIES -> "Declare Enemies"
+            PerkType.FORM_ALLIANCES -> "Form Alliances"
+            PerkType.DECLARE_WAR -> "Declare War"
+            PerkType.MARKET_STALL_ACCESS -> "Market Stall Access"
+            PerkType.ALLY_HOME -> "Ally Home Teleport"
+            PerkType.CUSTOM_EMOJI -> "Custom Guild Emoji"
         }
     }
 }

--- a/src/main/kotlin/net/lumalyte/lg/infrastructure/services/RelationServiceBukkit.kt
+++ b/src/main/kotlin/net/lumalyte/lg/infrastructure/services/RelationServiceBukkit.kt
@@ -16,7 +16,8 @@ import java.util.UUID
 
 class RelationServiceBukkit(
     private val relationRepository: RelationRepository,
-    private val memberService: MemberService
+    private val memberService: MemberService,
+    private val guildRepository: net.lumalyte.lg.application.persistence.GuildRepository
 ) : RelationService {
     
     private val logger = LoggerFactory.getLogger(RelationServiceBukkit::class.java)
@@ -26,6 +27,12 @@ class RelationServiceBukkit(
             // Validate permissions
             if (!canManageRelations(actorId, requestingGuildId)) {
                 logger.warn("Player $actorId does not have permission to manage relations for guild $requestingGuildId")
+                return null
+            }
+            
+            // Level 10 required for alliances
+            if (!meetsLevelRequirement(requestingGuildId, 10)) {
+                logger.debug("Guild $requestingGuildId does not meet level 10 requirement for alliances")
                 return null
             }
             
@@ -119,6 +126,12 @@ class RelationServiceBukkit(
             // Validate permissions
             if (!canManageRelations(actorId, declaringGuildId)) {
                 logger.warn("Player $actorId does not have permission to declare war for guild $declaringGuildId")
+                return null
+            }
+            
+            // Level 20 required for war/enemy declarations
+            if (!meetsLevelRequirement(declaringGuildId, 20)) {
+                logger.debug("Guild $declaringGuildId does not meet level 20 requirement for war declarations")
                 return null
             }
             
@@ -561,4 +574,9 @@ class RelationServiceBukkit(
             relation.isActive() && relation.type == RelationType.ENEMY
         }
     }
+    private fun meetsLevelRequirement(guildId: UUID, requiredLevel: Int): Boolean {
+        val guild = guildRepository.getById(guildId) ?: return false
+        return guild.level >= requiredLevel
+    }
+
 }

--- a/src/main/kotlin/net/lumalyte/lg/interaction/commands/GuildCommand.kt
+++ b/src/main/kotlin/net/lumalyte/lg/interaction/commands/GuildCommand.kt
@@ -1944,7 +1944,58 @@ class GuildCommand : BaseCommand(), KoinComponent {
         }
     }
 
-    @Subcommand("enemy")
+    @Subcommand("setallyhome")
+    @CommandPermission("lumaguilds.guild.setallyhome")
+    fun onSetAllyHome(player: Player, @Optional clear: String?) {
+        val playerId = player.uniqueId
+        val guilds = guildService.getPlayerGuilds(playerId)
+        if (guilds.isEmpty()) {
+            player.sendMessage("§cYou are not in a guild.")
+            return
+        }
+        val guild = guilds.first()
+        if (guild.level < 25) {
+            player.sendMessage("§c❌ Your guild must reach Level 25 to set an Ally Home.")
+            return
+        }
+        val location = if (clear.equals("clear", ignoreCase = true)) null else player.location
+        val success = guildService.setAllyHome(guild.id, location, playerId)
+        if (success) {
+            if (location == null) player.sendMessage("§a✅ Ally Home cleared.")
+            else player.sendMessage("§a✅ Ally Home set at your location.")
+        } else {
+            player.sendMessage("§c❌ Failed to set Ally Home. Check your permissions.")
+        }
+    }
+
+    @Subcommand("allyhome")
+    @CommandPermission("lumaguilds.guild.allyhome")
+    @CommandCompletion("@guilds")
+    fun onAllyHome(player: Player, guildName: String) {
+        val hostGuild = guildRepository.getByName(guildName)
+        if (hostGuild == null) {
+            player.sendMessage("§cGuild '$guildName' not found.")
+            return
+        }
+        if (!guildService.canAccessAllyHome(player.uniqueId, hostGuild.id)) {
+            player.sendMessage("§c❌ You are not allied with '${hostGuild.name}'.")
+            return
+        }
+        val home = guildService.getAllyHome(hostGuild.id)
+        if (home == null) {
+            player.sendMessage("§c❌ '${hostGuild.name}' has not set an Ally Home.")
+            return
+        }
+        val world = org.bukkit.Bukkit.getWorld(home.worldId)
+        if (world == null) {
+            player.sendMessage("§c❌ Ally Home world is unavailable.")
+            return
+        }
+        val destination = org.bukkit.Location(world, home.position.x.toDouble() + 0.5, home.position.y.toDouble(), home.position.z.toDouble() + 0.5)
+        startTeleportCountdown(player, destination)
+    }
+
+        @Subcommand("enemy")
     @CommandPermission("lumaguilds.guild.enemy")
     @CommandCompletion("@guilds")
     fun onEnemy(player: Player, guildName: String) {

--- a/src/main/kotlin/net/lumalyte/lg/interaction/commands/GuildCommand.kt
+++ b/src/main/kotlin/net/lumalyte/lg/interaction/commands/GuildCommand.kt
@@ -1880,6 +1880,12 @@ class GuildCommand : BaseCommand(), KoinComponent {
 
         val guild = guilds.first()
 
+        // Level 10 required for alliances
+        if (guild.level < 10) {
+            player.sendMessage("§c❌ Your guild must reach Level 10 to form alliances.")
+            return
+        }
+
         // Check MANAGE_RELATIONS permission
         if (!memberService.hasPermission(playerId, guild.id, RankPermission.MANAGE_RELATIONS)) {
             player.sendMessage("§cYou don't have permission to manage guild relations.")
@@ -1952,6 +1958,12 @@ class GuildCommand : BaseCommand(), KoinComponent {
         }
 
         val guild = guilds.first()
+
+        // Level 20 required for war/enemy declarations
+        if (guild.level < 20) {
+            player.sendMessage("§c❌ Your guild must reach Level 20 to declare war.")
+            return
+        }
 
         // Check DECLARE_WAR permission (specific permission for war)
         if (!memberService.hasPermission(playerId, guild.id, RankPermission.DECLARE_WAR)) {

--- a/src/main/kotlin/net/lumalyte/lg/interaction/commands/GuildCommand.kt
+++ b/src/main/kotlin/net/lumalyte/lg/interaction/commands/GuildCommand.kt
@@ -1881,7 +1881,7 @@ class GuildCommand : BaseCommand(), KoinComponent {
         val guild = guilds.first()
 
         // Level 10 required for alliances
-        if (guild.level < 10) {
+        if (progressionService.getGuildLevel(guild.id) < 10) {
             player.sendMessage("§c❌ Your guild must reach Level 10 to form alliances.")
             return
         }
@@ -1954,7 +1954,7 @@ class GuildCommand : BaseCommand(), KoinComponent {
             return
         }
         val guild = guilds.first()
-        if (guild.level < 25) {
+        if (progressionService.getGuildLevel(guild.id) < 25) {
             player.sendMessage("§c❌ Your guild must reach Level 25 to set an Ally Home.")
             return
         }
@@ -2011,7 +2011,7 @@ class GuildCommand : BaseCommand(), KoinComponent {
         val guild = guilds.first()
 
         // Level 20 required for war/enemy declarations
-        if (guild.level < 20) {
+        if (progressionService.getGuildLevel(guild.id) < 20) {
             player.sendMessage("§c❌ Your guild must reach Level 20 to declare war.")
             return
         }

--- a/src/main/kotlin/net/lumalyte/lg/interaction/commands/admin/CustomEmojiCommand.kt
+++ b/src/main/kotlin/net/lumalyte/lg/interaction/commands/admin/CustomEmojiCommand.kt
@@ -1,0 +1,61 @@
+package net.lumalyte.lg.interaction.commands.admin
+
+import net.lumalyte.lg.application.services.GuildService
+import org.bukkit.command.Command
+import org.bukkit.command.CommandExecutor
+import org.bukkit.command.CommandSender
+import org.bukkit.command.TabCompleter
+
+/**
+ * Admin command: /customemoji <guildName> <emoji|clear>
+ *
+ * Grants a custom emoji to a Level 100 guild. Bypasses tier system.
+ * Permission: lumaguilds.admin.emoji.custom
+ */
+class CustomEmojiCommand(
+    private val guildService: GuildService
+) : CommandExecutor, TabCompleter {
+
+    override fun onCommand(sender: CommandSender, command: Command, label: String, args: Array<out String>): Boolean {
+        if (!sender.hasPermission("lumaguilds.admin.emoji.custom")) {
+            sender.sendMessage("§cYou don't have permission to use this command.")
+            return true
+        }
+        if (args.size < 2) {
+            sender.sendMessage("§cUsage: /customemoji <guildName> <emoji|clear>")
+            return true
+        }
+
+        val guildName = args[0]
+        val emojiArg = args[1]
+
+        val guild = guildService.getGuildByName(guildName)
+        if (guild == null) {
+            sender.sendMessage("§cGuild '${guildName}' not found.")
+            return true
+        }
+
+        if (guild.level < 100) {
+            sender.sendMessage("§c❌ '${guildName}' is Level ${guild.level}. Custom emojis require Level 100.")
+            return true
+        }
+
+        val emoji = if (emojiArg.equals("clear", ignoreCase = true)) null else emojiArg
+
+        val success = guildService.setEmojiAdmin(guild.id, emoji)
+        if (success) {
+            if (emoji == null) sender.sendMessage("§a✅ Custom emoji cleared for '${guildName}'.")
+            else sender.sendMessage("§a✅ Custom emoji '${emoji}' set for '${guildName}'.")
+        } else {
+            sender.sendMessage("§c❌ Failed to set emoji. Check the emoji format (:name:).")
+        }
+        return true
+    }
+
+    override fun onTabComplete(sender: CommandSender, command: Command, alias: String, args: Array<out String>): List<String> {
+        return when (args.size) {
+            1 -> guildService.getAllGuilds().map { it.name }.filter { it.startsWith(args[0], ignoreCase = true) }
+            else -> emptyList()
+        }
+    }
+}

--- a/src/main/kotlin/net/lumalyte/lg/interaction/commands/admin/CustomEmojiCommand.kt
+++ b/src/main/kotlin/net/lumalyte/lg/interaction/commands/admin/CustomEmojiCommand.kt
@@ -26,8 +26,9 @@ class CustomEmojiCommand(
             return true
         }
 
-        val guildName = args[0]
-        val emojiArg = args[1]
+        // Last arg is emoji/clear; everything before it is the guild name (supports spaces)
+        val guildName = args.dropLast(1).joinToString(" ")
+        val emojiArg = args.last()
 
         val guild = guildService.getGuildByName(guildName)
         if (guild == null) {

--- a/src/main/kotlin/net/lumalyte/lg/interaction/menus/bedrock/BedrockGuildProgressionInfoMenu.kt
+++ b/src/main/kotlin/net/lumalyte/lg/interaction/menus/bedrock/BedrockGuildProgressionInfoMenu.kt
@@ -161,6 +161,18 @@ class BedrockGuildProgressionInfoMenu(
             net.lumalyte.lg.application.services.PerkType.SPECIAL_PARTICLES -> "Special Particles"
             net.lumalyte.lg.application.services.PerkType.ANNOUNCEMENT_SOUND_EFFECTS -> "Announcement Sound Effects"
             net.lumalyte.lg.application.services.PerkType.WAR_DECLARATION_SOUND_EFFECTS -> "War Declaration Sound Effects"
+
+            // Diplomacy perks
+            net.lumalyte.lg.application.services.PerkType.DECLARE_ENEMIES -> "Declare Enemies"
+            net.lumalyte.lg.application.services.PerkType.FORM_ALLIANCES -> "Form Alliances"
+            net.lumalyte.lg.application.services.PerkType.DECLARE_WAR -> "Declare War"
+
+            // Economic perks
+            net.lumalyte.lg.application.services.PerkType.MARKET_STALL_ACCESS -> "Market Stall Access"
+
+            // Social perks
+            net.lumalyte.lg.application.services.PerkType.ALLY_HOME -> "Ally Home Teleport"
+            net.lumalyte.lg.application.services.PerkType.CUSTOM_EMOJI -> "Custom Guild Emoji"
         }
     }
 

--- a/src/main/kotlin/net/lumalyte/lg/utils/SafeMiniMessage.kt
+++ b/src/main/kotlin/net/lumalyte/lg/utils/SafeMiniMessage.kt
@@ -1,0 +1,37 @@
+package net.lumalyte.lg.utils
+
+import net.kyori.adventure.text.minimessage.MiniMessage
+import net.kyori.adventure.text.minimessage.tag.resolver.TagResolver
+import net.kyori.adventure.text.minimessage.tag.standard.StandardTags
+
+/**
+ * A restricted MiniMessage parser that allows only visual formatting tags.
+ * Blocks interaction tags (<click>, <hover>, <insert>) that could be abused
+ * to execute commands or inject text when clicked by elevated-permission players.
+ *
+ * Use this instead of MiniMessage.miniMessage() wherever user-controlled content
+ * is parsed (guild descriptions, guild tags, etc.).
+ *
+ * Allowed: color, decoration, gradient, rainbow, reset, font, newline
+ * Blocked: click, hover, insertion, keybind
+ */
+object SafeMiniMessage {
+
+    private val INSTANCE: MiniMessage = MiniMessage.builder()
+        .tags(
+            TagResolver.builder()
+                .resolvers(
+                    StandardTags.color(),
+                    StandardTags.decorations(),
+                    StandardTags.gradient(),
+                    StandardTags.rainbow(),
+                    StandardTags.reset(),
+                    StandardTags.font(),
+                    StandardTags.newline(),
+                )
+                .build()
+        )
+        .build()
+
+    fun get(): MiniMessage = INSTANCE
+}

--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -75,11 +75,12 @@ permissions:
       lumaguilds.guild.war: true
       lumaguilds.guild.info: true
       lumaguilds.guild.history: true
-      lumaguilds.admin.emoji.custom:
-    description: Set custom emoji for a Level 100 guild
-    default: op
-  lumaguilds.guild.setallyhome: true
+      lumaguilds.guild.setallyhome: true
       lumaguilds.guild.allyhome: true
+
+  lumaguilds.admin.emoji.custom:
+    description: Set custom emoji for a Level 100 guild (admin only)
+    default: op
 
   lumaguilds.guild.setallyhome:
     description: Set the guild's Ally Home location

--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -70,7 +70,15 @@ permissions:
       lumaguilds.guild.war: true
       lumaguilds.guild.info: true
       lumaguilds.guild.history: true
+      lumaguilds.guild.setallyhome: true
+      lumaguilds.guild.allyhome: true
 
+  lumaguilds.guild.setallyhome:
+    description: Set the guild's Ally Home location
+    default: true
+  lumaguilds.guild.allyhome:
+    description: Teleport to an allied guild's Ally Home
+    default: true
   lumaguilds.guild.create:
     description: Create new guilds
     default: true

--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -48,6 +48,11 @@ commands:
     usage: /removevault <guild> [dropItems]
     permission: lumaguilds.admin.vault.remove
 
+  customemoji:
+    description: Set a custom guild emoji (admin only, Level 100 guilds)
+    usage: /customemoji <guildName> <emoji|clear>
+    permission: lumaguilds.admin.emoji.custom
+
 permissions:
   # Guild Management Permissions
   lumaguilds.guild.*:
@@ -70,7 +75,10 @@ permissions:
       lumaguilds.guild.war: true
       lumaguilds.guild.info: true
       lumaguilds.guild.history: true
-      lumaguilds.guild.setallyhome: true
+      lumaguilds.admin.emoji.custom:
+    description: Set custom emoji for a Level 100 guild
+    default: op
+  lumaguilds.guild.setallyhome: true
       lumaguilds.guild.allyhome: true
 
   lumaguilds.guild.setallyhome:

--- a/src/main/resources/progression.yml
+++ b/src/main/resources/progression.yml
@@ -2,33 +2,75 @@
 # Max level: 100
 # XP formula: base_xp * (level - 1)^level_exponent + (level * linear_bonus)
 
-progression:
-  enabled: true
-  max_level: 100
+enabled: true
+claims_based: true
+max_level: 100
 
-  xp_formula:
-    base_xp: 500.0
-    level_exponent: 1.15
-    linear_bonus: 150
+leveling:
+  base_xp: 500.0
+  level_exponent: 1.15
+  linear_bonus: 150
 
-  xp_sources:
-    kill_player: 50
-    kill_mob: 5
-    block_break: 1
-    block_place: 1
-    farm_harvest: 3
-    fish_catch: 10
-    craft_item: 2
-    smelt_item: 2
-    brew_potion: 5
-    enchant_item: 15
-    form_alliance: 200
-    declare_war: 100
-    win_war: 500
-    bank_deposit: 1
+rate_limiting:
+  xp_cooldown_ms: 5000
+  max_xp_per_batch: 50
 
-  # Levels when claims system is ENABLED
-  levels_claims:
+experience_sources:
+  guild:
+    bank_deposit:
+      enabled: true
+      xp_per_100_coins: 1
+    member_joined:
+      enabled: true
+      xp: 50
+    war_won:
+      enabled: true
+      xp: 500
+    war_lost:
+      enabled: true
+      xp: 100
+    claim_created:
+      enabled: true
+      xp: 100
+    alliance_formed:
+      enabled: true
+      xp: 200
+    party_created:
+      enabled: true
+      xp: 25
+  player:
+    player_kill:
+      enabled: true
+      xp: 50
+    mob_kill:
+      enabled: true
+      xp: 5
+    crop_harvest:
+      enabled: true
+      xp: 3
+    block_break:
+      enabled: true
+      xp: 1
+    block_place:
+      enabled: true
+      xp: 1
+    crafting:
+      enabled: true
+      xp: 2
+    smelting:
+      enabled: true
+      xp: 2
+    brewing:
+      enabled: true
+      xp: 5
+    fishing:
+      enabled: true
+      xp: 10
+    enchanting:
+      enabled: true
+      xp: 15
+
+levels_claims:
   1:
     perks: [CUSTOM_BANNER_COLORS, ANIMATED_EMOJIS]
     claim_blocks: 0
@@ -840,8 +882,9 @@ progression:
     withdrawal_fee_multiplier: 0.9
 
 
-  # Levels when claims system is DISABLED
-  levels_no_claims:
+# Levels when claims system is DISABLED
+
+levels_no_claims:
   1:
     perks: [CUSTOM_BANNER_COLORS, ANIMATED_EMOJIS]
     bank_limit: 50000

--- a/src/main/resources/progression.yml
+++ b/src/main/resources/progression.yml
@@ -1,400 +1,1454 @@
-# =====================================
 # LumaGuilds Progression Configuration
-# Fully configurable guild leveling system
-# Made with love by BadgersMC <3
-# =====================================
+# Max level: 100
+# XP formula: base_xp * (level - 1)^level_exponent + (level * linear_bonus)
 
-# =====================================
-# Global Settings
-# =====================================
-enabled: true
+progression:
+  enabled: true
+  max_level: 100
 
-# Use claims-based progression (if false, uses alternative non-claims path)
-claims_based: true
+  xp_formula:
+    base_xp: 500.0
+    level_exponent: 1.15
+    linear_bonus: 150
 
-# Maximum guild level
-max_level: 30
+  xp_sources:
+    kill_player: 50
+    kill_mob: 5
+    block_break: 1
+    block_place: 1
+    farm_harvest: 3
+    fish_catch: 10
+    craft_item: 2
+    smelt_item: 2
+    brew_potion: 5
+    enchant_item: 15
+    form_alliance: 200
+    declare_war: 100
+    win_war: 500
+    bank_deposit: 1
 
-# XP Leveling Formula: base_xp * (level - 1)^level_exponent + (level * linear_bonus)
-leveling:
-  base_xp: 800.0
-  level_exponent: 1.3
-  linear_bonus: 200
-
-# Rate limiting to prevent XP farming
-rate_limiting:
-  xp_cooldown_ms: 5000
-  max_xp_per_batch: 50
-
-# =====================================
-# Experience Sources
-# =====================================
-experience_sources:
-  # Guild-wide activities
-  guild:
-    bank_deposit:
-      enabled: true
-      xp_per_100_coins: 1
-
-    member_joined:
-      enabled: true
-      xp: 50
-
-    war_won:
-      enabled: true
-      xp: 500
-
-    war_lost:
-      enabled: true
-      xp: 100
-
-    claim_created:
-      enabled: true  # Auto-disabled if claims_based: false
-      xp: 100
-
-    alliance_formed:
-      enabled: true
-      xp: 150
-
-    party_created:
-      enabled: true
-      xp: 25
-
-  # Player activities (accumulated for guild)
-  player:
-    player_kill:
-      enabled: true
-      xp: 25
-
-    mob_kill:
-      enabled: true
-      xp: 2
-
-    crop_harvest:
-      enabled: true
-      xp: 1
-
-    block_break:
-      enabled: true
-      xp: 1
-
-    block_place:
-      enabled: true
-      xp: 1
-
-    crafting:
-      enabled: true
-      xp: 2
-
-    smelting:
-      enabled: true
-      xp: 2
-
-    brewing:
-      enabled: true
-      xp: 3
-
-    fishing:
-      enabled: true
-      xp: 3
-
-    enchanting:
-      enabled: true
-      xp: 10
-
-# =====================================
-# Level Rewards (Claims-Based)
-# Used when claims_based: true
-# =====================================
-levels_claims:
+  # Levels when claims system is ENABLED
+  levels_claims:
   1:
-    perks:
-      - CUSTOM_BANNER_COLORS
-      - ANIMATED_EMOJIS
+    perks: [CUSTOM_BANNER_COLORS, ANIMATED_EMOJIS]
     claim_blocks: 0
-    claim_count: 0
+    claim_count: 1
     bank_limit: 50000
-    interest_rate: 0.0
-    homes: 1
-    members: 10
-
-  2:
-    perks:
-      - INCREASED_CLAIM_BLOCKS
-    claim_blocks: 100
-    claim_count: 0
-    bank_limit: 75000
-    interest_rate: 0.0
-    homes: 1
-    members: 10
-
-  3:
-    perks:
-      - FASTER_CLAIM_REGEN
-    claim_blocks: 200
-    claim_count: 0
-    bank_limit: 100000
-    interest_rate: 0.0
-    homes: 1
-    members: 15
-
-  5:
-    perks:
-      - BANK_INTEREST
-      - ANNOUNCEMENT_SOUND_EFFECTS
-    claim_blocks: 500
-    claim_count: 0
-    bank_limit: 150000
-    interest_rate: 0.01
     homes: 1
     members: 20
 
-  7:
-    perks:
-      - REDUCED_WITHDRAWAL_FEES
+  2:
+    perks: []
+    claim_blocks: 500
+    claim_count: 2
+    bank_limit: 54545
+    homes: 1
+    members: 20
+
+  3:
+    perks: []
     claim_blocks: 1000
-    claim_count: 1
-    bank_limit: 200000
-    interest_rate: 0.01
+    claim_count: 3
+    bank_limit: 59090
+    homes: 1
+    members: 20
+
+  4:
+    perks: []
+    claim_blocks: 1500
+    claim_count: 4
+    bank_limit: 63635
+    homes: 1
+    members: 20
+
+  5:
+    perks: [DECLARE_ENEMIES]
+    claim_blocks: 2000
+    claim_count: 5
+    bank_limit: 68180
     homes: 1
     members: 25
-    withdrawal_fee_multiplier: 0.5
+
+  6:
+    perks: []
+    claim_blocks: 2500
+    claim_count: 6
+    bank_limit: 72725
+    homes: 1
+    members: 25
+
+  7:
+    perks: []
+    claim_blocks: 3000
+    claim_count: 7
+    bank_limit: 77270
+    homes: 1
+    members: 25
+
+  8:
+    perks: []
+    claim_blocks: 3500
+    claim_count: 8
+    bank_limit: 81815
+    homes: 1
+    members: 25
+
+  9:
+    perks: []
+    claim_blocks: 4000
+    claim_count: 9
+    bank_limit: 86360
+    homes: 1
+    members: 25
 
   10:
-    perks:
-      - SPECIAL_PARTICLES
-      - HOME_TELEPORT_SOUND_EFFECTS
-    claim_blocks: 2000
-    claim_count: 2
-    bank_limit: 300000
-    interest_rate: 0.015
-    homes: 2
+    perks: [FORM_ALLIANCES]
+    claim_blocks: 4500
+    claim_count: 10
+    bank_limit: 90905
+    homes: 1
+    members: 30
+    withdrawal_fee_multiplier: 0.99
+
+  11:
+    perks: []
+    claim_blocks: 5000
+    claim_count: 11
+    bank_limit: 95450
+    homes: 1
+    members: 30
+
+  12:
+    perks: []
+    claim_blocks: 5500
+    claim_count: 12
+    bank_limit: 99995
+    homes: 1
+    members: 30
+
+  13:
+    perks: []
+    claim_blocks: 6000
+    claim_count: 13
+    bank_limit: 104540
+    homes: 1
+    members: 30
+
+  14:
+    perks: []
+    claim_blocks: 6500
+    claim_count: 14
+    bank_limit: 109085
+    homes: 1
     members: 30
 
   15:
-    perks:
-      - ADDITIONAL_HOMES
-    claim_blocks: 5000
-    claim_count: 3
-    bank_limit: 500000
-    interest_rate: 0.015
-    homes: 3
-    members: 40
+    perks: [MARKET_STALL_ACCESS]
+    claim_blocks: 7000
+    claim_count: 15
+    bank_limit: 113630
+    homes: 1
+    members: 35
+
+  16:
+    perks: []
+    claim_blocks: 7500
+    claim_count: 16
+    bank_limit: 118175
+    homes: 1
+    members: 35
+
+  17:
+    perks: []
+    claim_blocks: 8000
+    claim_count: 17
+    bank_limit: 122720
+    homes: 1
+    members: 35
+
+  18:
+    perks: []
+    claim_blocks: 8500
+    claim_count: 18
+    bank_limit: 127265
+    homes: 1
+    members: 35
+
+  19:
+    perks: []
+    claim_blocks: 9000
+    claim_count: 19
+    bank_limit: 131810
+    homes: 1
+    members: 35
 
   20:
-    perks:
-      - TELEPORT_COOLDOWN_REDUCTION
-      - WAR_DECLARATION_SOUND_EFFECTS
+    perks: [DECLARE_WAR]
+    claim_blocks: 9500
+    claim_count: 20
+    bank_limit: 136355
+    homes: 1
+    members: 40
+    withdrawal_fee_multiplier: 0.98
+
+  21:
+    perks: []
     claim_blocks: 10000
-    claim_count: 5
-    bank_limit: 750000
-    interest_rate: 0.02
-    homes: 4
-    members: 50
-    home_cooldown_multiplier: 0.6
+    claim_count: 21
+    bank_limit: 140900
+    homes: 1
+    members: 40
+
+  22:
+    perks: []
+    claim_blocks: 10500
+    claim_count: 22
+    bank_limit: 145445
+    homes: 1
+    members: 40
+
+  23:
+    perks: []
+    claim_blocks: 11000
+    claim_count: 23
+    bank_limit: 149990
+    homes: 1
+    members: 40
+
+  24:
+    perks: []
+    claim_blocks: 11500
+    claim_count: 24
+    bank_limit: 154535
+    homes: 1
+    members: 40
 
   25:
-    perks:
-      - HIGHER_BANK_BALANCE
-    claim_blocks: 20000
-    claim_count: 8
-    bank_limit: 1000000
-    interest_rate: 0.02
-    homes: 5
-    members: 60
+    perks: [ALLY_HOME]
+    claim_blocks: 12000
+    claim_count: 25
+    bank_limit: 159080
+    homes: 1
+    members: 45
+
+  26:
+    perks: []
+    claim_blocks: 12500
+    claim_count: 26
+    bank_limit: 163625
+    homes: 1
+    members: 45
+
+  27:
+    perks: []
+    claim_blocks: 13000
+    claim_count: 27
+    bank_limit: 168170
+    homes: 1
+    members: 45
+
+  28:
+    perks: []
+    claim_blocks: 13500
+    claim_count: 28
+    bank_limit: 172715
+    homes: 1
+    members: 45
+
+  29:
+    perks: []
+    claim_blocks: 14000
+    claim_count: 29
+    bank_limit: 177260
+    homes: 1
+    members: 45
 
   30:
-    perks:
-      - INCREASED_BANK_LIMIT
-    claim_blocks: 35000
-    claim_count: 12
-    bank_limit: 1500000
-    interest_rate: 0.025
-    homes: 8
+    perks: [INCREASED_CLAIM_BLOCKS]
+    claim_blocks: 14500
+    claim_count: 30
+    bank_limit: 181805
+    homes: 1
+    members: 50
+    withdrawal_fee_multiplier: 0.97
+
+  31:
+    perks: []
+    claim_blocks: 15000
+    claim_count: 31
+    bank_limit: 186350
+    homes: 1
+    members: 50
+
+  32:
+    perks: []
+    claim_blocks: 15500
+    claim_count: 32
+    bank_limit: 190895
+    homes: 1
+    members: 50
+
+  33:
+    perks: []
+    claim_blocks: 16000
+    claim_count: 33
+    bank_limit: 195440
+    homes: 1
+    members: 50
+
+  34:
+    perks: []
+    claim_blocks: 16500
+    claim_count: 34
+    bank_limit: 199985
+    homes: 1
+    members: 50
+
+  35:
+    perks: []
+    claim_blocks: 17000
+    claim_count: 35
+    bank_limit: 204530
+    homes: 1
+    members: 55
+
+  36:
+    perks: []
+    claim_blocks: 17500
+    claim_count: 36
+    bank_limit: 209075
+    homes: 1
+    members: 55
+
+  37:
+    perks: []
+    claim_blocks: 18000
+    claim_count: 37
+    bank_limit: 213620
+    homes: 1
+    members: 55
+
+  38:
+    perks: []
+    claim_blocks: 18500
+    claim_count: 38
+    bank_limit: 218165
+    homes: 1
+    members: 55
+
+  39:
+    perks: []
+    claim_blocks: 19000
+    claim_count: 39
+    bank_limit: 222710
+    homes: 1
+    members: 55
+
+  40:
+    perks: [ADDITIONAL_HOMES]
+    claim_blocks: 19500
+    claim_count: 40
+    bank_limit: 227255
+    homes: 2
+    members: 60
+    withdrawal_fee_multiplier: 0.96
+
+  41:
+    perks: []
+    claim_blocks: 20000
+    claim_count: 41
+    bank_limit: 231800
+    homes: 2
+    members: 60
+
+  42:
+    perks: []
+    claim_blocks: 20500
+    claim_count: 42
+    bank_limit: 236345
+    homes: 2
+    members: 60
+
+  43:
+    perks: []
+    claim_blocks: 21000
+    claim_count: 43
+    bank_limit: 240890
+    homes: 2
+    members: 60
+
+  44:
+    perks: []
+    claim_blocks: 21500
+    claim_count: 44
+    bank_limit: 245435
+    homes: 2
+    members: 60
+
+  45:
+    perks: []
+    claim_blocks: 22000
+    claim_count: 45
+    bank_limit: 249980
+    homes: 2
+    members: 65
+
+  46:
+    perks: []
+    claim_blocks: 22500
+    claim_count: 46
+    bank_limit: 254525
+    homes: 2
+    members: 65
+
+  47:
+    perks: []
+    claim_blocks: 23000
+    claim_count: 47
+    bank_limit: 259070
+    homes: 2
+    members: 65
+
+  48:
+    perks: []
+    claim_blocks: 23500
+    claim_count: 48
+    bank_limit: 263615
+    homes: 2
+    members: 65
+
+  49:
+    perks: []
+    claim_blocks: 24000
+    claim_count: 49
+    bank_limit: 268160
+    homes: 2
+    members: 65
+
+  50:
+    perks: [BANK_INTEREST]
+    claim_blocks: 24500
+    claim_count: 50
+    bank_limit: 272705
+    homes: 2
+    members: 70
+    withdrawal_fee_multiplier: 0.95
+
+  51:
+    perks: []
+    claim_blocks: 25000
+    claim_count: 51
+    bank_limit: 277250
+    homes: 2
+    members: 70
+
+  52:
+    perks: []
+    claim_blocks: 25500
+    claim_count: 52
+    bank_limit: 281795
+    homes: 2
+    members: 70
+
+  53:
+    perks: []
+    claim_blocks: 26000
+    claim_count: 53
+    bank_limit: 286340
+    homes: 2
+    members: 70
+
+  54:
+    perks: []
+    claim_blocks: 26500
+    claim_count: 54
+    bank_limit: 290885
+    homes: 2
+    members: 70
+
+  55:
+    perks: []
+    claim_blocks: 27000
+    claim_count: 55
+    bank_limit: 295430
+    homes: 2
     members: 75
 
-# =====================================
-# Level Rewards (Non-Claims)
-# Used when claims_based: false
-# =====================================
-levels_no_claims:
+  56:
+    perks: []
+    claim_blocks: 27500
+    claim_count: 56
+    bank_limit: 299975
+    homes: 2
+    members: 75
+
+  57:
+    perks: []
+    claim_blocks: 28000
+    claim_count: 57
+    bank_limit: 304520
+    homes: 2
+    members: 75
+
+  58:
+    perks: []
+    claim_blocks: 28500
+    claim_count: 58
+    bank_limit: 309065
+    homes: 2
+    members: 75
+
+  59:
+    perks: []
+    claim_blocks: 29000
+    claim_count: 59
+    bank_limit: 313610
+    homes: 2
+    members: 75
+
+  60:
+    perks: [REDUCED_WITHDRAWAL_FEES]
+    claim_blocks: 29500
+    claim_count: 60
+    bank_limit: 318155
+    homes: 2
+    members: 80
+    withdrawal_fee_multiplier: 0.94
+
+  61:
+    perks: []
+    claim_blocks: 30000
+    claim_count: 61
+    bank_limit: 322700
+    homes: 2
+    members: 80
+
+  62:
+    perks: []
+    claim_blocks: 30500
+    claim_count: 62
+    bank_limit: 327245
+    homes: 2
+    members: 80
+
+  63:
+    perks: []
+    claim_blocks: 31000
+    claim_count: 63
+    bank_limit: 331790
+    homes: 2
+    members: 80
+
+  64:
+    perks: []
+    claim_blocks: 31500
+    claim_count: 64
+    bank_limit: 336335
+    homes: 2
+    members: 80
+
+  65:
+    perks: []
+    claim_blocks: 32000
+    claim_count: 65
+    bank_limit: 340880
+    homes: 2
+    members: 85
+
+  66:
+    perks: []
+    claim_blocks: 32500
+    claim_count: 66
+    bank_limit: 345425
+    homes: 2
+    members: 85
+
+  67:
+    perks: []
+    claim_blocks: 33000
+    claim_count: 67
+    bank_limit: 349970
+    homes: 2
+    members: 85
+
+  68:
+    perks: []
+    claim_blocks: 33500
+    claim_count: 68
+    bank_limit: 354515
+    homes: 2
+    members: 85
+
+  69:
+    perks: []
+    claim_blocks: 34000
+    claim_count: 69
+    bank_limit: 359060
+    homes: 2
+    members: 85
+
+  70:
+    perks: [ADDITIONAL_HOMES]
+    claim_blocks: 34500
+    claim_count: 70
+    bank_limit: 363605
+    homes: 3
+    members: 90
+    withdrawal_fee_multiplier: 0.93
+
+  71:
+    perks: []
+    claim_blocks: 35000
+    claim_count: 71
+    bank_limit: 368150
+    homes: 3
+    members: 90
+
+  72:
+    perks: []
+    claim_blocks: 35500
+    claim_count: 72
+    bank_limit: 372695
+    homes: 3
+    members: 90
+
+  73:
+    perks: []
+    claim_blocks: 36000
+    claim_count: 73
+    bank_limit: 377240
+    homes: 3
+    members: 90
+
+  74:
+    perks: []
+    claim_blocks: 36500
+    claim_count: 74
+    bank_limit: 381785
+    homes: 3
+    members: 90
+
+  75:
+    perks: []
+    claim_blocks: 37000
+    claim_count: 75
+    bank_limit: 386330
+    homes: 3
+    members: 95
+
+  76:
+    perks: []
+    claim_blocks: 37500
+    claim_count: 76
+    bank_limit: 390875
+    homes: 3
+    members: 95
+
+  77:
+    perks: []
+    claim_blocks: 38000
+    claim_count: 77
+    bank_limit: 395420
+    homes: 3
+    members: 95
+
+  78:
+    perks: []
+    claim_blocks: 38500
+    claim_count: 78
+    bank_limit: 399965
+    homes: 3
+    members: 95
+
+  79:
+    perks: []
+    claim_blocks: 39000
+    claim_count: 79
+    bank_limit: 404510
+    homes: 3
+    members: 95
+
+  80:
+    perks: [TELEPORT_COOLDOWN_REDUCTION]
+    claim_blocks: 39500
+    claim_count: 80
+    bank_limit: 409055
+    homes: 3
+    members: 100
+    withdrawal_fee_multiplier: 0.92
+
+  81:
+    perks: []
+    claim_blocks: 40000
+    claim_count: 81
+    bank_limit: 413600
+    homes: 3
+    members: 100
+
+  82:
+    perks: []
+    claim_blocks: 40500
+    claim_count: 82
+    bank_limit: 418145
+    homes: 3
+    members: 100
+
+  83:
+    perks: []
+    claim_blocks: 41000
+    claim_count: 83
+    bank_limit: 422690
+    homes: 3
+    members: 100
+
+  84:
+    perks: []
+    claim_blocks: 41500
+    claim_count: 84
+    bank_limit: 427235
+    homes: 3
+    members: 100
+
+  85:
+    perks: []
+    claim_blocks: 42000
+    claim_count: 85
+    bank_limit: 431780
+    homes: 3
+    members: 100
+
+  86:
+    perks: []
+    claim_blocks: 42500
+    claim_count: 86
+    bank_limit: 436325
+    homes: 3
+    members: 100
+
+  87:
+    perks: []
+    claim_blocks: 43000
+    claim_count: 87
+    bank_limit: 440870
+    homes: 3
+    members: 100
+
+  88:
+    perks: []
+    claim_blocks: 43500
+    claim_count: 88
+    bank_limit: 445415
+    homes: 3
+    members: 100
+
+  89:
+    perks: []
+    claim_blocks: 44000
+    claim_count: 89
+    bank_limit: 449960
+    homes: 3
+    members: 100
+
+  90:
+    perks: [SPECIAL_PARTICLES]
+    claim_blocks: 44500
+    claim_count: 90
+    bank_limit: 454505
+    homes: 3
+    members: 100
+    withdrawal_fee_multiplier: 0.91
+
+  91:
+    perks: []
+    claim_blocks: 45000
+    claim_count: 91
+    bank_limit: 459050
+    homes: 3
+    members: 100
+
+  92:
+    perks: []
+    claim_blocks: 45500
+    claim_count: 92
+    bank_limit: 463595
+    homes: 3
+    members: 100
+
+  93:
+    perks: []
+    claim_blocks: 46000
+    claim_count: 93
+    bank_limit: 468140
+    homes: 3
+    members: 100
+
+  94:
+    perks: []
+    claim_blocks: 46500
+    claim_count: 94
+    bank_limit: 472685
+    homes: 3
+    members: 100
+
+  95:
+    perks: []
+    claim_blocks: 47000
+    claim_count: 95
+    bank_limit: 477230
+    homes: 3
+    members: 100
+
+  96:
+    perks: []
+    claim_blocks: 47500
+    claim_count: 96
+    bank_limit: 481775
+    homes: 3
+    members: 100
+
+  97:
+    perks: []
+    claim_blocks: 48000
+    claim_count: 97
+    bank_limit: 486320
+    homes: 3
+    members: 100
+
+  98:
+    perks: []
+    claim_blocks: 48500
+    claim_count: 98
+    bank_limit: 490865
+    homes: 3
+    members: 100
+
+  99:
+    perks: []
+    claim_blocks: 49000
+    claim_count: 99
+    bank_limit: 495410
+    homes: 3
+    members: 100
+
+  100:
+    perks: [CUSTOM_EMOJI, ANNOUNCEMENT_SOUND_EFFECTS]
+    claim_blocks: 49500
+    claim_count: 100
+    bank_limit: 499955
+    homes: 3
+    members: 100
+    withdrawal_fee_multiplier: 0.9
+
+
+  # Levels when claims system is DISABLED
+  levels_no_claims:
   1:
-    perks:
-      - CUSTOM_BANNER_COLORS
-      - ANIMATED_EMOJIS
+    perks: [CUSTOM_BANNER_COLORS, ANIMATED_EMOJIS]
     bank_limit: 50000
-    interest_rate: 0.0
     homes: 1
-    members: 10
-    war_slots: 3
+    members: 20
 
   2:
-    perks:
-      - HIGHER_BANK_BALANCE
-    bank_limit: 100000
-    interest_rate: 0.005
+    perks: []
+    bank_limit: 54545
     homes: 1
-    members: 15
-    war_slots: 3
+    members: 20
 
   3:
-    perks:
-      - BANK_INTEREST
-    bank_limit: 150000
-    interest_rate: 0.01
+    perks: []
+    bank_limit: 59090
     homes: 1
-    members: 15
-    war_slots: 3
+    members: 20
+
+  4:
+    perks: []
+    bank_limit: 63635
+    homes: 1
+    members: 20
 
   5:
-    perks:
-      - ANNOUNCEMENT_SOUND_EFFECTS
-      - SPECIAL_PARTICLES
-    bank_limit: 250000
-    interest_rate: 0.015
-    homes: 2
-    members: 20
-    war_slots: 4
+    perks: [DECLARE_ENEMIES]
+    bank_limit: 68180
+    homes: 1
+    members: 25
+
+  6:
+    perks: []
+    bank_limit: 72725
+    homes: 1
+    members: 25
 
   7:
-    perks:
-      - REDUCED_WITHDRAWAL_FEES
-      - ADDITIONAL_HOMES
-    bank_limit: 400000
-    interest_rate: 0.015
-    homes: 3
+    perks: []
+    bank_limit: 77270
+    homes: 1
     members: 25
-    war_slots: 4
-    withdrawal_fee_multiplier: 0.5
+
+  8:
+    perks: []
+    bank_limit: 81815
+    homes: 1
+    members: 25
+
+  9:
+    perks: []
+    bank_limit: 86360
+    homes: 1
+    members: 25
 
   10:
-    perks:
-      - HOME_TELEPORT_SOUND_EFFECTS
-      - TELEPORT_COOLDOWN_REDUCTION
-    bank_limit: 600000
-    interest_rate: 0.02
-    homes: 4
+    perks: [FORM_ALLIANCES]
+    bank_limit: 90905
+    homes: 1
     members: 30
-    war_slots: 5
-    home_cooldown_multiplier: 0.6
+    withdrawal_fee_multiplier: 0.99
+
+  11:
+    perks: []
+    bank_limit: 95450
+    homes: 1
+    members: 30
+
+  12:
+    perks: []
+    bank_limit: 99995
+    homes: 1
+    members: 30
+
+  13:
+    perks: []
+    bank_limit: 104540
+    homes: 1
+    members: 30
+
+  14:
+    perks: []
+    bank_limit: 109085
+    homes: 1
+    members: 30
 
   15:
-    perks:
-      - INCREASED_BANK_LIMIT
-    bank_limit: 1000000
-    interest_rate: 0.02
-    homes: 6
+    perks: [MARKET_STALL_ACCESS]
+    bank_limit: 113630
+    homes: 1
+    members: 35
+
+  16:
+    perks: []
+    bank_limit: 118175
+    homes: 1
+    members: 35
+
+  17:
+    perks: []
+    bank_limit: 122720
+    homes: 1
+    members: 35
+
+  18:
+    perks: []
+    bank_limit: 127265
+    homes: 1
+    members: 35
+
+  19:
+    perks: []
+    bank_limit: 131810
+    homes: 1
+    members: 35
+
+  20:
+    perks: [DECLARE_WAR]
+    bank_limit: 136355
+    homes: 1
     members: 40
-    war_slots: 6
+    withdrawal_fee_multiplier: 0.98
 
-  20:
-    perks:
-      - WAR_DECLARATION_SOUND_EFFECTS
-    bank_limit: 1500000
-    interest_rate: 0.025
-    homes: 8
+  21:
+    perks: []
+    bank_limit: 140900
+    homes: 1
+    members: 40
+
+  22:
+    perks: []
+    bank_limit: 145445
+    homes: 1
+    members: 40
+
+  23:
+    perks: []
+    bank_limit: 149990
+    homes: 1
+    members: 40
+
+  24:
+    perks: []
+    bank_limit: 154535
+    homes: 1
+    members: 40
+
+  25:
+    perks: [ALLY_HOME]
+    bank_limit: 159080
+    homes: 1
+    members: 45
+
+  26:
+    perks: []
+    bank_limit: 163625
+    homes: 1
+    members: 45
+
+  27:
+    perks: []
+    bank_limit: 168170
+    homes: 1
+    members: 45
+
+  28:
+    perks: []
+    bank_limit: 172715
+    homes: 1
+    members: 45
+
+  29:
+    perks: []
+    bank_limit: 177260
+    homes: 1
+    members: 45
+
+  30:
+    perks: []
+    bank_limit: 181805
+    homes: 1
     members: 50
-    war_slots: 6
-    war_cost_multiplier: 0.75
+    withdrawal_fee_multiplier: 0.97
 
-  25:
-    perks:
-      - HIGHER_BANK_BALANCE
-    bank_limit: 2500000
-    interest_rate: 0.03
-    homes: 10
+  31:
+    perks: []
+    bank_limit: 186350
+    homes: 1
+    members: 50
+
+  32:
+    perks: []
+    bank_limit: 190895
+    homes: 1
+    members: 50
+
+  33:
+    perks: []
+    bank_limit: 195440
+    homes: 1
+    members: 50
+
+  34:
+    perks: []
+    bank_limit: 199985
+    homes: 1
+    members: 50
+
+  35:
+    perks: []
+    bank_limit: 204530
+    homes: 1
+    members: 55
+
+  36:
+    perks: []
+    bank_limit: 209075
+    homes: 1
+    members: 55
+
+  37:
+    perks: []
+    bank_limit: 213620
+    homes: 1
+    members: 55
+
+  38:
+    perks: []
+    bank_limit: 218165
+    homes: 1
+    members: 55
+
+  39:
+    perks: []
+    bank_limit: 222710
+    homes: 1
+    members: 55
+
+  40:
+    perks: [ADDITIONAL_HOMES]
+    bank_limit: 227255
+    homes: 2
     members: 60
-    war_slots: 8
+    withdrawal_fee_multiplier: 0.96
 
-  30:
-    perks:
-      - INCREASED_BANK_LIMIT
-    bank_limit: 5000000
-    interest_rate: 0.035
-    homes: 12
+  41:
+    perks: []
+    bank_limit: 231800
+    homes: 2
+    members: 60
+
+  42:
+    perks: []
+    bank_limit: 236345
+    homes: 2
+    members: 60
+
+  43:
+    perks: []
+    bank_limit: 240890
+    homes: 2
+    members: 60
+
+  44:
+    perks: []
+    bank_limit: 245435
+    homes: 2
+    members: 60
+
+  45:
+    perks: []
+    bank_limit: 249980
+    homes: 2
+    members: 65
+
+  46:
+    perks: []
+    bank_limit: 254525
+    homes: 2
+    members: 65
+
+  47:
+    perks: []
+    bank_limit: 259070
+    homes: 2
+    members: 65
+
+  48:
+    perks: []
+    bank_limit: 263615
+    homes: 2
+    members: 65
+
+  49:
+    perks: []
+    bank_limit: 268160
+    homes: 2
+    members: 65
+
+  50:
+    perks: [BANK_INTEREST]
+    bank_limit: 272705
+    homes: 2
+    members: 70
+    withdrawal_fee_multiplier: 0.95
+
+  51:
+    perks: []
+    bank_limit: 277250
+    homes: 2
+    members: 70
+
+  52:
+    perks: []
+    bank_limit: 281795
+    homes: 2
+    members: 70
+
+  53:
+    perks: []
+    bank_limit: 286340
+    homes: 2
+    members: 70
+
+  54:
+    perks: []
+    bank_limit: 290885
+    homes: 2
+    members: 70
+
+  55:
+    perks: []
+    bank_limit: 295430
+    homes: 2
+    members: 75
+
+  56:
+    perks: []
+    bank_limit: 299975
+    homes: 2
+    members: 75
+
+  57:
+    perks: []
+    bank_limit: 304520
+    homes: 2
+    members: 75
+
+  58:
+    perks: []
+    bank_limit: 309065
+    homes: 2
+    members: 75
+
+  59:
+    perks: []
+    bank_limit: 313610
+    homes: 2
+    members: 75
+
+  60:
+    perks: [REDUCED_WITHDRAWAL_FEES]
+    bank_limit: 318155
+    homes: 2
+    members: 80
+    withdrawal_fee_multiplier: 0.94
+
+  61:
+    perks: []
+    bank_limit: 322700
+    homes: 2
+    members: 80
+
+  62:
+    perks: []
+    bank_limit: 327245
+    homes: 2
+    members: 80
+
+  63:
+    perks: []
+    bank_limit: 331790
+    homes: 2
+    members: 80
+
+  64:
+    perks: []
+    bank_limit: 336335
+    homes: 2
+    members: 80
+
+  65:
+    perks: []
+    bank_limit: 340880
+    homes: 2
+    members: 85
+
+  66:
+    perks: []
+    bank_limit: 345425
+    homes: 2
+    members: 85
+
+  67:
+    perks: []
+    bank_limit: 349970
+    homes: 2
+    members: 85
+
+  68:
+    perks: []
+    bank_limit: 354515
+    homes: 2
+    members: 85
+
+  69:
+    perks: []
+    bank_limit: 359060
+    homes: 2
+    members: 85
+
+  70:
+    perks: [ADDITIONAL_HOMES]
+    bank_limit: 363605
+    homes: 3
+    members: 90
+    withdrawal_fee_multiplier: 0.93
+
+  71:
+    perks: []
+    bank_limit: 368150
+    homes: 3
+    members: 90
+
+  72:
+    perks: []
+    bank_limit: 372695
+    homes: 3
+    members: 90
+
+  73:
+    perks: []
+    bank_limit: 377240
+    homes: 3
+    members: 90
+
+  74:
+    perks: []
+    bank_limit: 381785
+    homes: 3
+    members: 90
+
+  75:
+    perks: []
+    bank_limit: 386330
+    homes: 3
+    members: 95
+
+  76:
+    perks: []
+    bank_limit: 390875
+    homes: 3
+    members: 95
+
+  77:
+    perks: []
+    bank_limit: 395420
+    homes: 3
+    members: 95
+
+  78:
+    perks: []
+    bank_limit: 399965
+    homes: 3
+    members: 95
+
+  79:
+    perks: []
+    bank_limit: 404510
+    homes: 3
+    members: 95
+
+  80:
+    perks: [TELEPORT_COOLDOWN_REDUCTION]
+    bank_limit: 409055
+    homes: 3
     members: 100
-    war_slots: 10
-    war_cost_multiplier: 0.5
+    withdrawal_fee_multiplier: 0.92
 
-# =====================================
-# Milestone Rewards
-# Special rewards given at certain levels
-# =====================================
-milestones:
-  # Every 5 levels
-  5:
-    broadcast: true
-    message: "&6&l{guild} has reached level {level}!"
-    coins: 1000
+  81:
+    perks: []
+    bank_limit: 413600
+    homes: 3
+    members: 100
 
-  10:
-    broadcast: true
-    message: "&e&l✨ {guild} has achieved level {level}! ✨"
-    coins: 5000
-    items:
-      - material: DIAMOND
-        amount: 10
+  82:
+    perks: []
+    bank_limit: 418145
+    homes: 3
+    members: 100
 
-  15:
-    broadcast: true
-    message: "&d&l{guild} has reached level 15!"
-    coins: 10000
-    items:
-      - material: DIAMOND_BLOCK
-        amount: 5
+  83:
+    perks: []
+    bank_limit: 422690
+    homes: 3
+    members: 100
 
-  20:
-    broadcast: true
-    message: "&b&l{guild} is now level 20!"
-    coins: 15000
+  84:
+    perks: []
+    bank_limit: 427235
+    homes: 3
+    members: 100
 
-  25:
-    broadcast: true
-    message: "&5&l{guild} has reached level 25!"
-    coins: 20000
+  85:
+    perks: []
+    bank_limit: 431780
+    homes: 3
+    members: 100
 
-  # Max level
-  30:
-    broadcast: true
-    message: "&4&l⚡ {guild} has reached MAX LEVEL! ⚡"
-    coins: 50000
-    items:
-      - material: NETHER_STAR
-        amount: 1
-        display_name: "&6&lLegendary Guild Star"
-        lore:
-          - "&7Proof of reaching max level"
-          - "&eGuild: {guild}"
-          - "&7{date}"
+  86:
+    perks: []
+    bank_limit: 436325
+    homes: 3
+    members: 100
 
-# =====================================
-# Activity Tracking
-# =====================================
-activity:
-  enabled: true
-  weekly_reset: true
-  reset_day: MONDAY
+  87:
+    perks: []
+    bank_limit: 440870
+    homes: 3
+    members: 100
 
-  # Activity score weights
-  weights:
-    member_count: 10
-    active_members: 50
-    claims_owned: 20
-    kills_this_week: 25
-    bank_deposits_this_week: 5
-    relations_formed: 75
-    wars_participated: 200
+  88:
+    perks: []
+    bank_limit: 445415
+    homes: 3
+    members: 100
 
-# =====================================
-# Leaderboards
-# =====================================
-leaderboards:
-  enabled: true
-  update_interval_minutes: 5
-  display_size: 10
-  types:
-    - LEVEL
-    - TOTAL_XP
-    - WEEKLY_ACTIVITY
-    - BANK_BALANCE
-    - MEMBER_COUNT
+  89:
+    perks: []
+    bank_limit: 449960
+    homes: 3
+    members: 100
+
+  90:
+    perks: [SPECIAL_PARTICLES]
+    bank_limit: 454505
+    homes: 3
+    members: 100
+    withdrawal_fee_multiplier: 0.91
+
+  91:
+    perks: []
+    bank_limit: 459050
+    homes: 3
+    members: 100
+
+  92:
+    perks: []
+    bank_limit: 463595
+    homes: 3
+    members: 100
+
+  93:
+    perks: []
+    bank_limit: 468140
+    homes: 3
+    members: 100
+
+  94:
+    perks: []
+    bank_limit: 472685
+    homes: 3
+    members: 100
+
+  95:
+    perks: []
+    bank_limit: 477230
+    homes: 3
+    members: 100
+
+  96:
+    perks: []
+    bank_limit: 481775
+    homes: 3
+    members: 100
+
+  97:
+    perks: []
+    bank_limit: 486320
+    homes: 3
+    members: 100
+
+  98:
+    perks: []
+    bank_limit: 490865
+    homes: 3
+    members: 100
+
+  99:
+    perks: []
+    bank_limit: 495410
+    homes: 3
+    members: 100
+
+  100:
+    perks: [CUSTOM_EMOJI, ANNOUNCEMENT_SOUND_EFFECTS]
+    bank_limit: 499955
+    homes: 3
+    members: 100
+    withdrawal_fee_multiplier: 0.9
+


### PR DESCRIPTION
## Summary
- **Expand guild progression from max level 30 to 100** with rebalanced XP formula (`500*(L-1)^1.15 + L*150`), member caps (20→100), home slots (1/2/3 at L1/40/70), and bank limits
- **Fix Guild.level sync** — `processLevelUp()` now writes back to `Guild.level` so all level-gated logic reads the authoritative value
- **Diplomacy level gates** — enemies require L5, alliances L10, war L20 with user-facing feedback messages
- **Ally Home** — new `/g setallyhome` and `/g allyhome <guild>` commands (L25), stored in SQLite with migration v19, alliance-verified access control
- **Custom emoji admin command** — `/customemoji <guild> <emoji>` for L100 guilds, with `setEmojiAdmin()` bypassing rank permissions
- **Market stall API** — `hasMarketStallAccess(guildId)` public method for Guild-ARM integration (L15 gate)
- **6 new PerkTypes** — `DECLARE_ENEMIES`, `FORM_ALLIANCES`, `DECLARE_WAR`, `MARKET_STALL_ACCESS`, `ALLY_HOME`, `CUSTOM_EMOJI`

## Test plan
- [ ] New guild starts at level 1, member cap shows 20
- [ ] `/g allyhome` rejected before guild reaches L25
- [ ] Alliance request rejected below L10 with "Level 10 required" message
- [ ] War declaration rejected below L20 with "Level 20 required" message
- [ ] `getAvailableHomeSlots()` returns 1 for L1-39, 2 for L40-69, 3 for L70+
- [ ] `/customemoji BadgersMC :emoji:` works for L100, fails for L99
- [ ] `hasMarketStallAccess()` returns false for L14, true for L15
- [ ] Level-up event syncs `Guild.level` — verify via `/g info` showing correct level
- [ ] SQLite migration v19 adds `ally_home_world/x/y/z` columns without errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * /customemoji admin command to set/clear guild emojis
  * Ally home system with set/teleport subcommands and access checks
  * Guild invitations (invite/accept/decline/list) with persistence
  * Announcements system (create/update/pin/expire) for guilds
  * Market stall perk and other new progression perks and level gates

* **Documentation**
  * Player lookup and guild-invitations docs added

* **Chores**
  * Overhauled progression config and leveling parameters (max level increased)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->