### PR TITLE
feat: live-data guild leaderboards + PAPI placeholders

### DIFF
--- a/docs/placeholders.md
+++ b/docs/placeholders.md
@@ -1,0 +1,128 @@
+# LumaGuilds Placeholders
+
+PlaceholderAPI expansion identifier: `lumaguilds`
+
+All placeholders are read-only and safe to use in chat plugins, scoreboards, holograms, and tab plugins. Top-N rankings are cached for 30 seconds.
+
+---
+
+## Player's Guild
+
+Resolve to `""` (empty) if the player has no guild — except `has_guild`, which returns `false`.
+
+| Placeholder | Value |
+|---|---|
+| `%lumaguilds_has_guild%` | `true` / `false` |
+| `%lumaguilds_guild_name%` | Guild name |
+| `%lumaguilds_guild_tag%` | Formatted tag, falls back to `§6<name>` |
+| `%lumaguilds_guild_emoji%` | Nexo placeholder (`%nexo_<name>%`) |
+| `%lumaguilds_guild_level%` | Current level |
+| `%lumaguilds_guild_balance%` | Bank balance |
+| `%lumaguilds_guild_mode%` | `Peaceful` / `Hostile` |
+| `%lumaguilds_guild_members%` | Member count |
+| `%lumaguilds_guild_online_members%` | Members currently online |
+| `%lumaguilds_guild_rank%` | Player's rank inside the guild |
+| `%lumaguilds_guild_age_days%` | Days since guild creation |
+| `%lumaguilds_guild_display%` | Composed `emoji tag [level]` |
+| `%lumaguilds_guild_chat_format%` | `emoji tag` for chat plugins |
+
+### Combat
+
+| Placeholder | Value |
+|---|---|
+| `%lumaguilds_guild_kills%` | Total guild kills |
+| `%lumaguilds_guild_deaths%` | Total guild deaths |
+| `%lumaguilds_guild_kdr%` | Kill/death ratio (e.g. `1.42`) |
+| `%lumaguilds_guild_efficiency%` | Kills as % of total combat actions (e.g. `58.7%`) |
+| `%lumaguilds_guild_wars_total%` | All wars participated in |
+| `%lumaguilds_guild_wars_active%` | Currently active wars |
+
+### Progression Detail
+
+| Placeholder | Value |
+|---|---|
+| `%lumaguilds_guild_xp_total%` | Lifetime XP |
+| `%lumaguilds_guild_xp_this_level%` | XP earned within the current level |
+| `%lumaguilds_guild_xp_next_level%` | XP needed to complete the current level |
+| `%lumaguilds_guild_xp_to_next%` | XP remaining to level up |
+| `%lumaguilds_guild_xp_progress_pct%` | Percent progress (e.g. `62.5`) |
+
+---
+
+## Player's Guild Rank in Leaderboards
+
+Returns the 1-based rank of the player's guild in the top 25, or `""` if not ranked.
+
+| Placeholder | Ranking metric |
+|---|---|
+| `%lumaguilds_guild_rank_level%` | Guild level (XP tie-breaks) |
+| `%lumaguilds_guild_rank_balance%` | Bank balance |
+| `%lumaguilds_guild_rank_activity%` | Current week activity score |
+| `%lumaguilds_guild_rank_members%` | Member count |
+| `%lumaguilds_guild_rank_age%` | Oldest first |
+
+---
+
+## Top-N Leaderboards
+
+Format: `%lumaguilds_top_<category>_<rank>_<field>%`
+
+- **category** — `level` · `balance` · `activity` · `members` · `age`
+- **rank** — `1` to `25` (1-based)
+- **field** — see table below
+
+Cached for 30 seconds. Returns `""` if the slot is empty.
+
+| Field | Value |
+|---|---|
+| `name` | Guild name |
+| `tag` | Formatted tag |
+| `tag_plain` | Tag with formatting stripped |
+| `id` | Guild UUID |
+| `value` | The metric being ranked on (level / balance / activity score / members / epoch second for age) |
+| `level` | Guild level |
+| `members` | Member count |
+| `balance` | Bank balance |
+| `activity` | Current week activity score |
+| `age_days` | Days since creation |
+| `emoji` | Nexo placeholder |
+
+### Examples
+
+```
+%lumaguilds_top_balance_1_name%        → "DiamondDelvers"
+%lumaguilds_top_balance_1_value%       → "152340"
+%lumaguilds_top_level_3_tag_plain%     → "Wolves"
+%lumaguilds_top_activity_2_members%    → "12"
+%lumaguilds_top_age_1_age_days%        → "287"
+```
+
+---
+
+## Global
+
+| Placeholder | Value |
+|---|---|
+| `%lumaguilds_guild_total_count%` | Total guilds on the server |
+
+---
+
+## Relations (Relational Placeholder)
+
+`%rel_lumaguilds_rel_<otherPlayerName>_status%`
+
+| Output | Meaning |
+|---|---|
+| `🟢` | Same guild |
+| `🔵` | Allied guild |
+| `🔴` | Enemy / at war |
+| `⚪` | Truce |
+| (empty) | Neutral or other player offline / no guild |
+
+---
+
+## Notes
+
+- Top-N rankings are computed live from `GuildService`, `BankService`, `LeaderboardRepository`, and `ProgressionRepository`. The 30-second cache prevents PAPI tick storms on busy scoreboards.
+- The same data is exposed over HTTP via the public web API (`/api/leaderboards/guilds?type=<category>`).
+- Service errors are swallowed and resolve to safe defaults (`0`, `""`, `0.0`) so PAPI never propagates exceptions to chat or scoreboards.

--- a/docs/placeholders.md
+++ b/docs/placeholders.md
@@ -89,7 +89,7 @@ Cached for 30 seconds. Returns `""` if the slot is empty.
 
 ### Examples
 
-```
+```text
 %lumaguilds_top_balance_1_name%        → "DiamondDelvers"
 %lumaguilds_top_balance_1_value%       → "152340"
 %lumaguilds_top_level_3_tag_plain%     → "Wolves"

--- a/src/main/kotlin/net/lumalyte/lg/di/Modules.kt
+++ b/src/main/kotlin/net/lumalyte/lg/di/Modules.kt
@@ -466,6 +466,8 @@ fun progressionModule() = module {
             memberService = get(),
             bannerService = get(),
             progressionRepository = get(),
+            leaderboardRepository = get(),
+            bankService = get(),
             config = get<ConfigService>().loadConfig().webApi
         )
     }

--- a/src/main/kotlin/net/lumalyte/lg/infrastructure/placeholders/LumaGuildsExpansion.kt
+++ b/src/main/kotlin/net/lumalyte/lg/infrastructure/placeholders/LumaGuildsExpansion.kt
@@ -1,11 +1,25 @@
 package net.lumalyte.lg.infrastructure.placeholders
 
+import net.lumalyte.lg.application.persistence.LeaderboardRepository
+import net.lumalyte.lg.application.persistence.ProgressionRepository
 import net.lumalyte.lg.application.services.*
+import net.lumalyte.lg.domain.entities.Guild
+import net.kyori.adventure.text.minimessage.MiniMessage
+import net.kyori.adventure.text.serializer.plain.PlainTextComponentSerializer
 import me.clip.placeholderapi.expansion.PlaceholderExpansion
 import org.bukkit.Bukkit
 import org.bukkit.entity.Player
 import org.koin.core.component.KoinComponent
 import org.koin.core.component.inject
+import java.time.DayOfWeek
+import java.time.Duration
+import java.time.Instant
+import java.time.ZoneOffset
+import java.time.ZonedDateTime
+import java.time.temporal.ChronoUnit
+import java.time.temporal.TemporalAdjusters
+import java.util.UUID
+import java.util.concurrent.ConcurrentHashMap
 
 /**
  * PlaceholderAPI expansion for LumaGuilds plugin.
@@ -25,6 +39,36 @@ import org.koin.core.component.inject
  * - %lumaguilds_guild_deaths% - Player's guild total deaths
  * - %lumaguilds_guild_kdr% - Player's guild K/D ratio
  * - %lumaguilds_rel_<player>_status% - Relationship with another player (🔴 enemy, 🔵 ally, 🟢 teammate, ⚪ truce, blank neutral)
+ *
+ * Progression detail (player's guild):
+ * - %lumaguilds_guild_age_days% - Days since guild creation
+ * - %lumaguilds_guild_xp_total% - Total experience earned
+ * - %lumaguilds_guild_xp_this_level% - Experience earned in current level
+ * - %lumaguilds_guild_xp_next_level% - Experience needed to complete current level
+ * - %lumaguilds_guild_xp_to_next% - Experience remaining to level up
+ * - %lumaguilds_guild_xp_progress_pct% - Percent progress through current level (e.g. "62.5")
+ * - %lumaguilds_guild_online_members% - Member count currently online
+ *
+ * Player's guild rank in each leaderboard (returns "" if not in top 25):
+ * - %lumaguilds_guild_rank_level%
+ * - %lumaguilds_guild_rank_balance%
+ * - %lumaguilds_guild_rank_activity%
+ * - %lumaguilds_guild_rank_members%
+ * - %lumaguilds_guild_rank_age%
+ *
+ * Global:
+ * - %lumaguilds_guild_total_count% - Total guild count on the server
+ *
+ * Top-N leaderboard (cached 30s, top 25):
+ *   Format: %lumaguilds_top_<category>_<rank>_<field>%
+ *   category = level | balance | activity | members | age
+ *   rank     = 1..25 (1-based)
+ *   field    = name | tag | tag_plain | id | value | level | members |
+ *              balance | activity | age_days | emoji
+ *   Examples:
+ *     %lumaguilds_top_balance_1_name%
+ *     %lumaguilds_top_level_3_value%
+ *     %lumaguilds_top_activity_2_members%
  */
 class LumaGuildsExpansion : PlaceholderExpansion(), KoinComponent {
 
@@ -35,6 +79,17 @@ class LumaGuildsExpansion : PlaceholderExpansion(), KoinComponent {
     private val rankService: RankService by inject()
     private val warService: WarService by inject()
     private val relationService: RelationService by inject()
+    private val progressionRepository: ProgressionRepository by inject()
+    private val leaderboardRepository: LeaderboardRepository by inject()
+
+    private val miniMessage = MiniMessage.miniMessage()
+    private val plainSerializer = PlainTextComponentSerializer.plainText()
+
+    // --- Top leaderboard cache (30s TTL) ---
+    private data class CachedTop(val expiresAt: Instant, val rows: List<TopRow>)
+    private data class TopRow(val guildId: UUID, val value: Double)
+    private val topCache = ConcurrentHashMap<String, CachedTop>()
+    private val topCacheTtlSeconds = 30L
 
     override fun getIdentifier(): String = "lumaguilds"
 
@@ -47,6 +102,14 @@ class LumaGuildsExpansion : PlaceholderExpansion(), KoinComponent {
     override fun canRegister(): Boolean = true
 
     override fun onPlaceholderRequest(player: Player?, identifier: String): String? {
+        val ident = identifier.lowercase()
+
+        // Global placeholders — no player required
+        when {
+            ident == "guild_total_count" -> return safeGuildCount()
+            ident.startsWith("top_") -> return handleTopPlaceholder(ident)
+        }
+
         if (player == null) return null
 
         val playerId = player.uniqueId
@@ -70,6 +133,33 @@ class LumaGuildsExpansion : PlaceholderExpansion(), KoinComponent {
             "guild_balance" -> guild.bankBalance.toString()
             "guild_mode" -> guild.mode.toString()
             "has_guild" -> "true"
+
+            // Age and progression detail
+            "guild_age_days" -> Duration.between(guild.createdAt, Instant.now()).toDays().toString()
+            "guild_xp_total" -> safeProgression(guildId)?.totalExperience?.toString() ?: "0"
+            "guild_xp_this_level" -> safeProgression(guildId)?.experienceThisLevel?.toString() ?: "0"
+            "guild_xp_next_level" -> safeProgression(guildId)?.experienceForNextLevel?.toString() ?: "0"
+            "guild_xp_to_next" -> safeProgression(guildId)?.experienceToNextLevel?.toString() ?: "0"
+            "guild_xp_progress_pct" -> {
+                val p = safeProgression(guildId)
+                if (p != null) String.format("%.1f", p.levelProgress * 100.0) else "0.0"
+            }
+
+            // This player's guild rank within each leaderboard
+            "guild_rank_level" -> rankInTop("level", guildId)
+            "guild_rank_balance" -> rankInTop("balance", guildId)
+            "guild_rank_activity" -> rankInTop("activity", guildId)
+            "guild_rank_members" -> rankInTop("members", guildId)
+            "guild_rank_age" -> rankInTop("age", guildId)
+
+            // Online member count
+            "guild_online_members" -> {
+                try {
+                    memberService.getGuildMembers(guildId).count {
+                        Bukkit.getPlayer(it.playerId)?.isOnline == true
+                    }.toString()
+                } catch (_: Exception) { "0" }
+            }
 
             // Member info
             "guild_members" -> memberService.getMemberCount(guildId).toString()
@@ -276,5 +366,132 @@ class LumaGuildsExpansion : PlaceholderExpansion(), KoinComponent {
 
         // If not in Discord format, return as-is
         return emoji
+    }
+
+    // -----------------------------------------------------------------
+    // Top-N leaderboard placeholders
+    // Format: top_<category>_<rank>_<field>
+    //   category: level | balance | activity | members | age
+    //   rank: 1..N (1-based)
+    //   field: name | tag | tag_plain | id | value | level | members |
+    //          balance | activity | age_days | emoji
+    // Examples: top_balance_1_name, top_level_3_value, top_activity_2_members
+    // -----------------------------------------------------------------
+    private fun handleTopPlaceholder(ident: String): String {
+        val parts = ident.split("_")
+        // expected: ["top", category, rank, field...]; field may have underscores
+        if (parts.size < 4) return ""
+        val category = parts[1]
+        val rank = parts[2].toIntOrNull() ?: return ""
+        if (rank < 1) return ""
+        val field = parts.drop(3).joinToString("_")
+        if (category !in TOP_CATEGORIES) return ""
+
+        val rows = getTop(category)
+        val row = rows.getOrNull(rank - 1) ?: return ""
+        val guild = guildService.getGuild(row.guildId) ?: return ""
+
+        return formatTopField(guild, row, field)
+    }
+
+    private fun formatTopField(guild: Guild, row: TopRow, field: String): String = when (field) {
+        "name" -> guild.name
+        "tag" -> guild.tag ?: "§6${guild.name}"
+        "tag_plain" -> guild.tag?.let { stripFormatting(it) } ?: guild.name
+        "id" -> guild.id.toString()
+        "value" -> formatScore(row.value)
+        "level" -> guild.level.toString()
+        "members" -> safeMemberCount(guild.id).toString()
+        "balance" -> safeBalance(guild.id).toString()
+        "activity" -> safeWeeklyActivityScore(guild.id).toString()
+        "age_days" -> Duration.between(guild.createdAt, Instant.now()).toDays().toString()
+        "emoji" -> convertEmojiToNexoPlaceholder(guild.emoji)
+        else -> ""
+    }
+
+    private fun formatScore(score: Double): String {
+        // age category stores epochSecond — render the level/balance/etc as integer where sensible
+        return if (score % 1.0 == 0.0) score.toLong().toString() else String.format("%.1f", score)
+    }
+
+    private fun rankInTop(category: String, guildId: UUID): String {
+        val rows = getTop(category)
+        val idx = rows.indexOfFirst { it.guildId == guildId }
+        return if (idx >= 0) (idx + 1).toString() else ""
+    }
+
+    private fun getTop(category: String): List<TopRow> {
+        val now = Instant.now()
+        val cached = topCache[category]
+        if (cached != null && cached.expiresAt.isAfter(now)) return cached.rows
+        val computed = try { computeTop(category) } catch (_: Exception) { emptyList() }
+        topCache[category] = CachedTop(now.plusSeconds(topCacheTtlSeconds), computed)
+        return computed
+    }
+
+    private fun computeTop(category: String): List<TopRow> {
+        val limit = TOP_CACHE_LIMIT
+        return when (category) {
+            "level" -> guildService.getAllGuilds()
+                .map { g ->
+                    val xp = progressionRepository.getGuildProgression(g.id)?.totalExperience ?: 0
+                    TopRow(g.id, g.level * 1_000_000.0 + xp)
+                }
+                .sortedByDescending { it.value }
+                .take(limit)
+            "balance" -> guildService.getAllGuilds()
+                .map { g -> TopRow(g.id, safeBalance(g.id).toDouble()) }
+                .sortedByDescending { it.value }
+                .take(limit)
+            "activity" -> leaderboardRepository
+                .getWeeklyActivityForPeriod(currentWeekStart(), 1000)
+                .map { TopRow(it.guildId, it.totalScore.toDouble()) }
+                .sortedByDescending { it.value }
+                .take(limit)
+            "members" -> guildService.getAllGuilds()
+                .map { g -> TopRow(g.id, safeMemberCount(g.id).toDouble()) }
+                .sortedByDescending { it.value }
+                .take(limit)
+            "age" -> guildService.getAllGuilds()
+                .sortedBy { it.createdAt }
+                .take(limit)
+                .map { TopRow(it.id, it.createdAt.epochSecond.toDouble()) }
+            else -> emptyList()
+        }
+    }
+
+    private fun safeProgression(guildId: UUID) =
+        try { progressionRepository.getGuildProgression(guildId) } catch (_: Exception) { null }
+
+    private fun safeBalance(guildId: UUID): Int =
+        try { bankService.getBalance(guildId) } catch (_: Exception) { 0 }
+
+    private fun safeMemberCount(guildId: UUID): Int =
+        try { memberService.getMemberCount(guildId) } catch (_: Exception) { 0 }
+
+    private fun safeWeeklyActivityScore(guildId: UUID): Int =
+        try {
+            leaderboardRepository.getWeeklyActivity(guildId, currentWeekStart())?.totalScore ?: 0
+        } catch (_: Exception) { 0 }
+
+    private fun safeGuildCount(): String =
+        try { guildService.getAllGuilds().size.toString() } catch (_: Exception) { "0" }
+
+    private fun stripFormatting(tag: String): String =
+        try {
+            plainSerializer.serialize(miniMessage.deserialize(tag))
+        } catch (_: Exception) {
+            tag
+        }
+
+    private fun currentWeekStart(): Instant =
+        ZonedDateTime.now(ZoneOffset.UTC)
+            .with(TemporalAdjusters.previousOrSame(DayOfWeek.MONDAY))
+            .truncatedTo(ChronoUnit.DAYS)
+            .toInstant()
+
+    companion object {
+        private const val TOP_CACHE_LIMIT = 25
+        private val TOP_CATEGORIES = setOf("level", "balance", "activity", "members", "age")
     }
 }

--- a/src/main/kotlin/net/lumalyte/lg/infrastructure/placeholders/LumaGuildsExpansion.kt
+++ b/src/main/kotlin/net/lumalyte/lg/infrastructure/placeholders/LumaGuildsExpansion.kt
@@ -18,6 +18,7 @@ import java.time.ZoneOffset
 import java.time.ZonedDateTime
 import java.time.temporal.ChronoUnit
 import java.time.temporal.TemporalAdjusters
+import java.util.Locale
 import java.util.UUID
 import java.util.concurrent.ConcurrentHashMap
 
@@ -142,7 +143,7 @@ class LumaGuildsExpansion : PlaceholderExpansion(), KoinComponent {
             "guild_xp_to_next" -> safeProgression(guildId)?.experienceToNextLevel?.toString() ?: "0"
             "guild_xp_progress_pct" -> {
                 val p = safeProgression(guildId)
-                if (p != null) String.format("%.1f", p.levelProgress * 100.0) else "0.0"
+                if (p != null) String.format(Locale.ROOT, "%.1f", p.levelProgress * 100.0) else "0.0"
             }
 
             // This player's guild rank within each leaderboard
@@ -411,7 +412,7 @@ class LumaGuildsExpansion : PlaceholderExpansion(), KoinComponent {
 
     private fun formatScore(score: Double): String {
         // age category stores epochSecond — render the level/balance/etc as integer where sensible
-        return if (score % 1.0 == 0.0) score.toLong().toString() else String.format("%.1f", score)
+        return if (score % 1.0 == 0.0) score.toLong().toString() else String.format(Locale.ROOT, "%.1f", score)
     }
 
     private fun rankInTop(category: String, guildId: UUID): String {

--- a/src/main/kotlin/net/lumalyte/lg/infrastructure/web/WebApiServer.kt
+++ b/src/main/kotlin/net/lumalyte/lg/infrastructure/web/WebApiServer.kt
@@ -66,6 +66,7 @@ class WebApiServer(
             // expected to be thread-safe — they are also called from PAPI / other
             // async paths in this plugin.
             val response = guildLeaderboardHandler.build(
+                typeParam = params["type"],
                 periodParam = params["period"],
                 limitParam = params["limit"]
             )

--- a/src/main/kotlin/net/lumalyte/lg/infrastructure/web/dto/LeaderboardDtos.kt
+++ b/src/main/kotlin/net/lumalyte/lg/infrastructure/web/dto/LeaderboardDtos.kt
@@ -19,9 +19,12 @@ data class GuildLeaderboardEntryDto(
     val experienceThisLevel: Int,
     val experienceForNextLevel: Int,
     val memberCount: Int,
+    val bankBalance: Int,
+    val activityScore: Int,
     val topMemberUuids: List<String>,
     val banner: BannerDto?,
-    val createdAt: String
+    val createdAt: String,
+    val score: Double
 )
 
 data class BannerDto(

--- a/src/main/kotlin/net/lumalyte/lg/infrastructure/web/handlers/GuildLeaderboardHandler.kt
+++ b/src/main/kotlin/net/lumalyte/lg/infrastructure/web/handlers/GuildLeaderboardHandler.kt
@@ -54,25 +54,47 @@ class GuildLeaderboardHandler(
 
     fun build(typeParam: String?, periodParam: String?, limitParam: String?): GuildLeaderboardResponse {
         val category = Category.parse(typeParam)
-        val period = parsePeriod(periodParam)
+        val requestedPeriod = parsePeriod(periodParam)
+        val effectivePeriod = effectivePeriodFor(category, requestedPeriod)
         val limit = parseLimit(limitParam)
 
-        val ranked = rankGuilds(category, limit)
+        val ranked = rankGuilds(category, effectivePeriod, limit)
 
-        val entries = ranked.mapIndexedNotNull { idx, (guildId, score) ->
-            buildEntry(guildId, idx + 1, score)
+        // Build entries first (some may be null if a guild lookup fails),
+        // then assign sequential ranks so we never return gaps like 1, 3, 4.
+        var nextRank = 1
+        val entries = ranked.mapNotNull { (guildId, score) ->
+            buildEntry(guildId, nextRank, score)?.also { nextRank++ }
         }
 
         return GuildLeaderboardResponse(
             type = category.id,
-            period = period.name,
+            period = effectivePeriod.name,
             generatedAt = Instant.now().toString(),
             count = entries.size,
             entries = entries
         )
     }
 
-    private fun rankGuilds(category: Category, limit: Int): List<Pair<UUID, Double>> {
+    /**
+     * Returns the period actually applied for a category. Only ACTIVITY varies
+     * by period today (weekly activity tracking); the others are point-in-time
+     * snapshots, so we always report ALL_TIME for them regardless of input.
+     */
+    private fun effectivePeriodFor(category: Category, requested: LeaderboardPeriod): LeaderboardPeriod =
+        when (category) {
+            Category.ACTIVITY -> if (requested == LeaderboardPeriod.ALL_TIME) LeaderboardPeriod.WEEKLY else requested
+            Category.LEVEL,
+            Category.BALANCE,
+            Category.MEMBERS,
+            Category.AGE -> LeaderboardPeriod.ALL_TIME
+        }
+
+    private fun rankGuilds(
+        category: Category,
+        period: LeaderboardPeriod,
+        limit: Int
+    ): List<Pair<UUID, Double>> {
         return when (category) {
             Category.LEVEL -> {
                 guildService.getAllGuilds()
@@ -91,7 +113,10 @@ class GuildLeaderboardHandler(
                     .take(limit)
             }
             Category.ACTIVITY -> {
-                val weekStart = currentWeekStart()
+                // Currently only weekly activity is tracked; map any non-ALL_TIME
+                // period onto the current week for now. Daily/monthly variants
+                // can be added when the repository supports them.
+                val weekStart = activityWindowStart(period)
                 leaderboardRepository.getWeeklyActivityForPeriod(weekStart, 1000)
                     .map { it.guildId to it.totalScore.toDouble() }
                     .sortedByDescending { it.second }
@@ -110,6 +135,16 @@ class GuildLeaderboardHandler(
                     .map { it.id to it.createdAt.epochSecond.toDouble() }
             }
         }
+    }
+
+    private fun activityWindowStart(period: LeaderboardPeriod): Instant = when (period) {
+        // Today the underlying tracking is week-bucketed, so every variant maps
+        // to the current week start. This indirection keeps the call site honest
+        // about what period it asked for.
+        LeaderboardPeriod.WEEKLY,
+        LeaderboardPeriod.DAILY,
+        LeaderboardPeriod.MONTHLY,
+        LeaderboardPeriod.ALL_TIME -> currentWeekStart()
     }
 
     private fun buildEntry(guildId: UUID, rank: Int, score: Double): GuildLeaderboardEntryDto? {

--- a/src/main/kotlin/net/lumalyte/lg/infrastructure/web/handlers/GuildLeaderboardHandler.kt
+++ b/src/main/kotlin/net/lumalyte/lg/infrastructure/web/handlers/GuildLeaderboardHandler.kt
@@ -2,21 +2,26 @@ package net.lumalyte.lg.infrastructure.web.handlers
 
 import net.kyori.adventure.text.minimessage.MiniMessage
 import net.kyori.adventure.text.serializer.plain.PlainTextComponentSerializer
+import net.lumalyte.lg.application.persistence.LeaderboardRepository
 import net.lumalyte.lg.application.persistence.ProgressionRepository
+import net.lumalyte.lg.application.services.BankService
 import net.lumalyte.lg.application.services.GuildBannerService
 import net.lumalyte.lg.application.services.GuildService
 import net.lumalyte.lg.application.services.LeaderboardService
 import net.lumalyte.lg.application.services.MemberService
 import net.lumalyte.lg.config.WebApiConfig
-import net.lumalyte.lg.domain.entities.ExtendedLeaderboardType
 import net.lumalyte.lg.domain.entities.LeaderboardPeriod
-import net.lumalyte.lg.domain.entities.LeaderboardType
-
 import net.lumalyte.lg.infrastructure.web.dto.BannerDto
 import net.lumalyte.lg.infrastructure.web.dto.BannerPatternDto
 import net.lumalyte.lg.infrastructure.web.dto.GuildLeaderboardEntryDto
 import net.lumalyte.lg.infrastructure.web.dto.GuildLeaderboardResponse
+import java.time.DayOfWeek
 import java.time.Instant
+import java.time.ZoneOffset
+import java.time.ZonedDateTime
+import java.time.temporal.ChronoUnit
+import java.time.temporal.TemporalAdjusters
+import java.util.UUID
 
 class GuildLeaderboardHandler(
     private val leaderboardService: LeaderboardService,
@@ -24,64 +29,148 @@ class GuildLeaderboardHandler(
     private val memberService: MemberService,
     private val bannerService: GuildBannerService,
     private val progressionRepository: ProgressionRepository,
+    private val leaderboardRepository: LeaderboardRepository,
+    private val bankService: BankService,
     private val config: WebApiConfig
 ) {
     private val miniMessage = MiniMessage.miniMessage()
     private val plainSerializer = PlainTextComponentSerializer.plainText()
 
-    fun build(periodParam: String?, limitParam: String?): GuildLeaderboardResponse {
+    enum class Category(val id: String) {
+        LEVEL("level"),
+        BALANCE("balance"),
+        ACTIVITY("activity"),
+        MEMBERS("members"),
+        AGE("age");
+
+        companion object {
+            fun parse(raw: String?): Category {
+                if (raw.isNullOrBlank()) return LEVEL
+                val v = raw.lowercase()
+                return entries.firstOrNull { it.id == v } ?: LEVEL
+            }
+        }
+    }
+
+    fun build(typeParam: String?, periodParam: String?, limitParam: String?): GuildLeaderboardResponse {
+        val category = Category.parse(typeParam)
         val period = parsePeriod(periodParam)
         val limit = parseLimit(limitParam)
 
-        val entries = leaderboardService
-            .getTopEntities(LeaderboardType.LEVEL, period, limit)
-            .mapNotNull { entry ->
-                val guild = guildService.getGuild(entry.entityId) ?: return@mapNotNull null
-                val progression = progressionRepository.getGuildProgression(guild.id)
-                val members = memberService.getGuildMembers(guild.id)
-                val topMembers = members
-                    .sortedBy { it.joinedAt }
-                    .take(config.topMembersPerGuild)
-                    .map { it.playerId.toString() }
-                val banner = bannerService.getGuildBanner(guild.id)?.designData?.let { design ->
-                    BannerDto(
-                        baseColor = design.baseColor.name,
-                        baseColorHex = design.baseColor.hexCode,
-                        patterns = design.patterns.map {
-                            BannerPatternDto(
-                                type = it.type,
-                                color = it.color.name,
-                                colorHex = it.color.hexCode
-                            )
-                        }
-                    )
-                }
+        val ranked = rankGuilds(category, limit)
 
-                GuildLeaderboardEntryDto(
-                    rank = entry.rank,
-                    id = guild.id.toString(),
-                    name = guild.name,
-                    tag = guild.tag,
-                    tagPlain = guild.tag?.let { stripFormatting(it) },
-                    level = guild.level,
-                    totalExperience = progression?.totalExperience ?: 0,
-                    experienceThisLevel = progression?.experienceThisLevel ?: 0,
-                    experienceForNextLevel = progression?.experienceForNextLevel ?: 0,
-                    memberCount = members.size,
-                    topMemberUuids = topMembers,
-                    banner = banner,
-                    createdAt = guild.createdAt.toString()
-                )
-            }
+        val entries = ranked.mapIndexedNotNull { idx, (guildId, score) ->
+            buildEntry(guildId, idx + 1, score)
+        }
 
         return GuildLeaderboardResponse(
-            type = ExtendedLeaderboardType.GUILD_LEVEL.name,
+            type = category.id,
             period = period.name,
             generatedAt = Instant.now().toString(),
             count = entries.size,
             entries = entries
         )
     }
+
+    private fun rankGuilds(category: Category, limit: Int): List<Pair<UUID, Double>> {
+        return when (category) {
+            Category.LEVEL -> {
+                guildService.getAllGuilds()
+                    .map { g ->
+                        val xp = progressionRepository.getGuildProgression(g.id)?.totalExperience ?: 0
+                        // composite: level dominates, xp tie-breaks
+                        g.id to (g.level * 1_000_000.0 + xp)
+                    }
+                    .sortedByDescending { it.second }
+                    .take(limit)
+            }
+            Category.BALANCE -> {
+                guildService.getAllGuilds()
+                    .map { g -> g.id to safeBalance(g.id) }
+                    .sortedByDescending { it.second }
+                    .take(limit)
+            }
+            Category.ACTIVITY -> {
+                val weekStart = currentWeekStart()
+                leaderboardRepository.getWeeklyActivityForPeriod(weekStart, 1000)
+                    .map { it.guildId to it.totalScore.toDouble() }
+                    .sortedByDescending { it.second }
+                    .take(limit)
+            }
+            Category.MEMBERS -> {
+                guildService.getAllGuilds()
+                    .map { g -> g.id to memberService.getGuildMembers(g.id).size.toDouble() }
+                    .sortedByDescending { it.second }
+                    .take(limit)
+            }
+            Category.AGE -> {
+                guildService.getAllGuilds()
+                    .sortedBy { it.createdAt }
+                    .take(limit)
+                    .map { it.id to it.createdAt.epochSecond.toDouble() }
+            }
+        }
+    }
+
+    private fun buildEntry(guildId: UUID, rank: Int, score: Double): GuildLeaderboardEntryDto? {
+        val guild = guildService.getGuild(guildId) ?: return null
+        val progression = progressionRepository.getGuildProgression(guild.id)
+        val members = memberService.getGuildMembers(guild.id)
+        val topMembers = members
+            .sortedBy { it.joinedAt }
+            .take(config.topMembersPerGuild)
+            .map { it.playerId.toString() }
+
+        val banner = bannerService.getGuildBanner(guild.id)?.designData?.let { design ->
+            BannerDto(
+                baseColor = design.baseColor.name,
+                baseColorHex = design.baseColor.hexCode,
+                patterns = design.patterns.map {
+                    BannerPatternDto(
+                        type = it.type,
+                        color = it.color.name,
+                        colorHex = it.color.hexCode
+                    )
+                }
+            )
+        }
+
+        val balance = safeBalance(guild.id).toInt()
+        val activityScore = currentWeekActivityScore(guild.id)
+
+        return GuildLeaderboardEntryDto(
+            rank = rank,
+            id = guild.id.toString(),
+            name = guild.name,
+            tag = guild.tag,
+            tagPlain = guild.tag?.let { stripFormatting(it) },
+            level = guild.level,
+            totalExperience = progression?.totalExperience ?: 0,
+            experienceThisLevel = progression?.experienceThisLevel ?: 0,
+            experienceForNextLevel = progression?.experienceForNextLevel ?: 0,
+            memberCount = members.size,
+            bankBalance = balance,
+            activityScore = activityScore,
+            topMemberUuids = topMembers,
+            banner = banner,
+            createdAt = guild.createdAt.toString(),
+            score = score
+        )
+    }
+
+    private fun safeBalance(guildId: UUID): Double =
+        try { bankService.getBalance(guildId).toDouble() } catch (_: Exception) { 0.0 }
+
+    private fun currentWeekActivityScore(guildId: UUID): Int =
+        try {
+            leaderboardService.getWeeklyActivity(guildId, currentWeekStart())?.totalScore ?: 0
+        } catch (_: Exception) { 0 }
+
+    private fun currentWeekStart(): Instant =
+        ZonedDateTime.now(ZoneOffset.UTC)
+            .with(TemporalAdjusters.previousOrSame(DayOfWeek.MONDAY))
+            .truncatedTo(ChronoUnit.DAYS)
+            .toInstant()
 
     private fun stripFormatting(tag: String): String =
         try {


### PR DESCRIPTION
## Summary
- Fixes prod issue where `/api/leaderboards/guilds` returned `entries: []`. Root cause: handler queried the persisted `leaderboard_entries` table, which nothing in the codebase ever populates. New handler reads live from `GuildService`, `BankService`, and `LeaderboardRepository.getWeeklyActivityForPeriod`.
- Extends the endpoint with `?type=level|balance|activity|members|age` (defaults to `level`).
- Adds matching PlaceholderAPI placeholders so in-game scoreboards/holograms/chat plugins can show the same data:
  - Top-N: `%lumaguilds_top_<category>_<rank>_<field>%` (30s in-memory cache to absorb PAPI tick storms).
  - Player's guild rank in each leaderboard: `%lumaguilds_guild_rank_<category>%`.
  - Progression detail: `guild_age_days`, `guild_xp_*`, `guild_online_members`.
  - Global: `guild_total_count`.
- New doc: `docs/placeholders.md`.

## Notes
- Unused `leaderboard_entries` persistence (table + repo + `updateEntityValue` service path) is left in place; tracked separately as a cleanup task.
- DTO gains `bankBalance`, `activityScore`, and `score` fields. Existing fields unchanged, so the website integration that depends on `level` rendering keeps working.

## Test plan
- [ ] `./gradlew compileKotlin` passes (verified locally; pre-existing deprecation warnings only).
- [ ] After deploy, `curl /api/leaderboards/guilds` returns non-empty `entries`.
- [ ] `?type=balance`, `?type=activity`, `?type=members`, `?type=age` each return ranked entries.
- [ ] PAPI: `%lumaguilds_top_balance_1_name%` resolves to the wealthiest guild's name in-game.
- [ ] PAPI: cache TTL holds for 30s — repeated requests within window don't re-query DB.
- [ ] No exceptions propagate to chat/scoreboards when a service errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added PlaceholderAPI expansion with guild and player placeholders
  * New guild progression placeholders: age (days), XP, level progress percentage, and online member count
  * Added global guild count placeholder
  * Enhanced guild leaderboards with multiple ranking categories (level, balance, activity, members, age)
  * Leaderboard results now include bank balance and activity score metrics
  * Implemented 30-second caching for top-N leaderboard results

* **Documentation**
  * Added comprehensive PlaceholderAPI expansion documentation

<!-- end of auto-generated comment: release notes by coderabbit.ai -->