### PR TITLE
feat: overhaul ally homes, hide coords, offline kick, ally chat

### DIFF
--- a/src/main/kotlin/net/lumalyte/lg/interaction/commands/GuildCommand.kt
+++ b/src/main/kotlin/net/lumalyte/lg/interaction/commands/GuildCommand.kt
@@ -452,12 +452,22 @@ class GuildCommand : BaseCommand(), KoinComponent {
         }
 
         val guild = guilds.first()
-        val success = guildService.removeHome(guild.id, homeName, playerId)
-        if (success) {
-            player.sendMessage("§a✅ Home '$homeName' removed.")
-        } else {
-            player.sendMessage("§c❌ Failed to remove home '$homeName'. It may not exist or you lack permission.")
+        if (guildService.getHome(guild.id, homeName) == null) {
+            player.sendMessage("§c❌ Home '$homeName' does not exist.")
+            return
         }
+
+        val menuNavigator = MenuNavigator(player)
+        menuNavigator.openMenu(net.lumalyte.lg.interaction.menus.common.ConfirmationMenu(
+            menuNavigator, player, "§cRemove home '$homeName'?"
+        ) {
+            val success = guildService.removeHome(guild.id, homeName, playerId)
+            if (success) {
+                player.sendMessage("§a✅ Home '$homeName' removed.")
+            } else {
+                player.sendMessage("§c❌ Failed to remove home '$homeName'.")
+            }
+        })
     }
 
     @Subcommand("setallyhome")
@@ -1239,6 +1249,13 @@ class GuildCommand : BaseCommand(), KoinComponent {
 
             if (targetMember.playerId == playerId) {
                 player.sendMessage("§cYou cannot kick yourself.")
+                return
+            }
+
+            val kickerRank = rankService.getPlayerRank(playerId, guild.id)
+            val targetRank = rankService.getPlayerRank(targetMember.playerId, guild.id)
+            if (kickerRank == null || targetRank == null || targetRank.priority <= kickerRank.priority) {
+                player.sendMessage("§c❌ You cannot kick a member of equal or higher rank.")
                 return
             }
 

--- a/src/main/kotlin/net/lumalyte/lg/interaction/listeners/GuildChatListener.kt
+++ b/src/main/kotlin/net/lumalyte/lg/interaction/listeners/GuildChatListener.kt
@@ -72,7 +72,7 @@ class GuildChatListener : Listener, KoinComponent {
             return false
         }
 
-        if (current != null) previousChannelId[player.uniqueId] = current.id
+        if (current != null && current.id != allyChannelId) previousChannelId[player.uniqueId] = current.id
         rose.switchChannel(guildChannel)
         return true
     }
@@ -105,7 +105,7 @@ class GuildChatListener : Listener, KoinComponent {
             return false
         }
 
-        if (current != null) previousChannelId[player.uniqueId] = current.id
+        if (current != null && current.id != guildChannelId) previousChannelId[player.uniqueId] = current.id
         rose.switchChannel(allyChannel)
         return true
     }


### PR DESCRIPTION
## Summary
- **Hide coordinates everywhere** — removed x/y/z from all menus, commands, and chat messages (world name still shown)
- **Explicit ally homes** — allies no longer teleport to regular guild homes; guilds must set a dedicated ally home via `/guild setallyhome`. Added `allyHome` field to Guild entity with DB migration
- **`/guild removehome <name>`** — new command to remove a specific home by name (service already existed, command was missing)
- **Offline kick support** — `/guild kick` now resolves offline players from the guild member list instead of requiring them to be online
- **Tab completions** — registered `@guilds` (all guild names), `@guildmembers` (all members including offline), `@guildhomes` (home names) for proper tab completion
- **`/g allychat`** — toggle into the RoseChat `guild-ally` channel, mirrors `/g chat` behavior

## Test plan
- [ ] Open guild home menu → no coordinates shown in any lore or chat
- [ ] Run `/guild homes` → world names only, no coords
- [ ] Run `/guild setallyhome` → sets explicit ally home
- [ ] Allied guild sees ally home in menu, can teleport to it (not regular home)
- [ ] Run `/guild removehome main` → home removed, tab completes home names
- [ ] Have a player go offline, run `/guild kick <name>` → kicked successfully
- [ ] Tab complete `/guild ally ` → shows all guild names
- [ ] Tab complete `/guild kick ` → shows all guild members (online + offline)
- [ ] Run `/g allychat` → toggles into ally channel, run again → toggles back

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added ally home management with `/guild setallyhome` and `/guild removeallyhome` commands
  * Added `/guild allychat` command to toggle ally-only chat mode
  * Added `/guild removehome` command for removing named homes
  * Enhanced command tab completions for guild members, guilds, and homes
  * Improved `/guild kick` to support offline members

* **Improvements**
  * Refactored guild chat system with better chat integration
  * Simplified home display in menus—shows generic confirmation instead of coordinates
  * Enhanced guild tag display with multiple formatting options

<!-- end of auto-generated comment: release notes by coderabbit.ai -->