### PR TITLE
fix: guild/party chat leaks to main when RoseChat installed

### DIFF
--- a/src/main/kotlin/net/lumalyte/lg/LumaGuilds.kt
+++ b/src/main/kotlin/net/lumalyte/lg/LumaGuilds.kt
@@ -780,8 +780,22 @@ class LumaGuilds : JavaPlugin() {
         val chatInputListener = get().get<ChatInputListener>()
         server.pluginManager.registerEvents(chatInputListener, this)
 
-        // Register party chat listener with configurable priority (auto-routes messages to party after /pc switch)
         val config = get().get<ConfigService>().loadConfig()
+
+        // Register guild chat listener at LOWEST so it fires first.
+        // It also clears event.viewers() which prevents RoseChat (HIGHEST) from re-broadcasting to main chat.
+        val guildChatListener = get().get<net.lumalyte.lg.interaction.listeners.GuildChatListener>()
+        server.pluginManager.registerEvent(
+            io.papermc.paper.event.player.AsyncChatEvent::class.java,
+            guildChatListener,
+            org.bukkit.event.EventPriority.LOWEST,
+            { _, event -> guildChatListener.onPlayerChat(event as io.papermc.paper.event.player.AsyncChatEvent) },
+            this,
+            false // ignoreCancelled=false: run even if another plugin already cancelled
+        )
+        logColored("✓ Guild chat toggle registered (/g chat)")
+
+        // Register party chat listener with configurable priority (auto-routes messages to party after /pc switch)
         val partyChatListener = PartyChatListener()
         val priority = parsePriority(config.party.partyChatListenerPriority)
         server.pluginManager.registerEvent(
@@ -790,7 +804,7 @@ class LumaGuilds : JavaPlugin() {
             priority,
             { _, event -> partyChatListener.onPlayerChat(event as io.papermc.paper.event.player.AsyncChatEvent) },
             this,
-            false // ignoreCancelled - MUST be false to ensure we process events even if ChatControl marks them cancelled
+            false // ignoreCancelled=false: run even if RoseChat/other plugins already cancelled
         )
         logColored("✓ Party chat auto-routing registered (priority: ${config.party.partyChatListenerPriority})")
 

--- a/src/main/kotlin/net/lumalyte/lg/di/Modules.kt
+++ b/src/main/kotlin/net/lumalyte/lg/di/Modules.kt
@@ -439,6 +439,9 @@ fun socialModule() = module {
 
     // Listeners
     single<ChatInputListener> { ChatInputListener() }
+    single<net.lumalyte.lg.interaction.listeners.GuildChatListener> {
+        net.lumalyte.lg.interaction.listeners.GuildChatListener()
+    }
     single<net.lumalyte.lg.infrastructure.listeners.GuildChannelCreationListener> {
         net.lumalyte.lg.infrastructure.listeners.GuildChannelCreationListener(get(), get())
     }

--- a/src/main/kotlin/net/lumalyte/lg/infrastructure/listeners/PlayerSessionListener.kt
+++ b/src/main/kotlin/net/lumalyte/lg/infrastructure/listeners/PlayerSessionListener.kt
@@ -3,6 +3,7 @@ package net.lumalyte.lg.infrastructure.listeners
 import net.lumalyte.lg.application.services.VaultInventoryManager
 import net.lumalyte.lg.infrastructure.services.TeleportationService
 import net.lumalyte.lg.infrastructure.services.VaultHologramService
+import net.lumalyte.lg.interaction.listeners.GuildChatListener
 import org.bukkit.event.EventHandler
 import org.bukkit.event.Listener
 import org.bukkit.event.player.PlayerQuitEvent
@@ -17,6 +18,7 @@ class PlayerSessionListener : Listener, KoinComponent {
     private val teleportationService: TeleportationService by inject()
     private val hologramService: VaultHologramService by inject()
     private val vaultInventoryManager: VaultInventoryManager by inject()
+    private val guildChatListener: GuildChatListener by inject()
 
     @EventHandler
     fun onPlayerQuit(event: PlayerQuitEvent) {
@@ -30,5 +32,8 @@ class PlayerSessionListener : Listener, KoinComponent {
 
         // Cleanup vault viewer sessions to prevent memory leaks
         vaultInventoryManager.cleanupDisconnectedPlayer(player.uniqueId)
+
+        // Remove guild chat mode so the in-memory set doesn't leak on reconnect
+        guildChatListener.removePlayer(player.uniqueId)
     }
 }

--- a/src/main/kotlin/net/lumalyte/lg/infrastructure/services/ConfigServiceBukkit.kt
+++ b/src/main/kotlin/net/lumalyte/lg/infrastructure/services/ConfigServiceBukkit.kt
@@ -269,7 +269,7 @@ class ConfigServiceBukkit(private val config: FileConfiguration): ConfigService 
             partyChatPrefix = config.getString("party.party_chat_prefix") ?: "[PARTY]",
             partyChatSuffix = config.getString("party.party_chat_suffix") ?: "",
             chatInputListenerPriority = config.getString("party.chat_input_listener_priority") ?: "HIGHEST",
-            partyChatListenerPriority = config.getString("party.party_chat_listener_priority") ?: "NORMAL",
+            partyChatListenerPriority = config.getString("party.party_chat_listener_priority") ?: "LOWEST",
             allowRoleRestrictions = config.getBoolean("party.allow_role_restrictions", true),
             defaultToAllMembers = config.getBoolean("party.default_to_all_members", true)
         )

--- a/src/main/kotlin/net/lumalyte/lg/interaction/commands/GuildCommand.kt
+++ b/src/main/kotlin/net/lumalyte/lg/interaction/commands/GuildCommand.kt
@@ -44,6 +44,7 @@ class GuildCommand : BaseCommand(), KoinComponent {
     private val menuFactory: MenuFactory by inject()
     private val progressionService: net.lumalyte.lg.application.services.ProgressionService by inject()
     private val historyRepository: MembershipHistoryRepository by inject()
+    private val guildChatListener: net.lumalyte.lg.interaction.listeners.GuildChatListener by inject()
 
     // Teleportation tracking for command-based teleports
     private data class TeleportSession(
@@ -709,6 +710,26 @@ class GuildCommand : BaseCommand(), KoinComponent {
         }
 
         player.sendMessage("§6§l╚${"═".repeat(20 + displayName.length)}╝")
+    }
+
+    @Subcommand("chat")
+    @CommandPermission("lumaguilds.guild.chat")
+    fun onGuildChat(player: Player) {
+        val playerId = player.uniqueId
+
+        val guilds = guildService.getPlayerGuilds(playerId)
+        if (guilds.isEmpty()) {
+            player.sendMessage("§c❌ You are not in a guild!")
+            return
+        }
+
+        val nowEnabled = guildChatListener.toggleGuildChat(player)
+        if (nowEnabled) {
+            player.sendMessage("§a✅ §2Guild chat §aenabled§a! Your messages go only to guild members.")
+            player.sendMessage("§7Run §f/g chat §7again to return to normal chat.")
+        } else {
+            player.sendMessage("§7Guild chat §cdisabled§7. Your messages go to main chat.")
+        }
     }
 
     @Subcommand("info")

--- a/src/main/kotlin/net/lumalyte/lg/interaction/listeners/GuildChatListener.kt
+++ b/src/main/kotlin/net/lumalyte/lg/interaction/listeners/GuildChatListener.kt
@@ -1,0 +1,102 @@
+package net.lumalyte.lg.interaction.listeners
+
+import io.papermc.paper.event.player.AsyncChatEvent
+import net.kyori.adventure.text.serializer.plain.PlainTextComponentSerializer
+import net.lumalyte.lg.application.services.ChatService
+import net.lumalyte.lg.application.services.GuildService
+import net.lumalyte.lg.domain.values.ChatChannel
+import org.bukkit.entity.Player
+import org.bukkit.event.Listener
+import org.koin.core.component.KoinComponent
+import org.koin.core.component.inject
+import org.slf4j.LoggerFactory
+import java.util.UUID
+import java.util.concurrent.ConcurrentHashMap
+
+/**
+ * Listener that intercepts regular chat messages and routes them to guild chat
+ * when a player has toggled guild chat mode on with /g chat.
+ *
+ * IMPORTANT: This listener ONLY intercepts messages when:
+ * - Player has used /g chat to enable guild chat mode
+ * - Player is currently a member of a guild
+ *
+ * EVENT PRIORITY: Registered at LOWEST so it fires first. We clear event.viewers()
+ * in addition to cancelling the event. This prevents RoseChat (HIGHEST priority,
+ * ignoreCancelled=false) from re-broadcasting to main chat — it iterates over the
+ * viewer set which is already empty by the time it runs.
+ *
+ * GLOBAL chat behavior:
+ * - Players with guild chat mode OFF = main chat (default)
+ * - Players with guild chat mode ON = guild chat only
+ */
+class GuildChatListener : Listener, KoinComponent {
+
+    private val chatService: ChatService by inject()
+    private val guildService: GuildService by inject()
+    private val chatInputListener: ChatInputListener by inject()
+
+    private val logger = LoggerFactory.getLogger(GuildChatListener::class.java)
+
+    /** Set of player UUIDs currently in guild chat mode. In-memory only — resets on server restart. */
+    private val guildChatPlayers: MutableSet<UUID> = ConcurrentHashMap.newKeySet()
+
+    fun onPlayerChat(event: AsyncChatEvent) {
+        val player = event.player
+
+        // Skip if player is in GUI input mode (ChatInputListener)
+        if (chatInputListener.isInInputMode(player)) return
+
+        val playerId = player.uniqueId
+
+        // Only intercept if player has guild chat mode enabled
+        if (!guildChatPlayers.contains(playerId)) return
+
+        // Verify player is still in a guild
+        val guilds = guildService.getPlayerGuilds(playerId)
+        if (guilds.isEmpty()) {
+            // Player left their guild — auto-disable guild chat mode
+            guildChatPlayers.remove(playerId)
+            player.sendMessage("§c❌ Guild chat disabled — you are no longer in a guild.")
+            return
+        }
+
+        // CANCEL THE EVENT IMMEDIATELY and clear viewers.
+        // Clearing viewers stops RoseChat (HIGHEST, ignoreCancelled=false) from
+        // iterating over recipients and delivering the message to main chat.
+        event.isCancelled = true
+        event.viewers().clear()
+
+        // Extract plain text from the Adventure component
+        val message = PlainTextComponentSerializer.plainText().serialize(event.message()).trim()
+        if (message.isEmpty()) return
+
+        // Route to guild chat
+        val success = chatService.routeMessage(playerId, message, ChatChannel.GUILD)
+        if (!success) {
+            logger.warn("Failed to route guild chat message from player $playerId")
+            player.sendMessage("§c❌ Failed to send guild message. Are you in a guild?")
+        }
+    }
+
+    /**
+     * Toggles guild chat mode for a player.
+     * @return true if guild chat is now ON, false if now OFF.
+     */
+    fun toggleGuildChat(player: Player): Boolean {
+        val playerId = player.uniqueId
+        return if (guildChatPlayers.remove(playerId)) {
+            false // was on, now off
+        } else {
+            guildChatPlayers.add(playerId)
+            true // was off, now on
+        }
+    }
+
+    fun isInGuildChatMode(playerId: UUID): Boolean = guildChatPlayers.contains(playerId)
+
+    /** Called when a player quits or is removed from a guild. */
+    fun removePlayer(playerId: UUID) {
+        guildChatPlayers.remove(playerId)
+    }
+}

--- a/src/main/kotlin/net/lumalyte/lg/interaction/listeners/GuildChatListener.kt
+++ b/src/main/kotlin/net/lumalyte/lg/interaction/listeners/GuildChatListener.kt
@@ -7,6 +7,8 @@ import net.lumalyte.lg.application.services.GuildService
 import net.lumalyte.lg.domain.values.ChatChannel
 import org.bukkit.entity.Player
 import org.bukkit.event.Listener
+import org.bukkit.metadata.FixedMetadataValue
+import org.bukkit.plugin.Plugin
 import org.koin.core.component.KoinComponent
 import org.koin.core.component.inject
 import org.slf4j.LoggerFactory
@@ -35,6 +37,10 @@ class GuildChatListener : Listener, KoinComponent {
     private val chatService: ChatService by inject()
     private val guildService: GuildService by inject()
     private val chatInputListener: ChatInputListener by inject()
+    private val plugin: Plugin by inject()
+
+    /** Marker read by RoseChat (and other forks) to skip its pipeline when we've claimed the chat. */
+    private val chatClaimMeta = "lumaguilds:chat_claimed"
 
     private val logger = LoggerFactory.getLogger(GuildChatListener::class.java)
 
@@ -61,11 +67,12 @@ class GuildChatListener : Listener, KoinComponent {
             return
         }
 
-        // CANCEL THE EVENT IMMEDIATELY and clear viewers.
-        // Clearing viewers stops RoseChat (HIGHEST, ignoreCancelled=false) from
-        // iterating over recipients and delivering the message to main chat.
+        // Cancel the event, clear viewers, and set a metadata marker for plugins
+        // that listen on the legacy AsyncPlayerChatEvent (e.g. RoseChat) so they
+        // skip their pipeline instead of re-broadcasting to main chat.
         event.isCancelled = true
         event.viewers().clear()
+        player.setMetadata(chatClaimMeta, FixedMetadataValue(plugin, true))
 
         // Extract plain text from the Adventure component
         val message = PlainTextComponentSerializer.plainText().serialize(event.message()).trim()

--- a/src/main/kotlin/net/lumalyte/lg/interaction/listeners/PartyChatListener.kt
+++ b/src/main/kotlin/net/lumalyte/lg/interaction/listeners/PartyChatListener.kt
@@ -11,6 +11,8 @@ import net.lumalyte.lg.application.services.ConfigService
 import net.lumalyte.lg.domain.values.ChatChannel
 import org.bukkit.entity.Player
 import org.bukkit.event.Listener
+import org.bukkit.metadata.FixedMetadataValue
+import org.bukkit.plugin.Plugin
 import org.koin.core.component.KoinComponent
 import org.koin.core.component.inject
 import org.slf4j.LoggerFactory
@@ -44,6 +46,9 @@ class PartyChatListener : Listener, KoinComponent {
     private val memberService: MemberService by inject()
     private val configService: ConfigService by inject()
     private val chatInputListener: ChatInputListener by inject()
+    private val plugin: Plugin by inject()
+
+    private val chatClaimMeta = "lumaguilds:chat_claimed"
 
     private val logger = LoggerFactory.getLogger(PartyChatListener::class.java)
 
@@ -66,12 +71,11 @@ class PartyChatListener : Listener, KoinComponent {
         val playerId = player.uniqueId
         val preference = preferenceRepository.getByPlayerId(playerId) ?: return // GLOBAL chat - don't intercept
 
-        // CANCEL THE EVENT IMMEDIATELY and clear viewers.
-        // Clearing viewers stops RoseChat (HIGHEST, ignoreCancelled=false) from
-        // iterating over recipients and delivering the message to main chat — even
-        // though it runs after us at a higher priority.
+        // Cancel, clear viewers, and set the chat-claim metadata marker so RoseChat's
+        // legacy AsyncPlayerChatEvent listener skips its pipeline.
         event.isCancelled = true
         event.viewers().clear()
+        player.setMetadata(chatClaimMeta, FixedMetadataValue(plugin, true))
 
         // Get the party
         val party = partyRepository.getById(preference.partyId)

--- a/src/main/kotlin/net/lumalyte/lg/interaction/listeners/PartyChatListener.kt
+++ b/src/main/kotlin/net/lumalyte/lg/interaction/listeners/PartyChatListener.kt
@@ -66,9 +66,12 @@ class PartyChatListener : Listener, KoinComponent {
         val playerId = player.uniqueId
         val preference = preferenceRepository.getByPlayerId(playerId) ?: return // GLOBAL chat - don't intercept
 
-        // CANCEL THE EVENT IMMEDIATELY to prevent ChatControl or other plugins from processing it
-        // This must happen BEFORE any other checks to ensure the message doesn't leak to global chat
+        // CANCEL THE EVENT IMMEDIATELY and clear viewers.
+        // Clearing viewers stops RoseChat (HIGHEST, ignoreCancelled=false) from
+        // iterating over recipients and delivering the message to main chat — even
+        // though it runs after us at a higher priority.
         event.isCancelled = true
+        event.viewers().clear()
 
         // Get the party
         val party = partyRepository.getById(preference.partyId)

--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -70,7 +70,11 @@ permissions:
       lumaguilds.guild.war: true
       lumaguilds.guild.info: true
       lumaguilds.guild.history: true
+      lumaguilds.guild.chat: true
 
+  lumaguilds.guild.chat:
+    description: Toggle guild chat mode (messages go to guild only)
+    default: true
   lumaguilds.guild.create:
     description: Create new guilds
     default: true


### PR DESCRIPTION
## Root Cause

`PartyChatListener` cancels `AsyncChatEvent` at `LOWEST`/`NORMAL` priority. RoseChat registers at `HIGHEST` with `ignoreCancelled=false`, so it runs **after** our cancellation and re-broadcasts the message to main chat regardless.

## Fix

**Clear `event.viewers()` in addition to `event.isCancelled = true`.** RoseChat (and any other chat plugin) iterates the viewer set to determine who receives the message. An empty viewer set means zero delivery, even when the plugin ignores the cancelled flag.

Applied to both `GuildChatListener` (new) and `PartyChatListener` (existing party chat).

## New feature: `/g chat` toggle

Players no longer need to run `/pc switch Guild_Chat`. Instead:
- `/g chat` → enables guild chat mode (all messages go to guild only)  
- `/g chat` again → disables, returns to normal chat
- Status shown on toggle

Guild chat mode is in-memory per-session (cleared on disconnect/server restart).

## Changes

| File | Change |
|------|--------|
| `GuildChatListener.kt` | New listener — toggles guild chat mode, clears viewers + cancels at LOWEST |
| `GuildCommand.kt` | Add `/g chat` subcommand |
| `PartyChatListener.kt` | Add `event.viewers().clear()` alongside existing cancel |
| `PlayerSessionListener.kt` | Remove player from guild chat mode on quit |
| `ConfigServiceBukkit.kt` | Default `partyChatListenerPriority` `NORMAL` → `LOWEST` |
| `Modules.kt` | Register `GuildChatListener` as Koin singleton |
| `LumaGuilds.kt` | Register `GuildChatListener` event at LOWEST |
| `plugin.yml` | Add `lumaguilds.guild.chat` permission (default: true) |

## Test plan

- [ ] Player in a guild: `/g chat` → confirm toggle message
- [ ] Type in chat while in guild chat mode → appears in guild chat with `[G]` prefix, NOT in main chat
- [ ] Type in chat while NOT in guild chat mode → appears normally in main chat only
- [ ] Player leaves guild while in guild chat mode → mode auto-disables
- [ ] Player disconnects and reconnects → guild chat mode is OFF (in-memory reset)
- [ ] Party chat (`/pc switch Guild_Chat`) → messages go to party only, not main chat
- [ ] Verify with RoseChat enabled

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `/guild chat` command to toggle guild chat mode, allowing players to send messages directly to their guild instead of global chat. When enabled, all player messages are automatically routed to guild chat only.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->