### PR TITLE
fix: register MenuItemBuilder in Koin module

### DIFF
--- a/src/main/kotlin/net/lumalyte/lg/di/Modules.kt
+++ b/src/main/kotlin/net/lumalyte/lg/di/Modules.kt
@@ -266,6 +266,9 @@ fun coreModule(plugin: LumaGuilds, storage: Storage<*>) = module {
     }
     single<FormValidationService> { FormValidationServiceImpl(get()) }
 
+    // Menu utilities
+    single { net.lumalyte.lg.utils.MenuItemBuilder(get(), get()) }
+
     // Menu factory
     single<net.lumalyte.lg.interaction.menus.MenuFactory> {
         net.lumalyte.lg.interaction.menus.MenuFactory(get(), get(), get())

--- a/src/main/kotlin/net/lumalyte/lg/utils/MenuItemBuilder.kt
+++ b/src/main/kotlin/net/lumalyte/lg/utils/MenuItemBuilder.kt
@@ -1,5 +1,6 @@
 package net.lumalyte.lg.utils
 
+import net.lumalyte.lg.application.services.ConfigService
 import net.lumalyte.lg.config.MainConfig
 import net.lumalyte.lg.config.MenuItemConfig
 import org.bukkit.Material
@@ -13,9 +14,12 @@ import java.util.UUID
  * Supports custom model data, materials, enchantments, and localized names/lore.
  */
 class MenuItemBuilder(
-    private val config: MainConfig,
+    private val configService: ConfigService,
     private val localizationProvider: net.lumalyte.lg.application.utilities.LocalizationProvider
 ) {
+
+    private val config: MainConfig
+        get() = configService.loadConfig()
     
     /**
      * Creates an ItemStack from a MenuItemConfig with localization.


### PR DESCRIPTION
## Summary
- `MenuItemBuilder` was used via `by inject()` and constructor injection in several guild menus, but never registered in `di/Modules.kt`.
- Add `single { MenuItemBuilder(get(), get()) }` next to the other utility bindings.

## Repro (production log, BadgersMC 1.21.11)
```
[08:23:44] [Server thread/ERROR]: [LumaGuilds] Exception while handling click event in inventory 'Change Guild Mode', slot=11, item=GREEN_WOOL
org.koin.core.error.NoDefinitionFoundException: No definition found for type 'net.lumalyte.lg.utils.MenuItemBuilder'
    at MenuFactory.createGuildSettingsMenu(MenuFactory.kt:1180)
    at GuildModeMenu.addModeOptions$lambda$7(GuildModeMenu.kt:138)
```
Same exception on slot=22 BARRIER (back button in `GuildModeMenu.addBackButton`).

## Test plan
- [ ] Open `/guild menu` -> Settings -> Change Guild Mode
- [ ] Click PEACEFUL/HOSTILE option (slot 11 / 13)
- [ ] Click BARRIER (back) (slot 22)
- [ ] Confirm no exception in console and menu transitions complete

🤖 Generated with [Claude Code](https://claude.com/claude-code)