### PR TITLE
fix: promote/demote shows real name for offline members

### DIFF
--- a/src/main/kotlin/net/lumalyte/lg/interaction/menus/bedrock/BedrockGuildMemberRankConfirmationMenu.kt
+++ b/src/main/kotlin/net/lumalyte/lg/interaction/menus/bedrock/BedrockGuildMemberRankConfirmationMenu.kt
@@ -34,8 +34,7 @@ class BedrockGuildMemberRankConfirmationMenu(
     private val rankService: RankService by inject()
 
     override fun getForm(): Form {
-        val targetPlayer = Bukkit.getPlayer(targetMember.playerId)
-        val targetName = targetPlayer?.name ?: "Unknown Player"
+        val targetName = Bukkit.getOfflinePlayer(targetMember.playerId).name ?: "Unknown Player"
         val currentRank = rankService.getRank(targetMember.rankId)
 
         return SimpleForm.builder()
@@ -77,8 +76,7 @@ class BedrockGuildMemberRankConfirmationMenu(
     }
 
     private fun changeRank() {
-        val targetPlayer = Bukkit.getPlayer(targetMember.playerId)
-        val targetName = targetPlayer?.name ?: "Unknown Player"
+        val targetName = Bukkit.getOfflinePlayer(targetMember.playerId).name ?: "Unknown Player"
 
         // Update the member's rank
         val success = memberService.changeMemberRank(targetMember.playerId, guild.id, newRank.id, player.uniqueId)
@@ -87,6 +85,7 @@ class BedrockGuildMemberRankConfirmationMenu(
             player.sendMessage("§a✅ Successfully changed $targetName's rank to ${newRank.name}!")
 
             // Notify the target player if they're online
+            val targetPlayer = Bukkit.getPlayer(targetMember.playerId)
             if (targetPlayer != null) {
                 targetPlayer.sendMessage("§6⚡ Your rank in ${guild.name} has been changed to ${newRank.name}")
             }

--- a/src/main/kotlin/net/lumalyte/lg/interaction/menus/guild/GuildMemberRankConfirmationMenu.kt
+++ b/src/main/kotlin/net/lumalyte/lg/interaction/menus/guild/GuildMemberRankConfirmationMenu.kt
@@ -67,7 +67,7 @@ class GuildMemberRankConfirmationMenu(
         pane.addItem(GuiItem(headItem), 0, 0)
 
         // Member info
-        val playerName = Bukkit.getPlayer(targetMember.playerId)?.name ?: "Unknown Player"
+        val playerName = Bukkit.getOfflinePlayer(targetMember.playerId).name ?: "Unknown Player"
         val infoItem = ItemStack.of(Material.PAPER)
             .name("§f👤 Member Details")
             .lore("§7Player: §f$playerName")
@@ -121,7 +121,7 @@ class GuildMemberRankConfirmationMenu(
         // Confirm button
         val confirmItem = ItemStack.of(Material.GREEN_WOOL)
             .name("§a✅ CONFIRM CHANGE")
-            .lore("§7Change ${Bukkit.getPlayer(targetMember.playerId)?.name ?: "Unknown"}'s rank")
+            .lore("§7Change ${Bukkit.getOfflinePlayer(targetMember.playerId).name ?: "Unknown"}'s rank")
             .lore("§7to ${newRank.name}")
 
         val confirmGuiItem = GuiItem(confirmItem) {
@@ -150,7 +150,7 @@ class GuildMemberRankConfirmationMenu(
             )
 
             if (success) {
-                val targetName = Bukkit.getPlayer(targetMember.playerId)?.name ?: "Unknown Player"
+                val targetName = Bukkit.getOfflinePlayer(targetMember.playerId).name ?: "Unknown Player"
                 val currentRank = rankService.getRank(targetMember.rankId)
 
                 val changeType = if (newRank.priority < (currentRank?.priority ?: 0)) {
@@ -185,7 +185,7 @@ class GuildMemberRankConfirmationMenu(
         val head = ItemStack.of(Material.PLAYER_HEAD)
         val meta = head.itemMeta as SkullMeta
 
-        val playerName = Bukkit.getPlayer(targetMember.playerId)?.name ?: "Unknown Player"
+        val playerName = Bukkit.getOfflinePlayer(targetMember.playerId).name ?: "Unknown Player"
 
         // Set skull owner using Craftatar API URL
         try {


### PR DESCRIPTION
## Bug
> Promoting/Demoting a member says "Unknown Player"
> — Fain (May 5, 2026)

## Root cause
The promote/demote confirmation menu looked up the target's display name with `Bukkit.getPlayer(uuid)`, which only returns currently-online players. Whenever a guild leader tried to promote or demote someone who wasn't logged in at that moment, the lookup returned null and the UI fell back to the literal string `"Unknown Player"` everywhere it printed the target.

Affected sites:

- [GuildMemberRankConfirmationMenu.kt:70](src/main/kotlin/net/lumalyte/lg/interaction/menus/guild/GuildMemberRankConfirmationMenu.kt#L70) — member-info card
- [GuildMemberRankConfirmationMenu.kt:124](src/main/kotlin/net/lumalyte/lg/interaction/menus/guild/GuildMemberRankConfirmationMenu.kt#L124) — confirm button lore
- [GuildMemberRankConfirmationMenu.kt:153](src/main/kotlin/net/lumalyte/lg/interaction/menus/guild/GuildMemberRankConfirmationMenu.kt#L153) — success message
- [GuildMemberRankConfirmationMenu.kt:188](src/main/kotlin/net/lumalyte/lg/interaction/menus/guild/GuildMemberRankConfirmationMenu.kt#L188) — skull head display
- [BedrockGuildMemberRankConfirmationMenu.kt:37–38, 80–81](src/main/kotlin/net/lumalyte/lg/interaction/menus/bedrock/BedrockGuildMemberRankConfirmationMenu.kt) — same bug on Bedrock

## Fix
Switch every name-display lookup to `Bukkit.getOfflinePlayer(uuid).name`, which resolves cached profiles for any guild member regardless of online status. The online-only `Bukkit.getPlayer(uuid)` lookup is kept exactly where it should be — deciding whether to push the "your rank changed" notification to the target, since you can only message online players.

This matches the pattern already used by every other guild member menu (`GuildMemberRankMenu`, `GuildKickMenu`, `GuildInfoMenu`, `GuildMemberManagementMenu`, etc.).

## Test plan
- [ ] Right-click an **offline** member's head in the member management menu → Promote/Demote → confirmation shows their real name everywhere (header, button lore, success message, skull).
- [ ] Same flow with an **online** member — name still resolves correctly.
- [ ] Online target receives the "Your rank in <guild> has been changed" notification message.
- [ ] Bedrock equivalent shows the real name in the form content and success message.

🤖 Generated with [Claude Code](https://claude.com/claude-code)