### PR TITLE
fix: handle malformed banner data in deserializeToItemStack

### DIFF
--- a/src/main/kotlin/net/lumalyte/lg/utils/ItemStackExtensions.kt
+++ b/src/main/kotlin/net/lumalyte/lg/utils/ItemStackExtensions.kt
@@ -207,7 +207,38 @@ fun ItemStack.serializeToString(): String {
 }
 
 /**
- * Deserializes a Base64 string back to an ItemStack
+ * Parses the legacy `key=value;key=value` fallback format.
+ *
+ * Returns null if any entry is malformed (missing `=`), instead of throwing
+ * IndexOutOfBoundsException from a destructuring assignment on a 1-element list.
+ * This was the cause of an Alliance/Diplomatic Relations menu crash when a guild's
+ * banner column held arbitrary text that was neither valid Base64 nor key=value pairs.
+ */
+private fun String.tryParseLegacyItemFormat(): ItemStack? {
+    return try {
+        val entries = mutableMapOf<String, Any>()
+        for (entry in this.split(";")) {
+            if (entry.isEmpty()) continue
+            val parts = entry.split("=", limit = 2)
+            if (parts.size != 2) return null // malformed segment, abort fallback
+            entries[parts[0]] = parts[1]
+        }
+        if (entries.isEmpty()) null else ItemStack.deserialize(entries)
+    } catch (e: IllegalArgumentException) {
+        // ItemStack.deserialize rejected the map (missing required keys, bad material, etc.)
+        null
+    } catch (e: ClassCastException) {
+        // Type coercion failed during deserialization
+        null
+    }
+}
+
+/**
+ * Deserializes a Base64 string back to an ItemStack.
+ *
+ * Returns null when the input is neither a valid Base64-encoded ObjectStream
+ * payload nor a parseable legacy `key=value;...` fallback string. Callers should
+ * substitute a default item (e.g. a placeholder banner) when null is returned.
  */
 fun String.deserializeToItemStack(): ItemStack? {
     return try {
@@ -224,29 +255,15 @@ fun String.deserializeToItemStack(): ItemStack? {
         ItemStack.deserialize(serialized)
     } catch (e: IllegalArgumentException) {
         // Invalid Base64 or deserialization data - try fallback to old string format
-        try {
-            val entries = this.split(";").associate { entry ->
-                val (key, value) = entry.split("=", limit = 2)
-                key to value
-            }
-            ItemStack.deserialize(entries)
-        } catch (fallbackException: IllegalArgumentException) {
-            // Old format also invalid
-            null
-        }
+        this.tryParseLegacyItemFormat()
     } catch (e: IOException) {
         // I/O error during deserialization - try fallback to old string format
-        try {
-            val entries = this.split(";").associate { entry ->
-                val (key, value) = entry.split("=", limit = 2)
-                key to value
-            }
-            ItemStack.deserialize(entries)
-        } catch (fallbackException: IllegalArgumentException) {
-            null
-        }
+        this.tryParseLegacyItemFormat()
     } catch (e: ClassNotFoundException) {
         // Serialized class not found - data corrupt or incompatible version
+        null
+    } catch (e: ClassCastException) {
+        // readObject() returned something that isn't Map<String, Any>
         null
     }
 }


### PR DESCRIPTION
## Summary
- `ItemStackExtensions.deserializeToItemStack()` crashed with `IndexOutOfBoundsException: Index: 1, Size: 1` when a stored guild banner string was neither valid Base64 nor a parseable `key=value;...` legacy payload.
- Root cause: legacy fallback used `val (key, value) = entry.split("=", limit = 2)` — destructuring throws when a segment has no `=` separator.
- Observed in production: `Diplomatic Relations → Request Alliance` crashed the click handler, breaking `AllianceRequestMenu` for the player.

## Stack trace
```
[15:16:12] [Server thread/ERROR]: [LumaGuilds] Exception while handling click event in inventory 'Diplomatic Relations - WeOnTop', slot=18, item=GOLDEN_APPLE
java.lang.IndexOutOfBoundsException: Index: 1, Size: 1
    at java.base/java.util.Collections$SingletonList.get(Collections.java:5179)
    at ItemStackExtensionsKt.deserializeToItemStack(ItemStackExtensions.kt:229)
    at AllianceRequestMenu.createGuildItem(AllianceRequestMenu.kt:135)
    at AllianceRequestMenu.updateGuildsDisplay(AllianceRequestMenu.kt:118)
    at AllianceRequestMenu.open(AllianceRequestMenu.kt:60)
    at MenuNavigator.openMenu(MenuNavigator.kt:18)
    at GuildRelationsMenu.openRequestAllianceMenu(GuildRelationsMenu.kt:284)
    at GuildRelationsMenu.addDiplomaticActionsSection$lambda$11(GuildRelationsMenu.kt:157)
    ...
```

## Changes
- Extract legacy fallback parsing into `tryParseLegacyItemFormat()` that **returns null** on malformed segments rather than throwing
- Add `ClassCastException` catch in case `readObject()` returns a non-Map
- Existing callers (e.g. `AllianceRequestMenu.createGuildItem`) already substitute a green banner on null, so this restores the intended fallback path

## Test plan
- [ ] Open `/guild → Relations → Request Alliance` while at least one guild on the server has a malformed/legacy banner string in storage
- [ ] Confirm no `IndexOutOfBoundsException` in console
- [ ] Confirm guilds with malformed banners now render as a plain green banner instead of crashing the menu
- [ ] Confirm guilds with valid Base64 banners still render correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved ItemStack deserialization robustness with enhanced error handling for corrupt or incompatible serialized data.
  * Strengthened legacy format fallback parsing to gracefully handle malformed entries.

* **Documentation**
  * Updated deserialization documentation to clarify null return behavior in edge cases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->