### PR TITLE
fix: Guild Banner menu opens empty (no border, buttons, or banner slot)

### DIFF
--- a/src/main/kotlin/net/lumalyte/lg/interaction/listeners/BannerSelectionListener.kt
+++ b/src/main/kotlin/net/lumalyte/lg/interaction/listeners/BannerSelectionListener.kt
@@ -7,7 +7,9 @@ import org.bukkit.entity.Player
 import org.bukkit.event.EventHandler
 import org.bukkit.event.Listener
 import org.bukkit.event.inventory.InventoryClickEvent
+import org.bukkit.event.inventory.InventoryCloseEvent
 import org.bukkit.event.inventory.InventoryType
+import org.bukkit.event.player.PlayerQuitEvent
 import org.bukkit.inventory.ItemStack
 import org.koin.core.component.KoinComponent
 import org.koin.core.component.inject
@@ -23,9 +25,9 @@ class BannerSelectionListener : Listener, KoinComponent {
     fun onInventoryClick(event: InventoryClickEvent) {
         val player = event.whoClicked as? Player ?: return
 
-        // Secure check: Use custom holder instead of deprecated title
-        val holder = event.inventory?.holder
-        if (holder !is GuildBannerMenu.BannerMenuHolder) return
+        // Identify the banner menu via the per-player tracker — InventoryFramework owns
+        // the inventory holder, so a custom InventoryHolder cannot be attached.
+        if (!GuildBannerMenu.activeViewers.contains(player.uniqueId)) return
 
         // Only handle clicks in the top inventory (menu)
         if (event.clickedInventory?.type != InventoryType.CHEST) return
@@ -79,6 +81,17 @@ class BannerSelectionListener : Listener, KoinComponent {
         else if (isPlaceholderSlot) {
             event.isCancelled = true
         }
+    }
+
+    @EventHandler
+    fun onInventoryClose(event: InventoryCloseEvent) {
+        val player = event.player as? Player ?: return
+        GuildBannerMenu.activeViewers.remove(player.uniqueId)
+    }
+
+    @EventHandler
+    fun onPlayerQuit(event: PlayerQuitEvent) {
+        GuildBannerMenu.activeViewers.remove(event.player.uniqueId)
     }
 
     private fun isBanner(material: Material): Boolean {

--- a/src/main/kotlin/net/lumalyte/lg/interaction/menus/guild/GuildBannerMenu.kt
+++ b/src/main/kotlin/net/lumalyte/lg/interaction/menus/guild/GuildBannerMenu.kt
@@ -22,6 +22,8 @@ import org.bukkit.inventory.ItemStack
 import org.bukkit.persistence.PersistentDataType
 import org.koin.core.component.KoinComponent
 import org.koin.core.component.inject
+import java.util.UUID
+import java.util.concurrent.ConcurrentHashMap
 
 class GuildBannerMenu(private val menuNavigator: MenuNavigator, private val player: Player,
                      private var guild: Guild): Menu, KoinComponent {
@@ -32,22 +34,16 @@ class GuildBannerMenu(private val menuNavigator: MenuNavigator, private val play
     private val configService: ConfigService by inject()
     private val menuFactory: net.lumalyte.lg.interaction.menus.MenuFactory by inject()
 
-    // Custom inventory holder for secure identification
-    class BannerMenuHolder(val guildName: String) : org.bukkit.inventory.InventoryHolder {
-        private var inventory: org.bukkit.inventory.Inventory? = null
-
-        override fun getInventory(): org.bukkit.inventory.Inventory {
-            return inventory ?: throw IllegalStateException("Inventory not set")
-        }
-
-        fun setInventory(inv: org.bukkit.inventory.Inventory) {
-            inventory = inv
-        }
+    companion object {
+        // Tracks which players currently have the Java guild banner menu open. Used by
+        // BannerSelectionListener to identify banner-placement clicks without relying on
+        // InventoryHolder identity (InventoryFramework owns the holder) or the inventory
+        // title (deprecated and exploit-prone).
+        val activeViewers: MutableSet<UUID> = ConcurrentHashMap.newKeySet()
     }
 
     override fun open() {
-        // Create secure custom holder to prevent title-based exploits
-        val holder = BannerMenuHolder(guild.name)
+        activeViewers.add(player.uniqueId)
 
         // Create a 3x9 GUI for banner selection
         val gui = ChestGui(3, "§6Guild Banner - ${guild.name}")
@@ -64,9 +60,6 @@ class GuildBannerMenu(private val menuNavigator: MenuNavigator, private val play
                 guiEvent.isCancelled = true
             }
         }
-
-        // Set the holder on the inventory
-        holder.setInventory(gui.getInventory())
 
         // Add banner selection slot at the position matching the visual border (2,1 = slot 11)
         addBannerSelectionSlot(pane, 2, 1)


### PR DESCRIPTION
## Bug
> Guild banner panel is empty — it's literally just empty there's nothing there or nothing you can do with it. In beta there was like a thing saying to put your banner in a certain spot.

Screenshot from report: 3-row chest titled \`Guild Banner - test\`, all 27 slots empty.

## Root cause

Two layered bugs in [GuildBannerMenu.kt](src/main/kotlin/net/lumalyte/lg/interaction/menus/guild/GuildBannerMenu.kt) and [BannerSelectionListener.kt](src/main/kotlin/net/lumalyte/lg/interaction/listeners/BannerSelectionListener.kt):

**1. Empty menu** — \`open()\` called \`holder.setInventory(gui.getInventory())\` before any panes were added. \`gui.getInventory()\` lazily creates the Bukkit inventory the first time it's called. InventoryFramework 0.11.6's \`ChestGui.show()\` only calls \`update()\` (which actually renders panes into the inventory) when the inventory is still null:

\`\`\`java
public void show(@NotNull HumanEntity humanEntity) {
    if (super.inventory == null) {
        update();
    }
    populateBottomInventory(humanEntity);
    humanEntity.openInventory(getInventory());
}
\`\`\`

Because we'd already forced creation, \`update()\` was skipped and the inventory opened blank.

**2. Placement listener never fired** — the \`BannerMenuHolder\` that line was trying to attach was never actually used by InventoryFramework. \`ChestGui.createInventory()\` always uses the \`ChestGui\` itself as the InventoryHolder:

\`\`\`java
@Override
public Inventory createInventory() {
    return getTitleHolder().asInventoryTitle(this, getRows() * 9);
}
\`\`\`

So \`BannerSelectionListener\`'s \`holder is BannerMenuHolder\` check had been silently failing on every click since it was introduced. That's the \"nothing you can do with it\" part — even after the menu rendered, slot 11 placement logic, single-banner clamping, and the \"Banner placed!\" message weren't running.

## Fix

- Remove the broken \`BannerMenuHolder\` class and the premature \`gui.getInventory()\` call from \`GuildBannerMenu.open()\`. Items now render.
- Replace the holder identity check with a \`companion object\` \`activeViewers: MutableSet<UUID>\` (ConcurrentHashMap-backed). Populated on \`open()\`, cleared on \`InventoryCloseEvent\` and \`PlayerQuitEvent\` from the same listener. Identifies the menu without relying on IF-owned holder identity or deprecated title strings.

## Test plan
- [ ] Open \`/guild settings\` → Banner. Border, current-banner display, placeholder banner slot (slot 11), Clear, Apply Changes, Get Banner Copy, Back all visible.
- [ ] Place a banner in slot 11 — single banner stays in slot, cursor is decremented, \"Banner placed!\" message appears.
- [ ] Click Apply Changes — banner saved to guild, returned to player inventory, menu closes.
- [ ] Click Clear Banner — banner cleared, menu refreshes.
- [ ] Click Back — returns to control panel.
- [ ] Open menu, close inventory (Esc) — \`activeViewers\` cleared (re-open works fresh).
- [ ] Open menu, disconnect — \`activeViewers\` cleared on quit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced banner menu tracking with improved per-player validation
  * Added automatic cleanup when players close banner menus or disconnect from the server

<!-- end of auto-generated comment: release notes by coderabbit.ai -->