### PR TITLE
fix: populate weekly activity table (kills/deaths/deposits/joins)

### DIFF
--- a/src/main/kotlin/net/lumalyte/lg/infrastructure/listeners/ProgressionEventListener.kt
+++ b/src/main/kotlin/net/lumalyte/lg/infrastructure/listeners/ProgressionEventListener.kt
@@ -1,7 +1,9 @@
 package net.lumalyte.lg.infrastructure.listeners
 
+import net.lumalyte.lg.application.services.ActivityType
 import net.lumalyte.lg.application.services.ConfigService
 import net.lumalyte.lg.application.services.ExperienceSource
+import net.lumalyte.lg.application.services.LeaderboardService
 import net.lumalyte.lg.application.services.MemberService
 import net.lumalyte.lg.application.services.ProgressionService
 import net.lumalyte.lg.domain.events.GuildBankDepositEvent
@@ -44,6 +46,7 @@ class ProgressionEventListener : Listener, KoinComponent {
     private val memberService: MemberService by inject()
     private val configService: ConfigService by inject()
     private val asyncTaskService: AsyncTaskService by inject()
+    private val leaderboardService: LeaderboardService by inject()
 
     private val logger = LoggerFactory.getLogger(ProgressionEventListener::class.java)
 
@@ -65,6 +68,29 @@ class ProgressionEventListener : Listener, KoinComponent {
         if (killer is Player) {
             awardExperience(killer, getConfig().playerKillXp, ExperienceSource.PLAYER_KILL)
         }
+        recordKillDeathActivity(killer, event.entity)
+    }
+
+    private fun recordKillDeathActivity(killer: Player?, victim: Player) {
+        if (killer != null && killer.uniqueId == victim.uniqueId) return
+        asyncTaskService.runAsyncCallback(
+            task = {
+                try {
+                    if (killer != null) {
+                        memberService.getPlayerGuilds(killer.uniqueId).forEach { gid ->
+                            leaderboardService.recordActivity(gid, ActivityType.KILL, 1)
+                        }
+                    }
+                    memberService.getPlayerGuilds(victim.uniqueId).forEach { gid ->
+                        leaderboardService.recordActivity(gid, ActivityType.DEATH, 1)
+                    }
+                } catch (e: Exception) {
+                    logger.warn("Failed to record kill/death activity", e)
+                }
+            },
+            onSuccess = {},
+            onError = { error -> logger.error("Async kill/death activity failed", error) }
+        )
     }
 
     @EventHandler(priority = EventPriority.MONITOR, ignoreCancelled = true)
@@ -251,6 +277,7 @@ class ProgressionEventListener : Listener, KoinComponent {
                     if (xpAmount > 0) {
                         progressionService.awardExperience(event.guildId, xpAmount, ExperienceSource.BANK_DEPOSIT)
                     }
+                    leaderboardService.recordActivity(event.guildId, ActivityType.BANK_DEPOSIT, event.amount.toInt().coerceAtLeast(1))
                 } catch (e: Exception) {
                     logger.warn("Failed to award progression XP for bank deposit", e)
                 }
@@ -276,6 +303,7 @@ class ProgressionEventListener : Listener, KoinComponent {
                     val config = configService.loadConfig()
                     val memberJoinXp = config.progression.memberJoinedXp
                     progressionService.awardExperience(event.guildId, memberJoinXp, ExperienceSource.MEMBER_JOINED)
+                    leaderboardService.recordActivity(event.guildId, ActivityType.MEMBER_JOINED, 1)
                 } catch (e: Exception) {
                     logger.warn("Failed to award progression XP for member join", e)
                 }


### PR DESCRIPTION
## Summary
- The activity leaderboard, the \`top_activity_*\` PAPI placeholders, and the \`/api/leaderboards/guilds?type=activity\` endpoint were all returning empty because **nothing called \`LeaderboardService.recordActivity\`**. The persistence layer and service were wired but never invoked.
- This change hooks \`ProgressionEventListener\` (already async, already listens to the relevant events) to record:
  - \`KILL\` / \`DEATH\` on \`PlayerDeathEvent\`
  - \`BANK_DEPOSIT\` on \`GuildBankDepositEvent\`
  - \`MEMBER_JOINED\` on \`GuildMemberJoinEvent\`
- All recording runs on the existing virtual-thread executor so the main thread never sees DB I/O.

## Test plan
- [ ] Build a shadow JAR, drop into a test server.
- [ ] Have two guild members PvP — confirm \`%lumaguilds_top_activity_1_value%\` increases.
- [ ] Deposit to a guild bank — confirm activity score increments.
- [ ] Add a member to a guild — confirm activity score increments.
- [ ] Hit \`/api/leaderboards/guilds?type=activity\` — confirm non-empty response.
- [ ] Confirm no main-thread lag during heavy PvP.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Leaderboard activity now tracks player kills and deaths within guilds
  * Guild leaderboard activity now records bank deposits
  * Guild leaderboard activity now records new member joins

<!-- end of auto-generated comment: release notes by coderabbit.ai -->