### PR TITLE
fix: persist non-default guild homes across restarts

### DIFF
--- a/schema.sql
+++ b/schema.sql
@@ -1,7 +1,7 @@
 -- =====================================
 -- LumaGuilds MariaDB Schema
 -- Complete database schema for production use
--- Version: 0.5.3 (Schema v15)
+-- Version: 0.5.3 (Schema v19)
 -- =====================================
 
 -- Create schema version table
@@ -9,15 +9,18 @@ CREATE TABLE IF NOT EXISTS schema_version (
     version INT PRIMARY KEY
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
 
--- Set schema version to 15
+-- Set schema version to 19
 DELETE FROM schema_version;
-INSERT INTO schema_version (version) VALUES (15);
+INSERT INTO schema_version (version) VALUES (19);
 
 -- =====================================
 -- Core Guild Tables
 -- =====================================
 
 -- Guilds table (main guild data)
+-- Note: home_world/home_x/home_y/home_z are legacy single-home columns retained for
+-- backward compatibility. The authoritative store for guild homes is the `guild_homes`
+-- table (added in v19), which supports multiple named homes per guild.
 CREATE TABLE IF NOT EXISTS guilds (
     id VARCHAR(36) PRIMARY KEY,
     name VARCHAR(255) NOT NULL UNIQUE,
@@ -46,6 +49,21 @@ CREATE TABLE IF NOT EXISTS guilds (
     INDEX idx_guilds_name (name),
     INDEX idx_guilds_mode (mode),
     INDEX idx_guilds_level (level)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+
+-- Guild homes table (v19)
+-- Stores all named homes for each guild. Replaces the single-home `guilds.home_*` columns
+-- as the authoritative source while those columns are retained for backward compatibility.
+CREATE TABLE IF NOT EXISTS guild_homes (
+    guild_id VARCHAR(36) NOT NULL,
+    name VARCHAR(64) NOT NULL,
+    world_id VARCHAR(36) NOT NULL,
+    x INT NOT NULL,
+    y INT NOT NULL,
+    z INT NOT NULL,
+    PRIMARY KEY (guild_id, name),
+    FOREIGN KEY (guild_id) REFERENCES guilds(id) ON DELETE CASCADE,
+    INDEX idx_guild_homes_guild_id (guild_id)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
 
 -- Ranks table (guild ranks/roles)

--- a/src/main/kotlin/net/lumalyte/lg/infrastructure/persistence/guilds/GuildRepositorySQLite.kt
+++ b/src/main/kotlin/net/lumalyte/lg/infrastructure/persistence/guilds/GuildRepositorySQLite.kt
@@ -53,6 +53,7 @@ class GuildRepositorySQLite(private val storage: Storage<Database>) : GuildRepos
 
     init {
         createGuildTable()
+        createGuildHomesTable()
         migrateTrackingColumn()
         migrateBankFrozenColumn()
         preload()
@@ -118,6 +119,35 @@ class GuildRepositorySQLite(private val storage: Storage<Database>) : GuildRepos
         }
     }
     
+    /**
+     * Creates the `guild_homes` table if it doesn't exist. This is the primary store
+     * for guild homes (introduced in schema v19); the legacy `guilds.home_*` columns
+     * remain in place as a single-home fallback for one release.
+     */
+    private fun createGuildHomesTable() {
+        val sql = """
+            CREATE TABLE IF NOT EXISTS guild_homes (
+                guild_id TEXT NOT NULL,
+                name TEXT NOT NULL,
+                world_id TEXT NOT NULL,
+                x INTEGER NOT NULL,
+                y INTEGER NOT NULL,
+                z INTEGER NOT NULL,
+                PRIMARY KEY (guild_id, name),
+                FOREIGN KEY (guild_id) REFERENCES guilds(id) ON DELETE CASCADE
+            );
+        """.trimIndent()
+
+        try {
+            storage.connection.executeUpdate(sql)
+            storage.connection.executeUpdate(
+                "CREATE INDEX IF NOT EXISTS idx_guild_homes_guild_id ON guild_homes(guild_id)"
+            )
+        } catch (e: SQLException) {
+            throw DatabaseOperationException("Failed to create guild_homes table", e)
+        }
+    }
+
     private fun migrateTrackingColumn() {
         // Always attempt ALTER TABLE; catch "duplicate column" silently so re-runs are safe.
         try {
@@ -150,19 +180,87 @@ class GuildRepositorySQLite(private val storage: Storage<Database>) : GuildRepos
 
     private fun preload() {
         val sql = "SELECT * FROM guilds"
-        
+
         try {
+            // Pre-load every guild's homes from guild_homes in a single pass to avoid
+            // N+1 queries during startup.
+            val homesByGuild = loadAllGuildHomes()
+
             val results = storage.connection.getResults(sql)
             for (result in results) {
-                val guild = mapResultSetToGuild(result)
+                val guild = mapResultSetToGuild(result, homesByGuild)
                 guilds[guild.id] = guild
             }
         } catch (e: SQLException) {
             throw DatabaseOperationException("Failed to preload guilds", e)
         }
     }
-    
-    private fun mapResultSetToGuild(rs: co.aikar.idb.DbRow): Guild {
+
+    /**
+     * Loads every row from `guild_homes` and groups them by guild id. Returns an empty
+     * map if the table doesn't exist (e.g. someone is running this build against an
+     * un-migrated DB) — `mapResultSetToGuild` will fall back to the legacy columns.
+     */
+    private fun loadAllGuildHomes(): Map<UUID, GuildHomes> {
+        val byGuild = mutableMapOf<UUID, MutableMap<String, GuildHome>>()
+        try {
+            val rows = storage.connection.getResults(
+                "SELECT guild_id, name, world_id, x, y, z FROM guild_homes"
+            )
+            for (row in rows) {
+                val guildId = UUID.fromString(row.getString("guild_id"))
+                val homeName = row.getString("name")
+                val worldId = UUID.fromString(row.getString("world_id"))
+                val x = row.getInt("x")
+                val y = row.getInt("y")
+                val z = row.getInt("z")
+                val home = GuildHome(worldId, net.lumalyte.lg.domain.values.Position3D(x, y, z))
+                byGuild.getOrPut(guildId) { mutableMapOf() }[homeName] = home
+            }
+        } catch (e: SQLException) {
+            // Table may not exist on a freshly upgraded plugin running against a stale DB.
+            // Fall back to legacy columns by returning an empty map.
+            println("WARN [GuildRepositorySQLite] guild_homes preload failed (continuing with legacy columns): ${e.message}")
+            return emptyMap()
+        }
+        return byGuild.mapValues { (_, m) -> GuildHomes(m.toMap()) }
+    }
+
+    /**
+     * Replaces all rows for the given guild in `guild_homes` with the entries from
+     * the in-memory model. Called from `add` and `update` after the legacy columns
+     * have been written, so failure here is logged but not propagated — the legacy
+     * columns still hold the default home as a fallback.
+     */
+    private fun writeGuildHomes(guild: Guild) {
+        try {
+            storage.connection.executeUpdate(
+                "DELETE FROM guild_homes WHERE guild_id = ?",
+                guild.id.toString()
+            )
+            for ((homeName, home) in guild.homes.homes) {
+                storage.connection.executeUpdate(
+                    """
+                    INSERT INTO guild_homes (guild_id, name, world_id, x, y, z)
+                    VALUES (?, ?, ?, ?, ?, ?)
+                    """.trimIndent(),
+                    guild.id.toString(),
+                    homeName,
+                    home.worldId.toString(),
+                    home.position.x,
+                    home.position.y,
+                    home.position.z
+                )
+            }
+        } catch (e: SQLException) {
+            println("WARN [GuildRepositorySQLite] Failed to persist guild_homes for ${guild.id}: ${e.message}")
+        }
+    }
+
+    private fun mapResultSetToGuild(
+        rs: co.aikar.idb.DbRow,
+        homesByGuild: Map<UUID, GuildHomes> = emptyMap()
+    ): Guild {
         val id = UUID.fromString(rs.getString("id"))
         val name = rs.getString("name")
         val banner = rs.getString("banner")
@@ -174,15 +272,21 @@ class GuildRepositorySQLite(private val storage: Storage<Database>) : GuildRepos
         val modeChangedAt = rs.getInstant("mode_changed_at")
         val createdAt = rs.getInstantNotNull("created_at")
 
-        val homes = if (rs.getString("home_world") != null) {
-            val worldId = UUID.fromString(rs.getString("home_world"))
-            val x = rs.getInt("home_x")
-            val y = rs.getInt("home_y")
-            val z = rs.getInt("home_z")
-            val mainHome = GuildHome(worldId, net.lumalyte.lg.domain.values.Position3D(x, y, z))
-            GuildHomes(mapOf("main" to mainHome))
-        } else {
-            GuildHomes.EMPTY
+        // Prefer rows from the new `guild_homes` table (supports multiple named homes).
+        // Fall back to the legacy `guilds.home_*` columns when no rows exist for this guild,
+        // mapping the legacy single home to the name "main" for backward compatibility.
+        val preloadedHomes = homesByGuild[id]
+        val homes = when {
+            preloadedHomes != null && preloadedHomes.hasHomes() -> preloadedHomes
+            rs.getString("home_world") != null -> {
+                val worldId = UUID.fromString(rs.getString("home_world"))
+                val x = rs.getInt("home_x")
+                val y = rs.getInt("home_y")
+                val z = rs.getInt("home_z")
+                val mainHome = GuildHome(worldId, net.lumalyte.lg.domain.values.Position3D(x, y, z))
+                GuildHomes(mapOf("main" to mainHome))
+            }
+            else -> GuildHomes.EMPTY
         }
 
         // Parse vault status
@@ -431,7 +535,11 @@ class GuildRepositorySQLite(private val storage: Storage<Database>) : GuildRepos
                     guild.createdAt.toSqlDateTime()
                 )
             }
-            guilds[guild.id] = guild
+            if (rowsAffected > 0) {
+                // Persist the full named-home map; legacy home_* columns above only cover the default home.
+                writeGuildHomes(guild)
+                guilds[guild.id] = guild
+            }
             rowsAffected > 0
         } catch (e: SQLException) {
             false
@@ -614,6 +722,8 @@ class GuildRepositorySQLite(private val storage: Storage<Database>) : GuildRepos
             println("  rows affected: $rowsAffected")
 
             if (rowsAffected > 0) {
+                // Persist the full named-home map; legacy home_* columns above only cover the default home.
+                writeGuildHomes(guild)
                 guilds[guild.id] = guild
             }
             rowsAffected > 0
@@ -623,7 +733,7 @@ class GuildRepositorySQLite(private val storage: Storage<Database>) : GuildRepos
             false
         }
     }
-    
+
     override fun remove(guildId: UUID): Boolean {
         val sql = "DELETE FROM guilds WHERE id = ?"
         

--- a/src/main/kotlin/net/lumalyte/lg/infrastructure/persistence/migrations/MariaDBMigrations.kt
+++ b/src/main/kotlin/net/lumalyte/lg/infrastructure/persistence/migrations/MariaDBMigrations.kt
@@ -34,6 +34,11 @@ class MariaDBMigrations(private val plugin: JavaPlugin, private val connection: 
                 updateDatabaseVersion(18)
                 currentDbVersion = 18
             }
+            if (currentDbVersion < 19) {
+                migrateToVersion19()
+                updateDatabaseVersion(19)
+                currentDbVersion = 19
+            }
 
             connection.commit()
 
@@ -512,6 +517,45 @@ class MariaDBMigrations(private val plugin: JavaPlugin, private val connection: 
             } else {
                 componentLogger.info(Component.text("✓ All Owner ranks already have shop permissions (migration v18)"))
             }
+        }
+    }
+
+    /**
+     * Migration from version 18 to version 19.
+     *
+     * Introduces the `guild_homes` table so guilds can persist multiple named homes,
+     * not just the single home stored in `guilds.home_*` columns. Backfills the new
+     * table from existing legacy columns as the home named "main". See SQLiteMigrations
+     * for the full bug history.
+     */
+    private fun migrateToVersion19() {
+        componentLogger.info(Component.text("Migrating to version 19: Adding guild_homes table for multiple named homes..."))
+
+        connection.createStatement().use { stmt ->
+            stmt.execute("""
+                CREATE TABLE IF NOT EXISTS guild_homes (
+                    guild_id VARCHAR(36) NOT NULL,
+                    name VARCHAR(64) NOT NULL,
+                    world_id VARCHAR(36) NOT NULL,
+                    x INT NOT NULL,
+                    y INT NOT NULL,
+                    z INT NOT NULL,
+                    PRIMARY KEY (guild_id, name),
+                    FOREIGN KEY (guild_id) REFERENCES guilds(id) ON DELETE CASCADE,
+                    INDEX idx_guild_homes_guild_id (guild_id)
+                ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci
+            """.trimIndent())
+
+            val rows = stmt.executeUpdate("""
+                INSERT IGNORE INTO guild_homes (guild_id, name, world_id, x, y, z)
+                SELECT id, 'main', home_world, home_x, home_y, home_z
+                FROM guilds
+                WHERE home_world IS NOT NULL
+                  AND home_x IS NOT NULL
+                  AND home_y IS NOT NULL
+                  AND home_z IS NOT NULL
+            """.trimIndent())
+            componentLogger.info(Component.text("✓ guild_homes table created; backfilled $rows existing 'main' homes"))
         }
     }
 }

--- a/src/main/kotlin/net/lumalyte/lg/infrastructure/persistence/migrations/SQLiteMigrations.kt
+++ b/src/main/kotlin/net/lumalyte/lg/infrastructure/persistence/migrations/SQLiteMigrations.kt
@@ -109,6 +109,11 @@ class SQLiteMigrations(private val plugin: JavaPlugin, private val connection: C
                 updateDatabaseVersion(18)
                 dbVersion = 18
             }
+            if (dbVersion < 19) {
+                migrateToVersion19()
+                updateDatabaseVersion(19)
+                dbVersion = 19
+            }
 
             // Validate that all required tables exist, recreate if missing
             validateAndRepairSchema()
@@ -1225,12 +1230,63 @@ class SQLiteMigrations(private val plugin: JavaPlugin, private val connection: C
     }
 
     /**
+     * Migration from version 18 to version 19.
+     *
+     * Fixes the long-standing bug where non-"main" guild homes were silently dropped
+     * on every save and wiped on restart. Previously, guilds had a `homes: Map<String, GuildHome>`
+     * domain model but only a single set of `home_world/home_x/home_y/home_z` columns on the
+     * `guilds` table, so the repository extracted `defaultHome` and discarded the rest.
+     *
+     * v19 introduces a `guild_homes` table keyed by `(guild_id, name)` that can hold every
+     * named home a guild has, and backfills it from the existing legacy columns (mapped as
+     * the home named "main"). The legacy `guilds.home_*` columns are left in place for one
+     * release for backward compatibility — the repository keeps writing the default home to
+     * them on update so older builds can still read at least one home.
+     */
+    private fun migrateToVersion19() {
+        componentLogger.info(Component.text("Migrating to version 19: Adding guild_homes table for multiple named homes..."))
+
+        val sqlCommands = mutableListOf(
+            """
+            CREATE TABLE IF NOT EXISTS guild_homes (
+                guild_id TEXT NOT NULL,
+                name TEXT NOT NULL,
+                world_id TEXT NOT NULL,
+                x INTEGER NOT NULL,
+                y INTEGER NOT NULL,
+                z INTEGER NOT NULL,
+                PRIMARY KEY (guild_id, name),
+                FOREIGN KEY (guild_id) REFERENCES guilds(id) ON DELETE CASCADE
+            )
+            """.trimIndent(),
+            "CREATE INDEX IF NOT EXISTS idx_guild_homes_guild_id ON guild_homes(guild_id);"
+        )
+        executeMigrationCommands(sqlCommands)
+
+        // Backfill: copy existing main homes from guilds.home_* into guild_homes as name='main'.
+        val backfill = """
+            INSERT OR IGNORE INTO guild_homes (guild_id, name, world_id, x, y, z)
+            SELECT id, 'main', home_world, home_x, home_y, home_z
+            FROM guilds
+            WHERE home_world IS NOT NULL
+              AND home_x IS NOT NULL
+              AND home_y IS NOT NULL
+              AND home_z IS NOT NULL
+        """.trimIndent()
+
+        connection.createStatement().use { stmt ->
+            val rows = stmt.executeUpdate(backfill)
+            componentLogger.info(Component.text("✓ guild_homes table created; backfilled $rows existing 'main' homes"))
+        }
+    }
+
+    /**
      * Validates that all required tables exist and recreates them if missing.
      * This handles cases where the schema version is correct but tables are missing.
      */
     private fun validateAndRepairSchema() {
         val requiredTables = mutableListOf(
-            "guilds", "members", "relations", "parties", "party_requests",
+            "guilds", "guild_homes", "members", "relations", "parties", "party_requests",
             "player_party_preferences", "bank_tx", "kills",
             "audits", "wars", "leaderboards", "guild_invitations",
             "vault_slots", "vault_gold", "vault_transaction_log"
@@ -1268,6 +1324,10 @@ class SQLiteMigrations(private val plugin: JavaPlugin, private val connection: C
             if ("vault_slots" in missingTables || "vault_gold" in missingTables || "vault_transaction_log" in missingTables) {
                 migrateToVersion12()
                 componentLogger.info(Component.text("✓ Recreated vault system tables"))
+            }
+            if ("guild_homes" in missingTables) {
+                migrateToVersion19()
+                componentLogger.info(Component.text("✓ Recreated guild_homes table"))
             }
             // Recreate claim tables if missing (only checked when claims enabled)
             if (claimsEnabled && missingTables.any { it in listOf("claims", "claim_partitions", "claim_flags", "claim_permissions", "player_access") }) {

--- a/src/test/kotlin/net/lumalyte/lg/infrastructure/persistence/migrations/GuildHomesMigrationTest.kt
+++ b/src/test/kotlin/net/lumalyte/lg/infrastructure/persistence/migrations/GuildHomesMigrationTest.kt
@@ -1,0 +1,356 @@
+package net.lumalyte.lg.infrastructure.persistence.migrations
+
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.Assertions.*
+import org.junit.jupiter.api.io.TempDir
+import java.io.File
+import java.nio.file.Path
+import java.sql.Connection
+import java.sql.DriverManager
+import java.util.UUID
+
+/**
+ * Tests for database migration v19 which introduces the `guild_homes` table for
+ * persisting multiple named homes per guild.
+ *
+ * Before v19, `Guild.homes: Map<String, GuildHome>` was flattened to the single
+ * `guilds.home_*` column set on every save, dropping every home that wasn't the default.
+ * The non-default homes survived in memory until the next restart and then vanished.
+ *
+ * These tests pin down: the table exists after migration, existing single homes are
+ * backfilled as `name = 'main'`, multiple homes per guild round-trip through SQL, and
+ * the migration is idempotent.
+ */
+class GuildHomesMigrationTest {
+
+    @TempDir
+    lateinit var tempDir: Path
+
+    private lateinit var sqliteFile: File
+    private lateinit var connection: Connection
+
+    @BeforeEach
+    fun setUp() {
+        sqliteFile = tempDir.resolve("test.db").toFile()
+        connection = DriverManager.getConnection("jdbc:sqlite:${sqliteFile.absolutePath}")
+        connection.autoCommit = true
+        // Foreign keys are off by default in SQLite; turn them on so the FK behaves like prod.
+        connection.createStatement().use { it.execute("PRAGMA foreign_keys = ON") }
+    }
+
+    @AfterEach
+    fun tearDown() {
+        connection.close()
+    }
+
+    @Test
+    fun `migration v19 creates guild_homes table`() {
+        createGuildsTableV18()
+
+        migrateToV19()
+
+        assertTrue(tableExists("guild_homes"), "guild_homes table should exist after migration")
+    }
+
+    @Test
+    fun `migration v19 backfills existing main home from legacy columns`() {
+        // Given a v18 guild with the legacy home columns populated
+        createGuildsTableV18()
+        val guildId = UUID.randomUUID()
+        val worldId = UUID.randomUUID()
+        connection.createStatement().use { stmt ->
+            stmt.execute(
+                """
+                INSERT INTO guilds (id, name, level, bank_balance, mode, created_at,
+                                    home_world, home_x, home_y, home_z)
+                VALUES ('$guildId', 'OldGuild', 1, 0, 'Hostile', datetime('now'),
+                        '$worldId', 100, 64, -200)
+                """.trimIndent()
+            )
+        }
+
+        // When we run the v19 migration
+        migrateToV19()
+
+        // Then the legacy home is now in guild_homes as 'main'
+        connection.prepareStatement(
+            "SELECT name, world_id, x, y, z FROM guild_homes WHERE guild_id = ?"
+        ).use { stmt ->
+            stmt.setString(1, guildId.toString())
+            stmt.executeQuery().use { rs ->
+                assertTrue(rs.next(), "Backfilled home row should exist")
+                assertEquals("main", rs.getString("name"))
+                assertEquals(worldId.toString(), rs.getString("world_id"))
+                assertEquals(100, rs.getInt("x"))
+                assertEquals(64, rs.getInt("y"))
+                assertEquals(-200, rs.getInt("z"))
+                assertFalse(rs.next(), "Should be exactly one backfilled row per guild")
+            }
+        }
+    }
+
+    @Test
+    fun `migration v19 does not backfill when legacy columns are null`() {
+        // Given a v18 guild with no home set
+        createGuildsTableV18()
+        val guildId = UUID.randomUUID()
+        connection.createStatement().use { stmt ->
+            stmt.execute(
+                """
+                INSERT INTO guilds (id, name, level, bank_balance, mode, created_at)
+                VALUES ('$guildId', 'NoHomeGuild', 1, 0, 'Hostile', datetime('now'))
+                """.trimIndent()
+            )
+        }
+
+        migrateToV19()
+
+        connection.prepareStatement(
+            "SELECT COUNT(*) FROM guild_homes WHERE guild_id = ?"
+        ).use { stmt ->
+            stmt.setString(1, guildId.toString())
+            stmt.executeQuery().use { rs ->
+                assertTrue(rs.next())
+                assertEquals(0, rs.getInt(1), "No row should be backfilled when legacy home is null")
+            }
+        }
+    }
+
+    @Test
+    fun `guild_homes round-trips multiple named homes per guild`() {
+        // Given a migrated DB with one guild
+        createGuildsTableV18()
+        migrateToV19()
+        val guildId = UUID.randomUUID()
+        connection.createStatement().use { stmt ->
+            stmt.execute(
+                """
+                INSERT INTO guilds (id, name, level, bank_balance, mode, created_at)
+                VALUES ('$guildId', 'MultiHomeGuild', 1, 0, 'Hostile', datetime('now'))
+                """.trimIndent()
+            )
+        }
+
+        // When we insert several named homes
+        val world = UUID.randomUUID().toString()
+        connection.prepareStatement(
+            "INSERT INTO guild_homes (guild_id, name, world_id, x, y, z) VALUES (?, ?, ?, ?, ?, ?)"
+        ).use { stmt ->
+            listOf(
+                Triple("main", 0, 64),
+                Triple("farm", 100, 70),
+                Triple("nether", -2000, 30)
+            ).forEach { (name, x, y) ->
+                stmt.setString(1, guildId.toString())
+                stmt.setString(2, name)
+                stmt.setString(3, world)
+                stmt.setInt(4, x)
+                stmt.setInt(5, y)
+                stmt.setInt(6, 0)
+                stmt.executeUpdate()
+            }
+        }
+
+        // Then all three round-trip
+        val readBack = mutableMapOf<String, Triple<Int, Int, Int>>()
+        connection.prepareStatement(
+            "SELECT name, x, y, z FROM guild_homes WHERE guild_id = ? ORDER BY name"
+        ).use { stmt ->
+            stmt.setString(1, guildId.toString())
+            stmt.executeQuery().use { rs ->
+                while (rs.next()) {
+                    readBack[rs.getString("name")] =
+                        Triple(rs.getInt("x"), rs.getInt("y"), rs.getInt("z"))
+                }
+            }
+        }
+        assertEquals(3, readBack.size)
+        assertEquals(Triple(0, 64, 0), readBack["main"])
+        assertEquals(Triple(100, 70, 0), readBack["farm"])
+        assertEquals(Triple(-2000, 30, 0), readBack["nether"])
+    }
+
+    @Test
+    fun `guild_homes primary key prevents duplicate names within a guild`() {
+        createGuildsTableV18()
+        migrateToV19()
+        val guildId = UUID.randomUUID()
+        connection.createStatement().use { stmt ->
+            stmt.execute(
+                """
+                INSERT INTO guilds (id, name, level, bank_balance, mode, created_at)
+                VALUES ('$guildId', 'DupGuild', 1, 0, 'Hostile', datetime('now'))
+                """.trimIndent()
+            )
+        }
+        val world = UUID.randomUUID().toString()
+
+        // First insert succeeds
+        connection.prepareStatement(
+            "INSERT INTO guild_homes (guild_id, name, world_id, x, y, z) VALUES (?, ?, ?, ?, ?, ?)"
+        ).use { stmt ->
+            stmt.setString(1, guildId.toString())
+            stmt.setString(2, "main")
+            stmt.setString(3, world)
+            stmt.setInt(4, 0)
+            stmt.setInt(5, 64)
+            stmt.setInt(6, 0)
+            stmt.executeUpdate()
+        }
+
+        // Duplicate (guild_id, name) is rejected
+        assertThrows(java.sql.SQLException::class.java) {
+            connection.prepareStatement(
+                "INSERT INTO guild_homes (guild_id, name, world_id, x, y, z) VALUES (?, ?, ?, ?, ?, ?)"
+            ).use { stmt ->
+                stmt.setString(1, guildId.toString())
+                stmt.setString(2, "main")
+                stmt.setString(3, world)
+                stmt.setInt(4, 1)
+                stmt.setInt(5, 65)
+                stmt.setInt(6, 1)
+                stmt.executeUpdate()
+            }
+        }
+    }
+
+    @Test
+    fun `migration v19 is idempotent`() {
+        createGuildsTableV18()
+        val guildId = UUID.randomUUID()
+        val worldId = UUID.randomUUID()
+        connection.createStatement().use { stmt ->
+            stmt.execute(
+                """
+                INSERT INTO guilds (id, name, level, bank_balance, mode, created_at,
+                                    home_world, home_x, home_y, home_z)
+                VALUES ('$guildId', 'IdemGuild', 1, 0, 'Hostile', datetime('now'),
+                        '$worldId', 1, 2, 3)
+                """.trimIndent()
+            )
+        }
+
+        migrateToV19()
+        migrateToV19() // second run must not throw or duplicate the backfill row
+
+        connection.prepareStatement(
+            "SELECT COUNT(*) FROM guild_homes WHERE guild_id = ?"
+        ).use { stmt ->
+            stmt.setString(1, guildId.toString())
+            stmt.executeQuery().use { rs ->
+                assertTrue(rs.next())
+                assertEquals(1, rs.getInt(1), "Backfill must be idempotent (INSERT OR IGNORE)")
+            }
+        }
+    }
+
+    @Test
+    fun `removing a guild cascade-deletes its homes`() {
+        createGuildsTableV18()
+        migrateToV19()
+        val guildId = UUID.randomUUID()
+        val world = UUID.randomUUID().toString()
+
+        connection.createStatement().use { stmt ->
+            stmt.execute(
+                """
+                INSERT INTO guilds (id, name, level, bank_balance, mode, created_at)
+                VALUES ('$guildId', 'CascadeGuild', 1, 0, 'Hostile', datetime('now'))
+                """.trimIndent()
+            )
+        }
+        connection.prepareStatement(
+            "INSERT INTO guild_homes (guild_id, name, world_id, x, y, z) VALUES (?, ?, ?, ?, ?, ?)"
+        ).use { stmt ->
+            stmt.setString(1, guildId.toString())
+            stmt.setString(2, "main")
+            stmt.setString(3, world)
+            stmt.setInt(4, 0); stmt.setInt(5, 64); stmt.setInt(6, 0)
+            stmt.executeUpdate()
+        }
+
+        connection.createStatement().use { stmt ->
+            stmt.execute("DELETE FROM guilds WHERE id = '$guildId'")
+        }
+
+        connection.prepareStatement(
+            "SELECT COUNT(*) FROM guild_homes WHERE guild_id = ?"
+        ).use { stmt ->
+            stmt.setString(1, guildId.toString())
+            stmt.executeQuery().use { rs ->
+                assertTrue(rs.next())
+                assertEquals(0, rs.getInt(1), "FK cascade must delete homes when the guild row is removed")
+            }
+        }
+    }
+
+    // -------- helpers (mirror SQLiteMigrations.migrateToVersion19) --------
+
+    private fun createGuildsTableV18() {
+        connection.createStatement().use { stmt ->
+            stmt.execute(
+                """
+                CREATE TABLE guilds (
+                    id TEXT PRIMARY KEY,
+                    name TEXT NOT NULL,
+                    banner TEXT,
+                    emoji TEXT,
+                    tag TEXT,
+                    home_world TEXT,
+                    home_x INTEGER,
+                    home_y INTEGER,
+                    home_z INTEGER,
+                    level INTEGER NOT NULL DEFAULT 1,
+                    bank_balance INTEGER NOT NULL DEFAULT 0,
+                    mode TEXT NOT NULL DEFAULT 'Hostile',
+                    mode_changed_at TEXT,
+                    created_at TEXT NOT NULL
+                )
+                """.trimIndent()
+            )
+        }
+    }
+
+    private fun migrateToV19() {
+        connection.createStatement().use { stmt ->
+            stmt.execute(
+                """
+                CREATE TABLE IF NOT EXISTS guild_homes (
+                    guild_id TEXT NOT NULL,
+                    name TEXT NOT NULL,
+                    world_id TEXT NOT NULL,
+                    x INTEGER NOT NULL,
+                    y INTEGER NOT NULL,
+                    z INTEGER NOT NULL,
+                    PRIMARY KEY (guild_id, name),
+                    FOREIGN KEY (guild_id) REFERENCES guilds(id) ON DELETE CASCADE
+                )
+                """.trimIndent()
+            )
+            stmt.execute(
+                "CREATE INDEX IF NOT EXISTS idx_guild_homes_guild_id ON guild_homes(guild_id)"
+            )
+            stmt.executeUpdate(
+                """
+                INSERT OR IGNORE INTO guild_homes (guild_id, name, world_id, x, y, z)
+                SELECT id, 'main', home_world, home_x, home_y, home_z
+                FROM guilds
+                WHERE home_world IS NOT NULL
+                  AND home_x IS NOT NULL
+                  AND home_y IS NOT NULL
+                  AND home_z IS NOT NULL
+                """.trimIndent()
+            )
+        }
+    }
+
+    private fun tableExists(name: String): Boolean {
+        connection.createStatement().use { stmt ->
+            stmt.executeQuery(
+                "SELECT name FROM sqlite_master WHERE type='table' AND name='$name'"
+            ).use { rs -> return rs.next() }
+        }
+    }
+}


### PR DESCRIPTION
## Summary

Fixes a regression where any guild home that wasn't the default (effectively, any home not named `main`) was wiped on every server restart. Setting `/g sethome farm` worked in-memory until the next restart, then `farm` was gone — and a single non-`main` home was silently renamed to `main` on the next save+load cycle.

## Root cause

The `Guild` domain model holds `homes: Map<String, GuildHome>` (unlimited named homes), but `GuildRepositorySQLite` only persisted a single home through the `guilds.home_world / home_x / home_y / home_z` columns. On save, it extracted `guild.homes.defaultHome` (= `homes["main"] ?: homes.values.firstOrNull()`) and discarded the rest. On load, it always reconstructed `GuildHomes(mapOf("main" to <legacy columns>))`.

## Fix

Schema v19 adds a `guild_homes` table keyed by `(guild_id, name)`:

```sql
CREATE TABLE guild_homes (
  guild_id TEXT NOT NULL,
  name     TEXT NOT NULL,
  world_id TEXT NOT NULL,
  x INTEGER NOT NULL, y INTEGER NOT NULL, z INTEGER NOT NULL,
  PRIMARY KEY (guild_id, name),
  FOREIGN KEY (guild_id) REFERENCES guilds(id) ON DELETE CASCADE
);
```

Migration backfills existing legacy homes as `name = 'main'` via `INSERT OR IGNORE` (idempotent).

`GuildRepositorySQLite`:
- Creates `guild_homes` defensively on init.
- Pre-loads every guild's homes in a single query in `preload()` (avoids N+1 on startup).
- Reads from `guild_homes` first, falls back to legacy `home_*` columns when no rows exist.
- Writes the full named-home map to `guild_homes` (delete + insert) on every `add` / `update`. Legacy columns are still synced with the default home so older builds running against a v19 DB still see at least one home.
- `remove(guildId)` is unchanged — `ON DELETE CASCADE` cleans up automatically.

Both `SQLiteMigrations` and `MariaDBMigrations` get a `migrateToVersion19()`. SQLite's `validateAndRepairSchema` learns to recreate `guild_homes` if it's ever missing.

## Test plan

`GuildHomesMigrationTest` covers:
- [x] Table creation after migration
- [x] Backfill of existing legacy single home as `name = 'main'`
- [x] No backfill row when legacy columns are null
- [x] Multiple named homes round-trip per guild
- [x] `(guild_id, name)` PK rejects duplicate names within a guild
- [x] Migration is idempotent — second run doesn't duplicate the backfill
- [x] `ON DELETE CASCADE` removes a guild's homes when the guild row is deleted

Manual verification needed:
- [ ] On a staging copy of the prod DB, run the plugin and confirm v19 migration completes and `SELECT COUNT(*) FROM guild_homes WHERE name = 'main'` matches the count of guilds with non-null `home_world`.
- [ ] `/g sethome farm` then restart → `farm` survives.
- [ ] `/g sethome farm` (with no main set) then restart → home is still named `farm`, no longer renamed to `main`.
- [ ] Old build temporarily running against the v19 DB still sees the default home (legacy columns kept in sync).

## Out of scope

The duplicate `removeHome` event noise from yesterday's logs (success + "doesn't exist" warn 1s apart on the same call) is a separate issue in the listener/event layer. End-state is correct, just log noise — worth a follow-up but not part of this fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Guilds can now create and manage multiple named home locations instead of just one, enabling more flexible organization of guild bases and gathering points.

* **Chores**
  * Updated database infrastructure to version 19 to support the new multi-home guild management system. Existing installations will be automatically migrated.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->