### PR TITLE
fix: guild home tp from nether works reliably (use teleportAsync)

### DIFF
--- a/src/main/kotlin/net/lumalyte/lg/infrastructure/services/TeleportationService.kt
+++ b/src/main/kotlin/net/lumalyte/lg/infrastructure/services/TeleportationService.kt
@@ -75,16 +75,17 @@ class TeleportationService(private val plugin: Plugin) {
                 }
 
                 if (currentSession.remainingSeconds <= 0) {
-                    // Use teleportAsync for reliable cross-dimension teleports.
-                    // Paper's sync teleport() can silently fail when the destination
-                    // chunk isn't loaded — common when going from nether to overworld.
+                    // teleportAsync future may complete off the main thread;
+                    // dispatch Bukkit API calls back to main via the scheduler.
                     player.teleportAsync(currentSession.targetLocation).thenAccept { success ->
-                        if (success) {
-                            player.sendMessage("§a✅ Welcome to your guild home!")
-                            player.sendActionBar(Component.text("§aTeleported to guild home!"))
-                        } else {
-                            player.sendMessage("§c❌ Teleport failed — please try again.")
-                        }
+                        plugin.server.scheduler.runTask(plugin, Runnable {
+                            if (success) {
+                                player.sendMessage("§a✅ Welcome to your guild home!")
+                                player.sendActionBar(Component.text("§aTeleported to guild home!"))
+                            } else {
+                                player.sendMessage("§c❌ Teleport failed — please try again.")
+                            }
+                        })
                     }
 
                     // Clean up

--- a/src/main/kotlin/net/lumalyte/lg/infrastructure/services/TeleportationService.kt
+++ b/src/main/kotlin/net/lumalyte/lg/infrastructure/services/TeleportationService.kt
@@ -75,10 +75,17 @@ class TeleportationService(private val plugin: Plugin) {
                 }
 
                 if (currentSession.remainingSeconds <= 0) {
-                    // Teleport the player
-                    player.teleport(currentSession.targetLocation)
-                    player.sendMessage("§a✅ Welcome to your guild home!")
-                    player.sendActionBar(Component.text("§aTeleported to guild home!"))
+                    // Use teleportAsync for reliable cross-dimension teleports.
+                    // Paper's sync teleport() can silently fail when the destination
+                    // chunk isn't loaded — common when going from nether to overworld.
+                    player.teleportAsync(currentSession.targetLocation).thenAccept { success ->
+                        if (success) {
+                            player.sendMessage("§a✅ Welcome to your guild home!")
+                            player.sendActionBar(Component.text("§aTeleported to guild home!"))
+                        } else {
+                            player.sendMessage("§c❌ Teleport failed — please try again.")
+                        }
+                    }
 
                     // Clean up
                     activeTeleports.remove(playerId)

--- a/src/main/kotlin/net/lumalyte/lg/interaction/commands/GuildCommand.kt
+++ b/src/main/kotlin/net/lumalyte/lg/interaction/commands/GuildCommand.kt
@@ -1462,6 +1462,7 @@ class GuildCommand : BaseCommand(), KoinComponent {
         player.sendMessage("§e◷ Teleportation countdown started! Don't move for 5 seconds...")
         player.sendActionBar(Component.text("§eTeleporting to guild home in §f5§e seconds..."))
 
+        val pluginRef = player.server.pluginManager.getPlugin("LumaGuilds") ?: return
         val countdownTask = object : BukkitRunnable() {
             override fun run() {
                 val currentSession = activeTeleports[playerId]
@@ -1478,18 +1479,18 @@ class GuildCommand : BaseCommand(), KoinComponent {
                 }
 
                 if (currentSession.remainingSeconds <= 0) {
-                    // Use teleportAsync for reliable cross-dimension teleports.
-                    // Paper's sync teleport() can silently fail when the destination
-                    // chunk isn't loaded — common when going from nether to overworld.
+                    // teleportAsync future may complete off the main thread;
+                    // dispatch Bukkit API calls back to main via the scheduler.
                     player.teleportAsync(currentSession.targetLocation).thenAccept { success ->
-                        if (success) {
-                            player.sendMessage("§a✅ Welcome to your guild home!")
-                            player.sendActionBar(Component.text("§aTeleported to guild home!"))
-                            // Record teleport time for cooldown only on success
-                            lastHomeTeleport[playerId] = System.currentTimeMillis()
-                        } else {
-                            player.sendMessage("§c❌ Teleport failed — please try again.")
-                        }
+                        Bukkit.getScheduler().runTask(pluginRef, Runnable {
+                            if (success) {
+                                player.sendMessage("§a✅ Welcome to your guild home!")
+                                player.sendActionBar(Component.text("§aTeleported to guild home!"))
+                                lastHomeTeleport[playerId] = System.currentTimeMillis()
+                            } else {
+                                player.sendMessage("§c❌ Teleport failed — please try again.")
+                            }
+                        })
                     }
 
                     // Clean up
@@ -1505,9 +1506,7 @@ class GuildCommand : BaseCommand(), KoinComponent {
         }
 
         session.countdownTask = countdownTask
-        val plugin = player.server.pluginManager.getPlugin("LumaGuilds")
-            ?: return // Plugin not found, cannot schedule countdown
-        countdownTask.runTaskTimer(plugin, 0L, 20L) // Start immediately, then every second
+        countdownTask.runTaskTimer(pluginRef, 0L, 20L) // Start immediately, then every second
     }
 
     private fun cancelTeleport(playerId: java.util.UUID) {

--- a/src/main/kotlin/net/lumalyte/lg/interaction/commands/GuildCommand.kt
+++ b/src/main/kotlin/net/lumalyte/lg/interaction/commands/GuildCommand.kt
@@ -1478,13 +1478,19 @@ class GuildCommand : BaseCommand(), KoinComponent {
                 }
 
                 if (currentSession.remainingSeconds <= 0) {
-                    // Teleport the player
-                    player.teleport(currentSession.targetLocation)
-                    player.sendMessage("§a✅ Welcome to your guild home!")
-                    player.sendActionBar(Component.text("§aTeleported to guild home!"))
-
-                    // Record teleport time for cooldown
-                    lastHomeTeleport[playerId] = System.currentTimeMillis()
+                    // Use teleportAsync for reliable cross-dimension teleports.
+                    // Paper's sync teleport() can silently fail when the destination
+                    // chunk isn't loaded — common when going from nether to overworld.
+                    player.teleportAsync(currentSession.targetLocation).thenAccept { success ->
+                        if (success) {
+                            player.sendMessage("§a✅ Welcome to your guild home!")
+                            player.sendActionBar(Component.text("§aTeleported to guild home!"))
+                            // Record teleport time for cooldown only on success
+                            lastHomeTeleport[playerId] = System.currentTimeMillis()
+                        } else {
+                            player.sendMessage("§c❌ Teleport failed — please try again.")
+                        }
+                    }
 
                     // Clean up
                     activeTeleports.remove(playerId)

--- a/src/main/kotlin/net/lumalyte/lg/interaction/menus/bedrock/BedrockGuildHomeMenu.kt
+++ b/src/main/kotlin/net/lumalyte/lg/interaction/menus/bedrock/BedrockGuildHomeMenu.kt
@@ -213,10 +213,17 @@ class BedrockGuildHomeMenu(
                 }
 
                 if (currentSession.remainingSeconds <= 0) {
-                    // Teleport the player
-                    player.teleport(currentSession.targetLocation)
-                    player.sendMessage("§a✅ Teleported to guild home!")
-                    player.sendActionBar(Component.text("§aTeleported to guild home!"))
+                    // Use teleportAsync for reliable cross-dimension teleports.
+                    // Paper's sync teleport() can silently fail when the destination
+                    // chunk isn't loaded — common when going from nether to overworld.
+                    player.teleportAsync(currentSession.targetLocation).thenAccept { success ->
+                        if (success) {
+                            player.sendMessage("§a✅ Teleported to guild home!")
+                            player.sendActionBar(Component.text("§aTeleported to guild home!"))
+                        } else {
+                            player.sendMessage("§c❌ Teleport failed — please try again.")
+                        }
+                    }
 
                     // Clean up
                     activeTeleports.remove(player.uniqueId)

--- a/src/main/kotlin/net/lumalyte/lg/interaction/menus/bedrock/BedrockGuildHomeMenu.kt
+++ b/src/main/kotlin/net/lumalyte/lg/interaction/menus/bedrock/BedrockGuildHomeMenu.kt
@@ -196,6 +196,7 @@ class BedrockGuildHomeMenu(
         player.sendMessage("§e⏰ Teleportation countdown started! Don't move for 5 seconds...")
         player.sendActionBar(Component.text("§eTeleporting to guild home in §f5§e seconds..."))
 
+        val pluginRef = Bukkit.getPluginManager().getPlugin("LumaGuilds") ?: return
         val countdownTask = object : BukkitRunnable() {
             override fun run() {
                 val currentSession = activeTeleports[player.uniqueId]
@@ -213,16 +214,17 @@ class BedrockGuildHomeMenu(
                 }
 
                 if (currentSession.remainingSeconds <= 0) {
-                    // Use teleportAsync for reliable cross-dimension teleports.
-                    // Paper's sync teleport() can silently fail when the destination
-                    // chunk isn't loaded — common when going from nether to overworld.
+                    // teleportAsync future may complete off the main thread;
+                    // dispatch Bukkit API calls back to main via the scheduler.
                     player.teleportAsync(currentSession.targetLocation).thenAccept { success ->
-                        if (success) {
-                            player.sendMessage("§a✅ Teleported to guild home!")
-                            player.sendActionBar(Component.text("§aTeleported to guild home!"))
-                        } else {
-                            player.sendMessage("§c❌ Teleport failed — please try again.")
-                        }
+                        Bukkit.getScheduler().runTask(pluginRef, Runnable {
+                            if (success) {
+                                player.sendMessage("§a✅ Teleported to guild home!")
+                                player.sendActionBar(Component.text("§aTeleported to guild home!"))
+                            } else {
+                                player.sendMessage("§c❌ Teleport failed — please try again.")
+                            }
+                        })
                     }
 
                     // Clean up
@@ -238,9 +240,7 @@ class BedrockGuildHomeMenu(
         }
 
         session.countdownTask = countdownTask
-        val plugin = Bukkit.getPluginManager().getPlugin("LumaGuilds")
-            ?: return // Plugin not found, cannot schedule countdown
-        countdownTask.runTaskTimer(plugin, 0L, 20L) // Start immediately, then every second
+        countdownTask.runTaskTimer(pluginRef, 0L, 20L) // Start immediately, then every second
     }
 
     private fun cancelTeleport(playerId: UUID) {

--- a/src/main/kotlin/net/lumalyte/lg/interaction/menus/guild/GuildHomeMenu.kt
+++ b/src/main/kotlin/net/lumalyte/lg/interaction/menus/guild/GuildHomeMenu.kt
@@ -404,6 +404,7 @@ class GuildHomeMenu(private val menuNavigator: MenuNavigator, private val player
         player.sendMessage("§e⏰ Teleportation countdown started! Don't move for 5 seconds...")
         player.sendActionBar(Component.text("§eTeleporting to guild home in §f5§e seconds..."))
 
+        val pluginRef = Bukkit.getPluginManager().getPlugin("LumaGuilds") ?: return
         val countdownTask = object : BukkitRunnable() {
             override fun run() {
                 val currentSession = activeTeleports[player.uniqueId]
@@ -420,16 +421,17 @@ class GuildHomeMenu(private val menuNavigator: MenuNavigator, private val player
                 }
 
                 if (currentSession.remainingSeconds <= 0) {
-                    // Use teleportAsync for reliable cross-dimension teleports.
-                    // Paper's sync teleport() can silently fail when the destination
-                    // chunk isn't loaded — common when going from nether to overworld.
+                    // teleportAsync future may complete off the main thread;
+                    // dispatch Bukkit API calls back to main via the scheduler.
                     player.teleportAsync(currentSession.targetLocation).thenAccept { success ->
-                        if (success) {
-                            player.sendMessage("§a✅ Teleported to guild home!")
-                            player.sendActionBar(Component.text("§aTeleported to guild home!"))
-                        } else {
-                            player.sendMessage("§c❌ Teleport failed — please try again.")
-                        }
+                        Bukkit.getScheduler().runTask(pluginRef, Runnable {
+                            if (success) {
+                                player.sendMessage("§a✅ Teleported to guild home!")
+                                player.sendActionBar(Component.text("§aTeleported to guild home!"))
+                            } else {
+                                player.sendMessage("§c❌ Teleport failed — please try again.")
+                            }
+                        })
                     }
 
                     // Clean up
@@ -445,9 +447,7 @@ class GuildHomeMenu(private val menuNavigator: MenuNavigator, private val player
         }
 
         session.countdownTask = countdownTask
-        val plugin = Bukkit.getPluginManager().getPlugin("LumaGuilds")
-            ?: return // Plugin not found, cannot schedule countdown
-        countdownTask.runTaskTimer(plugin, 0L, 20L) // Start immediately, then every second
+        countdownTask.runTaskTimer(pluginRef, 0L, 20L) // Start immediately, then every second
     }
 
     private fun cancelTeleport(playerId: UUID) {

--- a/src/main/kotlin/net/lumalyte/lg/interaction/menus/guild/GuildHomeMenu.kt
+++ b/src/main/kotlin/net/lumalyte/lg/interaction/menus/guild/GuildHomeMenu.kt
@@ -420,10 +420,17 @@ class GuildHomeMenu(private val menuNavigator: MenuNavigator, private val player
                 }
 
                 if (currentSession.remainingSeconds <= 0) {
-                    // Teleport the player
-                    player.teleport(currentSession.targetLocation)
-                    player.sendMessage("§a✅ Teleported to guild home!")
-                    player.sendActionBar(Component.text("§aTeleported to guild home!"))
+                    // Use teleportAsync for reliable cross-dimension teleports.
+                    // Paper's sync teleport() can silently fail when the destination
+                    // chunk isn't loaded — common when going from nether to overworld.
+                    player.teleportAsync(currentSession.targetLocation).thenAccept { success ->
+                        if (success) {
+                            player.sendMessage("§a✅ Teleported to guild home!")
+                            player.sendActionBar(Component.text("§aTeleported to guild home!"))
+                        } else {
+                            player.sendMessage("§c❌ Teleport failed — please try again.")
+                        }
+                    }
 
                     // Clean up
                     activeTeleports.remove(player.uniqueId)


### PR DESCRIPTION
## Bug
> If I try and tp to guild home in the nether it never works
> — Aquarium (May 5, 2026)
> I have this same issue … But it sometimes works. Idk what causes it
> — Za_Reaper (May 6, 2026)

## Root cause
All four guild-home teleport sites used `Player#teleport(Location)` (synchronous) and discarded the boolean return value:

- [GuildCommand.kt:1482](src/main/kotlin/net/lumalyte/lg/interaction/commands/GuildCommand.kt#L1482)
- [TeleportationService.kt:79](src/main/kotlin/net/lumalyte/lg/infrastructure/services/TeleportationService.kt#L79)
- [GuildHomeMenu.kt:424](src/main/kotlin/net/lumalyte/lg/interaction/menus/guild/GuildHomeMenu.kt#L424)
- [BedrockGuildHomeMenu.kt:217](src/main/kotlin/net/lumalyte/lg/interaction/menus/bedrock/BedrockGuildHomeMenu.kt#L217)

The sync teleport API can silently fail across dimensions when the destination chunk isn't loaded — exactly what happens when a player in the nether tries to teleport to an overworld home. When the destination chunk happens to already be loaded (e.g. someone else nearby), it works; otherwise the success message fires but the player never moves. That matches "sometimes works."

## Fix
Switch all four sites to `Player#teleportAsync(Location)`, which Paper uses to pre-load the destination chunk and returns a `CompletableFuture<Boolean>`. Only show "Welcome to your guild home!" when the future resolves `true`; otherwise show "Teleport failed — please try again." In the command path, also gate the cooldown timestamp on the success branch so a failed teleport doesn't cost a cooldown.

## Test plan
- [ ] Stand in the nether, run `/g home` to an overworld home — should teleport reliably every time.
- [ ] Stand in the overworld, run `/g home` to a nether home (multi-home setup) — should teleport reliably.
- [ ] Same-world `/g home` still works.
- [ ] Move during countdown — still cancels with "you moved!" message.
- [ ] Cooldown still applies on success; not consumed on failure.
- [ ] Java menu and Bedrock form home buttons behave the same.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added guild home management system with teleportation countdown tracking
  * Expanded guild commands for advanced guild management and control
  * Implemented location safety verification before teleportation
  * Added per-player teleport session tracking

* **Improvements**
  * Converted teleportation to asynchronous operations for improved reliability
  * Enhanced user feedback with detailed success/failure messages
  * Added movement detection during teleportation countdown
  * Improved cooldown and timestamp management

<!-- end of auto-generated comment: release notes by coderabbit.ai -->