### PR TITLE
fix: PENDING alliance requests no longer render as accepted

### DIFF
--- a/src/main/kotlin/net/lumalyte/lg/infrastructure/placeholders/LumaGuildsExpansion.kt
+++ b/src/main/kotlin/net/lumalyte/lg/infrastructure/placeholders/LumaGuildsExpansion.kt
@@ -319,7 +319,9 @@ class LumaGuildsExpansion : PlaceholderExpansion(), KoinComponent {
         // Check relations between guilds
         try {
             val relation = relationService.getRelation(playerGuildId, otherGuildId)
-            if (relation != null) {
+            // Only render the indicator for active relations; a PENDING ally request must
+            // not be rendered as accepted, and an EXPIRED truce/enemy must not be rendered.
+            if (relation != null && relation.isActive()) {
                 return when (relation.type) {
                     net.lumalyte.lg.domain.entities.RelationType.ENEMY -> "🔴"  // Enemy/War
                     net.lumalyte.lg.domain.entities.RelationType.ALLY -> "🔵"   // Ally

--- a/src/main/kotlin/net/lumalyte/lg/interaction/menus/guild/GuildInfoMenu.kt
+++ b/src/main/kotlin/net/lumalyte/lg/interaction/menus/guild/GuildInfoMenu.kt
@@ -145,9 +145,10 @@ class GuildInfoMenu(private val menuNavigator: MenuNavigator, private val player
     private fun addRelationsSection(pane: StaticPane, x: Int, y: Int) {
         val relations = relationService.getGuildRelations(guild.id)
 
-        // Allies — filter out relations where the allied guild no longer exists (disbanded)
+        // Allies — filter out relations where the allied guild no longer exists (disbanded).
+        // Also gate on isActive() so PENDING alliance requests don't display as accepted.
         val allies = relations.filter {
-            it.type == RelationType.ALLY && guildService.getGuild(it.getOtherGuild(guild.id)) != null
+            it.type == RelationType.ALLY && it.isActive() && guildService.getGuild(it.getOtherGuild(guild.id)) != null
         }
         val alliesItem = ItemStack.of(Material.LIME_BANNER)
             .name("§aAllies (§f${allies.size}§a)")
@@ -166,9 +167,9 @@ class GuildInfoMenu(private val menuNavigator: MenuNavigator, private val player
 
         pane.addItem(GuiItem(alliesItem), x, y)
 
-        // Truces — filter out disbanded guilds
+        // Truces — filter out disbanded guilds; gate on isActive() so PENDING/EXPIRED don't show.
         val truces = relations.filter {
-            it.type == RelationType.TRUCE && guildService.getGuild(it.getOtherGuild(guild.id)) != null
+            it.type == RelationType.TRUCE && it.isActive() && guildService.getGuild(it.getOtherGuild(guild.id)) != null
         }
         val trucesItem = ItemStack.of(Material.WHITE_BANNER)
             .name("§fTruces (§f${truces.size}§f)")
@@ -187,9 +188,9 @@ class GuildInfoMenu(private val menuNavigator: MenuNavigator, private val player
 
         pane.addItem(GuiItem(trucesItem), x, y + 1)
 
-        // Enemies/Wars — filter out disbanded guilds
+        // Enemies/Wars — filter out disbanded guilds; gate on isActive() so EXPIRED don't show.
         val enemies = relations.filter {
-            it.type == RelationType.ENEMY && guildService.getGuild(it.getOtherGuild(guild.id)) != null
+            it.type == RelationType.ENEMY && it.isActive() && guildService.getGuild(it.getOtherGuild(guild.id)) != null
         }
         val enemiesItem = ItemStack.of(Material.RED_BANNER)
             .name("§cWars (§f${enemies.size}§c)")


### PR DESCRIPTION
## Bug
> when someone does /guild ally it gets auto accepted
> — Lav (May 5, 2026)

## Root cause
The relation backend is correct — `RelationServiceBukkit.requestAlliance` creates the relation in `RelationStatus.PENDING`, and only `acceptAlliance` flips it to `ACTIVE` (firing `GuildRelationChangeEvent`). The bug lives in the **display** paths that filter relations purely on `RelationType` and ignore `RelationStatus`. As soon as `/guild ally` runs, those displays render the new PENDING row as if it were an accepted alliance, which looks identical to "auto-accepted" from the player's seat.

Two sites still had this bug on `main`:

- [GuildInfoMenu.kt:148–193](src/main/kotlin/net/lumalyte/lg/interaction/menus/guild/GuildInfoMenu.kt#L148) — the **Allies / Truces / Wars** cards on the main guild info menu filtered relations by `type` only, so a PENDING alliance request appeared under "Allies" and incremented the count immediately.
- [LumaGuildsExpansion.kt:319–328](src/main/kotlin/net/lumalyte/lg/infrastructure/placeholders/LumaGuildsExpansion.kt#L319) — the PlaceholderAPI **relation-indicator** placeholder (🔵 ally / 🔴 enemy / ⚪ truce shown next to player names) returned the icon based on `relation.type` regardless of `relation.status`, so a PENDING request rendered 🔵 right away.

## Fix
Both sites now also gate on `Relation.isActive()`, which already encodes `status == ACTIVE && not expired`. PENDING/EXPIRED/REJECTED rows render as no relation, exactly as players expect until someone clicks accept.

The other relation display paths (`AlliesListMenu`, `EnemiesListMenu`, `GuildRelationsMenu`, `BedrockGuildRelationsMenu`, `CombatServiceBukkit`, `ModeServiceBukkit`, `GuildServiceBukkit.allyRelations`, `RelationRepositorySQLite.getByGuildAndType`) already gate on `isActive()` and were not touched.

## Note
This addresses the same root cause as the still-open [#22](https://github.com/BadgersMC/LumaGuilds/pull/22). Whichever lands first should be merged; the other can be closed.

## Test plan
- [ ] GuildA runs `/guild ally GuildB`; GuildA opens main guild info — Allies count shows **0**, no GuildB entry, until GuildB clicks accept.
- [ ] After GuildB accepts the request, GuildA's guild info shows GuildB under Allies (count = 1).
- [ ] PAPI indicator next to a player from GuildB shows **no icon** while the request is PENDING, and **🔵** only after acceptance.
- [ ] Existing already-active alliances/truces/wars still display correctly.
- [ ] Truce that has expired no longer renders as a truce.

🤖 Generated with [Claude Code](https://claude.com/claude-code)