### PR TITLE
fix: block guild vault chest from being used as furnace fuel

### DIFF
--- a/src/main/kotlin/net/lumalyte/lg/LumaGuilds.kt
+++ b/src/main/kotlin/net/lumalyte/lg/LumaGuilds.kt
@@ -822,6 +822,7 @@ class LumaGuilds : JavaPlugin() {
         server.pluginManager.registerEvents(BannerSelectionListener(), this)
         server.pluginManager.registerEvents(BannerFuelPreventionListener(), this)
         server.pluginManager.registerEvents(net.lumalyte.lg.interaction.listeners.GuildVaultCraftingPreventionListener(), this)
+        server.pluginManager.registerEvents(GuildVaultFuelPreventionListener(), this)
 
         // Register progression event listener
         val progressionEventListener = get().get<ProgressionEventListener>()

--- a/src/main/kotlin/net/lumalyte/lg/interaction/listeners/GuildVaultFuelPreventionListener.kt
+++ b/src/main/kotlin/net/lumalyte/lg/interaction/listeners/GuildVaultFuelPreventionListener.kt
@@ -1,0 +1,30 @@
+package net.lumalyte.lg.interaction.listeners
+
+import net.lumalyte.lg.common.PluginKeys
+import org.bukkit.event.EventHandler
+import org.bukkit.event.EventPriority
+import org.bukkit.event.Listener
+import org.bukkit.event.inventory.FurnaceBurnEvent
+import org.bukkit.persistence.PersistentDataType
+
+/**
+ * Prevents guild vault chests (marked with GUILD_VAULT_ID) from being used as furnace fuel.
+ * Without this, chests with the guild-vault tag would still burn as ordinary chest fuel.
+ */
+class GuildVaultFuelPreventionListener : Listener {
+
+    @EventHandler(priority = EventPriority.HIGH, ignoreCancelled = true)
+    fun onFurnaceBurn(event: FurnaceBurnEvent) {
+        val fuel = event.fuel ?: return
+
+        val meta = fuel.itemMeta ?: return
+        val isGuildVault = meta.persistentDataContainer.has(
+            PluginKeys.GUILD_VAULT_ID,
+            PersistentDataType.STRING
+        )
+
+        if (isGuildVault) {
+            event.isCancelled = true
+        }
+    }
+}


### PR DESCRIPTION
## Bug
> You can use a guild chest to smelt items in a furnace. Minor issue but probably not intended
> — RedstoneIsGreat (May 6, 2026)

## Root cause
A guild vault chest is a normal `CHEST` item with a `PluginKeys.GUILD_VAULT_ID` tag stamped into its PDC. Vanilla furnace fuel logic only looks at the material, not the PDC, so it burns the chest like any other. There was no listener gating `FurnaceBurnEvent` for vault items — only [BannerFuelPreventionListener.kt](src/main/kotlin/net/lumalyte/lg/interaction/listeners/BannerFuelPreventionListener.kt) existed for guild banners.

## Fix
- New [GuildVaultFuelPreventionListener.kt](src/main/kotlin/net/lumalyte/lg/interaction/listeners/GuildVaultFuelPreventionListener.kt) mirrors the banner pattern: on `FurnaceBurnEvent` (HIGH, `ignoreCancelled = true`), check the fuel item's PDC for `GUILD_VAULT_ID` and cancel if present.
- Registered in `LumaGuilds.onEnable()` next to the banner listener.

## Test plan
- [ ] Place a guild vault chest in a furnace fuel slot — should not burn, no fuel consumed.
- [ ] Place a regular chest in a furnace fuel slot — burns normally (regression check).
- [ ] Place a guild banner in a furnace fuel slot — still cancelled (existing behavior unaffected).

🤖 Generated with [Claude Code](https://claude.com/claude-code)