### PR TITLE
fix: block guild vault chest item from being used in crafting

### DIFF
--- a/src/main/kotlin/net/lumalyte/lg/LumaGuilds.kt
+++ b/src/main/kotlin/net/lumalyte/lg/LumaGuilds.kt
@@ -821,6 +821,7 @@ class LumaGuilds : JavaPlugin() {
 
         server.pluginManager.registerEvents(BannerSelectionListener(), this)
         server.pluginManager.registerEvents(BannerFuelPreventionListener(), this)
+        server.pluginManager.registerEvents(net.lumalyte.lg.interaction.listeners.GuildVaultCraftingPreventionListener(), this)
 
         // Register progression event listener
         val progressionEventListener = get().get<ProgressionEventListener>()

--- a/src/main/kotlin/net/lumalyte/lg/interaction/listeners/GuildVaultCraftingPreventionListener.kt
+++ b/src/main/kotlin/net/lumalyte/lg/interaction/listeners/GuildVaultCraftingPreventionListener.kt
@@ -1,0 +1,36 @@
+package net.lumalyte.lg.interaction.listeners
+
+import net.lumalyte.lg.common.PluginKeys
+import org.bukkit.event.EventHandler
+import org.bukkit.event.EventPriority
+import org.bukkit.event.Listener
+import org.bukkit.event.inventory.PrepareItemCraftEvent
+import org.bukkit.Material
+import org.bukkit.inventory.ItemStack
+import org.bukkit.persistence.PersistentDataType
+
+/**
+ * Prevents the special "guild vault" chest item (marked with GUILD_VAULT_ID) from
+ * being consumed in crafting recipes (e.g. boat-with-chest, hopper, trapped chest).
+ * Without this, players could trade an unlimited supply of cheap recipe outputs for
+ * the labelled vault chest received from /guild getvault.
+ */
+class GuildVaultCraftingPreventionListener : Listener {
+
+    @EventHandler(priority = EventPriority.HIGH)
+    fun onPrepareItemCraft(event: PrepareItemCraftEvent) {
+        val matrix = event.inventory.matrix
+        if (matrix.any { it.isGuildVaultItem() }) {
+            event.inventory.result = ItemStack(Material.AIR)
+        }
+    }
+
+    private fun ItemStack?.isGuildVaultItem(): Boolean {
+        if (this == null) return false
+        val meta = this.itemMeta ?: return false
+        return meta.persistentDataContainer.has(
+            PluginKeys.GUILD_VAULT_ID,
+            PersistentDataType.STRING
+        )
+    }
+}


### PR DESCRIPTION
## Bug
Reported by RedstoneIsGreat: the special guild vault chest received via \`/guild getvault\` could be placed in a crafting grid like a regular chest — boat-with-chest, hopper, trapped chest, etc. This effectively let players \"launder\" an unlimited supply of cheap recipe outputs by trading in their labelled vault chest.

## Fix
Added [GuildVaultCraftingPreventionListener](src/main/kotlin/net/lumalyte/lg/interaction/listeners/GuildVaultCraftingPreventionListener.kt) that hooks \`PrepareItemCraftEvent\` and clears the result whenever any input slot contains an item carrying the \`GUILD_VAULT_ID\` persistent-data tag.

Mirrors the existing pattern used by [BannerFuelPreventionListener](src/main/kotlin/net/lumalyte/lg/interaction/listeners/BannerFuelPreventionListener.kt) for the analogous guild banner fuel exploit.

## Considered alternatives
RedstoneIsGreat suggested converting an inventory chest into a vault on `/g getvault` to remove the \"free chest\" angle entirely. That's a behavioral change worth a separate discussion — this PR just stops the immediate exploit without altering the existing UX.

## Test plan
- [ ] /g getvault → place vault chest item in crafting grid with a boat → no result shown
- [ ] Regular chest in crafting grid → recipes still work normally
- [ ] Place vault chest in world → still functions as guild vault (regression check)

🤖 Generated with [Claude Code](https://claude.com/claude-code)