### PR TITLE
fix: dispatch GuildLevelUpEvent on main thread

### DIFF
--- a/src/main/kotlin/net/lumalyte/lg/infrastructure/services/ProgressionServiceBukkit.kt
+++ b/src/main/kotlin/net/lumalyte/lg/infrastructure/services/ProgressionServiceBukkit.kt
@@ -364,14 +364,26 @@ class ProgressionServiceBukkit(
 
     override fun processLevelUp(guildId: UUID, newLevel: Int): List<PerkType> {
         val newPerks = getPerksForLevel(newLevel)
-        
-        // Send notifications to all online guild members
-        notifyGuildMembers(guildId, newLevel, newPerks)
 
-        // Apply any immediate effects of new perks
-        applyPerkEffects(guildId, newPerks)
+        // Bukkit API (event dispatch, player titles/sounds, online-player iteration) MUST run on the main thread.
+        // awardExperience() is invoked from a virtual thread (see ProgressionEventListener.awardExperience), so
+        // schedule the level-up side effects synchronously to avoid IllegalStateException from non-async events.
+        val plugin = Bukkit.getPluginManager().getPlugin("LumaGuilds")
+        val task = Runnable {
+            // Send notifications to all online guild members
+            notifyGuildMembers(guildId, newLevel, newPerks)
 
-        Bukkit.getPluginManager().callEvent(GuildLevelUpEvent(guildId, newLevel))
+            // Apply any immediate effects of new perks
+            applyPerkEffects(guildId, newPerks)
+
+            Bukkit.getPluginManager().callEvent(GuildLevelUpEvent(guildId, newLevel))
+        }
+
+        if (plugin != null && !Bukkit.isPrimaryThread()) {
+            Bukkit.getScheduler().runTask(plugin, task)
+        } else {
+            task.run()
+        }
 
         return newPerks
     }


### PR DESCRIPTION
## Summary
- `ProgressionServiceBukkit.processLevelUp()` was throwing `IllegalStateException: GuildLevelUpEvent may only be triggered synchronously` in production (LumaGuilds 2.0.0).
- Root cause: `ProgressionEventListener.awardExperience` dispatches `progressionService.awardExperience(...)` on a virtual thread via `AsyncTaskService.runAsyncCallback` (intentional, for DB writes). When XP crosses a level boundary, `processLevelUp()` then called `Bukkit.getPluginManager().callEvent(...)` directly on that virtual thread.
- Fix: wrap `notifyGuildMembers`, `applyPerkEffects`, and the event dispatch in a `Runnable` scheduled via `Bukkit.getScheduler().runTask(plugin, ...)` when not on the primary thread. Falls back to inline execution when already sync.

## Stack trace from console
```
[10:56:11] [/ERROR]: [ProgressionServiceBukkit] Error awarding experience to guild 2b8a4222-...
java.lang.IllegalStateException: GuildLevelUpEvent may only be triggered synchronously.
    at ProgressionServiceBukkit.processLevelUp(ProgressionServiceBukkit.kt:374)
    at ProgressionServiceBukkit.awardExperience(ProgressionServiceBukkit.kt:85)
    at ProgressionEventListener.awardExperience$lambda$6(ProgressionEventListener.kt:192)
    at AsyncTaskService$runAsyncCallback$2.invokeSuspend(AsyncTaskService.kt:94)
```

## Test plan
- [ ] Trigger XP award that crosses a level boundary while listener executes on virtual thread (e.g., claim creation, war activity)
- [ ] Confirm no `IllegalStateException` in console
- [ ] Confirm online guild members still see level-up title/sound notification
- [ ] Confirm `GuildLevelUpEvent` listeners still fire

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved thread safety for guild level-up operations. Level-up notifications, perk effects, and events now execute reliably regardless of when they're triggered.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->