### PR TITLE
fix: align /g tag CLI validation with TagEditorMenu

### DIFF
--- a/src/main/kotlin/net/lumalyte/lg/interaction/commands/GuildCommand.kt
+++ b/src/main/kotlin/net/lumalyte/lg/interaction/commands/GuildCommand.kt
@@ -1310,14 +1310,36 @@ class GuildCommand : BaseCommand(), KoinComponent {
         return
         }
 
-        // Validate tag length and format
-        if (tag.length > 5) {
-            player.sendMessage("§cGuild tag must be 5 characters or less.")
+        // Validate tag — mirrors TagEditorMenu.validateTag for consistency
+        if (tag.trim().isEmpty()) {
+            player.sendMessage("§cGuild tag cannot be empty.")
             return
         }
 
-        if (!tag.matches(Regex("^[A-Z0-9]+$"))) {
-            player.sendMessage("§cGuild tag can only contain uppercase letters and numbers.")
+        if (tag.contains("<<") || tag.contains(">>")) {
+            player.sendMessage("§cInvalid tag syntax: double brackets.")
+            return
+        }
+
+        val miniMessage = net.kyori.adventure.text.minimessage.MiniMessage.miniMessage()
+        val visibleChars = try {
+            val component = miniMessage.deserialize(tag)
+            net.kyori.adventure.text.serializer.plain.PlainTextComponentSerializer.plainText()
+                .serialize(component).length
+        } catch (e: Exception) {
+            val errorMsg = e.message ?: "Invalid format"
+            val msg = when {
+                errorMsg.contains("unclosed", ignoreCase = true) -> "Unclosed tag (missing closing tag)"
+                errorMsg.contains("unknown tag", ignoreCase = true) -> "Unknown tag format"
+                errorMsg.contains("invalid", ignoreCase = true) -> "Invalid MiniMessage syntax"
+                else -> "Format error: ${errorMsg.take(50)}"
+            }
+            player.sendMessage("§c❌ Invalid tag: $msg")
+            return
+        }
+
+        if (visibleChars > 32) {
+            player.sendMessage("§cGuild tag too long ($visibleChars/32 visible characters).")
             return
         }
 


### PR DESCRIPTION
## Summary
- `/g tag <tag>` enforced a stricter ruleset (≤5 chars, uppercase letters/numbers only) than the menu opened by `/g tag`, which allows MiniMessage formatting and up to 32 visible characters.
- Result: colored/gradient tags were rejected via CLI but accepted via the menu — confusing and inconsistent.

## Fix
Replaced the CLI validation in `GuildCommand.onTag` with the same logic used in `TagEditorMenu.validateTag`:
- Parse input via MiniMessage
- Count **visible** characters via `PlainTextComponentSerializer` (so `<gradient>`, `<bold>`, etc. don't count toward the 32-char limit)
- Surface the same syntax error messages (unclosed tag, unknown tag, double brackets, etc.)

Long inputs filled with formatting codes are still bounded by the 32 *visible* character limit.

## Test plan
- [ ] `/g tag ABC` — accepted (plain text, ≤32 visible)
- [ ] `/g tag hello` — accepted (lowercase no longer rejected)
- [ ] `/g tag <gradient:#FF0000:#00FF00>Rainbow</gradient>` — accepted (7 visible chars)
- [ ] `/g tag <red>` — rejected (unclosed tag)
- [ ] `/g tag aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa` — rejected (33 visible chars)
- [ ] `/g tag` (no arg) — opens TagEditorMenu (unchanged)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Enhanced guild tag validation to prevent empty tags and invalid formatting
  * Improved error messages for invalid tag formats
  * Enforced a 32-character visible length limit for guild tags

<!-- end of auto-generated comment: release notes by coderabbit.ai -->