### PR TITLE
fix: Clear Tag button in TagEditorMenu no longer silently reverts

### DIFF
--- a/src/main/kotlin/net/lumalyte/lg/interaction/menus/guild/TagEditorMenu.kt
+++ b/src/main/kotlin/net/lumalyte/lg/interaction/menus/guild/TagEditorMenu.kt
@@ -35,6 +35,7 @@ class TagEditorMenu(private val menuNavigator: MenuNavigator, private val player
     private var currentTag: String? = null
     private var inputTag: String? = null
     private var validationError: String? = null
+    private var inputInitialized: Boolean = false
 
     override fun open() {
         println("[LumaGuilds] TagEditorMenu: Opening menu for player ${player.name}")
@@ -47,9 +48,12 @@ class TagEditorMenu(private val menuNavigator: MenuNavigator, private val player
             println("[LumaGuilds] TagEditorMenu: Using existing currentTag: '$currentTag'")
         }
 
-        // Initialize inputTag only if it's null (preserve user input)
-        if (inputTag == null) {
+        // Initialize inputTag from currentTag on first open. After that, preserve
+        // user state — including an explicit clear (inputTag == null) — across
+        // re-opens triggered by button clicks.
+        if (!inputInitialized) {
             inputTag = currentTag
+            inputInitialized = true
             println("[LumaGuilds] TagEditorMenu: Initialized inputTag to currentTag: '$inputTag'")
         } else {
             println("[LumaGuilds] TagEditorMenu: Preserving existing inputTag: '$inputTag'")


### PR DESCRIPTION
## Bug
Reported by RedstoneIsGreat: clicking **Clear Tag** in `/g tag` GUI then **Save** does not clear the tag.

## Root cause
[TagEditorMenu.kt](src/main/kotlin/net/lumalyte/lg/interaction/menus/guild/TagEditorMenu.kt):

1. Clear button sets \`inputTag = null\` and calls \`open()\` to refresh.
2. \`open()\` re-initializes \`inputTag = currentTag\` whenever \`inputTag\` is null — silently undoing the clear.
3. Save button then sees \`inputTag == currentTag\` and short-circuits with \"No changes to save.\"

## Fix
Track first-open initialization with a boolean flag (\`inputInitialized\`). After the first open, an explicit \`null\` in \`inputTag\` is preserved across re-opens, so the save handler correctly calls \`guildService.setTag(guild.id, null, ...)\`.

## Test plan
- [ ] Set a tag, open `/g tag`, click Clear Tag, click Save — tag is cleared
- [ ] Set a tag, open `/g tag`, type new tag in chat — preserved across menu refreshes (regression check)
- [ ] Open `/g tag` with no existing tag, click Save — \"No changes to save\" (regression check)

🤖 Generated with [Claude Code](https://claude.com/claude-code)