### PR TITLE
fix: /guild sethome <name> can actually create additional named homes

### DIFF
--- a/src/main/kotlin/net/lumalyte/lg/interaction/commands/GuildCommand.kt
+++ b/src/main/kotlin/net/lumalyte/lg/interaction/commands/GuildCommand.kt
@@ -284,13 +284,18 @@ class GuildCommand : BaseCommand(), KoinComponent {
             }
         }
 
-        // Check if guild already has a home (separate from safety confirmation)
-        val currentHome = guildService.getHome(guild.id)
+        // Block only when the *named* home being set already exists. Looking up by guild.id
+        // alone returns the default ("main") home, which incorrectly blocked /g sethome <name>
+        // for any guild that had a main home and tricked players into overwriting main when
+        // they followed the "use /guild sethome confirm" hint.
+        val currentHome = guildService.getHome(guild.id, targetHomeName)
         if (currentHome != null && adjustedConfirm?.lowercase() != "confirm" && adjustedConfirm?.lowercase() != "unsafe") {
-            player.sendMessage("§c⚠️ Your guild already has a home set!")
-            player.sendMessage("§7Current home: §f${currentHome.position.x}, ${currentHome.position.y}, ${currentHome.position.z}")
+            val confirmCommand = if (adjustedHomeName != null) "/guild sethome $adjustedHomeName confirm" else "/guild sethome confirm"
+            val homeLabel = if (targetHomeName == "main") "main home" else "home '$targetHomeName'"
+            player.sendMessage("§c⚠️ Your guild already has a $homeLabel set!")
+            player.sendMessage("§7Current location: §f${currentHome.position.x}, ${currentHome.position.y}, ${currentHome.position.z}")
             player.sendMessage("§7New location: §f${location.blockX}, ${location.blockY}, ${location.blockZ}")
-            player.sendMessage("§7Use §6/guild sethome confirm §7to replace the current home")
+            player.sendMessage("§7Use §6$confirmCommand §7to replace it")
             player.sendMessage("§7Or use the guild menu for a confirmation dialog.")
             return
         }


### PR DESCRIPTION
## Bug
> It says we have 3 free slots, but you can only set up one (main one), tried to go around it and it removed our main home lol
> — Lav (May 5, 2026)

## Root cause
[GuildCommand.kt:288](src/main/kotlin/net/lumalyte/lg/interaction/commands/GuildCommand.kt#L288) — the early-exit "guild already has a home set" check in `onSetHome` looked up the existing home with `guildService.getHome(guild.id)`, which returns only the **default (`main`) home** regardless of what name the player typed:

- `/guild sethome shop` → `targetHomeName = "shop"`, but `getHome(guild.id)` finds the existing `main` home → command refuses with *"Your guild already has a home set!"* and suggests `/guild sethome confirm` to replace.
- `/guild sethome confirm` → the `confirm` keyword is parsed as the home-name positional, so `adjustedHomeName` becomes `null` and `targetHomeName` falls back to `"main"`. Result: the existing main home gets replaced, the `shop` home is never created.

The underlying `GuildServiceBukkit.setHome`, `GuildHomes.withHome`, and `getAvailableHomeSlots` already support multiple named homes correctly — only the command-layer guard was wrong. This is independent of the [#7](https://github.com/BadgersMC/LumaGuilds/pull/7) level-100 progression PR; PR #7 doesn't touch any home logic.

## Fix
Look up the existing home by the **target name** (`getHome(guild.id, targetHomeName)`) so only a name collision triggers the warning. Also include the home name in:

- The warning text (`"home 'shop'"` vs `"main home"`).
- The suggested confirm command (`/guild sethome shop confirm` vs `/guild sethome confirm`), so following the hint actually replaces the right home.

## Test plan
- [ ] Guild with main home only, ≥1 free slot — `/guild sethome shop` creates `shop` without warning. `/guild home shop` teleports there. `/guild home` still goes to main. (Regression check.)
- [ ] Guild with main + shop set — `/guild sethome shop` warns *"Your guild already has a home 'shop' set!"* and suggests `/guild sethome shop confirm`. Running that replaces just the `shop` home; main is untouched.
- [ ] Guild with main set — `/guild sethome` (no name) still warns about main and `/guild sethome confirm` still replaces main. (Regression check.)
- [ ] Trying to set a new named home with no free slots still fails at the service layer with the existing "max slots reached" path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)