### PR TITLE
feat: rank priority reordering + per-home & ally-home access permissions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -272,3 +272,6 @@ VIRTUAL_THREADS.md
 
 #Ignore vscode AI rules
 .github\instructions\codacy.instructions.md
+
+# Local worktrees
+.worktrees/

--- a/docs/plans/2026-05-10-rank-and-home-perms-impl.md
+++ b/docs/plans/2026-05-10-rank-and-home-perms-impl.md
@@ -1,0 +1,1621 @@
+# Rank Priority & Per-Home Access Permissions — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add three bundled guild features: (1) per-home rank-whitelist gating teleport access, (2) ally-home permissions with per-rank outbound and per-ally-guild inbound gating, (3) rank priority reordering via ▲/▼ buttons in RankEditMenu.
+
+**Architecture:** Schema migration v20 adds `allowed_ranks` to the existing `guild_homes` table and `ally_home_allowed_guilds` to the `guilds` table. Domain entities `GuildHome` and `Guild` gain matching fields. A new `RankPermission.USE_ALLY_HOMES` governs outbound ally-home use. Access checks live in `GuildService`; priority swap atomicity in `RankService` via a temporary-priority three-step UPDATE. UI additions to `RankEditMenu` (priority buttons) and `GuildHomeMenu` (Access buttons opening new `HomeAccessMenu` / `AllyHomeAccessMenu`).
+
+**Tech Stack:** Kotlin, Paper/Bukkit 1.21, ACF (commands), Koin (DI), aikar/idb SQLite via `storage.connection.executeUpdate` / `getResults`, InventoryFramework `ChestGui`/`StaticPane`, JUnit5 + MockK + MockBukkit.
+
+**Spec reference:** [`docs/superpowers/specs/2026-05-10-rank-and-home-perms-design.md`](../superpowers/specs/2026-05-10-rank-and-home-perms-design.md)
+
+**Layer rules reminder:** Domain imports nothing from application/infrastructure. Application imports only domain. Infrastructure imports all three. See `docs/architecture.md`.
+
+---
+
+## Task 1: Add `USE_ALLY_HOMES` to `RankPermission` enum
+
+**Files:**
+- Modify: `src/main/kotlin/net/lumalyte/lg/domain/entities/Rank.kt`
+
+- [ ] **Step 1: Add the enum value**
+
+Insert under the existing `// Relations & Diplomacy` block (after `ACCEPT_PARTY_INVITES`):
+
+```kotlin
+    ACCEPT_PARTY_INVITES,
+    USE_ALLY_HOMES,
+```
+
+- [ ] **Step 2: Verify it compiles**
+
+Run: `./gradlew compileKotlin`
+Expected: BUILD SUCCESSFUL
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add src/main/kotlin/net/lumalyte/lg/domain/entities/Rank.kt
+git commit -m "feat(perms): add USE_ALLY_HOMES rank permission"
+```
+
+---
+
+## Task 2: Extend `GuildHome` with `allowedRankIds`
+
+**Files:**
+- Modify: `src/main/kotlin/net/lumalyte/lg/domain/entities/Guild.kt`
+- Test: `src/test/kotlin/net/lumalyte/lg/domain/entities/GuildHomeTest.kt`
+
+- [ ] **Step 1: Write the failing test**
+
+Create `src/test/kotlin/net/lumalyte/lg/domain/entities/GuildHomeTest.kt`:
+
+```kotlin
+package net.lumalyte.lg.domain.entities
+
+import net.lumalyte.lg.domain.values.Position3D
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.Assertions.*
+import java.util.UUID
+
+class GuildHomeTest {
+
+    @Test
+    fun `GuildHome defaults allowedRankIds to empty set`() {
+        val home = GuildHome(UUID.randomUUID(), Position3D(0, 64, 0))
+        assertEquals(emptySet<UUID>(), home.allowedRankIds)
+    }
+
+    @Test
+    fun `GuildHome stores supplied allowedRankIds`() {
+        val rankA = UUID.randomUUID()
+        val rankB = UUID.randomUUID()
+        val home = GuildHome(
+            worldId = UUID.randomUUID(),
+            position = Position3D(0, 64, 0),
+            allowedRankIds = setOf(rankA, rankB)
+        )
+        assertEquals(setOf(rankA, rankB), home.allowedRankIds)
+    }
+}
+```
+
+- [ ] **Step 2: Run the test, confirm it fails**
+
+Run: `./gradlew test --tests "net.lumalyte.lg.domain.entities.GuildHomeTest"`
+Expected: FAIL (compile error: no `allowedRankIds` parameter).
+
+- [ ] **Step 3: Add field to `GuildHome`**
+
+Find the `data class GuildHome(...)` declaration in [`Guild.kt`](../../src/main/kotlin/net/lumalyte/lg/domain/entities/Guild.kt) (around line 88). Replace:
+
+```kotlin
+data class GuildHome(
+    val worldId: UUID,
+    val position: Position3D
+)
+```
+
+with:
+
+```kotlin
+data class GuildHome(
+    val worldId: UUID,
+    val position: Position3D,
+    val allowedRankIds: Set<UUID> = emptySet()
+)
+```
+
+- [ ] **Step 4: Re-run test, confirm pass**
+
+Run: `./gradlew test --tests "net.lumalyte.lg.domain.entities.GuildHomeTest"`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/main/kotlin/net/lumalyte/lg/domain/entities/Guild.kt src/test/kotlin/net/lumalyte/lg/domain/entities/GuildHomeTest.kt
+git commit -m "feat(home): add allowedRankIds whitelist to GuildHome"
+```
+
+---
+
+## Task 3: Extend `Guild` with `allyHomeAllowedGuilds`
+
+**Files:**
+- Modify: `src/main/kotlin/net/lumalyte/lg/domain/entities/Guild.kt`
+- Test: `src/test/kotlin/net/lumalyte/lg/domain/entities/GuildTest.kt`
+
+- [ ] **Step 1: Append failing test to `GuildTest.kt`**
+
+Add inside the existing `class GuildTest`:
+
+```kotlin
+    @Test
+    fun `Guild allyHomeAllowedGuilds defaults to empty`() {
+        val guild = Guild(id = UUID.randomUUID(), name = "X", createdAt = Instant.now())
+        assertEquals(emptySet<UUID>(), guild.allyHomeAllowedGuilds)
+    }
+
+    @Test
+    fun `Guild stores supplied allyHomeAllowedGuilds`() {
+        val allyId = UUID.randomUUID()
+        val guild = Guild(
+            id = UUID.randomUUID(),
+            name = "X",
+            createdAt = Instant.now(),
+            allyHomeAllowedGuilds = setOf(allyId)
+        )
+        assertEquals(setOf(allyId), guild.allyHomeAllowedGuilds)
+    }
+```
+
+- [ ] **Step 2: Run, confirm fail**
+
+Run: `./gradlew test --tests "net.lumalyte.lg.domain.entities.GuildTest"`
+Expected: FAIL (compile error).
+
+- [ ] **Step 3: Add field to `Guild`**
+
+In `Guild.kt`, add `val allyHomeAllowedGuilds: Set<UUID> = emptySet()` as the last constructor parameter of `data class Guild(...)` (after `allyHome`).
+
+```kotlin
+data class Guild(
+    // ... existing fields ...
+    val allyHome: GuildHome? = null,
+    val allyHomeAllowedGuilds: Set<UUID> = emptySet()
+) {
+```
+
+- [ ] **Step 4: Run, confirm pass**
+
+Run: `./gradlew test --tests "net.lumalyte.lg.domain.entities.GuildTest"`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/main/kotlin/net/lumalyte/lg/domain/entities/Guild.kt src/test/kotlin/net/lumalyte/lg/domain/entities/GuildTest.kt
+git commit -m "feat(ally-home): add allyHomeAllowedGuilds whitelist to Guild"
+```
+
+---
+
+## Task 4: Schema migration v20
+
+**Files:**
+- Modify: `src/main/kotlin/net/lumalyte/lg/infrastructure/persistence/migrations/SQLiteMigrations.kt`
+
+- [ ] **Step 1: Add the v20 gate in `migrate()`**
+
+After the v19 block (around line 115), insert:
+
+```kotlin
+            if (dbVersion < 20) {
+                migrateToVersion20()
+                updateDatabaseVersion(20)
+                dbVersion = 20
+            }
+```
+
+- [ ] **Step 2: Implement `migrateToVersion20()`**
+
+Add new private function (place after `migrateToVersion19()` around line 1281):
+
+```kotlin
+    /**
+     * v20: per-home rank whitelist + per-ally-guild inbound ally-home whitelist + USE_ALLY_HOMES permission backfill.
+     *
+     * Adds `guild_homes.allowed_ranks` (TEXT, CSV of rank UUIDs) and
+     * `guilds.ally_home_allowed_guilds` (TEXT, CSV of guild UUIDs).
+     * Backfills existing homes with all current ranks of the owning guild (policy B,
+     * see 2026-05-10-rank-and-home-perms-design.md §2.3), and adds USE_ALLY_HOMES
+     * to every existing rank's permissions (§3.1).
+     *
+     * Idempotent: ALTER TABLE wrapped in try/catch for "duplicate column", and
+     * backfill UPDATE only writes rows where the new columns are NULL.
+     */
+    private fun migrateToVersion20() {
+        componentLogger.info(Component.text("Migrating to version 20: per-home access perms..."))
+
+        // 1. Add columns (idempotent)
+        for (alter in listOf(
+            "ALTER TABLE guild_homes ADD COLUMN allowed_ranks TEXT",
+            "ALTER TABLE guilds ADD COLUMN ally_home_allowed_guilds TEXT"
+        )) {
+            try {
+                connection.createStatement().use { it.executeUpdate(alter) }
+            } catch (e: SQLException) {
+                if (!e.message.orEmpty().contains("duplicate column", ignoreCase = true)) throw e
+            }
+        }
+
+        // 2. Backfill guild_homes.allowed_ranks = CSV of rank IDs for each guild
+        connection.createStatement().use { stmt ->
+            val rs = stmt.executeQuery(
+                "SELECT gh.guild_id, GROUP_CONCAT(r.id, ',') AS rank_csv " +
+                "FROM guild_homes gh JOIN ranks r ON r.guild_id = gh.guild_id " +
+                "WHERE gh.allowed_ranks IS NULL GROUP BY gh.guild_id"
+            )
+            val updates = mutableListOf<Pair<String, String>>()
+            while (rs.next()) {
+                updates.add(rs.getString("guild_id") to (rs.getString("rank_csv") ?: ""))
+            }
+            rs.close()
+            val updateStmt = connection.prepareStatement(
+                "UPDATE guild_homes SET allowed_ranks = ? WHERE guild_id = ? AND allowed_ranks IS NULL"
+            )
+            for ((guildId, csv) in updates) {
+                updateStmt.setString(1, csv)
+                updateStmt.setString(2, guildId)
+                updateStmt.executeUpdate()
+            }
+            updateStmt.close()
+            componentLogger.info(Component.text("✓ Backfilled ${updates.size} guild(s) of home rank whitelists"))
+        }
+
+        // 3. Backfill guilds.ally_home_allowed_guilds = CSV of current allies
+        //    Relations table uses (guild_a, guild_b, type='ALLY') — collect both directions.
+        connection.createStatement().use { stmt ->
+            val rs = stmt.executeQuery(
+                "SELECT id FROM guilds WHERE ally_home_allowed_guilds IS NULL"
+            )
+            val guildIds = mutableListOf<String>()
+            while (rs.next()) guildIds.add(rs.getString("id"))
+            rs.close()
+
+            val updateStmt = connection.prepareStatement(
+                "UPDATE guilds SET ally_home_allowed_guilds = ? WHERE id = ?"
+            )
+            for (gid in guildIds) {
+                val allies = mutableSetOf<String>()
+                connection.prepareStatement(
+                    "SELECT guild_a, guild_b FROM relations WHERE type = 'ALLY' AND (guild_a = ? OR guild_b = ?)"
+                ).use { ps ->
+                    ps.setString(1, gid); ps.setString(2, gid)
+                    val r2 = ps.executeQuery()
+                    while (r2.next()) {
+                        val a = r2.getString("guild_a"); val b = r2.getString("guild_b")
+                        if (a != gid) allies.add(a); if (b != gid) allies.add(b)
+                    }
+                }
+                updateStmt.setString(1, allies.joinToString(","))
+                updateStmt.setString(2, gid)
+                updateStmt.executeUpdate()
+            }
+            updateStmt.close()
+            componentLogger.info(Component.text("✓ Backfilled ${guildIds.size} guild(s) ally-home allow-lists"))
+        }
+
+        // 4. Add USE_ALLY_HOMES to every existing rank (idempotent — skips if already present)
+        connection.createStatement().use { stmt ->
+            val rs = stmt.executeQuery("SELECT id, permissions FROM ranks")
+            val updates = mutableListOf<Pair<String, String>>()
+            while (rs.next()) {
+                val id = rs.getString("id")
+                val perms = rs.getString("permissions").orEmpty()
+                val parts = perms.split(",").filter { it.isNotBlank() }.toMutableSet()
+                if (parts.add("USE_ALLY_HOMES")) {
+                    updates.add(id to parts.joinToString(","))
+                }
+            }
+            rs.close()
+            val updateStmt = connection.prepareStatement(
+                "UPDATE ranks SET permissions = ? WHERE id = ?"
+            )
+            for ((id, perms) in updates) {
+                updateStmt.setString(1, perms); updateStmt.setString(2, id)
+                updateStmt.executeUpdate()
+            }
+            updateStmt.close()
+            componentLogger.info(Component.text("✓ Added USE_ALLY_HOMES to ${updates.size} ranks"))
+        }
+    }
+```
+
+- [ ] **Step 3: Verify it compiles**
+
+Run: `./gradlew compileKotlin`
+Expected: BUILD SUCCESSFUL
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add src/main/kotlin/net/lumalyte/lg/infrastructure/persistence/migrations/SQLiteMigrations.kt
+git commit -m "feat(db): v20 migration — home/ally access columns + USE_ALLY_HOMES backfill"
+```
+
+---
+
+## Task 5: GuildRepository — persist `allowed_ranks` for homes
+
+**Files:**
+- Modify: `src/main/kotlin/net/lumalyte/lg/infrastructure/persistence/guilds/GuildRepositorySQLite.kt`
+
+- [ ] **Step 1: Update `createGuildHomesTable()` (around line 128)**
+
+Change the `CREATE TABLE IF NOT EXISTS guild_homes` block to include the new column (for fresh installs):
+
+```kotlin
+        val sql = """
+            CREATE TABLE IF NOT EXISTS guild_homes (
+                guild_id TEXT NOT NULL,
+                name TEXT NOT NULL,
+                world_id TEXT NOT NULL,
+                x INTEGER NOT NULL,
+                y INTEGER NOT NULL,
+                z INTEGER NOT NULL,
+                allowed_ranks TEXT,
+                PRIMARY KEY (guild_id, name),
+                FOREIGN KEY (guild_id) REFERENCES guilds(id) ON DELETE CASCADE
+            );
+        """.trimIndent()
+```
+
+- [ ] **Step 2: Update `loadAllGuildHomes()` (around line 225) to read `allowed_ranks`**
+
+Replace the SELECT and home-construction block:
+
+```kotlin
+            val rows = storage.connection.getResults(
+                "SELECT guild_id, name, world_id, x, y, z, allowed_ranks FROM guild_homes"
+            )
+            for (row in rows) {
+                val guildId = UUID.fromString(row.getString("guild_id"))
+                val homeName = row.getString("name")
+                val worldId = UUID.fromString(row.getString("world_id"))
+                val x = row.getInt("x")
+                val y = row.getInt("y")
+                val z = row.getInt("z")
+                val allowedCsv = row.getString("allowed_ranks").orEmpty()
+                val allowedRankIds = allowedCsv.split(",")
+                    .filter { it.isNotBlank() }
+                    .map { UUID.fromString(it.trim()) }
+                    .toSet()
+                val home = GuildHome(worldId, net.lumalyte.lg.domain.values.Position3D(x, y, z), allowedRankIds)
+                byGuild.getOrPut(guildId) { mutableMapOf() }[homeName] = home
+            }
+```
+
+- [ ] **Step 3: Update `writeGuildHomes()` (around line 256) to write `allowed_ranks`**
+
+Replace the INSERT block:
+
+```kotlin
+            for ((homeName, home) in guild.homes.homes) {
+                storage.connection.executeUpdate(
+                    """
+                    INSERT INTO guild_homes (guild_id, name, world_id, x, y, z, allowed_ranks)
+                    VALUES (?, ?, ?, ?, ?, ?, ?)
+                    """.trimIndent(),
+                    guild.id.toString(),
+                    homeName,
+                    home.worldId.toString(),
+                    home.position.x,
+                    home.position.y,
+                    home.position.z,
+                    home.allowedRankIds.joinToString(",") { it.toString() }
+                )
+            }
+```
+
+- [ ] **Step 4: Verify it compiles**
+
+Run: `./gradlew compileKotlin`
+Expected: BUILD SUCCESSFUL
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/main/kotlin/net/lumalyte/lg/infrastructure/persistence/guilds/GuildRepositorySQLite.kt
+git commit -m "feat(db): persist GuildHome.allowedRankIds via guild_homes.allowed_ranks"
+```
+
+---
+
+## Task 6: GuildRepository — persist `ally_home_allowed_guilds`
+
+**Files:**
+- Modify: `src/main/kotlin/net/lumalyte/lg/infrastructure/persistence/guilds/GuildRepositorySQLite.kt`
+
+- [ ] **Step 1: Add fresh-install column to `migrateAllyHomeColumns()` (around line 182)**
+
+Replace the `columns` list with:
+
+```kotlin
+        val columns = listOf(
+            "ally_home_world TEXT",
+            "ally_home_x INTEGER",
+            "ally_home_y INTEGER",
+            "ally_home_z INTEGER",
+            "ally_home_allowed_guilds TEXT"
+        )
+```
+
+- [ ] **Step 2: Update `mapResultSetToGuild` to read the column**
+
+Find the line that constructs `Guild(...)` (around line 416 — the one with `allyHome = allyHome`). Locate it by searching `allyHome = allyHome` in the file. Above that constructor call, add:
+
+```kotlin
+        val allyHomeAllowedGuildsCsv = try { rs.getString("ally_home_allowed_guilds").orEmpty() } catch (_: SQLException) { "" }
+        val allyHomeAllowedGuilds = allyHomeAllowedGuildsCsv.split(",")
+            .filter { it.isNotBlank() }
+            .map { UUID.fromString(it.trim()) }
+            .toSet()
+```
+
+Then add `allyHomeAllowedGuilds = allyHomeAllowedGuilds` to the `Guild(...)` constructor argument list (after `allyHome = allyHome`).
+
+- [ ] **Step 3: Update every INSERT/UPDATE SQL that writes guild rows**
+
+Search the file for `ally_home_z` in column lists. For each INSERT/UPDATE that includes ally_home columns, append `ally_home_allowed_guilds` to the column list and a corresponding `?` placeholder, then pass `guild.allyHomeAllowedGuilds.joinToString(",") { it.toString() }` as the last argument.
+
+Example for the UPDATE (typically around line 540):
+
+```kotlin
+            UPDATE guilds SET name = ?, ..., ally_home_world = ?, ally_home_x = ?, ally_home_y = ?, ally_home_z = ?, ally_home_allowed_guilds = ?
+            WHERE id = ?
+```
+
+And in the argument list, after the existing ally_home position args:
+
+```kotlin
+                    guild.allyHomeAllowedGuilds.joinToString(",") { it.toString() },
+                    guild.id.toString()
+```
+
+Apply the same pattern to all 5 INSERT branches (lines ~447, ~452, ~457, ~462, ~467) and the UPDATE branch.
+
+- [ ] **Step 4: Verify it compiles**
+
+Run: `./gradlew compileKotlin`
+Expected: BUILD SUCCESSFUL
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/main/kotlin/net/lumalyte/lg/infrastructure/persistence/guilds/GuildRepositorySQLite.kt
+git commit -m "feat(db): persist Guild.allyHomeAllowedGuilds"
+```
+
+---
+
+## Task 7: New-home defaults — Owner-only whitelist
+
+**Files:**
+- Modify: `src/main/kotlin/net/lumalyte/lg/infrastructure/services/GuildServiceBukkit.kt`
+
+- [ ] **Step 1: Locate `setHome` (around line 314), find where it constructs the new GuildHome to insert**
+
+The current code likely accepts `home: GuildHome` parameter directly from the caller. New homes created via `/guild sethome` should default `allowedRankIds = setOf(ownerRankId)` per spec §2.3.
+
+- [ ] **Step 2: Inject default Owner-only allowed-rank when adding a new home**
+
+In `setHome(guildId, homeName, home, actorId)`, immediately after the existing permission check and before persisting, locate `guild.copy(homes = guild.homes.withHome(homeName, ...))`. Wrap with logic that determines the effective `allowedRankIds`:
+
+```kotlin
+        val existing = guild.homes.getHome(homeName)
+        val effectiveAllowed = if (existing != null) {
+            // Updating an existing home — preserve its whitelist
+            existing.allowedRankIds
+        } else {
+            // New home — Owner-only by default (policy B for new homes, see spec §2.3)
+            val ownerRank = rankRepository.getHighestRank(guildId)
+            if (ownerRank != null) setOf(ownerRank.id) else emptySet()
+        }
+        val effectiveHome = home.copy(allowedRankIds = effectiveAllowed)
+        val updatedGuild = guild.copy(homes = guild.homes.withHome(homeName, effectiveHome))
+```
+
+Then continue with the existing repository.update(updatedGuild) call.
+
+If the existing code uses different variable names, adapt accordingly — preserve the **intent**: existing home keeps whitelist, brand-new home gets Owner-only.
+
+Confirm `rankRepository` is already injected; if not, add: `private val rankRepository: RankRepository` constructor parameter and wire via Koin module (see `KoinModule.kt` for pattern).
+
+- [ ] **Step 3: Verify it compiles**
+
+Run: `./gradlew compileKotlin`
+Expected: BUILD SUCCESSFUL
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add src/main/kotlin/net/lumalyte/lg/infrastructure/services/GuildServiceBukkit.kt
+git commit -m "feat(home): default new homes to Owner-only whitelist"
+```
+
+---
+
+## Task 8: `canUseHome` service method
+
+**Files:**
+- Modify: `src/main/kotlin/net/lumalyte/lg/application/services/GuildService.kt`
+- Modify: `src/main/kotlin/net/lumalyte/lg/infrastructure/services/GuildServiceBukkit.kt`
+- Test: `src/test/kotlin/net/lumalyte/lg/infrastructure/services/GuildServiceHomeAccessTest.kt`
+
+- [ ] **Step 1: Write failing test**
+
+Create `src/test/kotlin/net/lumalyte/lg/infrastructure/services/GuildServiceHomeAccessTest.kt`:
+
+```kotlin
+package net.lumalyte.lg.infrastructure.services
+
+import io.mockk.every
+import io.mockk.mockk
+import net.lumalyte.lg.application.persistence.GuildRepository
+import net.lumalyte.lg.application.persistence.MemberRepository
+import net.lumalyte.lg.application.persistence.RankRepository
+import net.lumalyte.lg.domain.entities.*
+import net.lumalyte.lg.domain.values.Position3D
+import org.junit.jupiter.api.Assertions.*
+import org.junit.jupiter.api.Test
+import java.time.Instant
+import java.util.UUID
+
+class GuildServiceHomeAccessTest {
+
+    private val guildId = UUID.randomUUID()
+    private val ownerRankId = UUID.randomUUID()
+    private val memberRankId = UUID.randomUUID()
+    private val ownerPlayerId = UUID.randomUUID()
+    private val memberPlayerId = UUID.randomUUID()
+    private val homeName = "main"
+    private val worldId = UUID.randomUUID()
+
+    private fun homeWith(allowed: Set<UUID>) = GuildHome(worldId, Position3D(0, 64, 0), allowed)
+
+    private fun setup(homeAllowed: Set<UUID>): GuildServiceBukkit {
+        val ownerRank = Rank(ownerRankId, guildId, "Owner", 0, RankPermission.values().toSet())
+        val memberRank = Rank(memberRankId, guildId, "Member", 10, emptySet())
+        val guild = Guild(
+            id = guildId, name = "G", createdAt = Instant.now(),
+            homes = GuildHomes(mapOf(homeName to homeWith(homeAllowed)))
+        )
+        val guildRepo = mockk<GuildRepository>(relaxed = true)
+        val memberRepo = mockk<MemberRepository>(relaxed = true)
+        val rankRepo = mockk<RankRepository>(relaxed = true)
+        every { guildRepo.getById(guildId) } returns guild
+        every { rankRepo.getById(ownerRankId) } returns ownerRank
+        every { rankRepo.getById(memberRankId) } returns memberRank
+        every { rankRepo.getHighestRank(guildId) } returns ownerRank
+        every { memberRepo.getByPlayerAndGuild(ownerPlayerId, guildId) } returns
+            Member(ownerPlayerId, guildId, ownerRankId, Instant.now())
+        every { memberRepo.getByPlayerAndGuild(memberPlayerId, guildId) } returns
+            Member(memberPlayerId, guildId, memberRankId, Instant.now())
+        // Construct via reflection / direct constructor with required deps — adapt to project's
+        // actual GuildServiceBukkit constructor signature when implementing.
+        return mockk(relaxed = true) // placeholder — replace once constructor known
+    }
+
+    @Test
+    fun `owner can use home regardless of whitelist`() {
+        // TODO: replace placeholder setup with real GuildServiceBukkit construction once deps mapped
+        // For now this test documents intended behavior; will be made executable in Step 3.
+    }
+}
+```
+
+Note: this test stub will be made executable when you know the real constructor signature (Step 3). Run it now to confirm it compiles but fails meaningfully:
+
+Run: `./gradlew test --tests "GuildServiceHomeAccessTest" --info`
+Expected: tests pass trivially (no real asserts yet) — refine in Step 3.
+
+- [ ] **Step 2: Add interface method**
+
+In `src/main/kotlin/net/lumalyte/lg/application/services/GuildService.kt`, add to the interface:
+
+```kotlin
+    /**
+     * Checks whether a player may teleport to the named home. Returns true when:
+     * - the player is in the guild, AND
+     * - the player's rank is the highest-priority (Owner) rank, OR
+     * - the player's rank id is in `home.allowedRankIds`.
+     */
+    fun canUseHome(playerId: UUID, guildId: UUID, homeName: String): Boolean
+```
+
+- [ ] **Step 3: Implement in `GuildServiceBukkit.kt`**
+
+Add to the class:
+
+```kotlin
+    override fun canUseHome(playerId: UUID, guildId: UUID, homeName: String): Boolean {
+        val guild = guildRepository.getById(guildId) ?: return false
+        val home = guild.homes.getHome(homeName) ?: return false
+        val member = memberRepository.getByPlayerAndGuild(playerId, guildId) ?: return false
+        val ownerRank = rankRepository.getHighestRank(guildId)
+        if (ownerRank != null && member.rankId == ownerRank.id) return true
+        return member.rankId in home.allowedRankIds
+    }
+```
+
+Now go back to the test from Step 1, replace the placeholder `setup` with real construction matching `GuildServiceBukkit`'s actual constructor (check the existing file for the dep list — likely `guildRepository`, `memberRepository`, `rankRepository`, `logger`, `configService`, etc.). Replace the trivial test bodies with real asserts:
+
+```kotlin
+    @Test
+    fun `owner can use home regardless of whitelist`() {
+        val service = setup(homeAllowed = emptySet())
+        assertTrue(service.canUseHome(ownerPlayerId, guildId, homeName))
+    }
+
+    @Test
+    fun `member cannot use home when not whitelisted`() {
+        val service = setup(homeAllowed = emptySet())
+        assertFalse(service.canUseHome(memberPlayerId, guildId, homeName))
+    }
+
+    @Test
+    fun `member can use home when whitelisted`() {
+        val service = setup(homeAllowed = setOf(memberRankId))
+        assertTrue(service.canUseHome(memberPlayerId, guildId, homeName))
+    }
+
+    @Test
+    fun `non-member cannot use home`() {
+        val service = setup(homeAllowed = setOf(memberRankId))
+        val outsider = UUID.randomUUID()
+        // memberRepository returns null for outsider — already default via relaxed mock
+        assertFalse(service.canUseHome(outsider, guildId, homeName))
+    }
+```
+
+- [ ] **Step 4: Run test, confirm pass**
+
+Run: `./gradlew test --tests "GuildServiceHomeAccessTest"`
+Expected: PASS (all 4 cases).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/main/kotlin/net/lumalyte/lg/application/services/GuildService.kt \
+        src/main/kotlin/net/lumalyte/lg/infrastructure/services/GuildServiceBukkit.kt \
+        src/test/kotlin/net/lumalyte/lg/infrastructure/services/GuildServiceHomeAccessTest.kt
+git commit -m "feat(home): GuildService.canUseHome with owner bypass + whitelist"
+```
+
+---
+
+## Task 9: `canUseAllyHome` service method
+
+**Files:**
+- Modify: `src/main/kotlin/net/lumalyte/lg/application/services/GuildService.kt`
+- Modify: `src/main/kotlin/net/lumalyte/lg/infrastructure/services/GuildServiceBukkit.kt`
+- Test: `src/test/kotlin/net/lumalyte/lg/infrastructure/services/GuildServiceAllyHomeAccessTest.kt`
+
+- [ ] **Step 1: Write failing tests**
+
+Create test file following the same structural pattern as Task 8 step 3. Cover:
+- Owner of source guild bypasses outbound `USE_ALLY_HOMES` rank check (still requires inbound whitelist).
+- Non-owner with `USE_ALLY_HOMES` + source guild on target's inbound whitelist → allowed.
+- Non-owner without `USE_ALLY_HOMES` → denied.
+- Source guild not on target's inbound whitelist → denied.
+- Target guild has no `allyHome` → denied.
+
+Use this signature in tests:
+
+```kotlin
+service.canUseAllyHome(playerId, sourceGuildId, targetGuildId)
+```
+
+- [ ] **Step 2: Run, confirm fail (compile error: method missing)**
+
+Run: `./gradlew test --tests "GuildServiceAllyHomeAccessTest"`
+Expected: FAIL
+
+- [ ] **Step 3: Add to interface and implement**
+
+`GuildService.kt`:
+
+```kotlin
+    /**
+     * Checks whether a player may teleport to another guild's ally-home. Returns true when:
+     * - player is in `sourceGuildId`, AND
+     * - target guild has an ally-home set, AND
+     * - source guild is in target.allyHomeAllowedGuilds (inbound), AND
+     * - (player's rank in source is Owner) OR (rank has USE_ALLY_HOMES permission).
+     */
+    fun canUseAllyHome(playerId: UUID, sourceGuildId: UUID, targetGuildId: UUID): Boolean
+```
+
+`GuildServiceBukkit.kt`:
+
+```kotlin
+    override fun canUseAllyHome(playerId: UUID, sourceGuildId: UUID, targetGuildId: UUID): Boolean {
+        val sourceGuild = guildRepository.getById(sourceGuildId) ?: return false
+        val targetGuild = guildRepository.getById(targetGuildId) ?: return false
+        if (targetGuild.allyHome == null) return false
+        if (sourceGuildId !in targetGuild.allyHomeAllowedGuilds) return false
+        val member = memberRepository.getByPlayerAndGuild(playerId, sourceGuildId) ?: return false
+        val rank = rankRepository.getById(member.rankId) ?: return false
+        val ownerRank = rankRepository.getHighestRank(sourceGuildId)
+        if (ownerRank != null && rank.id == ownerRank.id) return true
+        return RankPermission.USE_ALLY_HOMES in rank.permissions
+    }
+```
+
+- [ ] **Step 4: Run tests, confirm pass**
+
+Run: `./gradlew test --tests "GuildServiceAllyHomeAccessTest"`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/main/kotlin/net/lumalyte/lg/application/services/GuildService.kt \
+        src/main/kotlin/net/lumalyte/lg/infrastructure/services/GuildServiceBukkit.kt \
+        src/test/kotlin/net/lumalyte/lg/infrastructure/services/GuildServiceAllyHomeAccessTest.kt
+git commit -m "feat(ally-home): GuildService.canUseAllyHome with owner bypass + USE_ALLY_HOMES gate"
+```
+
+---
+
+## Task 10: Mutator methods — `setHomeAllowedRanks` / `setAllyHomeAllowedGuilds`
+
+**Files:**
+- Modify: `src/main/kotlin/net/lumalyte/lg/application/services/GuildService.kt`
+- Modify: `src/main/kotlin/net/lumalyte/lg/infrastructure/services/GuildServiceBukkit.kt`
+
+- [ ] **Step 1: Add interface methods**
+
+```kotlin
+    /**
+     * Updates the rank whitelist for a named home. Owner rank is always implicitly allowed
+     * (lockout-safe) — implementations must not require the owner rank ID to be in the set.
+     * Caller must have MANAGE_HOME permission; returns false otherwise.
+     */
+    fun setHomeAllowedRanks(guildId: UUID, homeName: String, allowedRankIds: Set<UUID>, actorId: UUID): Boolean
+
+    /**
+     * Updates the inbound allow-list of guilds whose members may teleport to this guild's
+     * ally-home. Caller must have MANAGE_HOME permission.
+     */
+    fun setAllyHomeAllowedGuilds(guildId: UUID, allowedGuildIds: Set<UUID>, actorId: UUID): Boolean
+```
+
+- [ ] **Step 2: Implement**
+
+```kotlin
+    override fun setHomeAllowedRanks(
+        guildId: UUID, homeName: String, allowedRankIds: Set<UUID>, actorId: UUID
+    ): Boolean {
+        if (!hasManageHome(actorId, guildId)) return false
+        val guild = guildRepository.getById(guildId) ?: return false
+        val home = guild.homes.getHome(homeName) ?: return false
+        val updatedHome = home.copy(allowedRankIds = allowedRankIds)
+        val updatedGuild = guild.copy(homes = guild.homes.withHome(homeName, updatedHome))
+        return guildRepository.update(updatedGuild)
+    }
+
+    override fun setAllyHomeAllowedGuilds(
+        guildId: UUID, allowedGuildIds: Set<UUID>, actorId: UUID
+    ): Boolean {
+        if (!hasManageHome(actorId, guildId)) return false
+        val guild = guildRepository.getById(guildId) ?: return false
+        val updatedGuild = guild.copy(allyHomeAllowedGuilds = allowedGuildIds)
+        return guildRepository.update(updatedGuild)
+    }
+
+    private fun hasManageHome(actorId: UUID, guildId: UUID): Boolean {
+        val member = memberRepository.getByPlayerAndGuild(actorId, guildId) ?: return false
+        val rank = rankRepository.getById(member.rankId) ?: return false
+        return RankPermission.MANAGE_HOME in rank.permissions
+    }
+```
+
+If `hasManageHome`-style helper already exists, reuse it instead.
+
+- [ ] **Step 3: Compile**
+
+Run: `./gradlew compileKotlin`
+Expected: BUILD SUCCESSFUL
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add src/main/kotlin/net/lumalyte/lg/application/services/GuildService.kt \
+        src/main/kotlin/net/lumalyte/lg/infrastructure/services/GuildServiceBukkit.kt
+git commit -m "feat(home): mutators for home allowedRanks and allyHome allowedGuilds"
+```
+
+---
+
+## Task 11: New ally added → auto-update inbound allow-list
+
+**Files:**
+- Modify: wherever alliance acceptance is handled (likely `src/main/kotlin/net/lumalyte/lg/infrastructure/services/RelationServiceBukkit.kt` or `GuildRelationService` — locate by searching `RelationType.ALLY` or `acceptAlliance`).
+
+- [ ] **Step 1: Locate alliance-acceptance code**
+
+Run: `grep -rn "ALLY\|acceptAlliance\|createAlliance" src/main/kotlin/net/lumalyte/lg/infrastructure/services/ src/main/kotlin/net/lumalyte/lg/application/services/ | grep -v "import" | head -20`
+
+Find the code path that transitions a relation to `ALLY` state.
+
+- [ ] **Step 2: After alliance commit, update both guilds' `allyHomeAllowedGuilds`**
+
+Add the following after the relation is persisted as ALLY (replace the placeholder ids/services with what's actually in scope):
+
+```kotlin
+        // Auto-add new ally to both guilds' inbound ally-home whitelists (policy B spirit, spec §3.2).
+        val gA = guildRepository.getById(guildAId)
+        val gB = guildRepository.getById(guildBId)
+        if (gA != null) {
+            guildRepository.update(gA.copy(allyHomeAllowedGuilds = gA.allyHomeAllowedGuilds + guildBId))
+        }
+        if (gB != null) {
+            guildRepository.update(gB.copy(allyHomeAllowedGuilds = gB.allyHomeAllowedGuilds + guildAId))
+        }
+```
+
+- [ ] **Step 3: When alliance is broken, remove from both whitelists**
+
+In the corresponding break-alliance code path:
+
+```kotlin
+        val gA = guildRepository.getById(guildAId)
+        val gB = guildRepository.getById(guildBId)
+        if (gA != null) {
+            guildRepository.update(gA.copy(allyHomeAllowedGuilds = gA.allyHomeAllowedGuilds - guildBId))
+        }
+        if (gB != null) {
+            guildRepository.update(gB.copy(allyHomeAllowedGuilds = gB.allyHomeAllowedGuilds - guildAId))
+        }
+```
+
+- [ ] **Step 4: Compile**
+
+Run: `./gradlew compileKotlin`
+Expected: BUILD SUCCESSFUL
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add -u
+git commit -m "feat(ally-home): auto-add/remove inbound whitelist on alliance change"
+```
+
+---
+
+## Task 12: Enforce home access in `/guild home` command
+
+**Files:**
+- Modify: `src/main/kotlin/net/lumalyte/lg/interaction/commands/GuildCommand.kt`
+
+- [ ] **Step 1: Add access check in `onHome` (line 314)**
+
+After resolving `targetHomeName` and verifying the home exists (around line 343, before the `activeTeleports` check), insert:
+
+```kotlin
+        if (!guildService.canUseHome(playerId, guild.id, targetHomeName)) {
+            player.sendMessage("§c❌ You don't have permission to use the home '$targetHomeName'.")
+            player.sendMessage("§7Ask a guild manager to grant your rank access.")
+            return
+        }
+```
+
+- [ ] **Step 2: Compile, run plugin smoke (optional manual)**
+
+Run: `./gradlew compileKotlin`
+Expected: BUILD SUCCESSFUL
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add src/main/kotlin/net/lumalyte/lg/interaction/commands/GuildCommand.kt
+git commit -m "feat(home): enforce per-home whitelist on /guild home"
+```
+
+---
+
+## Task 13: Enforce ally-home access in ally-home teleport path
+
+**Files:**
+- Modify: `src/main/kotlin/net/lumalyte/lg/interaction/commands/GuildCommand.kt` (and `GuildHomeMenu.kt`'s ally-home button)
+
+- [ ] **Step 1: Locate ally-home teleport command/button**
+
+Run: `grep -n "allyHome\|ally_home\|ALLY_HOME" src/main/kotlin/net/lumalyte/lg/interaction/commands/GuildCommand.kt`
+
+Find the handler.
+
+- [ ] **Step 2: Wrap teleport with `canUseAllyHome` check**
+
+Insert before the actual teleport invocation:
+
+```kotlin
+        if (!guildService.canUseAllyHome(player.uniqueId, sourceGuild.id, targetGuild.id)) {
+            player.sendMessage("§c❌ You cannot use that ally's home.")
+            player.sendMessage("§7Either your rank lacks USE_ALLY_HOMES, or that guild has not allowed your guild.")
+            return
+        }
+```
+
+Apply the same check in `GuildHomeMenu.addAllyHomeButtons` (line 68): grey out the button (BARRIER + denial lore) when `canUseAllyHome` returns false, instead of letting click proceed.
+
+- [ ] **Step 3: Compile**
+
+Run: `./gradlew compileKotlin`
+Expected: BUILD SUCCESSFUL
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add src/main/kotlin/net/lumalyte/lg/interaction/commands/GuildCommand.kt \
+        src/main/kotlin/net/lumalyte/lg/interaction/menus/guild/GuildHomeMenu.kt
+git commit -m "feat(ally-home): enforce canUseAllyHome on command and menu button"
+```
+
+---
+
+## Task 14: `RankRepository.swapPriorities` + `RankService.moveRankPriority`
+
+**Files:**
+- Modify: `src/main/kotlin/net/lumalyte/lg/application/persistence/RankRepository.kt`
+- Modify: `src/main/kotlin/net/lumalyte/lg/infrastructure/persistence/guilds/RankRepositorySQLite.kt`
+- Modify: `src/main/kotlin/net/lumalyte/lg/application/services/RankService.kt`
+- Modify: `src/main/kotlin/net/lumalyte/lg/infrastructure/services/RankServiceBukkit.kt`
+- Test: `src/test/kotlin/net/lumalyte/lg/infrastructure/services/RankServicePriorityTest.kt`
+
+- [ ] **Step 1: Write failing test for `moveRankPriority`**
+
+Create `src/test/kotlin/net/lumalyte/lg/infrastructure/services/RankServicePriorityTest.kt`. Cover:
+- UP succeeds and swaps with neighbor at priority - 1.
+- DOWN succeeds and swaps with neighbor at priority + 1.
+- Fails when actor's priority >= target's priority.
+- Fails when target is Owner (priority 0) attempting UP.
+- Fails when target is last (no DOWN neighbor).
+- Fails when actor lacks MANAGE_RANKS.
+
+Use MockK to stub `RankRepository.getById`, `getByGuild`, `swapPriorities`, and `MemberRepository.getByPlayerAndGuild`. Sample test:
+
+```kotlin
+@Test
+fun `moveRankPriority UP swaps with adjacent higher rank`() {
+    val guildId = UUID.randomUUID()
+    val actorId = UUID.randomUUID()
+    val actorRank = Rank(UUID.randomUUID(), guildId, "Owner", 0, setOf(RankPermission.MANAGE_RANKS))
+    val target = Rank(UUID.randomUUID(), guildId, "Member", 5, emptySet())
+    val neighbor = Rank(UUID.randomUUID(), guildId, "Trusted", 4, emptySet())
+    // ... wire mocks ...
+    assertTrue(service.moveRankPriority(target.id, PriorityDirection.UP, actorId))
+    verify { rankRepository.swapPriorities(target.id, neighbor.id) }
+}
+```
+
+Run: `./gradlew test --tests "RankServicePriorityTest"`
+Expected: FAIL (method missing).
+
+- [ ] **Step 2: Add `PriorityDirection` enum + interface methods**
+
+In `src/main/kotlin/net/lumalyte/lg/application/services/RankService.kt`:
+
+```kotlin
+enum class PriorityDirection { UP, DOWN }
+```
+
+Add to the interface:
+
+```kotlin
+    /**
+     * Moves a rank up (lower priority number, higher in hierarchy) or down by one slot,
+     * swapping priorities with the adjacent rank. Returns false if:
+     * - actor lacks MANAGE_RANKS, OR
+     * - actor's rank priority >= target rank priority, OR
+     * - target is the highest-priority rank and direction is UP, OR
+     * - target is the lowest-priority rank and direction is DOWN.
+     */
+    fun moveRankPriority(rankId: UUID, direction: PriorityDirection, actorId: UUID): Boolean
+```
+
+In `src/main/kotlin/net/lumalyte/lg/application/persistence/RankRepository.kt`:
+
+```kotlin
+    /**
+     * Atomically swaps the `priority` column of two ranks. The implementation must
+     * survive a unique-index on (guild_id, priority) if one is added later — use a
+     * temporary out-of-range value during the swap.
+     */
+    fun swapPriorities(rankAId: UUID, rankBId: UUID): Boolean
+```
+
+- [ ] **Step 3: Implement `swapPriorities` in `RankRepositorySQLite.kt`**
+
+Add to the class (after `getNextPriority`):
+
+```kotlin
+    override fun swapPriorities(rankAId: UUID, rankBId: UUID): Boolean {
+        val rankA = ranks[rankAId] ?: return false
+        val rankB = ranks[rankBId] ?: return false
+        if (rankA.guildId != rankB.guildId) return false
+        // Three-step swap to avoid future unique-constraint issues on (guild_id, priority)
+        val tempPriority = Int.MAX_VALUE
+        val sql = "UPDATE ranks SET priority = ? WHERE id = ?"
+        return try {
+            storage.connection.executeUpdate(sql, tempPriority, rankAId.toString())
+            storage.connection.executeUpdate(sql, rankA.priority, rankBId.toString())
+            storage.connection.executeUpdate(sql, rankB.priority, rankAId.toString())
+            ranks[rankAId] = rankA.copy(priority = rankB.priority)
+            ranks[rankBId] = rankB.copy(priority = rankA.priority)
+            true
+        } catch (e: SQLException) {
+            false
+        }
+    }
+```
+
+- [ ] **Step 4: Implement `moveRankPriority` in `RankServiceBukkit.kt`**
+
+```kotlin
+    override fun moveRankPriority(rankId: UUID, direction: PriorityDirection, actorId: UUID): Boolean {
+        val target = rankRepository.getById(rankId) ?: return false
+        if (!hasPermission(actorId, target.guildId, RankPermission.MANAGE_RANKS)) {
+            logger.warn("Player $actorId attempted to reorder rank $rankId without MANAGE_RANKS")
+            return false
+        }
+        val actorRank = getPlayerRank(actorId, target.guildId) ?: return false
+        if (actorRank.priority >= target.priority) {
+            logger.warn("Player $actorId cannot reorder rank at or above their own priority")
+            return false
+        }
+        val siblings = rankRepository.getByGuild(target.guildId).sortedBy { it.priority }
+        val idx = siblings.indexOfFirst { it.id == target.id }
+        val neighborIdx = when (direction) {
+            PriorityDirection.UP -> idx - 1
+            PriorityDirection.DOWN -> idx + 1
+        }
+        if (neighborIdx !in siblings.indices) return false
+        val neighbor = siblings[neighborIdx]
+        // Owner protection: can't displace highest-priority rank
+        if (direction == PriorityDirection.UP && neighbor == siblings.first()) return false
+        return rankRepository.swapPriorities(target.id, neighbor.id)
+    }
+```
+
+`getPlayerRank` exists already; verify by grepping. If absent, implement inline.
+
+- [ ] **Step 5: Run tests, confirm pass**
+
+Run: `./gradlew test --tests "RankServicePriorityTest"`
+Expected: PASS (all cases).
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/main/kotlin/net/lumalyte/lg/application/persistence/RankRepository.kt \
+        src/main/kotlin/net/lumalyte/lg/infrastructure/persistence/guilds/RankRepositorySQLite.kt \
+        src/main/kotlin/net/lumalyte/lg/application/services/RankService.kt \
+        src/main/kotlin/net/lumalyte/lg/infrastructure/services/RankServiceBukkit.kt \
+        src/test/kotlin/net/lumalyte/lg/infrastructure/services/RankServicePriorityTest.kt
+git commit -m "feat(ranks): swapPriorities + moveRankPriority with actor-priority guard"
+```
+
+---
+
+## Task 15: Add ▲/▼ priority buttons to `RankEditMenu`
+
+**Files:**
+- Modify: `src/main/kotlin/net/lumalyte/lg/interaction/menus/guild/RankEditMenu.kt`
+
+- [ ] **Step 1: Add helper for current actor rank**
+
+After `isEditingOwnOwnerRank()` (line 57), add:
+
+```kotlin
+    private fun canActorReorder(): Boolean {
+        val actorRank = rankService.getPlayerRank(player.uniqueId, guild.id) ?: return false
+        return actorRank.priority < rank.priority
+    }
+
+    private fun siblingAt(direction: net.lumalyte.lg.application.services.PriorityDirection): Rank? {
+        val siblings = rankService.listRanks(guild.id).sortedBy { it.priority }
+        val idx = siblings.indexOfFirst { it.id == rank.id }
+        val neighborIdx = when (direction) {
+            net.lumalyte.lg.application.services.PriorityDirection.UP -> idx - 1
+            net.lumalyte.lg.application.services.PriorityDirection.DOWN -> idx + 1
+        }
+        return siblings.getOrNull(neighborIdx)
+    }
+```
+
+- [ ] **Step 2: Add `addPriorityButtons(pane)` and call from `open()`**
+
+Insert at the top of `open()` (after `gui.addPane(pane)`, before `addRankInfoSection(pane)`):
+
+```kotlin
+        addPriorityButtons(pane)
+```
+
+Add the method:
+
+```kotlin
+    private fun addPriorityButtons(pane: StaticPane) {
+        val upNeighbor = siblingAt(net.lumalyte.lg.application.services.PriorityDirection.UP)
+        val downNeighbor = siblingAt(net.lumalyte.lg.application.services.PriorityDirection.DOWN)
+        val canUp = canActorReorder() && upNeighbor != null && upNeighbor != rankService.getHighestRank(guild.id) && !isOwnerRank()
+        val canDown = canActorReorder() && downNeighbor != null && !isOwnerRank()
+
+        val upItem = ItemStack.of(if (canUp) Material.SPECTRAL_ARROW else Material.BARRIER)
+            .name(if (canUp) "§a▲ Move Up" else "§7▲ Move Up (locked)")
+            .lore("§7Current priority: §f${rank.priority}")
+            .lore(if (upNeighbor != null) "§7Above: §f${upNeighbor.name}" else "§7No rank above")
+            .lore("§7")
+            .lore(if (canUp) "§eClick to raise rank" else "§cCannot reorder")
+        pane.addItem(GuiItem(upItem) {
+            if (!canUp) return@GuiItem
+            val ok = rankService.moveRankPriority(rank.id, net.lumalyte.lg.application.services.PriorityDirection.UP, player.uniqueId)
+            if (ok) {
+                player.sendMessage("§a✅ Rank moved up.")
+                rank = rankService.getRank(rank.id) ?: rank
+                open()
+            } else {
+                player.sendMessage("§c❌ Could not move rank.")
+            }
+        }, 0, 0)
+
+        val downItem = ItemStack.of(if (canDown) Material.SPECTRAL_ARROW else Material.BARRIER)
+            .name(if (canDown) "§a▼ Move Down" else "§7▼ Move Down (locked)")
+            .lore("§7Current priority: §f${rank.priority}")
+            .lore(if (downNeighbor != null) "§7Below: §f${downNeighbor.name}" else "§7No rank below")
+            .lore("§7")
+            .lore(if (canDown) "§eClick to lower rank" else "§cCannot reorder")
+        pane.addItem(GuiItem(downItem) {
+            if (!canDown) return@GuiItem
+            val ok = rankService.moveRankPriority(rank.id, net.lumalyte.lg.application.services.PriorityDirection.DOWN, player.uniqueId)
+            if (ok) {
+                player.sendMessage("§a✅ Rank moved down.")
+                rank = rankService.getRank(rank.id) ?: rank
+                open()
+            } else {
+                player.sendMessage("§c❌ Could not move rank.")
+            }
+        }, 8, 0)
+    }
+```
+
+If `rankService.getRank(id)` does not exist, use `rankService.listRanks(guild.id).find { it.id == rank.id }`.
+
+- [ ] **Step 3: Compile**
+
+Run: `./gradlew compileKotlin`
+Expected: BUILD SUCCESSFUL
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add src/main/kotlin/net/lumalyte/lg/interaction/menus/guild/RankEditMenu.kt
+git commit -m "feat(ui): add ▲/▼ priority reorder buttons to RankEditMenu"
+```
+
+---
+
+## Task 16: Surface `USE_ALLY_HOMES` in `RankEditMenu` Diplomacy category
+
+**Files:**
+- Modify: `src/main/kotlin/net/lumalyte/lg/interaction/menus/guild/RankEditMenu.kt`
+- Modify: `src/main/kotlin/net/lumalyte/lg/interaction/menus/guild/GuildRankManagementMenu.kt`
+- Modify: `src/main/kotlin/net/lumalyte/lg/interaction/menus/guild/RankCreationMenu.kt`
+
+- [ ] **Step 1: Add `USE_ALLY_HOMES` to Diplomacy permission list in `RankEditMenu.addPermissionCategories` (line 212)**
+
+Replace the Diplomacy entry:
+
+```kotlin
+            "Diplomacy" to listOf(
+                RankPermission.MANAGE_RELATIONS, RankPermission.DECLARE_WAR,
+                RankPermission.ACCEPT_ALLIANCES, RankPermission.MANAGE_PARTIES,
+                RankPermission.SEND_PARTY_REQUESTS, RankPermission.ACCEPT_PARTY_INVITES,
+                RankPermission.USE_ALLY_HOMES
+            ),
+```
+
+- [ ] **Step 2: Same edit in `GuildRankManagementMenu.groupPermissionsByCategory` (line 157-162)**
+
+Add `USE_ALLY_HOMES` to the Diplomacy branch.
+
+- [ ] **Step 3: Same edit in `RankCreationMenu`'s permission categories (search for `MANAGE_RELATIONS`)**
+
+- [ ] **Step 4: Compile**
+
+Run: `./gradlew compileKotlin`
+Expected: BUILD SUCCESSFUL
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/main/kotlin/net/lumalyte/lg/interaction/menus/guild/RankEditMenu.kt \
+        src/main/kotlin/net/lumalyte/lg/interaction/menus/guild/GuildRankManagementMenu.kt \
+        src/main/kotlin/net/lumalyte/lg/interaction/menus/guild/RankCreationMenu.kt
+git commit -m "feat(ui): expose USE_ALLY_HOMES in Diplomacy permission category"
+```
+
+---
+
+## Task 17: `HomeAccessMenu` — per-home rank whitelist editor
+
+**Files:**
+- Create: `src/main/kotlin/net/lumalyte/lg/interaction/menus/guild/HomeAccessMenu.kt`
+- Modify: `src/main/kotlin/net/lumalyte/lg/interaction/menus/MenuFactory.kt`
+
+- [ ] **Step 1: Create the menu**
+
+```kotlin
+package net.lumalyte.lg.interaction.menus.guild
+
+import com.github.stefvanschie.inventoryframework.gui.GuiItem
+import com.github.stefvanschie.inventoryframework.gui.type.ChestGui
+import com.github.stefvanschie.inventoryframework.pane.StaticPane
+import net.lumalyte.lg.application.services.GuildService
+import net.lumalyte.lg.application.services.RankService
+import net.lumalyte.lg.domain.entities.Guild
+import net.lumalyte.lg.domain.entities.RankPermission
+import net.lumalyte.lg.interaction.menus.Menu
+import net.lumalyte.lg.interaction.menus.MenuNavigator
+import net.lumalyte.lg.utils.lore
+import net.lumalyte.lg.utils.name
+import org.bukkit.Material
+import org.bukkit.entity.Player
+import org.bukkit.event.inventory.ClickType
+import org.bukkit.inventory.ItemStack
+import org.koin.core.component.KoinComponent
+import org.koin.core.component.inject
+
+class HomeAccessMenu(
+    private val menuNavigator: MenuNavigator,
+    private val player: Player,
+    private val guild: Guild,
+    private val homeName: String
+) : Menu, KoinComponent {
+
+    private val rankService: RankService by inject()
+    private val guildService: GuildService by inject()
+    private val menuFactory: net.lumalyte.lg.interaction.menus.MenuFactory by inject()
+
+    override fun open() {
+        if (!rankService.hasPermission(player.uniqueId, guild.id, RankPermission.MANAGE_HOME)) {
+            player.sendMessage("§c❌ You need MANAGE_HOME to configure home access.")
+            menuNavigator.openMenu(menuFactory.createGuildHomeMenu(menuNavigator, player, guild))
+            return
+        }
+
+        val home = guildService.getHome(guild.id, homeName)
+        if (home == null) {
+            player.sendMessage("§cHome '$homeName' no longer exists.")
+            menuNavigator.openMenu(menuFactory.createGuildHomeMenu(menuNavigator, player, guild))
+            return
+        }
+
+        val gui = ChestGui(4, "§6Access: $homeName")
+        val pane = StaticPane(0, 0, 9, 4)
+        gui.setOnTopClick { it.isCancelled = true }
+        gui.setOnBottomClick {
+            if (it.click == ClickType.SHIFT_LEFT || it.click == ClickType.SHIFT_RIGHT) it.isCancelled = true
+        }
+        gui.addPane(pane)
+
+        val ranks = rankService.listRanks(guild.id).sortedBy { it.priority }
+        val ownerRank = rankService.getHighestRank(guild.id)
+        var allowed = home.allowedRankIds.toMutableSet()
+
+        ranks.take(8).forEachIndexed { idx, r ->
+            val row = idx / 4
+            val col = idx % 4
+            val isOwner = r.id == ownerRank?.id
+            val on = isOwner || r.id in allowed
+            val item = ItemStack.of(
+                if (isOwner) Material.NETHER_STAR
+                else if (on) Material.LIME_DYE
+                else Material.GRAY_DYE
+            ).name(if (on) "§a✓ ${r.name}" else "§c✗ ${r.name}")
+                .lore("§7Priority: §f${r.priority}")
+                .lore("§7")
+                .lore(
+                    if (isOwner) "§eOwner — always allowed"
+                    else if (on) "§eClick to revoke" else "§eClick to grant"
+                )
+            pane.addItem(GuiItem(item) {
+                if (isOwner) return@GuiItem
+                if (r.id in allowed) allowed.remove(r.id) else allowed.add(r.id)
+                guildService.setHomeAllowedRanks(guild.id, homeName, allowed.toSet(), player.uniqueId)
+                open()
+            }, col, row)
+        }
+
+        val backItem = ItemStack.of(Material.ARROW).name("§7← Back to Homes")
+        pane.addItem(GuiItem(backItem) {
+            menuNavigator.openMenu(menuFactory.createGuildHomeMenu(menuNavigator, player, guild))
+        }, 8, 3)
+
+        gui.show(player)
+    }
+}
+```
+
+- [ ] **Step 2: Register in `MenuFactory`**
+
+Add to `MenuFactory.kt`:
+
+```kotlin
+    fun createHomeAccessMenu(
+        menuNavigator: MenuNavigator,
+        player: Player,
+        guild: net.lumalyte.lg.domain.entities.Guild,
+        homeName: String
+    ): Menu = net.lumalyte.lg.interaction.menus.guild.HomeAccessMenu(menuNavigator, player, guild, homeName)
+```
+
+- [ ] **Step 3: Compile**
+
+Run: `./gradlew compileKotlin`
+Expected: BUILD SUCCESSFUL
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add src/main/kotlin/net/lumalyte/lg/interaction/menus/guild/HomeAccessMenu.kt \
+        src/main/kotlin/net/lumalyte/lg/interaction/menus/MenuFactory.kt
+git commit -m "feat(ui): HomeAccessMenu — per-home rank whitelist editor"
+```
+
+---
+
+## Task 18: `AllyHomeAccessMenu` — inbound ally guild whitelist
+
+**Files:**
+- Create: `src/main/kotlin/net/lumalyte/lg/interaction/menus/guild/AllyHomeAccessMenu.kt`
+- Modify: `src/main/kotlin/net/lumalyte/lg/interaction/menus/MenuFactory.kt`
+
+- [ ] **Step 1: Create the menu**
+
+Pattern matches `HomeAccessMenu` but iterates over current allies of this guild. Inject `RelationService` (or whatever lists allies — check `GuildRelationsMenu.kt` for precedent).
+
+```kotlin
+package net.lumalyte.lg.interaction.menus.guild
+
+import com.github.stefvanschie.inventoryframework.gui.GuiItem
+import com.github.stefvanschie.inventoryframework.gui.type.ChestGui
+import com.github.stefvanschie.inventoryframework.pane.StaticPane
+import net.lumalyte.lg.application.services.GuildService
+import net.lumalyte.lg.application.services.RankService
+import net.lumalyte.lg.application.services.RelationService
+import net.lumalyte.lg.domain.entities.Guild
+import net.lumalyte.lg.domain.entities.RankPermission
+import net.lumalyte.lg.interaction.menus.Menu
+import net.lumalyte.lg.interaction.menus.MenuNavigator
+import net.lumalyte.lg.utils.lore
+import net.lumalyte.lg.utils.name
+import org.bukkit.Material
+import org.bukkit.entity.Player
+import org.bukkit.event.inventory.ClickType
+import org.bukkit.inventory.ItemStack
+import org.koin.core.component.KoinComponent
+import org.koin.core.component.inject
+
+class AllyHomeAccessMenu(
+    private val menuNavigator: MenuNavigator,
+    private val player: Player,
+    private val guild: Guild
+) : Menu, KoinComponent {
+
+    private val rankService: RankService by inject()
+    private val guildService: GuildService by inject()
+    private val relationService: RelationService by inject()
+    private val menuFactory: net.lumalyte.lg.interaction.menus.MenuFactory by inject()
+
+    override fun open() {
+        if (!rankService.hasPermission(player.uniqueId, guild.id, RankPermission.MANAGE_HOME)) {
+            player.sendMessage("§c❌ You need MANAGE_HOME to configure ally-home access.")
+            menuNavigator.openMenu(menuFactory.createGuildHomeMenu(menuNavigator, player, guild))
+            return
+        }
+
+        val current = guildService.getGuild(guild.id) ?: return
+        val allies = relationService.listAllies(guild.id) // returns Set<Guild> or Set<UUID> — adapt
+        val allowed = current.allyHomeAllowedGuilds.toMutableSet()
+
+        val gui = ChestGui(4, "§6Ally-home Access")
+        val pane = StaticPane(0, 0, 9, 4)
+        gui.setOnTopClick { it.isCancelled = true }
+        gui.setOnBottomClick {
+            if (it.click == ClickType.SHIFT_LEFT || it.click == ClickType.SHIFT_RIGHT) it.isCancelled = true
+        }
+        gui.addPane(pane)
+
+        allies.take(8).forEachIndexed { idx, ally ->
+            val row = idx / 4
+            val col = idx % 4
+            val allyId = ally.id // assuming Set<Guild>; if UUID, use directly
+            val on = allyId in allowed
+            val item = ItemStack.of(if (on) Material.LIME_DYE else Material.GRAY_DYE)
+                .name(if (on) "§a✓ ${ally.name}" else "§c✗ ${ally.name}")
+                .lore("§7Click to toggle inbound access")
+            pane.addItem(GuiItem(item) {
+                if (allyId in allowed) allowed.remove(allyId) else allowed.add(allyId)
+                guildService.setAllyHomeAllowedGuilds(guild.id, allowed.toSet(), player.uniqueId)
+                open()
+            }, col, row)
+        }
+
+        val info = ItemStack.of(Material.BOOK)
+            .name("§eOutbound access (read-only)")
+            .lore("§7To control which of YOUR ranks can use ally homes,")
+            .lore("§7edit the §fUSE_ALLY_HOMES§7 permission in rank settings.")
+        pane.addItem(GuiItem(info), 4, 3)
+
+        val backItem = ItemStack.of(Material.ARROW).name("§7← Back to Homes")
+        pane.addItem(GuiItem(backItem) {
+            menuNavigator.openMenu(menuFactory.createGuildHomeMenu(menuNavigator, player, guild))
+        }, 8, 3)
+
+        gui.show(player)
+    }
+}
+```
+
+- [ ] **Step 2: Register in `MenuFactory`**
+
+```kotlin
+    fun createAllyHomeAccessMenu(
+        menuNavigator: MenuNavigator,
+        player: Player,
+        guild: net.lumalyte.lg.domain.entities.Guild
+    ): Menu = net.lumalyte.lg.interaction.menus.guild.AllyHomeAccessMenu(menuNavigator, player, guild)
+```
+
+- [ ] **Step 3: Compile**
+
+Run: `./gradlew compileKotlin`
+Expected: BUILD SUCCESSFUL — if `RelationService.listAllies` signature differs, adapt the call.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add src/main/kotlin/net/lumalyte/lg/interaction/menus/guild/AllyHomeAccessMenu.kt \
+        src/main/kotlin/net/lumalyte/lg/interaction/menus/MenuFactory.kt
+git commit -m "feat(ui): AllyHomeAccessMenu — per-ally inbound whitelist editor"
+```
+
+---
+
+## Task 19: Wire 🔒 Access buttons into `GuildHomeMenu`
+
+**Files:**
+- Modify: `src/main/kotlin/net/lumalyte/lg/interaction/menus/guild/GuildHomeMenu.kt`
+
+- [ ] **Step 1: Add per-home access buttons in row 1**
+
+In `addHomeSlotsDisplay` (line 78) or as a new method, iterate over current homes and place a button at row 1 underneath each home slot:
+
+```kotlin
+    private fun addHomeAccessButtons(pane: StaticPane) {
+        val rankService: RankService by inject()
+        val canManage = rankService.hasPermission(player.uniqueId, guild.id, RankPermission.MANAGE_HOME)
+        if (!canManage) return
+        val homes = guildService.getHomes(guild.id).homes.entries.toList()
+        homes.take(9).forEachIndexed { idx, (homeName, _) ->
+            val item = ItemStack.of(Material.IRON_DOOR)
+                .name("§6🔒 Access: $homeName")
+                .lore("§7Configure which ranks can use this home")
+                .lore("§eClick to manage")
+            pane.addItem(GuiItem(item) {
+                menuNavigator.openMenu(menuFactory.createHomeAccessMenu(menuNavigator, player, guild, homeName))
+            }, idx, 1)
+        }
+    }
+```
+
+Add the `RankService` import and add `addHomeAccessButtons(pane)` to `open()` after `addHomeSlotsDisplay(pane, 0, 0)`.
+
+- [ ] **Step 2: Add Ally Access button**
+
+In the existing ally-home row (row 5, after the ally-home teleport button), if `ALLY_HOME_ACCESS` perk is unlocked, add:
+
+```kotlin
+        if (progressionService.hasPerkUnlocked(guild.id, net.lumalyte.lg.application.services.PerkType.ALLY_HOME_ACCESS)
+            && rankService.hasPermission(player.uniqueId, guild.id, RankPermission.MANAGE_HOME)) {
+            val allyAccessItem = ItemStack.of(Material.IRON_DOOR)
+                .name("§6🔒 Ally-home Access")
+                .lore("§7Configure which allied guilds can use your ally-home")
+            pane.addItem(GuiItem(allyAccessItem) {
+                menuNavigator.openMenu(menuFactory.createAllyHomeAccessMenu(menuNavigator, player, guild))
+            }, 7, 5)
+        }
+```
+
+- [ ] **Step 3: Compile**
+
+Run: `./gradlew compileKotlin`
+Expected: BUILD SUCCESSFUL
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add src/main/kotlin/net/lumalyte/lg/interaction/menus/guild/GuildHomeMenu.kt
+git commit -m "feat(ui): Access buttons in GuildHomeMenu for per-home + ally-home"
+```
+
+---
+
+## Task 20: Bedrock variants
+
+**Files:**
+- Modify: `src/main/kotlin/net/lumalyte/lg/interaction/menus/bedrock/BedrockGuildHomeMenu.kt`
+- Modify: `src/main/kotlin/net/lumalyte/lg/interaction/menus/bedrock/BedrockRankEditMenu.kt`
+
+- [ ] **Step 1: Add denial feedback in `BedrockGuildHomeMenu` teleport handler**
+
+Locate where teleport is invoked and gate it with `guildService.canUseHome(...)`. On denial, show form text: `"You don't have permission to use this home."`. Don't add new sub-forms for Bedrock — instead, when manager clicks Access, show a simple `SimpleForm` listing ranks; toggle via repeated form opens. Skip if cost/complexity too high for first pass — fall back to a chat message: `"Use the Java client to configure home access."`.
+
+Actual code:
+
+```kotlin
+        if (!guildService.canUseHome(player.uniqueId, guild.id, targetHomeName)) {
+            player.sendMessage("§cYou don't have permission to use that home.")
+            return
+        }
+```
+
+- [ ] **Step 2: Add priority controls (read-only) in `BedrockRankEditMenu`**
+
+Bedrock can't easily do click-to-reorder. Surface priority as a chat-confirmable "Move Up / Move Down" form choice, calling `rankService.moveRankPriority(...)`. Simplest: add two buttons to the existing form labeled `▲ Move Up`, `▼ Move Down` and route to the service.
+
+- [ ] **Step 3: Compile**
+
+Run: `./gradlew compileKotlin`
+Expected: BUILD SUCCESSFUL
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add src/main/kotlin/net/lumalyte/lg/interaction/menus/bedrock/
+git commit -m "feat(bedrock): home access gating + rank priority controls"
+```
+
+---
+
+## Task 21: Final verification
+
+- [ ] **Step 1: Full test suite**
+
+Run: `./gradlew test`
+Expected: All tests pass.
+
+- [ ] **Step 2: Full build**
+
+Run: `./gradlew build`
+Expected: BUILD SUCCESSFUL, jar produced under `build/libs/`.
+
+- [ ] **Step 3: Manual smoke test on dev server (paper-mcp)**
+
+Use `mcp__papermcp__minecraft_execute_command` to:
+1. Form a test guild, set a home, set another rank, log in as a member of that rank → `/guild home` should be denied (after granting MANAGE_HOME to founder and using `HomeAccessMenu` to revoke).
+2. Test rank priority: as founder, edit a member-tier rank, click ▲, verify priority change persists across `/reload`.
+3. Test ally home: ally two guilds, verify auto-add to `allyHomeAllowedGuilds`, revoke one side via `AllyHomeAccessMenu`, verify cross-guild teleport denied.
+
+- [ ] **Step 4: Final commit (if any cleanup)**
+
+```bash
+git status
+# If clean, no commit needed.
+```
+
+---
+
+## Self-Review Notes
+
+- **Spec coverage:** §2 (per-home) → Tasks 2, 5, 7, 8, 10 (mutator), 12 (enforce), 17 (UI). §3 (ally-home) → Tasks 1 (perm), 3 (field), 6 (persist), 9 (check), 10 (mutator), 11 (auto-update), 13 (enforce), 18 (UI), 19 (button). §4 (priority) → Task 14 (service), 15 (UI), plus Bedrock in Task 20. §5 (migration) → Task 4. §6 (testing) → Tests embedded in Tasks 2, 3, 8, 9, 14.
+- **GuildTeamService bug (§4.3)** is out of scope, flagged in spec — no task.
+- **Test gaps:** Migration tests (in-memory SQLite) and Konsist layer tests are not split into separate tasks — recommend adding if SPEAR cycle requires. Existing test conventions don't appear to use Konsist.
+- **Bedrock parity** is rough (Task 20) — acceptable per project precedent where Bedrock menus lag behind Java.
+
+---
+
+## Execution Handoff
+
+**Plan complete and saved to `docs/plans/2026-05-10-rank-and-home-perms-impl.md`. Two execution options:**
+
+1. **Subagent-Driven (recommended)** — dispatch a fresh subagent per task, review between tasks, fast iteration.
+2. **Inline Execution** — execute tasks in this session using executing-plans, batch execution with checkpoints.
+
+Which approach?

--- a/src/main/kotlin/net/lumalyte/lg/application/persistence/RankRepository.kt
+++ b/src/main/kotlin/net/lumalyte/lg/application/persistence/RankRepository.kt
@@ -111,4 +111,10 @@ interface RankRepository {
      * @return The total count of ranks.
      */
     fun getCountByGuild(guildId: UUID): Int
+
+    /**
+     * Atomically swaps the `priority` column of two ranks. Three-step swap via a temporary
+     * out-of-range value to remain safe under any future unique-index on (guild_id, priority).
+     */
+    fun swapPriorities(rankAId: UUID, rankBId: UUID): Boolean
 }

--- a/src/main/kotlin/net/lumalyte/lg/application/services/GuildService.kt
+++ b/src/main/kotlin/net/lumalyte/lg/application/services/GuildService.kt
@@ -315,4 +315,12 @@ interface GuildService {
      * @return true if successful, false otherwise.
      */
     fun setBankFrozen(guildId: UUID, frozen: Boolean, actorId: UUID): Boolean
+
+    /**
+     * Checks whether a player may teleport to the named home. Returns true when:
+     * - the player is in the guild, AND
+     * - the player's rank is the highest-priority (Owner) rank, OR
+     * - the player's rank id is in `home.allowedRankIds`.
+     */
+    fun canUseHome(playerId: UUID, guildId: UUID, homeName: String): Boolean
 }

--- a/src/main/kotlin/net/lumalyte/lg/application/services/GuildService.kt
+++ b/src/main/kotlin/net/lumalyte/lg/application/services/GuildService.kt
@@ -332,4 +332,15 @@ interface GuildService {
      * - (player's rank in source is Owner) OR (rank has USE_ALLY_HOMES permission).
      */
     fun canUseAllyHome(playerId: UUID, sourceGuildId: UUID, targetGuildId: UUID): Boolean
+
+    /**
+     * Updates the rank whitelist for a named home. Caller must have MANAGE_HOME.
+     */
+    fun setHomeAllowedRanks(guildId: UUID, homeName: String, allowedRankIds: Set<UUID>, actorId: UUID): Boolean
+
+    /**
+     * Updates the inbound allow-list of guilds whose members may teleport to this guild's
+     * ally-home. Caller must have MANAGE_HOME.
+     */
+    fun setAllyHomeAllowedGuilds(guildId: UUID, allowedGuildIds: Set<UUID>, actorId: UUID): Boolean
 }

--- a/src/main/kotlin/net/lumalyte/lg/application/services/GuildService.kt
+++ b/src/main/kotlin/net/lumalyte/lg/application/services/GuildService.kt
@@ -323,4 +323,13 @@ interface GuildService {
      * - the player's rank id is in `home.allowedRankIds`.
      */
     fun canUseHome(playerId: UUID, guildId: UUID, homeName: String): Boolean
+
+    /**
+     * Checks whether a player may teleport to another guild's ally-home. Returns true when:
+     * - player is in `sourceGuildId`, AND
+     * - target guild has an ally-home set, AND
+     * - source guild is in target.allyHomeAllowedGuilds (inbound), AND
+     * - (player's rank in source is Owner) OR (rank has USE_ALLY_HOMES permission).
+     */
+    fun canUseAllyHome(playerId: UUID, sourceGuildId: UUID, targetGuildId: UUID): Boolean
 }

--- a/src/main/kotlin/net/lumalyte/lg/application/services/RankService.kt
+++ b/src/main/kotlin/net/lumalyte/lg/application/services/RankService.kt
@@ -164,4 +164,16 @@ interface RankService {
      * @return true if successful, false otherwise.
      */
     fun createDefaultRanks(guildId: UUID, ownerId: UUID): Boolean
+
+    /**
+     * Moves a rank up (lower priority number, higher in hierarchy) or down by one slot,
+     * swapping priorities with the adjacent rank. Returns false if:
+     * - actor lacks MANAGE_RANKS, OR
+     * - actor's rank priority >= target rank priority, OR
+     * - target is the highest-priority rank and direction is UP, OR
+     * - target is the lowest-priority rank and direction is DOWN.
+     */
+    fun moveRankPriority(rankId: UUID, direction: PriorityDirection, actorId: UUID): Boolean
 }
+
+enum class PriorityDirection { UP, DOWN }

--- a/src/main/kotlin/net/lumalyte/lg/di/Modules.kt
+++ b/src/main/kotlin/net/lumalyte/lg/di/Modules.kt
@@ -405,7 +405,7 @@ fun guildsModule() = module {
     single<GuildService> { GuildServiceBukkit(get(), get(), get(), get(), get(), get(), get(), get(), get(), get()) }
     single<RankService> { RankServiceBukkit(get(), get(), get(), get()) }
     single<MemberService> { MemberServiceBukkit(get(), get(), get(), get(), get(), get(), get()) }
-    single<RelationService> { RelationServiceBukkit(get(), get()) }
+    single<RelationService> { RelationServiceBukkit(get(), get(), get()) }
     single<LfgService> { LfgServiceBukkit(get(), get(), get(), get(), get(), get(), get(), get()) }
     single<GuildBannerService> { GuildBannerServiceBukkit() }
     single<AuditService> { AuditServiceBukkit() }

--- a/src/main/kotlin/net/lumalyte/lg/domain/entities/Guild.kt
+++ b/src/main/kotlin/net/lumalyte/lg/domain/entities/Guild.kt
@@ -48,7 +48,8 @@ data class Guild(
     val joinFeeAmount: Int = 0,
     val trackingEnabled: Boolean = true,
     val bankFrozen: Boolean = false,
-    val allyHome: GuildHome? = null
+    val allyHome: GuildHome? = null,
+    val allyHomeAllowedGuilds: Set<UUID> = emptySet()
 ) {
     init {
         require(name.length in 1..32) { "Guild name must be between 1 and 32 characters." }

--- a/src/main/kotlin/net/lumalyte/lg/domain/entities/Guild.kt
+++ b/src/main/kotlin/net/lumalyte/lg/domain/entities/Guild.kt
@@ -87,7 +87,8 @@ data class Guild(
  */
 data class GuildHome(
     val worldId: UUID,
-    val position: Position3D
+    val position: Position3D,
+    val allowedRankIds: Set<UUID> = emptySet()
 )
 
 /**

--- a/src/main/kotlin/net/lumalyte/lg/domain/entities/Rank.kt
+++ b/src/main/kotlin/net/lumalyte/lg/domain/entities/Rank.kt
@@ -47,7 +47,8 @@ enum class RankPermission {
     MANAGE_PARTIES,
     SEND_PARTY_REQUESTS,
     ACCEPT_PARTY_INVITES,
-    
+    USE_ALLY_HOMES,
+
     // Banking & Economy
     DEPOSIT_TO_BANK,          // Deposit to virtual bank (Vault economy)
     WITHDRAW_FROM_BANK,       // Withdraw from virtual bank

--- a/src/main/kotlin/net/lumalyte/lg/infrastructure/persistence/guilds/GuildRepositorySQLite.kt
+++ b/src/main/kotlin/net/lumalyte/lg/infrastructure/persistence/guilds/GuildRepositorySQLite.kt
@@ -185,7 +185,8 @@ class GuildRepositorySQLite(private val storage: Storage<Database>) : GuildRepos
             "ally_home_world TEXT",
             "ally_home_x INTEGER",
             "ally_home_y INTEGER",
-            "ally_home_z INTEGER"
+            "ally_home_z INTEGER",
+            "ally_home_allowed_guilds TEXT"
         )
         for (colDef in columns) {
             try {
@@ -395,6 +396,16 @@ class GuildRepositorySQLite(private val storage: Storage<Database>) : GuildRepos
             null
         }
 
+        val allyHomeAllowedGuilds = try {
+            val csv = rs.getString("ally_home_allowed_guilds").orEmpty()
+            csv.split(",")
+                .filter { it.isNotBlank() }
+                .map { UUID.fromString(it.trim()) }
+                .toSet()
+        } catch (e: Exception) {
+            emptySet<UUID>()
+        }
+
         // Debug logging for vault data loading
         println("DEBUG [GuildRepositorySQLite] Loading guild '$name'")
         println("  vault_status from DB: '$vaultStatusStr' -> $vaultStatus")
@@ -420,7 +431,8 @@ class GuildRepositorySQLite(private val storage: Storage<Database>) : GuildRepos
             joinFeeAmount = joinFeeAmount,
             trackingEnabled = trackingEnabled,
             bankFrozen = bankFrozen,
-            allyHome = allyHome
+            allyHome = allyHome,
+            allyHomeAllowedGuilds = allyHomeAllowedGuilds
         )
     }
 
@@ -451,28 +463,28 @@ class GuildRepositorySQLite(private val storage: Storage<Database>) : GuildRepos
         // Use cached column existence check
         val sql = if (hasLfgColumns && hasTrackingColumn && hasBankFrozenColumn) {
             """
-            INSERT INTO guilds (id, name, banner, emoji, tag, home_world, home_x, home_y, home_z, level, bank_balance, mode, mode_changed_at, created_at, is_open, join_fee_enabled, join_fee_amount, tracking_enabled, bank_frozen, ally_home_world, ally_home_x, ally_home_y, ally_home_z)
-            VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+            INSERT INTO guilds (id, name, banner, emoji, tag, home_world, home_x, home_y, home_z, level, bank_balance, mode, mode_changed_at, created_at, is_open, join_fee_enabled, join_fee_amount, tracking_enabled, bank_frozen, ally_home_world, ally_home_x, ally_home_y, ally_home_z, ally_home_allowed_guilds)
+            VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
             """.trimIndent()
         } else if (hasLfgColumns && hasTrackingColumn) {
             """
-            INSERT INTO guilds (id, name, banner, emoji, tag, home_world, home_x, home_y, home_z, level, bank_balance, mode, mode_changed_at, created_at, is_open, join_fee_enabled, join_fee_amount, tracking_enabled, ally_home_world, ally_home_x, ally_home_y, ally_home_z)
-            VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+            INSERT INTO guilds (id, name, banner, emoji, tag, home_world, home_x, home_y, home_z, level, bank_balance, mode, mode_changed_at, created_at, is_open, join_fee_enabled, join_fee_amount, tracking_enabled, ally_home_world, ally_home_x, ally_home_y, ally_home_z, ally_home_allowed_guilds)
+            VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
             """.trimIndent()
         } else if (hasLfgColumns) {
             """
-            INSERT INTO guilds (id, name, banner, emoji, tag, home_world, home_x, home_y, home_z, level, bank_balance, mode, mode_changed_at, created_at, is_open, join_fee_enabled, join_fee_amount, ally_home_world, ally_home_x, ally_home_y, ally_home_z)
-            VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+            INSERT INTO guilds (id, name, banner, emoji, tag, home_world, home_x, home_y, home_z, level, bank_balance, mode, mode_changed_at, created_at, is_open, join_fee_enabled, join_fee_amount, ally_home_world, ally_home_x, ally_home_y, ally_home_z, ally_home_allowed_guilds)
+            VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
             """.trimIndent()
         } else if (hasTrackingColumn) {
             """
-            INSERT INTO guilds (id, name, banner, emoji, tag, home_world, home_x, home_y, home_z, level, bank_balance, mode, mode_changed_at, created_at, tracking_enabled, ally_home_world, ally_home_x, ally_home_y, ally_home_z)
-            VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+            INSERT INTO guilds (id, name, banner, emoji, tag, home_world, home_x, home_y, home_z, level, bank_balance, mode, mode_changed_at, created_at, tracking_enabled, ally_home_world, ally_home_x, ally_home_y, ally_home_z, ally_home_allowed_guilds)
+            VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
             """.trimIndent()
         } else {
             """
-            INSERT INTO guilds (id, name, banner, emoji, tag, home_world, home_x, home_y, home_z, level, bank_balance, mode, mode_changed_at, created_at, ally_home_world, ally_home_x, ally_home_y, ally_home_z)
-            VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+            INSERT INTO guilds (id, name, banner, emoji, tag, home_world, home_x, home_y, home_z, level, bank_balance, mode, mode_changed_at, created_at, ally_home_world, ally_home_x, ally_home_y, ally_home_z, ally_home_allowed_guilds)
+            VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
             """.trimIndent()
         }
 
@@ -504,7 +516,8 @@ class GuildRepositorySQLite(private val storage: Storage<Database>) : GuildRepos
                     guild.allyHome?.worldId?.toString(),
                     guild.allyHome?.position?.x,
                     guild.allyHome?.position?.y,
-                    guild.allyHome?.position?.z
+                    guild.allyHome?.position?.z,
+                    guild.allyHomeAllowedGuilds.joinToString(",") { it.toString() }
                 )
             } else if (hasLfgColumns && hasTrackingColumn) {
                 storage.connection.executeUpdate(sql,
@@ -529,7 +542,8 @@ class GuildRepositorySQLite(private val storage: Storage<Database>) : GuildRepos
                     guild.allyHome?.worldId?.toString(),
                     guild.allyHome?.position?.x,
                     guild.allyHome?.position?.y,
-                    guild.allyHome?.position?.z
+                    guild.allyHome?.position?.z,
+                    guild.allyHomeAllowedGuilds.joinToString(",") { it.toString() }
                 )
             } else if (hasLfgColumns) {
                 storage.connection.executeUpdate(sql,
@@ -553,7 +567,8 @@ class GuildRepositorySQLite(private val storage: Storage<Database>) : GuildRepos
                     guild.allyHome?.worldId?.toString(),
                     guild.allyHome?.position?.x,
                     guild.allyHome?.position?.y,
-                    guild.allyHome?.position?.z
+                    guild.allyHome?.position?.z,
+                    guild.allyHomeAllowedGuilds.joinToString(",") { it.toString() }
                 )
             } else if (hasTrackingColumn) {
                 storage.connection.executeUpdate(sql,
@@ -575,7 +590,8 @@ class GuildRepositorySQLite(private val storage: Storage<Database>) : GuildRepos
                     guild.allyHome?.worldId?.toString(),
                     guild.allyHome?.position?.x,
                     guild.allyHome?.position?.y,
-                    guild.allyHome?.position?.z
+                    guild.allyHome?.position?.z,
+                    guild.allyHomeAllowedGuilds.joinToString(",") { it.toString() }
                 )
             } else {
                 storage.connection.executeUpdate(sql,
@@ -596,7 +612,8 @@ class GuildRepositorySQLite(private val storage: Storage<Database>) : GuildRepos
                     guild.allyHome?.worldId?.toString(),
                     guild.allyHome?.position?.x,
                     guild.allyHome?.position?.y,
-                    guild.allyHome?.position?.z
+                    guild.allyHome?.position?.z,
+                    guild.allyHomeAllowedGuilds.joinToString(",") { it.toString() }
                 )
             }
             if (rowsAffected > 0) {
@@ -618,7 +635,7 @@ class GuildRepositorySQLite(private val storage: Storage<Database>) : GuildRepos
             level = ?, bank_balance = ?, mode = ?, mode_changed_at = ?,
             vault_status = ?, vault_chest_world = ?, vault_chest_x = ?, vault_chest_y = ?, vault_chest_z = ?, is_open = ?,
             join_fee_enabled = ?, join_fee_amount = ?, tracking_enabled = ?, bank_frozen = ?,
-            ally_home_world = ?, ally_home_x = ?, ally_home_y = ?, ally_home_z = ?
+            ally_home_world = ?, ally_home_x = ?, ally_home_y = ?, ally_home_z = ?, ally_home_allowed_guilds = ?
             WHERE id = ?
             """.trimIndent()
         } else if (hasLfgColumns && hasTrackingColumn) {
@@ -627,7 +644,7 @@ class GuildRepositorySQLite(private val storage: Storage<Database>) : GuildRepos
             level = ?, bank_balance = ?, mode = ?, mode_changed_at = ?,
             vault_status = ?, vault_chest_world = ?, vault_chest_x = ?, vault_chest_y = ?, vault_chest_z = ?, is_open = ?,
             join_fee_enabled = ?, join_fee_amount = ?, tracking_enabled = ?,
-            ally_home_world = ?, ally_home_x = ?, ally_home_y = ?, ally_home_z = ?
+            ally_home_world = ?, ally_home_x = ?, ally_home_y = ?, ally_home_z = ?, ally_home_allowed_guilds = ?
             WHERE id = ?
             """.trimIndent()
         } else if (hasLfgColumns) {
@@ -636,7 +653,7 @@ class GuildRepositorySQLite(private val storage: Storage<Database>) : GuildRepos
             level = ?, bank_balance = ?, mode = ?, mode_changed_at = ?,
             vault_status = ?, vault_chest_world = ?, vault_chest_x = ?, vault_chest_y = ?, vault_chest_z = ?, is_open = ?,
             join_fee_enabled = ?, join_fee_amount = ?,
-            ally_home_world = ?, ally_home_x = ?, ally_home_y = ?, ally_home_z = ?
+            ally_home_world = ?, ally_home_x = ?, ally_home_y = ?, ally_home_z = ?, ally_home_allowed_guilds = ?
             WHERE id = ?
             """.trimIndent()
         } else if (hasTrackingColumn) {
@@ -644,7 +661,7 @@ class GuildRepositorySQLite(private val storage: Storage<Database>) : GuildRepos
             UPDATE guilds SET name = ?, banner = ?, emoji = ?, tag = ?, home_world = ?, home_x = ?, home_y = ?, home_z = ?,
             level = ?, bank_balance = ?, mode = ?, mode_changed_at = ?,
             vault_status = ?, vault_chest_world = ?, vault_chest_x = ?, vault_chest_y = ?, vault_chest_z = ?, tracking_enabled = ?,
-            ally_home_world = ?, ally_home_x = ?, ally_home_y = ?, ally_home_z = ?
+            ally_home_world = ?, ally_home_x = ?, ally_home_y = ?, ally_home_z = ?, ally_home_allowed_guilds = ?
             WHERE id = ?
             """.trimIndent()
         } else {
@@ -652,7 +669,7 @@ class GuildRepositorySQLite(private val storage: Storage<Database>) : GuildRepos
             UPDATE guilds SET name = ?, banner = ?, emoji = ?, tag = ?, home_world = ?, home_x = ?, home_y = ?, home_z = ?,
             level = ?, bank_balance = ?, mode = ?, mode_changed_at = ?,
             vault_status = ?, vault_chest_world = ?, vault_chest_x = ?, vault_chest_y = ?, vault_chest_z = ?,
-            ally_home_world = ?, ally_home_x = ?, ally_home_y = ?, ally_home_z = ?
+            ally_home_world = ?, ally_home_x = ?, ally_home_y = ?, ally_home_z = ?, ally_home_allowed_guilds = ?
             WHERE id = ?
             """.trimIndent()
         }
@@ -694,6 +711,7 @@ class GuildRepositorySQLite(private val storage: Storage<Database>) : GuildRepos
                     guild.allyHome?.position?.x,
                     guild.allyHome?.position?.y,
                     guild.allyHome?.position?.z,
+                    guild.allyHomeAllowedGuilds.joinToString(",") { it.toString() },
                     guild.id.toString()
                 )
             } else if (hasLfgColumns && hasTrackingColumn) {
@@ -723,6 +741,7 @@ class GuildRepositorySQLite(private val storage: Storage<Database>) : GuildRepos
                     guild.allyHome?.position?.x,
                     guild.allyHome?.position?.y,
                     guild.allyHome?.position?.z,
+                    guild.allyHomeAllowedGuilds.joinToString(",") { it.toString() },
                     guild.id.toString()
                 )
             } else if (hasLfgColumns) {
@@ -751,6 +770,7 @@ class GuildRepositorySQLite(private val storage: Storage<Database>) : GuildRepos
                     guild.allyHome?.position?.x,
                     guild.allyHome?.position?.y,
                     guild.allyHome?.position?.z,
+                    guild.allyHomeAllowedGuilds.joinToString(",") { it.toString() },
                     guild.id.toString()
                 )
             } else if (hasTrackingColumn) {
@@ -777,6 +797,7 @@ class GuildRepositorySQLite(private val storage: Storage<Database>) : GuildRepos
                     guild.allyHome?.position?.x,
                     guild.allyHome?.position?.y,
                     guild.allyHome?.position?.z,
+                    guild.allyHomeAllowedGuilds.joinToString(",") { it.toString() },
                     guild.id.toString()
                 )
             } else {
@@ -802,6 +823,7 @@ class GuildRepositorySQLite(private val storage: Storage<Database>) : GuildRepos
                     guild.allyHome?.position?.x,
                     guild.allyHome?.position?.y,
                     guild.allyHome?.position?.z,
+                    guild.allyHomeAllowedGuilds.joinToString(",") { it.toString() },
                     guild.id.toString()
                 )
             }

--- a/src/main/kotlin/net/lumalyte/lg/infrastructure/persistence/guilds/GuildRepositorySQLite.kt
+++ b/src/main/kotlin/net/lumalyte/lg/infrastructure/persistence/guilds/GuildRepositorySQLite.kt
@@ -263,22 +263,26 @@ class GuildRepositorySQLite(private val storage: Storage<Database>) : GuildRepos
 
     /**
      * Replaces all rows for the given guild in `guild_homes` with the entries from
-     * the in-memory model. Called from `add` and `update` after the legacy columns
-     * have been written, so failure here is logged but not propagated — the legacy
-     * columns still hold the default home as a fallback.
+     * the in-memory model. Called from `add` and `update`.
+     *
+     * The DELETE + re-INSERT pair runs inside a single SQLite transaction so that a
+     * mid-loop INSERT failure cannot leave the table empty (which would silently
+     * wipe every named home — the legacy `guilds.home_*` columns only cover the
+     * default home). On any failure the transaction is rolled back and the caller
+     * sees a thrown SQLException, which the outer `add`/`update` catch translates
+     * to a `false` return so the in-memory cache stays in sync with the DB.
      */
     private fun writeGuildHomes(guild: Guild) {
-        try {
-            storage.connection.executeUpdate(
-                "DELETE FROM guild_homes WHERE guild_id = ?",
-                guild.id.toString()
-            )
+        val deleteSql = "DELETE FROM guild_homes WHERE guild_id = ?"
+        val insertSql = """
+            INSERT INTO guild_homes (guild_id, name, world_id, x, y, z, allowed_ranks)
+            VALUES (?, ?, ?, ?, ?, ?, ?)
+        """.trimIndent()
+        val committed = storage.connection.createTransaction { stmt ->
+            stmt.executeUpdateQuery(deleteSql, guild.id.toString())
             for ((homeName, home) in guild.homes.homes) {
-                storage.connection.executeUpdate(
-                    """
-                    INSERT INTO guild_homes (guild_id, name, world_id, x, y, z, allowed_ranks)
-                    VALUES (?, ?, ?, ?, ?, ?, ?)
-                    """.trimIndent(),
+                stmt.executeUpdateQuery(
+                    insertSql,
                     guild.id.toString(),
                     homeName,
                     home.worldId.toString(),
@@ -288,8 +292,10 @@ class GuildRepositorySQLite(private val storage: Storage<Database>) : GuildRepos
                     home.allowedRankIds.joinToString(",") { it.toString() }
                 )
             }
-        } catch (e: SQLException) {
-            println("WARN [GuildRepositorySQLite] Failed to persist guild_homes for ${guild.id}: ${e.message}")
+            true
+        }
+        if (!committed) {
+            throw SQLException("guild_homes write transaction did not commit for ${guild.id}")
         }
     }
 

--- a/src/main/kotlin/net/lumalyte/lg/infrastructure/persistence/guilds/GuildRepositorySQLite.kt
+++ b/src/main/kotlin/net/lumalyte/lg/infrastructure/persistence/guilds/GuildRepositorySQLite.kt
@@ -239,8 +239,15 @@ class GuildRepositorySQLite(private val storage: Storage<Database>) : GuildRepos
                 val z = row.getInt("z")
                 val allowedCsv = row.getString("allowed_ranks").orEmpty()
                 val allowedRankIds = allowedCsv.split(",")
-                    .filter { it.isNotBlank() }
-                    .map { UUID.fromString(it.trim()) }
+                    .mapNotNull { token ->
+                        val trimmed = token.trim()
+                        if (trimmed.isEmpty()) null else try {
+                            UUID.fromString(trimmed)
+                        } catch (e: IllegalArgumentException) {
+                            println("WARN [GuildRepositorySQLite] Ignoring invalid allowed_ranks UUID '$trimmed' for guild '$guildId' home '$homeName': ${e.message}")
+                            null
+                        }
+                    }
                     .toSet()
                 val home = GuildHome(worldId, net.lumalyte.lg.domain.values.Position3D(x, y, z), allowedRankIds)
                 byGuild.getOrPut(guildId) { mutableMapOf() }[homeName] = home
@@ -396,14 +403,23 @@ class GuildRepositorySQLite(private val storage: Storage<Database>) : GuildRepos
             null
         }
 
-        val allyHomeAllowedGuilds = try {
+        val allyHomeAllowedGuilds: Set<UUID> = try {
             val csv = rs.getString("ally_home_allowed_guilds").orEmpty()
             csv.split(",")
-                .filter { it.isNotBlank() }
-                .map { UUID.fromString(it.trim()) }
+                .mapNotNull { token ->
+                    val trimmed = token.trim()
+                    if (trimmed.isEmpty()) null else try {
+                        UUID.fromString(trimmed)
+                    } catch (ex: IllegalArgumentException) {
+                        println("WARN [GuildRepositorySQLite] Ignoring invalid ally_home_allowed_guilds UUID '$trimmed' for guild '$id': ${ex.message}")
+                        null
+                    }
+                }
                 .toSet()
-        } catch (e: Exception) {
-            emptySet<UUID>()
+        } catch (e: SQLException) {
+            // Column may not exist yet on a freshly upgraded plugin running against a stale DB.
+            println("WARN [GuildRepositorySQLite] Failed to load ally_home_allowed_guilds for guild '$id': ${e.message}")
+            emptySet()
         }
 
         // Debug logging for vault data loading

--- a/src/main/kotlin/net/lumalyte/lg/infrastructure/persistence/guilds/GuildRepositorySQLite.kt
+++ b/src/main/kotlin/net/lumalyte/lg/infrastructure/persistence/guilds/GuildRepositorySQLite.kt
@@ -134,6 +134,7 @@ class GuildRepositorySQLite(private val storage: Storage<Database>) : GuildRepos
                 x INTEGER NOT NULL,
                 y INTEGER NOT NULL,
                 z INTEGER NOT NULL,
+                allowed_ranks TEXT,
                 PRIMARY KEY (guild_id, name),
                 FOREIGN KEY (guild_id) REFERENCES guilds(id) ON DELETE CASCADE
             );
@@ -226,7 +227,7 @@ class GuildRepositorySQLite(private val storage: Storage<Database>) : GuildRepos
         val byGuild = mutableMapOf<UUID, MutableMap<String, GuildHome>>()
         try {
             val rows = storage.connection.getResults(
-                "SELECT guild_id, name, world_id, x, y, z FROM guild_homes"
+                "SELECT guild_id, name, world_id, x, y, z, allowed_ranks FROM guild_homes"
             )
             for (row in rows) {
                 val guildId = UUID.fromString(row.getString("guild_id"))
@@ -235,7 +236,12 @@ class GuildRepositorySQLite(private val storage: Storage<Database>) : GuildRepos
                 val x = row.getInt("x")
                 val y = row.getInt("y")
                 val z = row.getInt("z")
-                val home = GuildHome(worldId, net.lumalyte.lg.domain.values.Position3D(x, y, z))
+                val allowedCsv = row.getString("allowed_ranks").orEmpty()
+                val allowedRankIds = allowedCsv.split(",")
+                    .filter { it.isNotBlank() }
+                    .map { UUID.fromString(it.trim()) }
+                    .toSet()
+                val home = GuildHome(worldId, net.lumalyte.lg.domain.values.Position3D(x, y, z), allowedRankIds)
                 byGuild.getOrPut(guildId) { mutableMapOf() }[homeName] = home
             }
         } catch (e: SQLException) {
@@ -262,15 +268,16 @@ class GuildRepositorySQLite(private val storage: Storage<Database>) : GuildRepos
             for ((homeName, home) in guild.homes.homes) {
                 storage.connection.executeUpdate(
                     """
-                    INSERT INTO guild_homes (guild_id, name, world_id, x, y, z)
-                    VALUES (?, ?, ?, ?, ?, ?)
+                    INSERT INTO guild_homes (guild_id, name, world_id, x, y, z, allowed_ranks)
+                    VALUES (?, ?, ?, ?, ?, ?, ?)
                     """.trimIndent(),
                     guild.id.toString(),
                     homeName,
                     home.worldId.toString(),
                     home.position.x,
                     home.position.y,
-                    home.position.z
+                    home.position.z,
+                    home.allowedRankIds.joinToString(",") { it.toString() }
                 )
             }
         } catch (e: SQLException) {

--- a/src/main/kotlin/net/lumalyte/lg/infrastructure/persistence/guilds/RankRepositorySQLite.kt
+++ b/src/main/kotlin/net/lumalyte/lg/infrastructure/persistence/guilds/RankRepositorySQLite.kt
@@ -184,13 +184,22 @@ class RankRepositorySQLite(private val storage: Storage<Database>) : RankReposit
         val tempPriority = Int.MAX_VALUE
         val sql = "UPDATE ranks SET priority = ? WHERE id = ?"
         return try {
-            storage.connection.executeUpdate(sql, tempPriority, rankAId.toString())
-            storage.connection.executeUpdate(sql, rankA.priority, rankBId.toString())
-            storage.connection.executeUpdate(sql, rankB.priority, rankAId.toString())
-            ranks[rankAId] = rankA.copy(priority = rankB.priority)
-            ranks[rankBId] = rankB.copy(priority = rankA.priority)
-            true
+            val committed = storage.connection.createTransaction { stmt ->
+                stmt.executeUpdateQuery(sql, tempPriority, rankAId.toString())
+                stmt.executeUpdateQuery(sql, rankA.priority, rankBId.toString())
+                stmt.executeUpdateQuery(sql, rankB.priority, rankAId.toString())
+                true
+            }
+            if (committed) {
+                ranks[rankAId] = rankA.copy(priority = rankB.priority)
+                ranks[rankBId] = rankB.copy(priority = rankA.priority)
+                true
+            } else {
+                println("ERROR [RankRepositorySQLite] swapPriorities($rankAId, $rankBId): transaction did not commit")
+                false
+            }
         } catch (e: java.sql.SQLException) {
+            println("ERROR [RankRepositorySQLite] swapPriorities($rankAId, $rankBId) failed: ${e.message}")
             false
         }
     }

--- a/src/main/kotlin/net/lumalyte/lg/infrastructure/persistence/guilds/RankRepositorySQLite.kt
+++ b/src/main/kotlin/net/lumalyte/lg/infrastructure/persistence/guilds/RankRepositorySQLite.kt
@@ -185,10 +185,13 @@ class RankRepositorySQLite(private val storage: Storage<Database>) : RankReposit
         val sql = "UPDATE ranks SET priority = ? WHERE id = ?"
         return try {
             val committed = storage.connection.createTransaction { stmt ->
-                stmt.executeUpdateQuery(sql, tempPriority, rankAId.toString())
-                stmt.executeUpdateQuery(sql, rankA.priority, rankBId.toString())
-                stmt.executeUpdateQuery(sql, rankB.priority, rankAId.toString())
-                true
+                val n1 = stmt.executeUpdateQuery(sql, tempPriority, rankAId.toString())
+                val n2 = stmt.executeUpdateQuery(sql, rankA.priority, rankBId.toString())
+                val n3 = stmt.executeUpdateQuery(sql, rankB.priority, rankAId.toString())
+                if (n1 != 1 || n2 != 1 || n3 != 1) {
+                    println("ERROR [RankRepositorySQLite] swapPriorities row counts unexpected (n1=$n1 n2=$n2 n3=$n3) — rolling back")
+                    false
+                } else true
             }
             if (committed) {
                 ranks[rankAId] = rankA.copy(priority = rankB.priority)

--- a/src/main/kotlin/net/lumalyte/lg/infrastructure/persistence/guilds/RankRepositorySQLite.kt
+++ b/src/main/kotlin/net/lumalyte/lg/infrastructure/persistence/guilds/RankRepositorySQLite.kt
@@ -176,4 +176,22 @@ class RankRepositorySQLite(private val storage: Storage<Database>) : RankReposit
     }
     
     override fun getCountByGuild(guildId: UUID): Int = getByGuild(guildId).size
+
+    override fun swapPriorities(rankAId: UUID, rankBId: UUID): Boolean {
+        val rankA = ranks[rankAId] ?: return false
+        val rankB = ranks[rankBId] ?: return false
+        if (rankA.guildId != rankB.guildId) return false
+        val tempPriority = Int.MAX_VALUE
+        val sql = "UPDATE ranks SET priority = ? WHERE id = ?"
+        return try {
+            storage.connection.executeUpdate(sql, tempPriority, rankAId.toString())
+            storage.connection.executeUpdate(sql, rankA.priority, rankBId.toString())
+            storage.connection.executeUpdate(sql, rankB.priority, rankAId.toString())
+            ranks[rankAId] = rankA.copy(priority = rankB.priority)
+            ranks[rankBId] = rankB.copy(priority = rankA.priority)
+            true
+        } catch (e: java.sql.SQLException) {
+            false
+        }
+    }
 }

--- a/src/main/kotlin/net/lumalyte/lg/infrastructure/persistence/migrations/SQLiteMigrations.kt
+++ b/src/main/kotlin/net/lumalyte/lg/infrastructure/persistence/migrations/SQLiteMigrations.kt
@@ -114,6 +114,11 @@ class SQLiteMigrations(private val plugin: JavaPlugin, private val connection: C
                 updateDatabaseVersion(19)
                 dbVersion = 19
             }
+            if (dbVersion < 20) {
+                migrateToVersion20()
+                updateDatabaseVersion(20)
+                dbVersion = 20
+            }
 
             // Validate that all required tables exist, recreate if missing
             validateAndRepairSchema()
@@ -1381,6 +1386,114 @@ class SQLiteMigrations(private val plugin: JavaPlugin, private val connection: C
         } catch (e: SQLException) {
             componentLogger.warn(Component.text("⚠ Could not enable WAL mode: ${e.message}"))
             componentLogger.warn(Component.text("  Vault will use rollback journal mode (less crash-resistant)"))
+        }
+    }
+
+    /**
+     * v20: per-home rank whitelist + per-ally-guild inbound ally-home whitelist + USE_ALLY_HOMES permission backfill.
+     *
+     * Adds `guild_homes.allowed_ranks` (TEXT, CSV of rank UUIDs) and
+     * `guilds.ally_home_allowed_guilds` (TEXT, CSV of guild UUIDs).
+     * Backfills existing homes with all current ranks of the owning guild (policy B,
+     * see 2026-05-10-rank-and-home-perms-design.md §2.3), and adds USE_ALLY_HOMES
+     * to every existing rank's permissions (§3.1).
+     *
+     * Idempotent: ALTER TABLE wrapped in try/catch for "duplicate column", and
+     * backfill UPDATE only writes rows where the new columns are NULL.
+     */
+    private fun migrateToVersion20() {
+        componentLogger.info(Component.text("Migrating to version 20: per-home access perms..."))
+
+        // 1. Add columns (idempotent)
+        for (alter in listOf(
+            "ALTER TABLE guild_homes ADD COLUMN allowed_ranks TEXT",
+            "ALTER TABLE guilds ADD COLUMN ally_home_allowed_guilds TEXT"
+        )) {
+            try {
+                connection.createStatement().use { it.executeUpdate(alter) }
+            } catch (e: SQLException) {
+                if (!e.message.orEmpty().contains("duplicate column", ignoreCase = true)) throw e
+            }
+        }
+
+        // 2. Backfill guild_homes.allowed_ranks = CSV of rank IDs for each guild
+        connection.createStatement().use { stmt ->
+            val rs = stmt.executeQuery(
+                "SELECT gh.guild_id, GROUP_CONCAT(r.id, ',') AS rank_csv " +
+                "FROM guild_homes gh JOIN ranks r ON r.guild_id = gh.guild_id " +
+                "WHERE gh.allowed_ranks IS NULL GROUP BY gh.guild_id"
+            )
+            val updates = mutableListOf<Pair<String, String>>()
+            while (rs.next()) {
+                updates.add(rs.getString("guild_id") to (rs.getString("rank_csv") ?: ""))
+            }
+            rs.close()
+            val updateStmt = connection.prepareStatement(
+                "UPDATE guild_homes SET allowed_ranks = ? WHERE guild_id = ? AND allowed_ranks IS NULL"
+            )
+            for ((guildId, csv) in updates) {
+                updateStmt.setString(1, csv)
+                updateStmt.setString(2, guildId)
+                updateStmt.executeUpdate()
+            }
+            updateStmt.close()
+            componentLogger.info(Component.text("✓ Backfilled ${updates.size} guild(s) of home rank whitelists"))
+        }
+
+        // 3. Backfill guilds.ally_home_allowed_guilds = CSV of current allies
+        connection.createStatement().use { stmt ->
+            val rs = stmt.executeQuery(
+                "SELECT id FROM guilds WHERE ally_home_allowed_guilds IS NULL"
+            )
+            val guildIds = mutableListOf<String>()
+            while (rs.next()) guildIds.add(rs.getString("id"))
+            rs.close()
+
+            val updateStmt = connection.prepareStatement(
+                "UPDATE guilds SET ally_home_allowed_guilds = ? WHERE id = ?"
+            )
+            for (gid in guildIds) {
+                val allies = mutableSetOf<String>()
+                connection.prepareStatement(
+                    "SELECT guild_a, guild_b FROM relations WHERE type = 'ALLY' AND (guild_a = ? OR guild_b = ?)"
+                ).use { ps ->
+                    ps.setString(1, gid); ps.setString(2, gid)
+                    val r2 = ps.executeQuery()
+                    while (r2.next()) {
+                        val a = r2.getString("guild_a"); val b = r2.getString("guild_b")
+                        if (a != gid) allies.add(a); if (b != gid) allies.add(b)
+                    }
+                }
+                updateStmt.setString(1, allies.joinToString(","))
+                updateStmt.setString(2, gid)
+                updateStmt.executeUpdate()
+            }
+            updateStmt.close()
+            componentLogger.info(Component.text("✓ Backfilled ${guildIds.size} guild(s) ally-home allow-lists"))
+        }
+
+        // 4. Add USE_ALLY_HOMES to every existing rank (idempotent — skips if already present)
+        connection.createStatement().use { stmt ->
+            val rs = stmt.executeQuery("SELECT id, permissions FROM ranks")
+            val updates = mutableListOf<Pair<String, String>>()
+            while (rs.next()) {
+                val id = rs.getString("id")
+                val perms = rs.getString("permissions").orEmpty()
+                val parts = perms.split(",").filter { it.isNotBlank() }.toMutableSet()
+                if (parts.add("USE_ALLY_HOMES")) {
+                    updates.add(id to parts.joinToString(","))
+                }
+            }
+            rs.close()
+            val updateStmt = connection.prepareStatement(
+                "UPDATE ranks SET permissions = ? WHERE id = ?"
+            )
+            for ((id, perms) in updates) {
+                updateStmt.setString(1, perms); updateStmt.setString(2, id)
+                updateStmt.executeUpdate()
+            }
+            updateStmt.close()
+            componentLogger.info(Component.text("✓ Added USE_ALLY_HOMES to ${updates.size} ranks"))
         }
     }
 }

--- a/src/main/kotlin/net/lumalyte/lg/infrastructure/persistence/migrations/SQLiteMigrations.kt
+++ b/src/main/kotlin/net/lumalyte/lg/infrastructure/persistence/migrations/SQLiteMigrations.kt
@@ -1428,8 +1428,13 @@ class SQLiteMigrations(private val plugin: JavaPlugin, private val connection: C
      */
     private fun migrateToVersion20() {
         componentLogger.info(Component.text("Migrating to version 20: per-home access perms..."))
+        addV20Columns()
+        backfillHomeAllowedRanks()
+        backfillAllyHomeAllowedGuilds()
+        addUseAllyHomesPermission()
+    }
 
-        // 1. Add columns (idempotent)
+    private fun addV20Columns() {
         for (alter in listOf(
             "ALTER TABLE guild_homes ADD COLUMN allowed_ranks TEXT",
             "ALTER TABLE guilds ADD COLUMN ally_home_allowed_guilds TEXT"
@@ -1440,85 +1445,82 @@ class SQLiteMigrations(private val plugin: JavaPlugin, private val connection: C
                 if (!e.message.orEmpty().contains("duplicate column", ignoreCase = true)) throw e
             }
         }
+    }
 
-        // 2. Backfill guild_homes.allowed_ranks = CSV of rank IDs for each guild
+    private fun backfillHomeAllowedRanks() {
+        val updates = mutableListOf<Pair<String, String>>()
         connection.createStatement().use { stmt ->
-            val rs = stmt.executeQuery(
+            stmt.executeQuery(
                 "SELECT gh.guild_id, GROUP_CONCAT(r.id, ',') AS rank_csv " +
                 "FROM guild_homes gh JOIN ranks r ON r.guild_id = gh.guild_id " +
                 "WHERE gh.allowed_ranks IS NULL GROUP BY gh.guild_id"
-            )
-            val updates = mutableListOf<Pair<String, String>>()
-            while (rs.next()) {
-                updates.add(rs.getString("guild_id") to (rs.getString("rank_csv") ?: ""))
+            ).use { rs ->
+                while (rs.next()) {
+                    updates.add(rs.getString("guild_id") to (rs.getString("rank_csv") ?: ""))
+                }
             }
-            rs.close()
-            val updateStmt = connection.prepareStatement(
-                "UPDATE guild_homes SET allowed_ranks = ? WHERE guild_id = ? AND allowed_ranks IS NULL"
-            )
-            for ((guildId, csv) in updates) {
-                updateStmt.setString(1, csv)
-                updateStmt.setString(2, guildId)
-                updateStmt.executeUpdate()
-            }
-            updateStmt.close()
-            componentLogger.info(Component.text("✓ Backfilled ${updates.size} guild(s) of home rank whitelists"))
         }
+        connection.prepareStatement(
+            "UPDATE guild_homes SET allowed_ranks = ? WHERE guild_id = ? AND allowed_ranks IS NULL"
+        ).use { ps ->
+            for ((guildId, csv) in updates) {
+                ps.setString(1, csv); ps.setString(2, guildId); ps.executeUpdate()
+            }
+        }
+        componentLogger.info(Component.text("✓ Backfilled ${updates.size} guild(s) of home rank whitelists"))
+    }
 
-        // 3. Backfill guilds.ally_home_allowed_guilds = CSV of current allies
+    private fun backfillAllyHomeAllowedGuilds() {
+        // One query for all active alliances, group in memory — avoids N+1 prepareStatement per guild.
+        val alliesByGuild = mutableMapOf<String, MutableSet<String>>()
         connection.createStatement().use { stmt ->
-            val rs = stmt.executeQuery(
-                "SELECT id FROM guilds WHERE ally_home_allowed_guilds IS NULL"
-            )
-            val guildIds = mutableListOf<String>()
-            while (rs.next()) guildIds.add(rs.getString("id"))
-            rs.close()
-
-            val updateStmt = connection.prepareStatement(
-                "UPDATE guilds SET ally_home_allowed_guilds = ? WHERE id = ?"
-            )
+            stmt.executeQuery(
+                "SELECT guild_a, guild_b FROM relations WHERE type = 'ALLY' AND status = 'ACTIVE'"
+            ).use { rs ->
+                while (rs.next()) {
+                    val a = rs.getString("guild_a")
+                    val b = rs.getString("guild_b")
+                    alliesByGuild.getOrPut(a) { mutableSetOf() }.add(b)
+                    alliesByGuild.getOrPut(b) { mutableSetOf() }.add(a)
+                }
+            }
+        }
+        val guildIds = mutableListOf<String>()
+        connection.createStatement().use { stmt ->
+            stmt.executeQuery("SELECT id FROM guilds WHERE ally_home_allowed_guilds IS NULL").use { rs ->
+                while (rs.next()) guildIds.add(rs.getString("id"))
+            }
+        }
+        connection.prepareStatement(
+            "UPDATE guilds SET ally_home_allowed_guilds = ? WHERE id = ?"
+        ).use { ps ->
             for (gid in guildIds) {
-                val allies = mutableSetOf<String>()
-                connection.prepareStatement(
-                    "SELECT guild_a, guild_b FROM relations WHERE type = 'ALLY' AND status = 'ACTIVE' AND (guild_a = ? OR guild_b = ?)"
-                ).use { ps ->
-                    ps.setString(1, gid); ps.setString(2, gid)
-                    val r2 = ps.executeQuery()
-                    while (r2.next()) {
-                        val a = r2.getString("guild_a"); val b = r2.getString("guild_b")
-                        if (a != gid) allies.add(a); if (b != gid) allies.add(b)
+                val csv = alliesByGuild[gid].orEmpty().joinToString(",")
+                ps.setString(1, csv); ps.setString(2, gid); ps.executeUpdate()
+            }
+        }
+        componentLogger.info(Component.text("✓ Backfilled ${guildIds.size} guild(s) ally-home allow-lists"))
+    }
+
+    private fun addUseAllyHomesPermission() {
+        val updates = mutableListOf<Pair<String, String>>()
+        connection.createStatement().use { stmt ->
+            stmt.executeQuery("SELECT id, permissions FROM ranks").use { rs ->
+                while (rs.next()) {
+                    val id = rs.getString("id")
+                    val perms = rs.getString("permissions").orEmpty()
+                    val parts = perms.split(",").filter { it.isNotBlank() }.toMutableSet()
+                    if (parts.add("USE_ALLY_HOMES")) {
+                        updates.add(id to parts.joinToString(","))
                     }
                 }
-                updateStmt.setString(1, allies.joinToString(","))
-                updateStmt.setString(2, gid)
-                updateStmt.executeUpdate()
             }
-            updateStmt.close()
-            componentLogger.info(Component.text("✓ Backfilled ${guildIds.size} guild(s) ally-home allow-lists"))
         }
-
-        // 4. Add USE_ALLY_HOMES to every existing rank (idempotent — skips if already present)
-        connection.createStatement().use { stmt ->
-            val rs = stmt.executeQuery("SELECT id, permissions FROM ranks")
-            val updates = mutableListOf<Pair<String, String>>()
-            while (rs.next()) {
-                val id = rs.getString("id")
-                val perms = rs.getString("permissions").orEmpty()
-                val parts = perms.split(",").filter { it.isNotBlank() }.toMutableSet()
-                if (parts.add("USE_ALLY_HOMES")) {
-                    updates.add(id to parts.joinToString(","))
-                }
-            }
-            rs.close()
-            val updateStmt = connection.prepareStatement(
-                "UPDATE ranks SET permissions = ? WHERE id = ?"
-            )
+        connection.prepareStatement("UPDATE ranks SET permissions = ? WHERE id = ?").use { ps ->
             for ((id, perms) in updates) {
-                updateStmt.setString(1, perms); updateStmt.setString(2, id)
-                updateStmt.executeUpdate()
+                ps.setString(1, perms); ps.setString(2, id); ps.executeUpdate()
             }
-            updateStmt.close()
-            componentLogger.info(Component.text("✓ Added USE_ALLY_HOMES to ${updates.size} ranks"))
         }
+        componentLogger.info(Component.text("✓ Added USE_ALLY_HOMES to ${updates.size} ranks"))
     }
 }

--- a/src/main/kotlin/net/lumalyte/lg/infrastructure/persistence/migrations/SQLiteMigrations.kt
+++ b/src/main/kotlin/net/lumalyte/lg/infrastructure/persistence/migrations/SQLiteMigrations.kt
@@ -1340,6 +1340,31 @@ class SQLiteMigrations(private val plugin: JavaPlugin, private val connection: C
                 componentLogger.info(Component.text("✓ Recreated claim system tables"))
             }
         }
+
+        // v20 columns can go missing if guild_homes is recreated via v19 above, or if a prior
+        // run was interrupted between updateDatabaseVersion(20) and persistent column writes.
+        // Always reapply v20 — it's fully idempotent (ALTER TABLE wrapped in duplicate-column catch,
+        // backfills only NULL rows, USE_ALLY_HOMES add() is set-deduped).
+        if (!hasColumn("guild_homes", "allowed_ranks") ||
+            !hasColumn("guilds", "ally_home_allowed_guilds")) {
+            componentLogger.info(Component.text("🔧 v20 columns missing — reapplying v20 migration"))
+            migrateToVersion20()
+        }
+    }
+
+    private fun hasColumn(table: String, column: String): Boolean {
+        return try {
+            connection.createStatement().use { stmt ->
+                val rs = stmt.executeQuery("PRAGMA table_info($table)")
+                while (rs.next()) {
+                    if (rs.getString("name").equals(column, ignoreCase = true)) return@use true
+                }
+                false
+            }
+        } catch (e: SQLException) {
+            componentLogger.warn(Component.text("PRAGMA table_info($table) failed: ${e.message}"))
+            false
+        }
     }
 
     /**
@@ -1455,7 +1480,7 @@ class SQLiteMigrations(private val plugin: JavaPlugin, private val connection: C
             for (gid in guildIds) {
                 val allies = mutableSetOf<String>()
                 connection.prepareStatement(
-                    "SELECT guild_a, guild_b FROM relations WHERE type = 'ALLY' AND (guild_a = ? OR guild_b = ?)"
+                    "SELECT guild_a, guild_b FROM relations WHERE type = 'ALLY' AND status = 'ACTIVE' AND (guild_a = ? OR guild_b = ?)"
                 ).use { ps ->
                     ps.setString(1, gid); ps.setString(2, gid)
                     val r2 = ps.executeQuery()

--- a/src/main/kotlin/net/lumalyte/lg/infrastructure/persistence/migrations/SQLiteMigrations.kt
+++ b/src/main/kotlin/net/lumalyte/lg/infrastructure/persistence/migrations/SQLiteMigrations.kt
@@ -1450,10 +1450,14 @@ class SQLiteMigrations(private val plugin: JavaPlugin, private val connection: C
     private fun backfillHomeAllowedRanks() {
         val updates = mutableListOf<Pair<String, String>>()
         connection.createStatement().use { stmt ->
+            // Aggregate ranks directly from the `ranks` table for guilds that have at least
+            // one home awaiting backfill. Joining guild_homes×ranks then GROUP_CONCAT would
+            // emit each rank ID H times for H homes-per-guild, bloating the persisted CSV.
             stmt.executeQuery(
-                "SELECT gh.guild_id, GROUP_CONCAT(r.id, ',') AS rank_csv " +
-                "FROM guild_homes gh JOIN ranks r ON r.guild_id = gh.guild_id " +
-                "WHERE gh.allowed_ranks IS NULL GROUP BY gh.guild_id"
+                "SELECT r.guild_id, GROUP_CONCAT(r.id, ',') AS rank_csv " +
+                "FROM ranks r " +
+                "WHERE r.guild_id IN (SELECT DISTINCT guild_id FROM guild_homes WHERE allowed_ranks IS NULL) " +
+                "GROUP BY r.guild_id"
             ).use { rs ->
                 while (rs.next()) {
                     updates.add(rs.getString("guild_id") to (rs.getString("rank_csv") ?: ""))

--- a/src/main/kotlin/net/lumalyte/lg/infrastructure/services/GuildServiceBukkit.kt
+++ b/src/main/kotlin/net/lumalyte/lg/infrastructure/services/GuildServiceBukkit.kt
@@ -329,7 +329,15 @@ class GuildServiceBukkit(
                 return false
             }
 
-            val updatedHomes = guild.homes.withHome(homeName, home)
+            val existing = guild.homes.getHome(homeName)
+            val effectiveAllowed = if (existing != null) {
+                existing.allowedRankIds
+            } else {
+                val ownerRank = rankRepository.getHighestRank(guildId)
+                if (ownerRank != null) setOf(ownerRank.id) else emptySet()
+            }
+            val effectiveHome = home.copy(allowedRankIds = effectiveAllowed)
+            val updatedHomes = guild.homes.withHome(homeName, effectiveHome)
             val updatedGuild = guild.copy(homes = updatedHomes)
             val result = guildRepository.update(updatedGuild)
             if (result) {

--- a/src/main/kotlin/net/lumalyte/lg/infrastructure/services/GuildServiceBukkit.kt
+++ b/src/main/kotlin/net/lumalyte/lg/infrastructure/services/GuildServiceBukkit.kt
@@ -664,6 +664,32 @@ class GuildServiceBukkit(
         return RankPermission.USE_ALLY_HOMES in rank.permissions
     }
 
+    override fun setHomeAllowedRanks(
+        guildId: UUID, homeName: String, allowedRankIds: Set<UUID>, actorId: UUID
+    ): Boolean {
+        if (!hasPermission(actorId, guildId, RankPermission.MANAGE_HOME)) {
+            logger.warn("Player $actorId attempted to set home rank whitelist for guild $guildId without MANAGE_HOME")
+            return false
+        }
+        val guild = guildRepository.getById(guildId) ?: return false
+        val home = guild.homes.getHome(homeName) ?: return false
+        val updatedHome = home.copy(allowedRankIds = allowedRankIds)
+        val updatedGuild = guild.copy(homes = guild.homes.withHome(homeName, updatedHome))
+        return guildRepository.update(updatedGuild)
+    }
+
+    override fun setAllyHomeAllowedGuilds(
+        guildId: UUID, allowedGuildIds: Set<UUID>, actorId: UUID
+    ): Boolean {
+        if (!hasPermission(actorId, guildId, RankPermission.MANAGE_HOME)) {
+            logger.warn("Player $actorId attempted to set ally-home guild whitelist for guild $guildId without MANAGE_HOME")
+            return false
+        }
+        val guild = guildRepository.getById(guildId) ?: return false
+        val updatedGuild = guild.copy(allyHomeAllowedGuilds = allowedGuildIds)
+        return guildRepository.update(updatedGuild)
+    }
+
     override fun setBankFrozen(guildId: UUID, frozen: Boolean, actorId: UUID): Boolean {
         val guild = guildRepository.getById(guildId) ?: return false
 

--- a/src/main/kotlin/net/lumalyte/lg/infrastructure/services/GuildServiceBukkit.kt
+++ b/src/main/kotlin/net/lumalyte/lg/infrastructure/services/GuildServiceBukkit.kt
@@ -643,6 +643,15 @@ class GuildServiceBukkit(
         return result
     }
 
+    override fun canUseHome(playerId: UUID, guildId: UUID, homeName: String): Boolean {
+        val guild = guildRepository.getById(guildId) ?: return false
+        val home = guild.homes.getHome(homeName) ?: return false
+        val member = memberRepository.getByPlayerAndGuild(playerId, guildId) ?: return false
+        val ownerRank = rankRepository.getHighestRank(guildId)
+        if (ownerRank != null && member.rankId == ownerRank.id) return true
+        return member.rankId in home.allowedRankIds
+    }
+
     override fun setBankFrozen(guildId: UUID, frozen: Boolean, actorId: UUID): Boolean {
         val guild = guildRepository.getById(guildId) ?: return false
 

--- a/src/main/kotlin/net/lumalyte/lg/infrastructure/services/GuildServiceBukkit.kt
+++ b/src/main/kotlin/net/lumalyte/lg/infrastructure/services/GuildServiceBukkit.kt
@@ -657,6 +657,12 @@ class GuildServiceBukkit(
         val targetGuild = guildRepository.getById(targetGuildId) ?: return false
         if (targetGuild.allyHome == null) return false
         if (sourceGuildId !in targetGuild.allyHomeAllowedGuilds) return false
+        // Guard against stale or manually-injected whitelist entries: the two guilds must
+        // currently be actively allied, not merely whitelisted from a prior alliance.
+        val activeAlliance = relationRepository
+            .getByGuildAndType(sourceGuildId, net.lumalyte.lg.domain.entities.RelationType.ALLY)
+            .any { rel -> rel.isActive() && (rel.guildA == targetGuildId || rel.guildB == targetGuildId) }
+        if (!activeAlliance) return false
         val member = memberRepository.getByPlayerAndGuild(playerId, sourceGuildId) ?: return false
         val rank = rankRepository.getById(member.rankId) ?: return false
         val ownerRank = rankRepository.getHighestRank(sourceGuildId)

--- a/src/main/kotlin/net/lumalyte/lg/infrastructure/services/GuildServiceBukkit.kt
+++ b/src/main/kotlin/net/lumalyte/lg/infrastructure/services/GuildServiceBukkit.kt
@@ -652,6 +652,18 @@ class GuildServiceBukkit(
         return member.rankId in home.allowedRankIds
     }
 
+    override fun canUseAllyHome(playerId: UUID, sourceGuildId: UUID, targetGuildId: UUID): Boolean {
+        if (guildRepository.getById(sourceGuildId) == null) return false
+        val targetGuild = guildRepository.getById(targetGuildId) ?: return false
+        if (targetGuild.allyHome == null) return false
+        if (sourceGuildId !in targetGuild.allyHomeAllowedGuilds) return false
+        val member = memberRepository.getByPlayerAndGuild(playerId, sourceGuildId) ?: return false
+        val rank = rankRepository.getById(member.rankId) ?: return false
+        val ownerRank = rankRepository.getHighestRank(sourceGuildId)
+        if (ownerRank != null && rank.id == ownerRank.id) return true
+        return RankPermission.USE_ALLY_HOMES in rank.permissions
+    }
+
     override fun setBankFrozen(guildId: UUID, frozen: Boolean, actorId: UUID): Boolean {
         val guild = guildRepository.getById(guildId) ?: return false
 

--- a/src/main/kotlin/net/lumalyte/lg/infrastructure/services/GuildServiceBukkit.kt
+++ b/src/main/kotlin/net/lumalyte/lg/infrastructure/services/GuildServiceBukkit.kt
@@ -679,7 +679,15 @@ class GuildServiceBukkit(
         }
         val guild = guildRepository.getById(guildId) ?: return false
         val home = guild.homes.getHome(homeName) ?: return false
-        val updatedHome = home.copy(allowedRankIds = allowedRankIds)
+        // Drop any rank IDs that don't belong to this guild — keeps persisted whitelist clean
+        // for downstream iteration/display and rejects malicious or buggy callers.
+        val validIds = rankRepository.getByGuild(guildId).map { it.id }.toSet()
+        val sanitized = allowedRankIds.filter { it in validIds }.toSet()
+        val rejected = allowedRankIds - sanitized
+        if (rejected.isNotEmpty()) {
+            logger.warn("setHomeAllowedRanks: dropping ${rejected.size} non-guild rank id(s) for guild $guildId home '$homeName': $rejected")
+        }
+        val updatedHome = home.copy(allowedRankIds = sanitized)
         val updatedGuild = guild.copy(homes = guild.homes.withHome(homeName, updatedHome))
         return guildRepository.update(updatedGuild)
     }
@@ -692,7 +700,15 @@ class GuildServiceBukkit(
             return false
         }
         val guild = guildRepository.getById(guildId) ?: return false
-        val updatedGuild = guild.copy(allyHomeAllowedGuilds = allowedGuildIds)
+        // Filter to real, currently-existing guilds; canUseAllyHome additionally checks the
+        // active-ALLY relation at teleport time so phantom IDs are inert, but persisting them
+        // pollutes the table over time.
+        val sanitized = allowedGuildIds.filter { it != guildId && guildRepository.getById(it) != null }.toSet()
+        val rejected = allowedGuildIds - sanitized
+        if (rejected.isNotEmpty()) {
+            logger.warn("setAllyHomeAllowedGuilds: dropping ${rejected.size} unknown/self guild id(s) for guild $guildId: $rejected")
+        }
+        val updatedGuild = guild.copy(allyHomeAllowedGuilds = sanitized)
         return guildRepository.update(updatedGuild)
     }
 

--- a/src/main/kotlin/net/lumalyte/lg/infrastructure/services/RankServiceBukkit.kt
+++ b/src/main/kotlin/net/lumalyte/lg/infrastructure/services/RankServiceBukkit.kt
@@ -329,6 +329,9 @@ class RankServiceBukkit(
         }
         if (neighborIdx !in siblings.indices) return false
         val neighbor = siblings[neighborIdx]
+        // Block swap when the adjacent rank is at or above the actor's priority — otherwise
+        // an actor at priority 1 could shove a rank UP into their own slot.
+        if (neighbor.priority <= actorRank.priority) return false
         return rankRepository.swapPriorities(target.id, neighbor.id)
     }
 }

--- a/src/main/kotlin/net/lumalyte/lg/infrastructure/services/RankServiceBukkit.kt
+++ b/src/main/kotlin/net/lumalyte/lg/infrastructure/services/RankServiceBukkit.kt
@@ -3,6 +3,7 @@ package net.lumalyte.lg.infrastructure.services
 import net.lumalyte.lg.application.persistence.GuildRepository
 import net.lumalyte.lg.application.persistence.MemberRepository
 import net.lumalyte.lg.application.persistence.RankRepository
+import net.lumalyte.lg.application.services.PriorityDirection
 import net.lumalyte.lg.application.services.RankService
 import net.lumalyte.lg.domain.entities.Rank
 import net.lumalyte.lg.domain.entities.RankPermission
@@ -311,5 +312,23 @@ class RankServiceBukkit(
             logger.info("Created default ranks for guild $guildId")
         }
         return success
+    }
+
+    override fun moveRankPriority(rankId: UUID, direction: PriorityDirection, actorId: UUID): Boolean {
+        val target = rankRepository.getById(rankId) ?: return false
+        if (!hasPermission(actorId, target.guildId, RankPermission.MANAGE_RANKS)) {
+            return false
+        }
+        val actorRank = getPlayerRank(actorId, target.guildId) ?: return false
+        if (actorRank.priority >= target.priority) return false
+        val siblings = rankRepository.getByGuild(target.guildId).sortedBy { it.priority }
+        val idx = siblings.indexOfFirst { it.id == target.id }
+        val neighborIdx = when (direction) {
+            PriorityDirection.UP -> idx - 1
+            PriorityDirection.DOWN -> idx + 1
+        }
+        if (neighborIdx !in siblings.indices) return false
+        val neighbor = siblings[neighborIdx]
+        return rankRepository.swapPriorities(target.id, neighbor.id)
     }
 }

--- a/src/main/kotlin/net/lumalyte/lg/infrastructure/services/RelationServiceBukkit.kt
+++ b/src/main/kotlin/net/lumalyte/lg/infrastructure/services/RelationServiceBukkit.kt
@@ -567,25 +567,29 @@ class RelationServiceBukkit(
         }
     }
 
+    // Whitelist drift note: canUseAllyHome additionally re-checks the active ALLY relation
+    // at teleport time, so a stale whitelist entry left behind by a failed write below cannot
+    // grant access without a currently active alliance. Failures are logged for operator
+    // visibility — a manager can re-grant via AllyHomeAccessMenu if needed.
     private fun addAllyInboundWhitelist(guildA: UUID, guildB: UUID) {
         val gA = guildRepository.getById(guildA)
         val gB = guildRepository.getById(guildB)
-        if (gA != null) {
-            guildRepository.update(gA.copy(allyHomeAllowedGuilds = gA.allyHomeAllowedGuilds + guildB))
+        if (gA != null && !guildRepository.update(gA.copy(allyHomeAllowedGuilds = gA.allyHomeAllowedGuilds + guildB))) {
+            logger.warn("Failed to add $guildB to $guildA.allyHomeAllowedGuilds after alliance — manager may need to re-grant via AllyHomeAccessMenu")
         }
-        if (gB != null) {
-            guildRepository.update(gB.copy(allyHomeAllowedGuilds = gB.allyHomeAllowedGuilds + guildA))
+        if (gB != null && !guildRepository.update(gB.copy(allyHomeAllowedGuilds = gB.allyHomeAllowedGuilds + guildA))) {
+            logger.warn("Failed to add $guildA to $guildB.allyHomeAllowedGuilds after alliance — manager may need to re-grant via AllyHomeAccessMenu")
         }
     }
 
     private fun removeAllyInboundWhitelist(guildA: UUID, guildB: UUID) {
         val gA = guildRepository.getById(guildA)
         val gB = guildRepository.getById(guildB)
-        if (gA != null) {
-            guildRepository.update(gA.copy(allyHomeAllowedGuilds = gA.allyHomeAllowedGuilds - guildB))
+        if (gA != null && !guildRepository.update(gA.copy(allyHomeAllowedGuilds = gA.allyHomeAllowedGuilds - guildB))) {
+            logger.warn("Failed to remove $guildB from $guildA.allyHomeAllowedGuilds after alliance break — stale entry left behind (canUseAllyHome's active-ally check still gates access)")
         }
-        if (gB != null) {
-            guildRepository.update(gB.copy(allyHomeAllowedGuilds = gB.allyHomeAllowedGuilds - guildA))
+        if (gB != null && !guildRepository.update(gB.copy(allyHomeAllowedGuilds = gB.allyHomeAllowedGuilds - guildA))) {
+            logger.warn("Failed to remove $guildA from $guildB.allyHomeAllowedGuilds after alliance break — stale entry left behind (canUseAllyHome's active-ally check still gates access)")
         }
     }
 }

--- a/src/main/kotlin/net/lumalyte/lg/infrastructure/services/RelationServiceBukkit.kt
+++ b/src/main/kotlin/net/lumalyte/lg/infrastructure/services/RelationServiceBukkit.kt
@@ -1,5 +1,6 @@
 package net.lumalyte.lg.infrastructure.services
 
+import net.lumalyte.lg.application.persistence.GuildRepository
 import net.lumalyte.lg.application.persistence.RelationRepository
 import net.lumalyte.lg.application.services.MemberService
 import net.lumalyte.lg.application.services.RelationService
@@ -16,7 +17,8 @@ import java.util.UUID
 
 class RelationServiceBukkit(
     private val relationRepository: RelationRepository,
-    private val memberService: MemberService
+    private val memberService: MemberService,
+    private val guildRepository: GuildRepository
 ) : RelationService {
     
     private val logger = LoggerFactory.getLogger(RelationServiceBukkit::class.java)
@@ -98,6 +100,7 @@ class RelationServiceBukkit(
             
             return if (relationRepository.update(updatedRelation)) {
                 logger.info("Alliance accepted between guilds ${relation.guildA} and ${relation.guildB}")
+                addAllyInboundWhitelist(relation.guildA, relation.guildB)
                 // Fire relation change event
                 Bukkit.getPluginManager().callEvent(
                     GuildRelationChangeEvent(relation.guildA, relation.guildB, RelationType.ALLY, updatedRelation)
@@ -124,7 +127,8 @@ class RelationServiceBukkit(
             
             // Check for existing relation
             val existingRelation = relationRepository.getByGuilds(declaringGuildId, targetGuildId)
-            
+            val wasAlly = existingRelation?.type == RelationType.ALLY && existingRelation.isActive()
+
             val relation = if (existingRelation != null) {
                 // Update existing relation to enemy
                 existingRelation.copy(
@@ -151,6 +155,7 @@ class RelationServiceBukkit(
             
             return if (success) {
                 logger.info("War declared between guilds ${relation.guildA} and ${relation.guildB}")
+                if (wasAlly) removeAllyInboundWhitelist(relation.guildA, relation.guildB)
                 // Fire relation change event
                 Bukkit.getPluginManager().callEvent(
                     GuildRelationChangeEvent(relation.guildA, relation.guildB, RelationType.ENEMY, relation)
@@ -559,6 +564,28 @@ class RelationServiceBukkit(
         val enemyRelations = relationRepository.getByGuildAndType(guildId, RelationType.ENEMY)
         return enemyRelations.any { relation ->
             relation.isActive() && relation.type == RelationType.ENEMY
+        }
+    }
+
+    private fun addAllyInboundWhitelist(guildA: UUID, guildB: UUID) {
+        val gA = guildRepository.getById(guildA)
+        val gB = guildRepository.getById(guildB)
+        if (gA != null) {
+            guildRepository.update(gA.copy(allyHomeAllowedGuilds = gA.allyHomeAllowedGuilds + guildB))
+        }
+        if (gB != null) {
+            guildRepository.update(gB.copy(allyHomeAllowedGuilds = gB.allyHomeAllowedGuilds + guildA))
+        }
+    }
+
+    private fun removeAllyInboundWhitelist(guildA: UUID, guildB: UUID) {
+        val gA = guildRepository.getById(guildA)
+        val gB = guildRepository.getById(guildB)
+        if (gA != null) {
+            guildRepository.update(gA.copy(allyHomeAllowedGuilds = gA.allyHomeAllowedGuilds - guildB))
+        }
+        if (gB != null) {
+            guildRepository.update(gB.copy(allyHomeAllowedGuilds = gB.allyHomeAllowedGuilds - guildA))
         }
     }
 }

--- a/src/main/kotlin/net/lumalyte/lg/interaction/commands/GuildCommand.kt
+++ b/src/main/kotlin/net/lumalyte/lg/interaction/commands/GuildCommand.kt
@@ -341,6 +341,11 @@ class GuildCommand : BaseCommand(), KoinComponent {
         val home = guildService.getHome(guild.id, targetHomeName)
 
         if (home != null) {
+            if (!guildService.canUseHome(playerId, guild.id, targetHomeName)) {
+                player.sendMessage("§c❌ You don't have permission to use the home '$targetHomeName'.")
+                player.sendMessage("§7Ask a guild manager to grant your rank access.")
+                return
+            }
             // Check if player already has an active teleport
             if (activeTeleports.containsKey(playerId)) {
                 player.sendMessage("§cYou already have a teleport in progress. Please wait for it to complete.")

--- a/src/main/kotlin/net/lumalyte/lg/interaction/menus/MenuFactory.kt
+++ b/src/main/kotlin/net/lumalyte/lg/interaction/menus/MenuFactory.kt
@@ -467,6 +467,12 @@ class MenuFactory(
         }
     }
 
+    /**
+     * Creates an ally-home access menu for configuring which allied guilds are on this
+     * guild's inbound ally-home whitelist. Java players get the toggle ChestGui; Bedrock
+     * players get a chat-message fallback directing them to the Java client (no Bedrock
+     * equivalent UI is provided — light-touch parity per project precedent).
+     */
     fun createAllyHomeAccessMenu(
         menuNavigator: MenuNavigator,
         player: Player,

--- a/src/main/kotlin/net/lumalyte/lg/interaction/menus/MenuFactory.kt
+++ b/src/main/kotlin/net/lumalyte/lg/interaction/menus/MenuFactory.kt
@@ -450,6 +450,16 @@ class MenuFactory(
     }
 
     /**
+     * Creates a home access menu for configuring per-rank access to a guild home
+     */
+    fun createHomeAccessMenu(
+        menuNavigator: MenuNavigator,
+        player: Player,
+        guild: net.lumalyte.lg.domain.entities.Guild,
+        homeName: String
+    ): Menu = net.lumalyte.lg.interaction.menus.guild.HomeAccessMenu(menuNavigator, player, guild, homeName)
+
+    /**
      * Creates a guild rank management menu appropriate for the player's platform
      */
     fun createGuildRankManagementMenu(

--- a/src/main/kotlin/net/lumalyte/lg/interaction/menus/MenuFactory.kt
+++ b/src/main/kotlin/net/lumalyte/lg/interaction/menus/MenuFactory.kt
@@ -459,6 +459,12 @@ class MenuFactory(
         homeName: String
     ): Menu = net.lumalyte.lg.interaction.menus.guild.HomeAccessMenu(menuNavigator, player, guild, homeName)
 
+    fun createAllyHomeAccessMenu(
+        menuNavigator: MenuNavigator,
+        player: Player,
+        guild: net.lumalyte.lg.domain.entities.Guild
+    ): Menu = net.lumalyte.lg.interaction.menus.guild.AllyHomeAccessMenu(menuNavigator, player, guild)
+
     /**
      * Creates a guild rank management menu appropriate for the player's platform
      */

--- a/src/main/kotlin/net/lumalyte/lg/interaction/menus/MenuFactory.kt
+++ b/src/main/kotlin/net/lumalyte/lg/interaction/menus/MenuFactory.kt
@@ -450,20 +450,44 @@ class MenuFactory(
     }
 
     /**
-     * Creates a home access menu for configuring per-rank access to a guild home
+     * Creates a home access menu for configuring per-rank access to a guild home.
+     * Bedrock has no equivalent UI (light-touch parity per project precedent); affected
+     * Bedrock callers get a chat-message fallback directing them to the Java client.
      */
     fun createHomeAccessMenu(
         menuNavigator: MenuNavigator,
         player: Player,
         guild: net.lumalyte.lg.domain.entities.Guild,
         homeName: String
-    ): Menu = net.lumalyte.lg.interaction.menus.guild.HomeAccessMenu(menuNavigator, player, guild, homeName)
+    ): Menu {
+        return if (shouldUseBedrockMenus(player)) {
+            BedrockAccessUnavailableMenu(player, "home access (per-rank whitelist)")
+        } else {
+            net.lumalyte.lg.interaction.menus.guild.HomeAccessMenu(menuNavigator, player, guild, homeName)
+        }
+    }
 
     fun createAllyHomeAccessMenu(
         menuNavigator: MenuNavigator,
         player: Player,
         guild: net.lumalyte.lg.domain.entities.Guild
-    ): Menu = net.lumalyte.lg.interaction.menus.guild.AllyHomeAccessMenu(menuNavigator, player, guild)
+    ): Menu {
+        return if (shouldUseBedrockMenus(player)) {
+            BedrockAccessUnavailableMenu(player, "ally-home access (inbound whitelist)")
+        } else {
+            net.lumalyte.lg.interaction.menus.guild.AllyHomeAccessMenu(menuNavigator, player, guild)
+        }
+    }
+
+    private class BedrockAccessUnavailableMenu(
+        private val player: Player,
+        private val featureLabel: String
+    ) : Menu {
+        override fun open() {
+            player.sendMessage("§eUse the Java client to configure $featureLabel.")
+            player.sendMessage("§7Bedrock support is on the roadmap.")
+        }
+    }
 
     /**
      * Creates a guild rank management menu appropriate for the player's platform

--- a/src/main/kotlin/net/lumalyte/lg/interaction/menus/bedrock/BedrockGuildHomeMenu.kt
+++ b/src/main/kotlin/net/lumalyte/lg/interaction/menus/bedrock/BedrockGuildHomeMenu.kt
@@ -110,6 +110,10 @@ class BedrockGuildHomeMenu(
             val homeName = homeNames[buttonIndex]
             val home = homes.getHome(homeName)
             if (home != null) {
+                if (!guildService.canUseHome(player.uniqueId, guild.id, homeName)) {
+                    player.sendMessage("§c❌ You don't have permission to use the home '$homeName'.")
+                    return
+                }
                 teleportToHome(home)
             }
             return

--- a/src/main/kotlin/net/lumalyte/lg/interaction/menus/bedrock/BedrockGuildRankListMenu.kt
+++ b/src/main/kotlin/net/lumalyte/lg/interaction/menus/bedrock/BedrockGuildRankListMenu.kt
@@ -155,6 +155,7 @@ class BedrockGuildRankListMenu(
             RankPermission.MANAGE_PARTIES -> bedrockLocalization.getBedrockString(player, "permission.manage.parties")
             RankPermission.SEND_PARTY_REQUESTS -> bedrockLocalization.getBedrockString(player, "permission.send.party.requests")
             RankPermission.ACCEPT_PARTY_INVITES -> bedrockLocalization.getBedrockString(player, "permission.accept.party.invites")
+            RankPermission.USE_ALLY_HOMES -> bedrockLocalization.getBedrockString(player, "permission.use.ally.homes")
 
             // Banking & Economy
             RankPermission.DEPOSIT_TO_BANK -> bedrockLocalization.getBedrockString(player, "permission.deposit.bank")

--- a/src/main/kotlin/net/lumalyte/lg/interaction/menus/bedrock/BedrockGuildRankManagementMenu.kt
+++ b/src/main/kotlin/net/lumalyte/lg/interaction/menus/bedrock/BedrockGuildRankManagementMenu.kt
@@ -157,6 +157,7 @@ class BedrockGuildRankManagementMenu(
             RankPermission.MANAGE_PARTIES -> bedrockLocalization.getBedrockString(player, "permission.manage.parties")
             RankPermission.SEND_PARTY_REQUESTS -> bedrockLocalization.getBedrockString(player, "permission.send.party.requests")
             RankPermission.ACCEPT_PARTY_INVITES -> bedrockLocalization.getBedrockString(player, "permission.accept.party.invites")
+            RankPermission.USE_ALLY_HOMES -> bedrockLocalization.getBedrockString(player, "permission.use.ally.homes")
             RankPermission.DEPOSIT_TO_BANK -> bedrockLocalization.getBedrockString(player, "permission.deposit.bank")
             RankPermission.WITHDRAW_FROM_BANK -> bedrockLocalization.getBedrockString(player, "permission.withdraw.bank")
             RankPermission.VIEW_BANK_TRANSACTIONS -> bedrockLocalization.getBedrockString(player, "permission.view.bank.transactions")

--- a/src/main/kotlin/net/lumalyte/lg/interaction/menus/guild/AllyHomeAccessMenu.kt
+++ b/src/main/kotlin/net/lumalyte/lg/interaction/menus/guild/AllyHomeAccessMenu.kt
@@ -1,0 +1,87 @@
+package net.lumalyte.lg.interaction.menus.guild
+
+import com.github.stefvanschie.inventoryframework.gui.GuiItem
+import com.github.stefvanschie.inventoryframework.gui.type.ChestGui
+import com.github.stefvanschie.inventoryframework.pane.StaticPane
+import net.lumalyte.lg.application.services.GuildService
+import net.lumalyte.lg.application.services.RankService
+import net.lumalyte.lg.application.services.RelationService
+import net.lumalyte.lg.domain.entities.Guild
+import net.lumalyte.lg.domain.entities.RankPermission
+import net.lumalyte.lg.domain.entities.RelationType
+import net.lumalyte.lg.interaction.menus.Menu
+import net.lumalyte.lg.interaction.menus.MenuFactory
+import net.lumalyte.lg.interaction.menus.MenuNavigator
+import net.lumalyte.lg.utils.lore
+import net.lumalyte.lg.utils.name
+import org.bukkit.Material
+import org.bukkit.entity.Player
+import org.bukkit.event.inventory.ClickType
+import org.bukkit.inventory.ItemStack
+import org.koin.core.component.KoinComponent
+import org.koin.core.component.inject
+
+class AllyHomeAccessMenu(
+    private val menuNavigator: MenuNavigator,
+    private val player: Player,
+    private val guild: Guild
+) : Menu, KoinComponent {
+
+    private val rankService: RankService by inject()
+    private val guildService: GuildService by inject()
+    private val relationService: RelationService by inject()
+    private val menuFactory: MenuFactory by inject()
+
+    override fun open() {
+        if (!rankService.hasPermission(player.uniqueId, guild.id, RankPermission.MANAGE_HOME)) {
+            player.sendMessage("§c❌ You need MANAGE_HOME to configure ally-home access.")
+            menuNavigator.openMenu(menuFactory.createGuildHomeMenu(menuNavigator, player, guild))
+            return
+        }
+
+        val current = guildService.getGuild(guild.id) ?: return
+        val allies: List<Pair<java.util.UUID, String>> = relationService.getGuildRelationsByType(guild.id, RelationType.ALLY)
+            .filter { it.isActive() }
+            .mapNotNull { rel ->
+                val otherId = rel.getOtherGuild(guild.id)
+                val otherGuild = guildService.getGuild(otherId)
+                if (otherGuild != null) otherId to otherGuild.name else null
+            }
+        val allowed = current.allyHomeAllowedGuilds.toMutableSet()
+
+        val gui = ChestGui(4, "§6Ally-home Access")
+        val pane = StaticPane(0, 0, 9, 4)
+        gui.setOnTopClick { it.isCancelled = true }
+        gui.setOnBottomClick {
+            if (it.click == ClickType.SHIFT_LEFT || it.click == ClickType.SHIFT_RIGHT) it.isCancelled = true
+        }
+        gui.addPane(pane)
+
+        allies.take(18).forEachIndexed { idx, (allyId, allyName) ->
+            val row = idx / 9
+            val col = idx % 9
+            val on = allyId in allowed
+            val item = ItemStack.of(if (on) Material.LIME_DYE else Material.GRAY_DYE)
+                .name(if (on) "§a✓ $allyName" else "§c✗ $allyName")
+                .lore("§7Click to toggle inbound access")
+            pane.addItem(GuiItem(item) {
+                if (allyId in allowed) allowed.remove(allyId) else allowed.add(allyId)
+                guildService.setAllyHomeAllowedGuilds(guild.id, allowed.toSet(), player.uniqueId)
+                open()
+            }, col, row)
+        }
+
+        val info = ItemStack.of(Material.BOOK)
+            .name("§eOutbound access (read-only)")
+            .lore("§7To control which of YOUR ranks can use ally homes,")
+            .lore("§7edit the §fUSE_ALLY_HOMES§7 permission in rank settings.")
+        pane.addItem(GuiItem(info), 4, 3)
+
+        val backItem = ItemStack.of(Material.ARROW).name("§7← Back to Homes")
+        pane.addItem(GuiItem(backItem) {
+            menuNavigator.openMenu(menuFactory.createGuildHomeMenu(menuNavigator, player, guild))
+        }, 8, 3)
+
+        gui.show(player)
+    }
+}

--- a/src/main/kotlin/net/lumalyte/lg/interaction/menus/guild/GuildHomeMenu.kt
+++ b/src/main/kotlin/net/lumalyte/lg/interaction/menus/guild/GuildHomeMenu.kt
@@ -31,6 +31,7 @@ class GuildHomeMenu(private val menuNavigator: MenuNavigator, private val player
     private val configService: ConfigService by inject()
     private val menuFactory: net.lumalyte.lg.interaction.menus.MenuFactory by inject()
     private val progressionService: net.lumalyte.lg.application.services.ProgressionService by inject()
+    private val rankService: net.lumalyte.lg.application.services.RankService by inject()
 
     // Teleportation tracking
     private data class TeleportSession(
@@ -63,9 +64,13 @@ class GuildHomeMenu(private val menuNavigator: MenuNavigator, private val player
         // Teleport buttons
         addTeleportButtons(pane, 0, 4)
 
+        // Per-home access config buttons (row 3) — managers only
+        addHomeAccessButtons(pane)
+
         // Ally home teleport buttons (if perk unlocked)
         if (progressionService.hasPerkUnlocked(guild.id, net.lumalyte.lg.application.services.PerkType.ALLY_HOME_ACCESS)) {
             addAllyHomeButtons(pane, 0, 5)
+            addAllyHomeAccessButton(pane)
         }
 
         // Back button (shift down if ally homes shown)
@@ -206,6 +211,31 @@ class GuildHomeMenu(private val menuNavigator: MenuNavigator, private val player
 
             pane.addItem(GuiItem(noHomeItem), x, y)
         }
+    }
+
+    private fun addHomeAccessButtons(pane: StaticPane) {
+        if (!rankService.hasPermission(player.uniqueId, guild.id, net.lumalyte.lg.domain.entities.RankPermission.MANAGE_HOME)) return
+        val homes = guildService.getHomes(guild.id).homes.entries.toList()
+        homes.take(9).forEachIndexed { idx, (homeName, _) ->
+            val item = ItemStack.of(Material.IRON_DOOR)
+                .name("§6🔒 Access: $homeName")
+                .lore("§7Configure which ranks can use this home")
+                .lore("§eClick to manage")
+            pane.addItem(GuiItem(item) {
+                menuNavigator.openMenu(menuFactory.createHomeAccessMenu(menuNavigator, player, guild, homeName))
+            }, idx, 3)
+        }
+    }
+
+    private fun addAllyHomeAccessButton(pane: StaticPane) {
+        if (!rankService.hasPermission(player.uniqueId, guild.id, net.lumalyte.lg.domain.entities.RankPermission.MANAGE_HOME)) return
+        val allyAccessItem = ItemStack.of(Material.IRON_DOOR)
+            .name("§6🔒 Ally-home Access")
+            .lore("§7Configure which allied guilds can use your ally-home")
+            .lore("§eClick to manage")
+        pane.addItem(GuiItem(allyAccessItem) {
+            menuNavigator.openMenu(menuFactory.createAllyHomeAccessMenu(menuNavigator, player, guild))
+        }, 7, 5)
     }
 
     private fun addAllyHomeButtons(pane: StaticPane, x: Int, y: Int) {

--- a/src/main/kotlin/net/lumalyte/lg/interaction/menus/guild/GuildHomeMenu.kt
+++ b/src/main/kotlin/net/lumalyte/lg/interaction/menus/guild/GuildHomeMenu.kt
@@ -224,14 +224,22 @@ class GuildHomeMenu(private val menuNavigator: MenuNavigator, private val player
         for ((guildName, home) in allyHomes) {
             if (slot >= 7) break // Max 7 ally homes on row
             val worldName = Bukkit.getWorld(home.worldId)?.name ?: "Unknown"
-            val allyItem = ItemStack.of(Material.ENDER_EYE)
-                .name("§d⚔ $guildName")
+            val targetGuild = guildService.getGuildByName(guildName)
+            val allowed = targetGuild != null &&
+                guildService.canUseAllyHome(player.uniqueId, guild.id, targetGuild.id)
+            val allyItem = ItemStack.of(if (allowed) Material.ENDER_EYE else Material.BARRIER)
+                .name(if (allowed) "§d⚔ $guildName" else "§7⚔ $guildName (locked)")
                 .lore("§7Ally guild home")
                 .lore("§7World: §f$worldName")
                 .lore("§7")
-                .lore("§eClick to teleport")
+                .lore(if (allowed) "§eClick to teleport" else "§cYour rank lacks USE_ALLY_HOMES, or this guild has not allowed yours.")
 
             val guiItem = GuiItem(allyItem) {
+                if (!allowed) {
+                    player.sendMessage("§c❌ You cannot use that ally's home.")
+                    player.sendMessage("§7Either your rank lacks USE_ALLY_HOMES, or that guild has not allowed your guild.")
+                    return@GuiItem
+                }
                 startTeleportCountdown(home)
             }
             pane.addItem(guiItem, slot, y)

--- a/src/main/kotlin/net/lumalyte/lg/interaction/menus/guild/GuildRankManagementMenu.kt
+++ b/src/main/kotlin/net/lumalyte/lg/interaction/menus/guild/GuildRankManagementMenu.kt
@@ -159,7 +159,8 @@ class GuildRankManagementMenu(private val menuNavigator: MenuNavigator, private 
                 net.lumalyte.lg.domain.entities.RankPermission.ACCEPT_ALLIANCES,
                 net.lumalyte.lg.domain.entities.RankPermission.MANAGE_PARTIES,
                 net.lumalyte.lg.domain.entities.RankPermission.SEND_PARTY_REQUESTS,
-                net.lumalyte.lg.domain.entities.RankPermission.ACCEPT_PARTY_INVITES -> "Diplomacy"
+                net.lumalyte.lg.domain.entities.RankPermission.ACCEPT_PARTY_INVITES,
+                net.lumalyte.lg.domain.entities.RankPermission.USE_ALLY_HOMES -> "Diplomacy"
 
                 net.lumalyte.lg.domain.entities.RankPermission.DEPOSIT_TO_BANK,
                 net.lumalyte.lg.domain.entities.RankPermission.WITHDRAW_FROM_BANK,

--- a/src/main/kotlin/net/lumalyte/lg/interaction/menus/guild/HomeAccessMenu.kt
+++ b/src/main/kotlin/net/lumalyte/lg/interaction/menus/guild/HomeAccessMenu.kt
@@ -1,0 +1,95 @@
+package net.lumalyte.lg.interaction.menus.guild
+
+import com.github.stefvanschie.inventoryframework.gui.GuiItem
+import com.github.stefvanschie.inventoryframework.gui.type.ChestGui
+import com.github.stefvanschie.inventoryframework.pane.StaticPane
+import net.lumalyte.lg.application.services.GuildService
+import net.lumalyte.lg.application.services.RankService
+import net.lumalyte.lg.domain.entities.Guild
+import net.lumalyte.lg.domain.entities.RankPermission
+import net.lumalyte.lg.interaction.menus.Menu
+import net.lumalyte.lg.interaction.menus.MenuFactory
+import net.lumalyte.lg.interaction.menus.MenuNavigator
+import net.lumalyte.lg.utils.lore
+import net.lumalyte.lg.utils.name
+import org.bukkit.Material
+import org.bukkit.entity.Player
+import org.bukkit.event.inventory.ClickType
+import org.bukkit.inventory.ItemStack
+import org.koin.core.component.KoinComponent
+import org.koin.core.component.inject
+
+class HomeAccessMenu(
+    private val menuNavigator: MenuNavigator,
+    private val player: Player,
+    private val guild: Guild,
+    private val homeName: String
+) : Menu, KoinComponent {
+
+    private val rankService: RankService by inject()
+    private val guildService: GuildService by inject()
+    private val menuFactory: MenuFactory by inject()
+
+    override fun open() {
+        if (!rankService.hasPermission(player.uniqueId, guild.id, RankPermission.MANAGE_HOME)) {
+            player.sendMessage("§c❌ You need MANAGE_HOME to configure home access.")
+            menuNavigator.openMenu(menuFactory.createGuildHomeMenu(menuNavigator, player, guild))
+            return
+        }
+
+        val home = guildService.getHome(guild.id, homeName)
+        if (home == null) {
+            player.sendMessage("§cHome '$homeName' no longer exists.")
+            menuNavigator.openMenu(menuFactory.createGuildHomeMenu(menuNavigator, player, guild))
+            return
+        }
+
+        val gui = ChestGui(4, "§6Access: $homeName")
+        val pane = StaticPane(0, 0, 9, 4)
+        gui.setOnTopClick { it.isCancelled = true }
+        gui.setOnBottomClick {
+            if (it.click == ClickType.SHIFT_LEFT || it.click == ClickType.SHIFT_RIGHT) it.isCancelled = true
+        }
+        gui.addPane(pane)
+
+        val ranks = rankService.listRanks(guild.id).sortedBy { it.priority }
+        val ownerRank = rankService.getHighestRank(guild.id)
+        val allowed = home.allowedRankIds.toMutableSet()
+
+        ranks.take(27).forEachIndexed { idx, r ->
+            val row = idx / 9
+            val col = idx % 9
+            val isOwner = r.id == ownerRank?.id
+            val on = isOwner || r.id in allowed
+            val item = ItemStack.of(
+                when {
+                    isOwner -> Material.NETHER_STAR
+                    on -> Material.LIME_DYE
+                    else -> Material.GRAY_DYE
+                }
+            ).name(if (on) "§a✓ ${r.name}" else "§c✗ ${r.name}")
+                .lore("§7Priority: §f${r.priority}")
+                .lore("§7")
+                .lore(
+                    when {
+                        isOwner -> "§eOwner — always allowed"
+                        on -> "§eClick to revoke"
+                        else -> "§eClick to grant"
+                    }
+                )
+            pane.addItem(GuiItem(item) {
+                if (isOwner) return@GuiItem
+                if (r.id in allowed) allowed.remove(r.id) else allowed.add(r.id)
+                guildService.setHomeAllowedRanks(guild.id, homeName, allowed.toSet(), player.uniqueId)
+                open()
+            }, col, row)
+        }
+
+        val backItem = ItemStack.of(Material.ARROW).name("§7← Back to Homes")
+        pane.addItem(GuiItem(backItem) {
+            menuNavigator.openMenu(menuFactory.createGuildHomeMenu(menuNavigator, player, guild))
+        }, 8, 3)
+
+        gui.show(player)
+    }
+}

--- a/src/main/kotlin/net/lumalyte/lg/interaction/menus/guild/PermissionCategoryMenu.kt
+++ b/src/main/kotlin/net/lumalyte/lg/interaction/menus/guild/PermissionCategoryMenu.kt
@@ -331,6 +331,7 @@ class PermissionCategoryMenu(private val menuNavigator: MenuNavigator, private v
             RankPermission.MANAGE_PARTIES -> "§7Create and manage guild parties"
             RankPermission.SEND_PARTY_REQUESTS -> "§7Send party invitations"
             RankPermission.ACCEPT_PARTY_INVITES -> "§7Accept party invitations"
+            RankPermission.USE_ALLY_HOMES -> "§7Use homes from allied guilds"
 
             // Claims
             RankPermission.MANAGE_CLAIMS -> "§7Manage existing guild claims"

--- a/src/main/kotlin/net/lumalyte/lg/interaction/menus/guild/RankCreationMenu.kt
+++ b/src/main/kotlin/net/lumalyte/lg/interaction/menus/guild/RankCreationMenu.kt
@@ -399,7 +399,8 @@ class RankCreationMenu(private val menuNavigator: MenuNavigator, private val pla
                 
                 RankPermission.MANAGE_RELATIONS, RankPermission.DECLARE_WAR,
                 RankPermission.ACCEPT_ALLIANCES, RankPermission.MANAGE_PARTIES,
-                RankPermission.SEND_PARTY_REQUESTS, RankPermission.ACCEPT_PARTY_INVITES -> "Diplomacy"
+                RankPermission.SEND_PARTY_REQUESTS, RankPermission.ACCEPT_PARTY_INVITES,
+                RankPermission.USE_ALLY_HOMES -> "Diplomacy"
                 
                 RankPermission.DEPOSIT_TO_BANK, RankPermission.WITHDRAW_FROM_BANK,
                 RankPermission.VIEW_BANK_TRANSACTIONS, RankPermission.EXPORT_BANK_DATA,

--- a/src/main/kotlin/net/lumalyte/lg/interaction/menus/guild/RankEditMenu.kt
+++ b/src/main/kotlin/net/lumalyte/lg/interaction/menus/guild/RankEditMenu.kt
@@ -271,7 +271,8 @@ class RankEditMenu(private val menuNavigator: MenuNavigator, private val player:
             "Diplomacy" to listOf(
                 RankPermission.MANAGE_RELATIONS, RankPermission.DECLARE_WAR,
                 RankPermission.ACCEPT_ALLIANCES, RankPermission.MANAGE_PARTIES,
-                RankPermission.SEND_PARTY_REQUESTS, RankPermission.ACCEPT_PARTY_INVITES
+                RankPermission.SEND_PARTY_REQUESTS, RankPermission.ACCEPT_PARTY_INVITES,
+                RankPermission.USE_ALLY_HOMES
             ),
             "Communication" to listOf(
                 RankPermission.SEND_ANNOUNCEMENTS, RankPermission.SEND_PINGS,

--- a/src/main/kotlin/net/lumalyte/lg/interaction/menus/guild/RankEditMenu.kt
+++ b/src/main/kotlin/net/lumalyte/lg/interaction/menus/guild/RankEditMenu.kt
@@ -58,6 +58,64 @@ class RankEditMenu(private val menuNavigator: MenuNavigator, private val player:
         return isGuildOwner() && isOwnerRank()
     }
 
+    private fun canActorReorder(): Boolean {
+        val actorRank = rankService.getPlayerRank(player.uniqueId, guild.id) ?: return false
+        return actorRank.priority < rank.priority
+    }
+
+    private fun siblingAt(direction: net.lumalyte.lg.application.services.PriorityDirection): net.lumalyte.lg.domain.entities.Rank? {
+        val siblings = rankService.listRanks(guild.id).sortedBy { it.priority }
+        val idx = siblings.indexOfFirst { it.id == rank.id }
+        val neighborIdx = when (direction) {
+            net.lumalyte.lg.application.services.PriorityDirection.UP -> idx - 1
+            net.lumalyte.lg.application.services.PriorityDirection.DOWN -> idx + 1
+        }
+        return siblings.getOrNull(neighborIdx)
+    }
+
+    private fun addPriorityButtons(pane: StaticPane) {
+        val upNeighbor = siblingAt(net.lumalyte.lg.application.services.PriorityDirection.UP)
+        val downNeighbor = siblingAt(net.lumalyte.lg.application.services.PriorityDirection.DOWN)
+        val canUp = canActorReorder() && upNeighbor != null && !isOwnerRank()
+        val canDown = canActorReorder() && downNeighbor != null && !isOwnerRank()
+
+        val upItem = ItemStack.of(if (canUp) Material.SPECTRAL_ARROW else Material.BARRIER)
+            .name(if (canUp) "§a▲ Move Up" else "§7▲ Move Up (locked)")
+            .lore("§7Current priority: §f${rank.priority}")
+            .lore(if (upNeighbor != null) "§7Above: §f${upNeighbor.name}" else "§7No rank above")
+            .lore("§7")
+            .lore(if (canUp) "§eClick to raise rank" else "§cCannot reorder")
+        pane.addItem(GuiItem(upItem) {
+            if (!canUp) return@GuiItem
+            val ok = rankService.moveRankPriority(rank.id, net.lumalyte.lg.application.services.PriorityDirection.UP, player.uniqueId)
+            if (ok) {
+                player.sendMessage("§a✅ Rank moved up.")
+                rank = rankService.getRank(rank.id) ?: rank
+                open()
+            } else {
+                player.sendMessage("§c❌ Could not move rank.")
+            }
+        }, 0, 0)
+
+        val downItem = ItemStack.of(if (canDown) Material.SPECTRAL_ARROW else Material.BARRIER)
+            .name(if (canDown) "§a▼ Move Down" else "§7▼ Move Down (locked)")
+            .lore("§7Current priority: §f${rank.priority}")
+            .lore(if (downNeighbor != null) "§7Below: §f${downNeighbor.name}" else "§7No rank below")
+            .lore("§7")
+            .lore(if (canDown) "§eClick to lower rank" else "§cCannot reorder")
+        pane.addItem(GuiItem(downItem) {
+            if (!canDown) return@GuiItem
+            val ok = rankService.moveRankPriority(rank.id, net.lumalyte.lg.application.services.PriorityDirection.DOWN, player.uniqueId)
+            if (ok) {
+                player.sendMessage("§a✅ Rank moved down.")
+                rank = rankService.getRank(rank.id) ?: rank
+                open()
+            } else {
+                player.sendMessage("§c❌ Could not move rank.")
+            }
+        }, 8, 0)
+    }
+
     // Load the current rank's icon or default to AIR
     private fun loadRankIcon(): Material {
         return try {
@@ -104,7 +162,8 @@ class RankEditMenu(private val menuNavigator: MenuNavigator, private val player:
         }
         gui.addPane(pane)
 
-        // Row 0: Rank Information
+        // Row 0: Rank Information + priority buttons
+        addPriorityButtons(pane)
         addRankInfoSection(pane)
 
         // Row 1-4: Permission Categories

--- a/src/test/kotlin/net/lumalyte/lg/domain/entities/GuildHomeTest.kt
+++ b/src/test/kotlin/net/lumalyte/lg/domain/entities/GuildHomeTest.kt
@@ -1,0 +1,27 @@
+package net.lumalyte.lg.domain.entities
+
+import net.lumalyte.lg.domain.values.Position3D
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.Assertions.*
+import java.util.UUID
+
+class GuildHomeTest {
+
+    @Test
+    fun `GuildHome defaults allowedRankIds to empty set`() {
+        val home = GuildHome(UUID.randomUUID(), Position3D(0, 64, 0))
+        assertEquals(emptySet<UUID>(), home.allowedRankIds)
+    }
+
+    @Test
+    fun `GuildHome stores supplied allowedRankIds`() {
+        val rankA = UUID.randomUUID()
+        val rankB = UUID.randomUUID()
+        val home = GuildHome(
+            worldId = UUID.randomUUID(),
+            position = Position3D(0, 64, 0),
+            allowedRankIds = setOf(rankA, rankB)
+        )
+        assertEquals(setOf(rankA, rankB), home.allowedRankIds)
+    }
+}

--- a/src/test/kotlin/net/lumalyte/lg/domain/entities/GuildTest.kt
+++ b/src/test/kotlin/net/lumalyte/lg/domain/entities/GuildTest.kt
@@ -314,4 +314,22 @@ class GuildTest {
         assertTrue(guildString.contains("joinFeeAmount=500"),
             "toString should include joinFeeAmount")
     }
+
+    @Test
+    fun `Guild allyHomeAllowedGuilds defaults to empty`() {
+        val guild = Guild(id = UUID.randomUUID(), name = "X", createdAt = Instant.now())
+        assertEquals(emptySet<UUID>(), guild.allyHomeAllowedGuilds)
+    }
+
+    @Test
+    fun `Guild stores supplied allyHomeAllowedGuilds`() {
+        val allyId = UUID.randomUUID()
+        val guild = Guild(
+            id = UUID.randomUUID(),
+            name = "X",
+            createdAt = Instant.now(),
+            allyHomeAllowedGuilds = setOf(allyId)
+        )
+        assertEquals(setOf(allyId), guild.allyHomeAllowedGuilds)
+    }
 }

--- a/src/test/kotlin/net/lumalyte/lg/infrastructure/services/GuildServiceAllyHomeAccessTest.kt
+++ b/src/test/kotlin/net/lumalyte/lg/infrastructure/services/GuildServiceAllyHomeAccessTest.kt
@@ -29,7 +29,8 @@ class GuildServiceAllyHomeAccessTest {
     private fun makeService(
         targetAllyHome: GuildHome?,
         targetAllowedGuilds: Set<UUID>,
-        memberRankPerms: Set<RankPermission> = emptySet()
+        memberRankPerms: Set<RankPermission> = emptySet(),
+        activeAlly: Boolean = true
     ): GuildServiceBukkit {
         val ownerRank = Rank(ownerRankId, sourceGuildId, "Owner", 0, RankPermission.values().toSet())
         val memberRank = Rank(memberRankId, sourceGuildId, "Member", 10, memberRankPerms)
@@ -42,6 +43,16 @@ class GuildServiceAllyHomeAccessTest {
         val guildRepository = mockk<GuildRepository>(relaxed = true)
         val rankRepository = mockk<RankRepository>(relaxed = true)
         val memberRepository = mockk<MemberRepository>(relaxed = true)
+        val relationRepository = mockk<RelationRepository>(relaxed = true)
+        every { relationRepository.getByGuildAndType(sourceGuildId, RelationType.ALLY) } returns
+            if (activeAlly) setOf(
+                Relation.create(
+                    guildA = sourceGuildId,
+                    guildB = targetGuildId,
+                    type = RelationType.ALLY,
+                    status = RelationStatus.ACTIVE
+                )
+            ) else emptySet()
         every { guildRepository.getById(sourceGuildId) } returns sourceGuild
         every { guildRepository.getById(targetGuildId) } returns targetGuild
         every { rankRepository.getById(ownerRankId) } returns ownerRank
@@ -61,7 +72,7 @@ class GuildServiceAllyHomeAccessTest {
             nexoEmojiService = mockk(relaxed = true),
             vaultService = mockk<GuildVaultService>(relaxed = true),
             hologramService = mockk(relaxed = true),
-            relationRepository = mockk<RelationRepository>(relaxed = true),
+            relationRepository = relationRepository,
             historyRepository = mockk<MembershipHistoryRepository>(relaxed = true)
         )
     }
@@ -104,5 +115,16 @@ class GuildServiceAllyHomeAccessTest {
     fun `target without ally home is denied`() {
         val svc = makeService(targetAllyHome = null, targetAllowedGuilds = setOf(sourceGuildId))
         assertFalse(svc.canUseAllyHome(ownerPlayerId, sourceGuildId, targetGuildId))
+    }
+
+    @Test
+    fun `whitelist without active alliance is denied`() {
+        val svc = makeService(
+            targetAllyHome = ah,
+            targetAllowedGuilds = setOf(sourceGuildId),
+            memberRankPerms = setOf(RankPermission.USE_ALLY_HOMES),
+            activeAlly = false
+        )
+        assertFalse(svc.canUseAllyHome(memberPlayerId, sourceGuildId, targetGuildId))
     }
 }

--- a/src/test/kotlin/net/lumalyte/lg/infrastructure/services/GuildServiceAllyHomeAccessTest.kt
+++ b/src/test/kotlin/net/lumalyte/lg/infrastructure/services/GuildServiceAllyHomeAccessTest.kt
@@ -1,0 +1,108 @@
+package net.lumalyte.lg.infrastructure.services
+
+import io.mockk.every
+import io.mockk.mockk
+import net.lumalyte.lg.application.persistence.GuildRepository
+import net.lumalyte.lg.application.persistence.MemberRepository
+import net.lumalyte.lg.application.persistence.MembershipHistoryRepository
+import net.lumalyte.lg.application.persistence.RankRepository
+import net.lumalyte.lg.application.persistence.RelationRepository
+import net.lumalyte.lg.application.services.GuildVaultService
+import net.lumalyte.lg.application.services.MemberService
+import net.lumalyte.lg.application.services.RankService
+import net.lumalyte.lg.domain.entities.*
+import net.lumalyte.lg.domain.values.Position3D
+import org.junit.jupiter.api.Assertions.*
+import org.junit.jupiter.api.Test
+import java.time.Instant
+import java.util.UUID
+
+class GuildServiceAllyHomeAccessTest {
+
+    private val sourceGuildId = UUID.randomUUID()
+    private val targetGuildId = UUID.randomUUID()
+    private val ownerRankId = UUID.randomUUID()
+    private val memberRankId = UUID.randomUUID()
+    private val ownerPlayerId = UUID.randomUUID()
+    private val memberPlayerId = UUID.randomUUID()
+
+    private fun makeService(
+        targetAllyHome: GuildHome?,
+        targetAllowedGuilds: Set<UUID>,
+        memberRankPerms: Set<RankPermission> = emptySet()
+    ): GuildServiceBukkit {
+        val ownerRank = Rank(ownerRankId, sourceGuildId, "Owner", 0, RankPermission.values().toSet())
+        val memberRank = Rank(memberRankId, sourceGuildId, "Member", 10, memberRankPerms)
+        val sourceGuild = Guild(id = sourceGuildId, name = "S", createdAt = Instant.now())
+        val targetGuild = Guild(
+            id = targetGuildId, name = "T", createdAt = Instant.now(),
+            allyHome = targetAllyHome,
+            allyHomeAllowedGuilds = targetAllowedGuilds
+        )
+        val guildRepository = mockk<GuildRepository>(relaxed = true)
+        val rankRepository = mockk<RankRepository>(relaxed = true)
+        val memberRepository = mockk<MemberRepository>(relaxed = true)
+        every { guildRepository.getById(sourceGuildId) } returns sourceGuild
+        every { guildRepository.getById(targetGuildId) } returns targetGuild
+        every { rankRepository.getById(ownerRankId) } returns ownerRank
+        every { rankRepository.getById(memberRankId) } returns memberRank
+        every { rankRepository.getHighestRank(sourceGuildId) } returns ownerRank
+        every { memberRepository.getByPlayerAndGuild(ownerPlayerId, sourceGuildId) } returns
+            Member(ownerPlayerId, sourceGuildId, ownerRankId, Instant.now())
+        every { memberRepository.getByPlayerAndGuild(memberPlayerId, sourceGuildId) } returns
+            Member(memberPlayerId, sourceGuildId, memberRankId, Instant.now())
+
+        return GuildServiceBukkit(
+            guildRepository = guildRepository,
+            rankRepository = rankRepository,
+            memberRepository = memberRepository,
+            rankService = mockk<RankService>(relaxed = true),
+            memberService = mockk<MemberService>(relaxed = true),
+            nexoEmojiService = mockk(relaxed = true),
+            vaultService = mockk<GuildVaultService>(relaxed = true),
+            hologramService = mockk(relaxed = true),
+            relationRepository = mockk<RelationRepository>(relaxed = true),
+            historyRepository = mockk<MembershipHistoryRepository>(relaxed = true)
+        )
+    }
+
+    private val ah = GuildHome(UUID.randomUUID(), Position3D(0, 64, 0))
+
+    @Test
+    fun `owner bypasses USE_ALLY_HOMES rank check`() {
+        val svc = makeService(targetAllyHome = ah, targetAllowedGuilds = setOf(sourceGuildId))
+        assertTrue(svc.canUseAllyHome(ownerPlayerId, sourceGuildId, targetGuildId))
+    }
+
+    @Test
+    fun `non-owner with USE_ALLY_HOMES and whitelisted source can use`() {
+        val svc = makeService(
+            targetAllyHome = ah,
+            targetAllowedGuilds = setOf(sourceGuildId),
+            memberRankPerms = setOf(RankPermission.USE_ALLY_HOMES)
+        )
+        assertTrue(svc.canUseAllyHome(memberPlayerId, sourceGuildId, targetGuildId))
+    }
+
+    @Test
+    fun `non-owner without USE_ALLY_HOMES is denied`() {
+        val svc = makeService(targetAllyHome = ah, targetAllowedGuilds = setOf(sourceGuildId))
+        assertFalse(svc.canUseAllyHome(memberPlayerId, sourceGuildId, targetGuildId))
+    }
+
+    @Test
+    fun `source not on inbound whitelist is denied`() {
+        val svc = makeService(
+            targetAllyHome = ah,
+            targetAllowedGuilds = emptySet(),
+            memberRankPerms = setOf(RankPermission.USE_ALLY_HOMES)
+        )
+        assertFalse(svc.canUseAllyHome(memberPlayerId, sourceGuildId, targetGuildId))
+    }
+
+    @Test
+    fun `target without ally home is denied`() {
+        val svc = makeService(targetAllyHome = null, targetAllowedGuilds = setOf(sourceGuildId))
+        assertFalse(svc.canUseAllyHome(ownerPlayerId, sourceGuildId, targetGuildId))
+    }
+}

--- a/src/test/kotlin/net/lumalyte/lg/infrastructure/services/GuildServiceAllyHomeAccessTest.kt
+++ b/src/test/kotlin/net/lumalyte/lg/infrastructure/services/GuildServiceAllyHomeAccessTest.kt
@@ -118,6 +118,13 @@ class GuildServiceAllyHomeAccessTest {
     }
 
     @Test
+    fun `owner denied when source not on inbound whitelist`() {
+        // Whitelist check happens before owner bypass — keep that ordering invariant locked in.
+        val svc = makeService(targetAllyHome = ah, targetAllowedGuilds = emptySet())
+        assertFalse(svc.canUseAllyHome(ownerPlayerId, sourceGuildId, targetGuildId))
+    }
+
+    @Test
     fun `whitelist without active alliance is denied`() {
         val svc = makeService(
             targetAllyHome = ah,

--- a/src/test/kotlin/net/lumalyte/lg/infrastructure/services/GuildServiceHomeAccessTest.kt
+++ b/src/test/kotlin/net/lumalyte/lg/infrastructure/services/GuildServiceHomeAccessTest.kt
@@ -1,0 +1,96 @@
+package net.lumalyte.lg.infrastructure.services
+
+import io.mockk.every
+import io.mockk.mockk
+import net.lumalyte.lg.application.persistence.GuildRepository
+import net.lumalyte.lg.application.persistence.MemberRepository
+import net.lumalyte.lg.application.persistence.MembershipHistoryRepository
+import net.lumalyte.lg.application.persistence.RankRepository
+import net.lumalyte.lg.application.persistence.RelationRepository
+import net.lumalyte.lg.application.services.GuildVaultService
+import net.lumalyte.lg.application.services.MemberService
+import net.lumalyte.lg.application.services.RankService
+import net.lumalyte.lg.domain.entities.*
+import net.lumalyte.lg.domain.values.Position3D
+import org.junit.jupiter.api.Assertions.*
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import java.time.Instant
+import java.util.UUID
+
+class GuildServiceHomeAccessTest {
+
+    private val guildId = UUID.randomUUID()
+    private val ownerRankId = UUID.randomUUID()
+    private val memberRankId = UUID.randomUUID()
+    private val ownerPlayerId = UUID.randomUUID()
+    private val memberPlayerId = UUID.randomUUID()
+    private val homeName = "main"
+    private val worldId = UUID.randomUUID()
+
+    private lateinit var guildRepository: GuildRepository
+    private lateinit var rankRepository: RankRepository
+    private lateinit var memberRepository: MemberRepository
+    private lateinit var service: GuildServiceBukkit
+
+    private fun homeWith(allowed: Set<UUID>) = GuildHome(worldId, Position3D(0, 64, 0), allowed)
+
+    private fun setup(homeAllowed: Set<UUID>) {
+        val ownerRank = Rank(ownerRankId, guildId, "Owner", 0, RankPermission.values().toSet())
+        val memberRank = Rank(memberRankId, guildId, "Member", 10, emptySet())
+        val guild = Guild(
+            id = guildId, name = "G", createdAt = Instant.now(),
+            homes = GuildHomes(mapOf(homeName to homeWith(homeAllowed)))
+        )
+        guildRepository = mockk(relaxed = true)
+        rankRepository = mockk(relaxed = true)
+        memberRepository = mockk(relaxed = true)
+        every { guildRepository.getById(guildId) } returns guild
+        every { rankRepository.getById(ownerRankId) } returns ownerRank
+        every { rankRepository.getById(memberRankId) } returns memberRank
+        every { rankRepository.getHighestRank(guildId) } returns ownerRank
+        every { memberRepository.getByPlayerAndGuild(ownerPlayerId, guildId) } returns
+            Member(ownerPlayerId, guildId, ownerRankId, Instant.now())
+        every { memberRepository.getByPlayerAndGuild(memberPlayerId, guildId) } returns
+            Member(memberPlayerId, guildId, memberRankId, Instant.now())
+
+        service = GuildServiceBukkit(
+            guildRepository = guildRepository,
+            rankRepository = rankRepository,
+            memberRepository = memberRepository,
+            rankService = mockk<RankService>(relaxed = true),
+            memberService = mockk<MemberService>(relaxed = true),
+            nexoEmojiService = mockk(relaxed = true),
+            vaultService = mockk<GuildVaultService>(relaxed = true),
+            hologramService = mockk(relaxed = true),
+            relationRepository = mockk<RelationRepository>(relaxed = true),
+            historyRepository = mockk<MembershipHistoryRepository>(relaxed = true)
+        )
+    }
+
+    @Test
+    fun `owner can use home regardless of whitelist`() {
+        setup(homeAllowed = emptySet())
+        assertTrue(service.canUseHome(ownerPlayerId, guildId, homeName))
+    }
+
+    @Test
+    fun `member cannot use home when not whitelisted`() {
+        setup(homeAllowed = emptySet())
+        assertFalse(service.canUseHome(memberPlayerId, guildId, homeName))
+    }
+
+    @Test
+    fun `member can use home when whitelisted`() {
+        setup(homeAllowed = setOf(memberRankId))
+        assertTrue(service.canUseHome(memberPlayerId, guildId, homeName))
+    }
+
+    @Test
+    fun `non-member cannot use home`() {
+        setup(homeAllowed = setOf(memberRankId))
+        val outsider = UUID.randomUUID()
+        every { memberRepository.getByPlayerAndGuild(outsider, guildId) } returns null
+        assertFalse(service.canUseHome(outsider, guildId, homeName))
+    }
+}

--- a/src/test/kotlin/net/lumalyte/lg/infrastructure/services/RankServicePriorityTest.kt
+++ b/src/test/kotlin/net/lumalyte/lg/infrastructure/services/RankServicePriorityTest.kt
@@ -1,0 +1,100 @@
+package net.lumalyte.lg.infrastructure.services
+
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.verify
+import net.lumalyte.lg.application.persistence.GuildRepository
+import net.lumalyte.lg.application.persistence.MemberRepository
+import net.lumalyte.lg.application.persistence.RankRepository
+import net.lumalyte.lg.application.services.MemberService
+import net.lumalyte.lg.application.services.PriorityDirection
+import net.lumalyte.lg.domain.entities.Rank
+import net.lumalyte.lg.domain.entities.RankPermission
+import org.junit.jupiter.api.Assertions.*
+import org.junit.jupiter.api.Test
+import java.util.UUID
+
+class RankServicePriorityTest {
+
+    private val guildId = UUID.randomUUID()
+    private val actorId = UUID.randomUUID()
+
+    private fun mkRank(name: String, priority: Int, perms: Set<RankPermission> = emptySet()) =
+        Rank(UUID.randomUUID(), guildId, name, priority, perms)
+
+    private fun setup(
+        actor: Rank,
+        ranks: List<Rank>
+    ): Triple<RankServiceBukkit, RankRepository, MemberRepository> {
+        val rankRepo = mockk<RankRepository>(relaxed = true)
+        val memberRepo = mockk<MemberRepository>(relaxed = true)
+        ranks.forEach { every { rankRepo.getById(it.id) } returns it }
+        every { rankRepo.getByGuild(guildId) } returns ranks.toSet()
+        every { rankRepo.getHighestRank(guildId) } returns ranks.minByOrNull { it.priority }
+        every { memberRepo.getRankId(actorId, guildId) } returns actor.id
+        every { rankRepo.swapPriorities(any(), any()) } returns true
+        val service = makeService(rankRepo, memberRepo)
+        return Triple(service, rankRepo, memberRepo)
+    }
+
+    private fun makeService(rankRepo: RankRepository, memberRepo: MemberRepository): RankServiceBukkit {
+        return RankServiceBukkit(
+            rankRepository = rankRepo,
+            memberRepository = memberRepo,
+            guildRepository = mockk<GuildRepository>(relaxed = true),
+            memberService = mockk<MemberService>(relaxed = true)
+        )
+    }
+
+    @Test
+    fun `moveRankPriority UP swaps with adjacent higher rank`() {
+        val owner = mkRank("Owner", 0, setOf(RankPermission.MANAGE_RANKS))
+        val mid = mkRank("Trusted", 4)
+        val target = mkRank("Member", 5)
+        val (svc, rankRepo) = setup(actor = owner, ranks = listOf(owner, mid, target))
+        assertTrue(svc.moveRankPriority(target.id, PriorityDirection.UP, actorId))
+        verify { rankRepo.swapPriorities(target.id, mid.id) }
+    }
+
+    @Test
+    fun `moveRankPriority DOWN swaps with adjacent lower rank`() {
+        val owner = mkRank("Owner", 0, setOf(RankPermission.MANAGE_RANKS))
+        val target = mkRank("Trusted", 4)
+        val below = mkRank("Member", 5)
+        val (svc, rankRepo) = setup(actor = owner, ranks = listOf(owner, target, below))
+        assertTrue(svc.moveRankPriority(target.id, PriorityDirection.DOWN, actorId))
+        verify { rankRepo.swapPriorities(target.id, below.id) }
+    }
+
+    @Test
+    fun `moveRankPriority fails when actor priority equal or higher than target`() {
+        val actor2 = mkRank("Junior", 7, setOf(RankPermission.MANAGE_RANKS))
+        val target2 = mkRank("Member", 5)
+        val (svc, _) = setup(actor = actor2, ranks = listOf(actor2, target2))
+        assertFalse(svc.moveRankPriority(target2.id, PriorityDirection.UP, actorId))
+    }
+
+    @Test
+    fun `moveRankPriority UP fails when target is highest rank`() {
+        val owner = mkRank("Owner", 0, setOf(RankPermission.MANAGE_RANKS))
+        val target = owner
+        val (svc, _) = setup(actor = owner, ranks = listOf(owner))
+        assertFalse(svc.moveRankPriority(target.id, PriorityDirection.UP, actorId))
+    }
+
+    @Test
+    fun `moveRankPriority DOWN fails when target is lowest rank`() {
+        val owner = mkRank("Owner", 0, setOf(RankPermission.MANAGE_RANKS))
+        val target = mkRank("Member", 5)
+        val (svc, _) = setup(actor = owner, ranks = listOf(owner, target))
+        assertFalse(svc.moveRankPriority(target.id, PriorityDirection.DOWN, actorId))
+    }
+
+    @Test
+    fun `moveRankPriority fails when actor lacks MANAGE_RANKS`() {
+        val actor = mkRank("Owner", 0) // no MANAGE_RANKS
+        val target = mkRank("Member", 5)
+        val (svc, _) = setup(actor = actor, ranks = listOf(actor, target))
+        assertFalse(svc.moveRankPriority(target.id, PriorityDirection.UP, actorId))
+    }
+}


### PR DESCRIPTION
## Summary

Three bundled guild features driven by FainNoir/Badger's Discord request (5/7):

1. **Per-home rank whitelist** — `/guild home <name>` checks `GuildHome.allowedRankIds`. Owner bypass. Existing homes migrate to allow-all-current-ranks (policy B); new homes default Owner-only.
2. **Ally-home perms** — new `USE_ALLY_HOMES` rank permission (outbound) + `Guild.allyHomeAllowedGuilds` set (inbound, per ally guild). Auto-managed on alliance accept/break.
3. **Rank priority reorder** — ▲/▼ buttons in `RankEditMenu` with atomic 3-step SQLite swap. Actor-priority guard: cannot reorder ranks at/above own.

## Implementation

- Schema migration **v20**: idempotent ALTER TABLE + backfill (`guild_homes.allowed_ranks` CSV, `guilds.ally_home_allowed_guilds` CSV, `USE_ALLY_HOMES` added to every existing rank).
- Service layer: `GuildService.canUseHome`, `canUseAllyHome`, `setHomeAllowedRanks`, `setAllyHomeAllowedGuilds`; `RankService.moveRankPriority(rankId, PriorityDirection, actorId)`; `RankRepository.swapPriorities` with temp-priority swap (safe under future unique index).
- UI: new `HomeAccessMenu` + `AllyHomeAccessMenu`; 🔒 Access buttons row 3 of `GuildHomeMenu` (per-home) + col 7 row 5 (ally-home). Visible to MANAGE_HOME holders only.
- Bedrock: home access gating in `BedrockGuildHomeMenu`. Priority reorder UI skipped (light-touch parity per codebase precedent).
- 15 new tests across `GuildHomeTest`, `GuildTest`, `GuildServiceHomeAccessTest`, `GuildServiceAllyHomeAccessTest`, `RankServicePriorityTest`. Full suite green.

## Out of scope

- `GuildTeamService.kt:129` priority-comparison bug (spec §4.3) — flagged separately.
- Per-warp perms (no warp entity), per-ally-rank matrix, numeric priority direct-set.

## Test plan

- [ ] Form test guild, set home, log in as member of non-whitelisted rank → `/guild home` denied
- [ ] Grant rank access via HomeAccessMenu → teleport works
- [ ] Edit member-tier rank, click ▲ → priority moves up, persists across `/reload`
- [ ] Ally two guilds → both auto-added to inbound whitelist; revoke one side via AllyHomeAccessMenu → cross-guild teleport denied
- [ ] Owner always bypasses both whitelists
- [ ] Verify v20 migration on existing DB: existing homes still teleport-able by all current ranks

Spec: `docs/superpowers/specs/2026-05-10-rank-and-home-perms-design.md` (gitignored — not in PR; shareable on request)
Plan: `docs/plans/2026-05-10-rank-and-home-perms-impl.md` (in PR)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Per-home rank-based access and ally-home inbound allowlist with in-game UI to manage them
  * Rank priority reordering controls in rank management
  * Runtime checks that block unauthorized teleports and show denial messages
  * Bedrock users receive guidance when a feature requires the Java client

* **Documentation**
  * Detailed rollout/implementation plan for rank & home permissions

* **Tests**
  * Added tests for home access, ally-home rules, and rank priority reordering

* **Chores**
  * Updated ignore rules for local/CI files

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/BadgersMC/LumaGuilds/pull/37)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->