### PR TITLE
Fix: prevent role escalation — enforce priority hierarchy in role management

### DIFF
--- a/src/main/kotlin/net/lumalyte/lg/infrastructure/services/MemberServiceBukkit.kt
+++ b/src/main/kotlin/net/lumalyte/lg/infrastructure/services/MemberServiceBukkit.kt
@@ -183,6 +183,14 @@ class MemberServiceBukkit(
             return false
         }
 
+        // PRIORITY CHECK: Actor must strictly outrank the target (lower priority number = higher rank)
+        val actorMember = memberRepository.getByPlayerAndGuild(actorId, guildId) ?: return false
+        val actorRank = rankRepository.getById(actorMember.rankId) ?: return false
+        if (actorRank.priority >= currentRank.priority) {
+            logger.warn("Player $actorId (priority ${actorRank.priority}) cannot manage member $playerId (priority ${currentRank.priority})")
+            return false
+        }
+
         // Check if new rank exists and belongs to the guild
         val newRank = rankRepository.getById(newRankId) ?: return false
         if (newRank.guildId != guildId) {
@@ -193,6 +201,12 @@ class MemberServiceBukkit(
         // OWNER PROTECTION: Prevent promoting anyone to owner rank (priority 0) - use ownership transfer instead
         if (newRank.priority == 0) {
             logger.warn("Cannot directly promote to owner rank - use ownership transfer instead")
+            return false
+        }
+
+        // PRIORITY CHECK: New rank must be strictly lower than actor's rank (cannot promote to own level or above)
+        if (newRank.priority <= actorRank.priority) {
+            logger.warn("Player $actorId (priority ${actorRank.priority}) cannot assign rank with priority ${newRank.priority} — must be greater than actor's own priority")
             return false
         }
 
@@ -253,6 +267,14 @@ class MemberServiceBukkit(
         val member = memberRepository.getByPlayerAndGuild(playerId, guildId) ?: return false
         val currentRank = rankRepository.getById(member.rankId) ?: return false
 
+        // PRIORITY CHECK: Actor must strictly outrank the target
+        val actorMember = memberRepository.getByPlayerAndGuild(actorId, guildId) ?: return false
+        val actorRank = rankRepository.getById(actorMember.rankId) ?: return false
+        if (actorRank.priority >= currentRank.priority) {
+            logger.warn("Player $actorId (priority ${actorRank.priority}) cannot promote member $playerId (priority ${currentRank.priority})")
+            return false
+        }
+
         // Get all ranks for the guild, sorted by priority (ascending)
         val guildRanks = rankRepository.getByGuild(guildId).sortedBy { it.priority }
 
@@ -268,6 +290,12 @@ class MemberServiceBukkit(
         // OWNER PROTECTION: Prevent promoting anyone to owner rank (priority 0) - use ownership transfer instead
         if (nextRank.priority == 0) {
             logger.warn("Cannot promote to owner rank - use ownership transfer instead")
+            return false
+        }
+
+        // PRIORITY CHECK: Cannot promote target to rank equal to or higher than actor's own rank
+        if (nextRank.priority <= actorRank.priority) {
+            logger.warn("Player $actorId (priority ${actorRank.priority}) cannot promote member $playerId to priority ${nextRank.priority} — must remain greater than actor's own priority")
             return false
         }
 
@@ -292,6 +320,14 @@ class MemberServiceBukkit(
         // OWNER PROTECTION: Prevent owner from demoting themselves
         if (currentRank.priority == 0 && playerId == actorId) {
             logger.warn("Player $actorId (owner) attempted to demote themselves - ownership transfer required")
+            return false
+        }
+
+        // PRIORITY CHECK: Actor must strictly outrank the target (also blocks self-demotion)
+        val actorMember = memberRepository.getByPlayerAndGuild(actorId, guildId) ?: return false
+        val actorRank = rankRepository.getById(actorMember.rankId) ?: return false
+        if (actorRank.priority >= currentRank.priority) {
+            logger.warn("Player $actorId (priority ${actorRank.priority}) cannot demote member $playerId (priority ${currentRank.priority})")
             return false
         }
 


### PR DESCRIPTION
## Summary

- **Bug:** `MANAGE_MEMBERS` permission was the only gate on `changeMemberRank`, `promoteMember`, and `demoteMember`. No check compared the actor's rank priority against the target's, so a mod could manage co-owners, and any member with `MANAGE_MEMBERS` could pass their own UUID as the target to self-promote to co-owner.
- **Root cause:** `MemberServiceBukkit` was missing priority hierarchy validation in all three role management methods.
- **Fix:** Added strict priority guards to all three methods. Convention: priority `0` = owner (highest rank), larger numbers = lower ranks.

### Methods fixed

| Method | Guards added |
|---|---|
| `changeMemberRank` | (1) Actor must strictly outrank the target; (2) new rank must be a strictly lower priority number than the actor's own rank |
| `promoteMember` | Same two guards, applied before computing the next rank in the chain |
| `demoteMember` | Actor must strictly outrank the target (also blocks self-demotion without needing a separate self-check) |

## Test plan

- [ ] Mod (priority 2) cannot promote/demote/change-rank of co-owner (priority 1) — returns false
- [ ] Mod cannot promote themselves (self as target) to co-owner — returns false
- [ ] Mod cannot assign a rank equal to or above their own to any member — returns false
- [ ] Co-owner (priority 1) can still manage mods (priority 2) and below — returns true
- [ ] Owner (priority 0) is unaffected — existing owner-protection checks remain
- [ ] Ownership transfer path is unaffected (separate method, not touched)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced rank management security by enforcing stricter permission checks for rank changes, promotions, and demotions to prevent unauthorized rank assignments and ensure proper hierarchical control.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->