### PR TITLE
fix: dispatch GuildLevelUpEvent on the main thread

### DIFF
--- a/src/main/kotlin/net/lumalyte/lg/di/Modules.kt
+++ b/src/main/kotlin/net/lumalyte/lg/di/Modules.kt
@@ -456,7 +456,7 @@ fun progressionModule() = module {
     // Services
     single<KillService> { KillServiceBukkit(get()) }
     single<CombatService> { CombatServiceBukkit(get()) }
-    single<ProgressionService> { ProgressionServiceBukkit(get(), get(), get(), get(), get()) }
+    single<ProgressionService> { ProgressionServiceBukkit(get(), get(), get(), get(), get(), get<LumaGuilds>()) }
     single<WarService> { WarServiceBukkit(get(), get(), get(), get()) }
     single<LeaderboardService> { LeaderboardServiceBukkit(get()) }
     single {

--- a/src/main/kotlin/net/lumalyte/lg/infrastructure/services/ProgressionServiceBukkit.kt
+++ b/src/main/kotlin/net/lumalyte/lg/infrastructure/services/ProgressionServiceBukkit.kt
@@ -22,7 +22,8 @@ class ProgressionServiceBukkit(
     private val guildRepository: net.lumalyte.lg.application.persistence.GuildRepository,
     private val memberRepository: net.lumalyte.lg.application.persistence.MemberRepository,
     private val configService: ConfigService,
-    private val progressionConfigService: ProgressionConfigService
+    private val progressionConfigService: ProgressionConfigService,
+    private val plugin: org.bukkit.plugin.Plugin
 ) : ProgressionService {
 
     private val logger = LoggerFactory.getLogger(ProgressionServiceBukkit::class.java)
@@ -371,7 +372,17 @@ class ProgressionServiceBukkit(
         // Apply any immediate effects of new perks
         applyPerkEffects(guildId, newPerks)
 
-        Bukkit.getPluginManager().callEvent(GuildLevelUpEvent(guildId, newLevel))
+        // GuildLevelUpEvent must be fired synchronously. awardExperience may be
+        // invoked from async coroutines (see ProgressionEventListener), so dispatch
+        // the event onto the main thread when needed.
+        val fireEvent = Runnable {
+            Bukkit.getPluginManager().callEvent(GuildLevelUpEvent(guildId, newLevel))
+        }
+        if (Bukkit.isPrimaryThread()) {
+            fireEvent.run()
+        } else {
+            Bukkit.getScheduler().runTask(plugin, fireEvent)
+        }
 
         return newPerks
     }

--- a/src/main/kotlin/net/lumalyte/lg/infrastructure/services/ProgressionServiceBukkit.kt
+++ b/src/main/kotlin/net/lumalyte/lg/infrastructure/services/ProgressionServiceBukkit.kt
@@ -365,23 +365,19 @@ class ProgressionServiceBukkit(
 
     override fun processLevelUp(guildId: UUID, newLevel: Int): List<PerkType> {
         val newPerks = getPerksForLevel(newLevel)
-        
-        // Send notifications to all online guild members
-        notifyGuildMembers(guildId, newLevel, newPerks)
 
-        // Apply any immediate effects of new perks
-        applyPerkEffects(guildId, newPerks)
-
-        // GuildLevelUpEvent must be fired synchronously. awardExperience may be
-        // invoked from async coroutines (see ProgressionEventListener), so dispatch
-        // the event onto the main thread when needed.
-        val fireEvent = Runnable {
+        // Notifications, perk effects, and GuildLevelUpEvent all touch Bukkit API and
+        // must run on the primary thread. awardExperience may be invoked from a virtual
+        // thread (see ProgressionEventListener), so bounce the side effects when needed.
+        val sideEffects = Runnable {
+            notifyGuildMembers(guildId, newLevel, newPerks)
+            applyPerkEffects(guildId, newPerks)
             Bukkit.getPluginManager().callEvent(GuildLevelUpEvent(guildId, newLevel))
         }
         if (Bukkit.isPrimaryThread()) {
-            fireEvent.run()
+            sideEffects.run()
         } else {
-            Bukkit.getScheduler().runTask(plugin, fireEvent)
+            Bukkit.getScheduler().runTask(plugin, sideEffects)
         }
 
         return newPerks


### PR DESCRIPTION
## Summary
- `ProgressionServiceBukkit.processLevelUp` fired `GuildLevelUpEvent` directly via `Bukkit.getPluginManager().callEvent` even when called from an async coroutine (the path through `ProgressionEventListener.awardExperience$lambda$6` -> `AsyncTaskService.runAsyncCallback`), and Paper rejects async-fired sync events.
- Inject the plugin instance and bounce the event onto the main thread when `Bukkit.isPrimaryThread()` is `false`. Sync calls remain synchronous.

## Repro (production log, BadgersMC 1.21.11)
```
[08:21:39] [/INFO]: [ProgressionServiceBukkit] Guild ... leveled up from 4 to 5 (gained 300 XP from ENCHANTING)
[08:21:39] [/ERROR]: [ProgressionServiceBukkit] Error awarding experience to guild ...
java.lang.IllegalStateException: GuildLevelUpEvent may only be triggered synchronously.
    at ProgressionServiceBukkit.processLevelUp(ProgressionServiceBukkit.kt:374)
    at ProgressionServiceBukkit.awardExperience(ProgressionServiceBukkit.kt:85)
    at ProgressionEventListener.awardExperience$lambda$6(ProgressionEventListener.kt:192)
    at AsyncTaskService$runAsyncCallback$2.invokeSuspend(AsyncTaskService.kt:94)
```

## Changes
- `ProgressionServiceBukkit` constructor: add `plugin: org.bukkit.plugin.Plugin` param.
- `processLevelUp`: wrap `callEvent` in `runTask(plugin, ...)` when not on the primary thread.
- `Modules.kt`: pass `get<LumaGuilds>()` into the `ProgressionService` binding.

## Test plan
- [ ] Trigger XP gain that causes a level-up from an async source (enchanting, mining, etc.)
- [ ] Confirm no `IllegalStateException` in console
- [ ] Confirm `GuildLevelUpEvent` listeners (notifications, perk apply) still run

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Enhanced thread-safety for level-up operations by ensuring side effects execute on the primary server thread when required.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->