### PR TITLE
fix: PENDING ally requests no longer show as accepted alliances

### DIFF
--- a/src/main/kotlin/net/lumalyte/lg/infrastructure/placeholders/LumaGuildsExpansion.kt
+++ b/src/main/kotlin/net/lumalyte/lg/infrastructure/placeholders/LumaGuildsExpansion.kt
@@ -319,7 +319,7 @@ class LumaGuildsExpansion : PlaceholderExpansion(), KoinComponent {
         // Check relations between guilds
         try {
             val relation = relationService.getRelation(playerGuildId, otherGuildId)
-            if (relation != null) {
+            if (relation != null && relation.isActive()) {
                 return when (relation.type) {
                     net.lumalyte.lg.domain.entities.RelationType.ENEMY -> "🔴"  // Enemy/War
                     net.lumalyte.lg.domain.entities.RelationType.ALLY -> "🔵"   // Ally

--- a/src/main/kotlin/net/lumalyte/lg/interaction/menus/guild/GuildInfoMenu.kt
+++ b/src/main/kotlin/net/lumalyte/lg/interaction/menus/guild/GuildInfoMenu.kt
@@ -145,9 +145,10 @@ class GuildInfoMenu(private val menuNavigator: MenuNavigator, private val player
     private fun addRelationsSection(pane: StaticPane, x: Int, y: Int) {
         val relations = relationService.getGuildRelations(guild.id)
 
-        // Allies — filter out relations where the allied guild no longer exists (disbanded)
+        // Allies — only include active alliances; PENDING/REJECTED/EXPIRED requests do not count.
+        // Also filter out relations where the allied guild no longer exists (disbanded).
         val allies = relations.filter {
-            it.type == RelationType.ALLY && guildService.getGuild(it.getOtherGuild(guild.id)) != null
+            it.type == RelationType.ALLY && it.isActive() && guildService.getGuild(it.getOtherGuild(guild.id)) != null
         }
         val alliesItem = ItemStack.of(Material.LIME_BANNER)
             .name("§aAllies (§f${allies.size}§a)")
@@ -166,9 +167,9 @@ class GuildInfoMenu(private val menuNavigator: MenuNavigator, private val player
 
         pane.addItem(GuiItem(alliesItem), x, y)
 
-        // Truces — filter out disbanded guilds
+        // Truces — only include active truces; filter out disbanded guilds.
         val truces = relations.filter {
-            it.type == RelationType.TRUCE && guildService.getGuild(it.getOtherGuild(guild.id)) != null
+            it.type == RelationType.TRUCE && it.isActive() && guildService.getGuild(it.getOtherGuild(guild.id)) != null
         }
         val trucesItem = ItemStack.of(Material.WHITE_BANNER)
             .name("§fTruces (§f${truces.size}§f)")
@@ -187,9 +188,9 @@ class GuildInfoMenu(private val menuNavigator: MenuNavigator, private val player
 
         pane.addItem(GuiItem(trucesItem), x, y + 1)
 
-        // Enemies/Wars — filter out disbanded guilds
+        // Enemies/Wars — only include active wars; filter out disbanded guilds.
         val enemies = relations.filter {
-            it.type == RelationType.ENEMY && guildService.getGuild(it.getOtherGuild(guild.id)) != null
+            it.type == RelationType.ENEMY && it.isActive() && guildService.getGuild(it.getOtherGuild(guild.id)) != null
         }
         val enemiesItem = ItemStack.of(Material.RED_BANNER)
             .name("§cWars (§f${enemies.size}§c)")


### PR DESCRIPTION
## Bug
Reported: \"when someone does /guild ally it gets auto accepted\"

## Root cause
RelationService correctly creates the relation as `RelationStatus.PENDING`. Two display paths ignored status and rendered any relation by type alone:

1. GuildInfoMenu relations panel — listed allies/truces/enemies without `isActive()` filter, so pending requests showed up immediately.
2. LumaGuildsExpansion PAPI indicator — returned 🔵/🔴/⚪ regardless of pending/expired/rejected status.

Other paths (AlliesListMenu, GuildRelationsMenu, CombatService, ModeService) already gate on `isActive()`.

## Fix
Both paths now additionally require `relation.isActive()` (ACTIVE + not expired).

## Test plan
- [ ] GuildA `/g ally GuildB` → GuildA `/g info` shows 0 allies until GuildB accepts
- [ ] GuildB accepts via Incoming Requests → both `/g info` show 1 ally
- [ ] PAPI relation indicator empty for pending, 🔵 after acceptance
- [ ] Existing accepted alliances unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)