### PR TITLE
fix: /g sethome confirmation respects home name

### DIFF
--- a/src/main/kotlin/net/lumalyte/lg/interaction/commands/GuildCommand.kt
+++ b/src/main/kotlin/net/lumalyte/lg/interaction/commands/GuildCommand.kt
@@ -284,20 +284,30 @@ class GuildCommand : BaseCommand(), KoinComponent {
             }
         }
 
-        // Check if guild already has a home (separate from safety confirmation)
-        val currentHome = guildService.getHome(guild.id)
+        // Check if a home with this specific name already exists (separate from safety confirmation)
+        val currentHome = guildService.getHome(guild.id, targetHomeName)
         if (currentHome != null && adjustedConfirm?.lowercase() != "confirm" && adjustedConfirm?.lowercase() != "unsafe") {
-            player.sendMessage("§c⚠️ Your guild already has a home set!")
+            val confirmCommand = if (adjustedHomeName != null) {
+                "/guild sethome $adjustedHomeName confirm"
+            } else {
+                "/guild sethome confirm"
+            }
+            player.sendMessage("§c⚠️ Your guild already has a home named '§f$targetHomeName§c'!")
             player.sendMessage("§7Current home: §f${currentHome.position.x}, ${currentHome.position.y}, ${currentHome.position.z}")
             player.sendMessage("§7New location: §f${location.blockX}, ${location.blockY}, ${location.blockZ}")
-            player.sendMessage("§7Use §6/guild sethome confirm §7to replace the current home")
+            player.sendMessage("§7Use §6$confirmCommand §7to replace it")
             player.sendMessage("§7Or use the guild menu for a confirmation dialog.")
             return
         }
 
         // Check safety and handle confirmation system
         if (config.guild.homeTeleportSafetyCheck) {
-            if (!GuildHomeSafety.checkOrAskConfirm(player, location, "/guild sethome unsafe")) {
+            val unsafeCommand = if (adjustedHomeName != null) {
+                "/guild sethome $adjustedHomeName unsafe"
+            } else {
+                "/guild sethome unsafe"
+            }
+            if (!GuildHomeSafety.checkOrAskConfirm(player, location, unsafeCommand)) {
                 return
             }
         }


### PR DESCRIPTION
## Bug
Reported by RedstoneIsGreat:
- `/g sethome test` — sets home named \"test\"
- `/g sethome test` again — message says \"Use `/guild sethome confirm`\"
- That command does not work; only `/guild sethome test confirm` does.

## Root cause
[GuildCommand.kt:288](src/main/kotlin/net/lumalyte/lg/interaction/commands/GuildCommand.kt#L288):
1. The duplicate-home check called `guildService.getHome(guildId)` (no name), which returns the primary `main` home. So setting a named home like `test` would compare against `main` instead of `test` — causing false warnings against `main` and silently allowing duplicates of named homes (depending on existing state).
2. The confirmation message hardcoded `/guild sethome confirm` regardless of which home name the user typed.

## Fix
- Use the named lookup `guildService.getHome(guildId, targetHomeName)` so the existence check actually targets the home being set.
- When a home name was provided, render the confirm/unsafe prompts with the name included (`/guild sethome <name> confirm`, `/guild sethome <name> unsafe`).

## Test plan
- [ ] `/g sethome test` then `/g sethome test` → message says `/guild sethome test confirm`, and that command replaces the home
- [ ] `/g sethome` then `/g sethome` → message says `/guild sethome confirm` (unchanged behavior for unnamed/main home)
- [ ] `/g sethome test` while a `main` home exists but no `test` → sets the new `test` home without false warning
- [ ] Unsafe-location warning includes the home name in the suggested confirm command

🤖 Generated with [Claude Code](https://claude.com/claude-code)