### PR TITLE
fix: sync Guild.level with XP-derived progression level

### DIFF
--- a/src/main/kotlin/net/lumalyte/lg/LumaGuilds.kt
+++ b/src/main/kotlin/net/lumalyte/lg/LumaGuilds.kt
@@ -132,6 +132,17 @@ class LumaGuilds : JavaPlugin() {
         // Initialize file export cleanup
         get().get<FileExportManager>().cleanupOldFiles()
 
+        // Repair Guild.level drift from XP (one-shot at startup; cheap if already in sync).
+        try {
+            val progressionService = get().get<net.lumalyte.lg.application.services.ProgressionService>()
+            val synced = progressionService.syncGuildLevels()
+            if (synced > 0) {
+                logColored("✓ Synced $synced guild level(s) from stored XP")
+            }
+        } catch (e: Exception) {
+            logger.warning("Failed to sync guild levels from XP: ${e.message}")
+        }
+
         // Initialize daily war costs scheduler
         initDailyWarCostsScheduler()
 

--- a/src/main/kotlin/net/lumalyte/lg/application/services/ProgressionService.kt
+++ b/src/main/kotlin/net/lumalyte/lg/application/services/ProgressionService.kt
@@ -190,6 +190,13 @@ interface ProgressionService {
      * @return List of newly unlocked perks.
      */
     fun processLevelUp(guildId: UUID, newLevel: Int): List<PerkType>
+
+    /**
+     * Recomputes Guild.level from each guild's stored XP and writes back any drift.
+     * Cheap repair pass for the bug where Guild.level was never updated alongside
+     * GuildProgression.currentLevel. Returns the number of guild rows updated.
+     */
+    fun syncGuildLevels(): Int
 }
 
 /**

--- a/src/main/kotlin/net/lumalyte/lg/infrastructure/services/ProgressionServiceBukkit.kt
+++ b/src/main/kotlin/net/lumalyte/lg/infrastructure/services/ProgressionServiceBukkit.kt
@@ -374,10 +374,12 @@ class ProgressionServiceBukkit(
                     if (guildRepository.update(guild.copy(level = computed))) {
                         updated++
                         logger.info("Backfilled Guild.level for ${guild.name} (${guild.id}): ${guild.level} -> $computed")
+                    } else {
+                        logger.warn("Backfill failed to update Guild.level for ${guild.name} (${guild.id}): ${guild.level} -> $computed")
                     }
                 }
                 if (computed != progression.currentLevel) {
-                    progressionRepository.saveGuildProgression(
+                    val saved = progressionRepository.saveGuildProgression(
                         progression.copy(
                             currentLevel = computed,
                             experienceThisLevel = progression.totalExperience - getTotalExperienceForLevel(computed),
@@ -385,6 +387,9 @@ class ProgressionServiceBukkit(
                             lastUpdated = Instant.now()
                         )
                     )
+                    if (!saved) {
+                        logger.warn("Backfill failed to update GuildProgression for ${guild.id}: currentLevel ${progression.currentLevel} -> $computed")
+                    }
                 }
             }
         } catch (e: Exception) {
@@ -397,7 +402,9 @@ class ProgressionServiceBukkit(
         try {
             val guild = guildRepository.getById(guildId) ?: return
             if (guild.level != newLevel) {
-                guildRepository.update(guild.copy(level = newLevel))
+                if (!guildRepository.update(guild.copy(level = newLevel))) {
+                    logger.warn("Failed to persist Guild.level for $guildId: ${guild.level} -> $newLevel")
+                }
             }
         } catch (e: Exception) {
             // Don't let a stale Guild.level write fail the XP award.

--- a/src/main/kotlin/net/lumalyte/lg/infrastructure/services/ProgressionServiceBukkit.kt
+++ b/src/main/kotlin/net/lumalyte/lg/infrastructure/services/ProgressionServiceBukkit.kt
@@ -83,6 +83,7 @@ class ProgressionServiceBukkit(
             // Process level up if occurred
             if (newLevel > oldLevel) {
                 logger.info("Guild $guildId leveled up from $oldLevel to $newLevel (gained $experience XP from $source)")
+                syncGuildLevelField(guildId, newLevel)
                 processLevelUp(guildId, newLevel)
                 return newLevel
             }
@@ -361,6 +362,47 @@ class ProgressionServiceBukkit(
             if (wars > maxWars) maxWars = wars
         }
         return maxWars
+    }
+
+    override fun syncGuildLevels(): Int {
+        var updated = 0
+        try {
+            for (guild in guildRepository.getAll()) {
+                val progression = progressionRepository.getGuildProgression(guild.id) ?: continue
+                val computed = getLevelFromExperience(progression.totalExperience)
+                if (computed != guild.level) {
+                    if (guildRepository.update(guild.copy(level = computed))) {
+                        updated++
+                        logger.info("Backfilled Guild.level for ${guild.name} (${guild.id}): ${guild.level} -> $computed")
+                    }
+                }
+                if (computed != progression.currentLevel) {
+                    progressionRepository.saveGuildProgression(
+                        progression.copy(
+                            currentLevel = computed,
+                            experienceThisLevel = progression.totalExperience - getTotalExperienceForLevel(computed),
+                            experienceForNextLevel = getExperienceForNextLevel(computed),
+                            lastUpdated = Instant.now()
+                        )
+                    )
+                }
+            }
+        } catch (e: Exception) {
+            logger.error("Failed to sync guild levels", e)
+        }
+        return updated
+    }
+
+    private fun syncGuildLevelField(guildId: UUID, newLevel: Int) {
+        try {
+            val guild = guildRepository.getById(guildId) ?: return
+            if (guild.level != newLevel) {
+                guildRepository.update(guild.copy(level = newLevel))
+            }
+        } catch (e: Exception) {
+            // Don't let a stale Guild.level write fail the XP award.
+            logger.error("Failed to sync Guild.level for $guildId to $newLevel", e)
+        }
     }
 
     override fun processLevelUp(guildId: UUID, newLevel: Int): List<PerkType> {

--- a/src/main/kotlin/net/lumalyte/lg/interaction/commands/LumaGuildsCommand.kt
+++ b/src/main/kotlin/net/lumalyte/lg/interaction/commands/LumaGuildsCommand.kt
@@ -26,7 +26,12 @@ class LumaGuildsCommand : CommandExecutor, TabCompleter, KoinComponent {
     private val fileExportManager: FileExportManager by inject()
     private val guildService: GuildService by inject()
     private val adminOverrideService: AdminOverrideService by inject()
-    private val guildRolePermissionResolver: GuildRolePermissionResolver by inject()
+
+    // Resolved lazily and nullable: GuildRolePermissionResolver is only registered when
+    // claims are enabled. Touching it via `by inject()` would crash the override command
+    // on claims-disabled servers.
+    private val guildRolePermissionResolver: GuildRolePermissionResolver?
+        get() = getKoin().getOrNull()
     private val progressionConfigService: net.lumalyte.lg.infrastructure.services.ProgressionConfigService by inject()
 
     override fun onCommand(sender: CommandSender, command: Command, label: String, args: Array<out String>): Boolean {
@@ -295,8 +300,9 @@ class LumaGuildsCommand : CommandExecutor, TabCompleter, KoinComponent {
         // Toggle the override state
         val newState = adminOverrideService.toggleOverride(sender.uniqueId)
 
-        // Invalidate the permission cache to apply changes immediately
-        guildRolePermissionResolver.invalidatePlayerCache(sender.uniqueId)
+        // Invalidate the claim-permission cache so changes apply immediately. Resolver is
+        // null on claims-disabled servers; the override still toggles for guild-level checks.
+        guildRolePermissionResolver?.invalidatePlayerCache(sender.uniqueId)
 
         // Send appropriate message based on new state
         if (newState) {


### PR DESCRIPTION
## Summary

- Guilds were stuck at `Lvl 1` everywhere (in-game leaderboard holograms, web leaderboard, info menus) despite accumulating hundreds of thousands of XP.
- Root cause: two parallel level fields. `Guild.level` (on the `guilds` table) defaulted to `1` and was **never written** after creation. `awardExperience` only updated `GuildProgression.currentLevel`. Every display reads `guild.level`, so it never moved.
- Fix: sync `Guild.level` on every level-up so the two can never diverge again, plus a one-shot startup backfill that recomputes the level from stored XP for every existing guild.

## Changes

- `ProgressionService.syncGuildLevels()` — new interface method. Iterates all guilds, recomputes level from `totalExperience`, and writes drift back to both `Guild.level` and `GuildProgression.currentLevel` (also fixing `experienceThisLevel` / `experienceForNextLevel` so the progress bar is correct).
- `ProgressionServiceBukkit.awardExperience` — on level-up, also writes the new level into the `guilds` table via `guildRepository.update`. Wrapped so a failed write logs but never blocks the XP award.
- `LumaGuilds.onEnable` — calls `syncGuildLevels()` once after Koin init. Logs the count if any rows were repaired.

## Reviewer notes

- The backfill is idempotent and cheap when nothing's drifted — safe to run on every startup.
- No schema migration required; the column already exists, it just wasn't being maintained.
- A longer-term cleanup would collapse the two level fields into one (read everywhere from `progression.currentLevel`), but that touches ~10 menus and felt out of scope for the bug fix. With this patch the two stay in sync, so reads from either source give the same answer.

## Test plan

- [ ] Start server with the attached database — confirm startup log shows `Synced N guild level(s) from stored XP` with a non-zero N.
- [ ] Open the in-game `TOP GUILD LEVEL` hologram — guilds with XP show their actual level instead of `Lvl 1`.
- [ ] Hit the website leaderboard — ranks reflect computed levels, XP tie-breaks within the same level.
- [ ] Award XP to a guild that crosses a level threshold — verify both `guilds.level` and `guild_progression.current_level` advance in the DB.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Guild levels are now automatically synchronized with their experience values during plugin startup to correct any inconsistencies.
  * Added logging to track synchronization results and errors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->