### PR TITLE
feat(commands): centralize guild resolution + fix /g home autocomplete

### DIFF
--- a/src/main/kotlin/net/lumalyte/lg/LumaGuilds.kt
+++ b/src/main/kotlin/net/lumalyte/lg/LumaGuilds.kt
@@ -674,7 +674,25 @@ class LumaGuilds : JavaPlugin() {
 
         commandManager.commandCompletions.registerAsyncCompletion("guilds") { _ ->
             val guildService = get().get<net.lumalyte.lg.application.services.GuildService>()
-            guildService.getAllGuilds().map { it.name }
+            net.lumalyte.lg.utils.GuildResolver.suggestions(guildService)
+        }
+
+        // Pending invites for the executing player (used by /g decline, /g join in closed guilds)
+        commandManager.commandCompletions.registerAsyncCompletion("pendinginvites") { context ->
+            val player = context.player ?: return@registerAsyncCompletion emptyList()
+            net.lumalyte.lg.infrastructure.services.GuildInvitationManager.getInvites(player.uniqueId)
+                .map { (_, guildName) -> net.lumalyte.lg.utils.ColorCodeUtils.stripAllFormatting(guildName).trim() }
+                .filter { it.isNotBlank() }
+                .distinct()
+                .sorted()
+        }
+
+        // Guilds OR online player names — used by /g info, which supports both.
+        commandManager.commandCompletions.registerAsyncCompletion("guildsorplayers") { _ ->
+            val guildService = get().get<net.lumalyte.lg.application.services.GuildService>()
+            val guildNames = net.lumalyte.lg.utils.GuildResolver.suggestions(guildService)
+            val playerNames = Bukkit.getOnlinePlayers().mapNotNull { it.name }
+            (guildNames + playerNames).distinct().sorted()
         }
 
         commandManager.commandCompletions.registerAsyncCompletion("guildhomes") { context ->

--- a/src/main/kotlin/net/lumalyte/lg/interaction/commands/GuildCommand.kt
+++ b/src/main/kotlin/net/lumalyte/lg/interaction/commands/GuildCommand.kt
@@ -301,6 +301,7 @@ class GuildCommand : BaseCommand(), KoinComponent {
     
     @Subcommand("home")
     @CommandPermission("lumaguilds.guild.home")
+    @CommandCompletion("@guildhomes")
     fun onHome(player: Player, @Optional homeName: String?, @Optional confirm: String?) {
         // Handle "/guild home confirm" — ACF puts "confirm" into homeName, not confirm param
         val isConfirm = confirm?.lowercase() == "confirm" || homeName?.lowercase() == "confirm"
@@ -835,17 +836,16 @@ class GuildCommand : BaseCommand(), KoinComponent {
     }
 
     @Subcommand("info")
-    @CommandCompletion("@guilds")
+    @CommandCompletion("@guildsorplayers")
     fun onInfo(player: Player, @Optional targetGuild: String?) {
         val menuNavigator = MenuNavigator(player)
 
         if (targetGuild != null) {
-            // Show info about another guild by name
-            val guilds = guildService.getAllGuilds()
-            val targetGuildObj = guilds.find { it.name.equals(targetGuild, ignoreCase = true) }
+            // Resolve by guild name (exact / normalized) or by player name
+            val targetGuildObj = net.lumalyte.lg.utils.GuildResolver.resolve(targetGuild, guildService)
 
             if (targetGuildObj == null) {
-                player.sendMessage("§cGuild '$targetGuild' not found.")
+                player.sendMessage("§cNo guild or player named '$targetGuild' found.")
                 return
             }
 
@@ -985,7 +985,7 @@ class GuildCommand : BaseCommand(), KoinComponent {
         menuNavigator.openMenu(menuFactory.createGuildInviteConfirmationMenu(menuNavigator, player, guild, targetPlayer))
     }
 
-    @Subcommand("join")
+    @Subcommand("join|accept")
     @CommandPermission("lumaguilds.guild.join")
     @CommandCompletion("@guilds")
     fun onJoin(player: Player, guildName: String) {
@@ -1001,8 +1001,9 @@ class GuildCommand : BaseCommand(), KoinComponent {
             return
         }
 
-        // First, try to find the guild by name
-        val guild = guildRepository.getByName(guildName)
+        // Resolve guild by name (exact / normalized). Player-name resolution is
+        // intentionally NOT used here — joining via a player's name is ambiguous.
+        val guild = net.lumalyte.lg.utils.GuildResolver.resolveGuildByName(guildName, guildService)
         if (guild == null) {
             player.sendMessage("§cGuild §6$guildName§c doesn't exist!")
             player.sendMessage("§7Check §e/guild list§7 to see available guilds.")
@@ -1024,8 +1025,8 @@ class GuildCommand : BaseCommand(), KoinComponent {
             return
         }
 
-        // Closed guild - check for pending invite
-        val invite = net.lumalyte.lg.infrastructure.services.GuildInvitationManager.getInviteByGuildName(playerId, guildName)
+        // Closed guild - check for pending invite (use canonical guild name, not raw user input)
+        val invite = net.lumalyte.lg.infrastructure.services.GuildInvitationManager.getInviteByGuildName(playerId, guild.name)
         if (invite == null) {
             player.sendMessage("§cYou don't have an invitation to join §6$guildName§c!")
             player.sendMessage("§7This guild is invite-only. Ask a member to invite you.")
@@ -1152,12 +1153,16 @@ class GuildCommand : BaseCommand(), KoinComponent {
 
     @Subcommand("decline")
     @CommandPermission("lumaguilds.guild.decline")
-    @CommandCompletion("@guilds")
+    @CommandCompletion("@pendinginvites")
     fun onDecline(player: Player, guildName: String) {
         val playerId = player.uniqueId
 
-        // Check if player has a pending invite for this guild
-        val invite = net.lumalyte.lg.infrastructure.services.GuildInvitationManager.getInviteByGuildName(playerId, guildName)
+        // Resolve invite using exact name first, then normalized name match across
+        // the player's pending invites so colored/lowercased input also works.
+        val invites = net.lumalyte.lg.infrastructure.services.GuildInvitationManager.getInvites(playerId)
+        val needle = net.lumalyte.lg.utils.GuildResolver.normalize(guildName)
+        val invite = invites.firstOrNull { it.second.equals(guildName, ignoreCase = true) }
+            ?: invites.firstOrNull { net.lumalyte.lg.utils.GuildResolver.normalize(it.second) == needle }
         if (invite == null) {
             player.sendMessage("§cYou don't have an invitation to join §6$guildName§c!")
             player.sendMessage("§7Check §e/guild invites§7 to see your pending invitations.")
@@ -1988,10 +1993,10 @@ class GuildCommand : BaseCommand(), KoinComponent {
             return
         }
 
-        // Find target guild
-        val targetGuild = guildRepository.getByName(guildName)
+        // Resolve target guild (by name or by player name)
+        val targetGuild = net.lumalyte.lg.utils.GuildResolver.resolve(guildName, guildService)
         if (targetGuild == null) {
-            player.sendMessage("§cGuild '$guildName' not found.")
+            player.sendMessage("§cNo guild or player named '$guildName' found.")
             return
         }
 
@@ -2061,10 +2066,10 @@ class GuildCommand : BaseCommand(), KoinComponent {
             return
         }
 
-        // Find target guild
-        val targetGuild = guildRepository.getByName(guildName)
+        // Resolve target guild (by name or by player name)
+        val targetGuild = net.lumalyte.lg.utils.GuildResolver.resolve(guildName, guildService)
         if (targetGuild == null) {
-            player.sendMessage("§cGuild '$guildName' not found.")
+            player.sendMessage("§cNo guild or player named '$guildName' found.")
             return
         }
 
@@ -2129,10 +2134,10 @@ class GuildCommand : BaseCommand(), KoinComponent {
             return
         }
 
-        // Find target guild
-        val targetGuild = guildRepository.getByName(guildName)
+        // Resolve target guild (by name or by player name)
+        val targetGuild = net.lumalyte.lg.utils.GuildResolver.resolve(guildName, guildService)
         if (targetGuild == null) {
-            player.sendMessage("§cGuild '$guildName' not found.")
+            player.sendMessage("§cNo guild or player named '$guildName' found.")
             return
         }
 
@@ -2197,10 +2202,10 @@ class GuildCommand : BaseCommand(), KoinComponent {
             return
         }
 
-        // Find target guild
-        val targetGuild = guildRepository.getByName(guildName)
+        // Resolve target guild (by name or by player name)
+        val targetGuild = net.lumalyte.lg.utils.GuildResolver.resolve(guildName, guildService)
         if (targetGuild == null) {
-            player.sendMessage("§cGuild '$guildName' not found.")
+            player.sendMessage("§cNo guild or player named '$guildName' found.")
             return
         }
 

--- a/src/main/kotlin/net/lumalyte/lg/interaction/commands/LumaGuildsCommand.kt
+++ b/src/main/kotlin/net/lumalyte/lg/interaction/commands/LumaGuildsCommand.kt
@@ -183,7 +183,7 @@ class LumaGuildsCommand : CommandExecutor, TabCompleter, KoinComponent {
             args.drop(1).joinToString(" ")
         }
 
-        val guild = guildService.getGuildByName(guildName)
+        val guild = net.lumalyte.lg.utils.GuildResolver.resolveGuildByName(guildName, guildService)
 
         if (guild == null) {
             sender.sendMessage("§c❌ Guild not found: $guildName")
@@ -539,9 +539,7 @@ class LumaGuildsCommand : CommandExecutor, TabCompleter, KoinComponent {
                         .toMutableList()
                 }
                 "disband" -> {
-                    // Tab complete guild names
-                    guildService.getAllGuilds()
-                        .map { it.name }
+                    net.lumalyte.lg.utils.GuildResolver.suggestions(guildService)
                         .filter { it.contains(args[1], ignoreCase = true) }
                         .toMutableList()
                 }

--- a/src/main/kotlin/net/lumalyte/lg/interaction/commands/admin/RemoveVaultCommand.kt
+++ b/src/main/kotlin/net/lumalyte/lg/interaction/commands/admin/RemoveVaultCommand.kt
@@ -45,8 +45,8 @@ class RemoveVaultCommand(
             true // Default to dropping items
         }
 
-        // Find guild
-        val guild = guildService.getGuildByName(guildName)
+        // Find guild (resolve handles exact, case-insensitive, and stripped names)
+        val guild = net.lumalyte.lg.utils.GuildResolver.resolveGuildByName(guildName, guildService)
         if (guild == null) {
             sender.sendMessage("§cGuild '$guildName' not found")
             return true
@@ -96,14 +96,9 @@ class RemoveVaultCommand(
         }
 
         return when (args.size) {
-            1 -> {
-                // Guild name suggestions would go here
-                // For now, return empty list
-                emptyList()
-            }
-            2 -> {
-                listOf("true", "false").filter { it.startsWith(args[1], ignoreCase = true) }
-            }
+            1 -> net.lumalyte.lg.utils.GuildResolver.suggestions(guildService)
+                .filter { it.startsWith(args[0], ignoreCase = true) }
+            2 -> listOf("true", "false").filter { it.startsWith(args[1], ignoreCase = true) }
             else -> emptyList()
         }
     }

--- a/src/main/kotlin/net/lumalyte/lg/interaction/commands/admin/VaultRollbackCommand.kt
+++ b/src/main/kotlin/net/lumalyte/lg/interaction/commands/admin/VaultRollbackCommand.kt
@@ -63,7 +63,7 @@ class VaultRollbackCommand(
         }
 
         val guildName = args[1]
-        val guild = guildService.getGuildByName(guildName)
+        val guild = net.lumalyte.lg.utils.GuildResolver.resolveGuildByName(guildName, guildService)
 
         if (guild == null) {
             sender.sendMessage("§cGuild '$guildName' not found")
@@ -108,7 +108,7 @@ class VaultRollbackCommand(
         val guildName = args[1]
         val backupId = args[2]
 
-        val guild = guildService.getGuildByName(guildName)
+        val guild = net.lumalyte.lg.utils.GuildResolver.resolveGuildByName(guildName, guildService)
 
         if (guild == null) {
             sender.sendMessage("§cGuild '$guildName' not found")
@@ -159,10 +159,8 @@ class VaultRollbackCommand(
 
         return when (args.size) {
             1 -> listOf("list", "restore").filter { it.startsWith(args[0].lowercase()) }
-            2 -> {
-                // Guild name suggestions would go here
-                emptyList()
-            }
+            2 -> net.lumalyte.lg.utils.GuildResolver.suggestions(guildService)
+                .filter { it.startsWith(args[1], ignoreCase = true) }
             else -> emptyList()
         }
     }

--- a/src/main/kotlin/net/lumalyte/lg/utils/GuildResolver.kt
+++ b/src/main/kotlin/net/lumalyte/lg/utils/GuildResolver.kt
@@ -1,0 +1,77 @@
+package net.lumalyte.lg.utils
+
+import net.lumalyte.lg.application.services.GuildService
+import net.lumalyte.lg.domain.entities.Guild
+import org.bukkit.Bukkit
+import org.bukkit.entity.Player
+
+/**
+ * Centralized guild lookup used by commands, completions, and any caller that
+ * accepts user-supplied strings. Guild names are validated as plain ASCII
+ * (see GuildCommand.onCreate), but this resolver still strips MiniMessage and
+ * legacy color codes defensively in case legacy/imported data contains them.
+ *
+ * Resolution priority for [resolve]:
+ *   1. exact (case-insensitive) guild name match
+ *   2. normalized guild name match (formatting + non-alphanumerics stripped)
+ *   3. online player name -> that player's first guild
+ *   4. offline player name -> that player's first guild
+ */
+object GuildResolver {
+
+    /**
+     * Strip MiniMessage tags, legacy & codes, section codes, and lowercase.
+     * Used both for storage-side index and query-side input.
+     */
+    fun normalize(input: String): String {
+        val stripped = ColorCodeUtils.stripAllFormatting(input)
+        return stripped.lowercase().filter { it.isLetterOrDigit() }
+    }
+
+    /** Plain-text display name for a stored guild (best effort strip). */
+    fun displayName(guild: Guild): String =
+        ColorCodeUtils.stripAllFormatting(guild.name).trim().ifEmpty { guild.name }
+
+    /** Lookup by guild name only (exact, then normalized). */
+    fun resolveGuildByName(input: String, guildService: GuildService): Guild? {
+        if (input.isBlank()) return null
+        guildService.getGuildByName(input)?.let { return it }
+        val needle = normalize(input)
+        if (needle.isEmpty()) return null
+        return guildService.getAllGuilds().firstOrNull { normalize(it.name) == needle }
+    }
+
+    /**
+     * Lookup by player name (online first, then cached offline).
+     *
+     * Uses `getOfflinePlayerIfCached` to avoid the synchronous Mojang API lookup
+     * `getOfflinePlayer(String)` performs on uncached names — that would block the
+     * main thread when called from a command handler.
+     */
+    fun resolveGuildByPlayerName(input: String, guildService: GuildService): Guild? {
+        if (input.isBlank()) return null
+        val online: Player? = Bukkit.getPlayerExact(input)
+        val playerId = online?.uniqueId
+            ?: Bukkit.getOfflinePlayerIfCached(input)?.uniqueId
+            ?: return null
+        return guildService.getPlayerGuilds(playerId).firstOrNull()
+    }
+
+    /** Guild-name first, then player-name. */
+    fun resolve(input: String, guildService: GuildService): Guild? {
+        return resolveGuildByName(input, guildService)
+            ?: resolveGuildByPlayerName(input, guildService)
+    }
+
+    /** Plain-text suggestion list (no MiniMessage tags) for tab completion. */
+    fun suggestions(guildService: GuildService, filter: (Guild) -> Boolean = { true }): List<String> {
+        return guildService.getAllGuilds()
+            .asSequence()
+            .filter(filter)
+            .map { displayName(it) }
+            .filter { it.isNotBlank() }
+            .distinct()
+            .sorted()
+            .toList()
+    }
+}

--- a/src/main/kotlin/net/lumalyte/lg/utils/GuildResolver.kt
+++ b/src/main/kotlin/net/lumalyte/lg/utils/GuildResolver.kt
@@ -13,40 +13,66 @@ import org.bukkit.entity.Player
  *
  * Resolution priority for [resolve]:
  *   1. exact (case-insensitive) guild name match
- *   2. normalized guild name match (formatting + non-alphanumerics stripped)
+ *   2. unambiguous normalized guild name match (formatting + non-alphanumerics
+ *      stripped). Ambiguous normalized matches return null so destructive
+ *      commands never act on the wrong guild.
  *   3. online player name -> that player's first guild
- *   4. offline player name -> that player's first guild
+ *   4. cached offline player name -> that player's first guild
  */
 object GuildResolver {
 
+    // Legacy colour-code regex used as a safety net for inputs MiniMessage
+    // parses as plain text (it doesn't strip raw `&c`-style codes).
+    private val LEGACY_CODES = Regex("[&§][0-9a-fk-orA-FK-OR]")
+
     /**
-     * Strip MiniMessage tags, legacy & codes, section codes, and lowercase.
-     * Used both for storage-side index and query-side input.
+     * Strip MiniMessage tags, legacy `&` codes, section `§` codes, lowercase,
+     * and drop everything that isn't a letter or digit. Used both for the
+     * storage-side index and for query-side input so they match.
+     *
+     * The legacy-code regex runs both before and after [ColorCodeUtils.stripAllFormatting]
+     * because that helper's happy path goes through MiniMessage, which treats
+     * `&c` as plain text rather than a formatting code.
      */
     fun normalize(input: String): String {
-        val stripped = ColorCodeUtils.stripAllFormatting(input)
-        return stripped.lowercase().filter { it.isLetterOrDigit() }
+        val preStripped = LEGACY_CODES.replace(input, "")
+        val mmStripped = ColorCodeUtils.stripAllFormatting(preStripped)
+        val postStripped = LEGACY_CODES.replace(mmStripped, "")
+        return postStripped.lowercase().filter { it.isLetterOrDigit() }
     }
 
-    /** Plain-text display name for a stored guild (best effort strip). */
+    /**
+     * Plain-text display name for a stored guild — used in tab-completion
+     * suggestions and user-facing messages. Falls back to the raw stored name
+     * if stripping somehow produces an empty string.
+     */
     fun displayName(guild: Guild): String =
         ColorCodeUtils.stripAllFormatting(guild.name).trim().ifEmpty { guild.name }
 
-    /** Lookup by guild name only (exact, then normalized). */
+    /**
+     * Lookup by guild name only: exact (case-insensitive) match first, then a
+     * normalized fallback over all guilds.
+     *
+     * Returns null when the normalized form matches more than one guild —
+     * ambiguity is treated as "no match" so destructive commands such as
+     * disband or removevault never operate on the wrong guild.
+     */
     fun resolveGuildByName(input: String, guildService: GuildService): Guild? {
         if (input.isBlank()) return null
         guildService.getGuildByName(input)?.let { return it }
         val needle = normalize(input)
         if (needle.isEmpty()) return null
-        return guildService.getAllGuilds().firstOrNull { normalize(it.name) == needle }
+        val matches = guildService.getAllGuilds().filter { normalize(it.name) == needle }
+        return matches.singleOrNull()
     }
 
     /**
-     * Lookup by player name (online first, then cached offline).
+     * Lookup by player name (online first, then cached offline) and return
+     * that player's first guild.
      *
-     * Uses `getOfflinePlayerIfCached` to avoid the synchronous Mojang API lookup
-     * `getOfflinePlayer(String)` performs on uncached names — that would block the
-     * main thread when called from a command handler.
+     * Uses [Bukkit.getOfflinePlayerIfCached] to avoid the synchronous Mojang
+     * API call [Bukkit.getOfflinePlayer] performs for uncached names — that
+     * would block the main thread when invoked from a command handler.
      */
     fun resolveGuildByPlayerName(input: String, guildService: GuildService): Guild? {
         if (input.isBlank()) return null
@@ -57,13 +83,22 @@ object GuildResolver {
         return guildService.getPlayerGuilds(playerId).firstOrNull()
     }
 
-    /** Guild-name first, then player-name. */
+    /**
+     * Resolve an arbitrary user-supplied string to a guild — guild name first,
+     * then player name. Returns null if neither path produces an unambiguous
+     * match.
+     */
     fun resolve(input: String, guildService: GuildService): Guild? {
         return resolveGuildByName(input, guildService)
             ?: resolveGuildByPlayerName(input, guildService)
     }
 
-    /** Plain-text suggestion list (no MiniMessage tags) for tab completion. */
+    /**
+     * Plain-text suggestion list (no MiniMessage tags, sorted, de-duplicated)
+     * for tab completion. The optional [filter] lets callers scope suggestions
+     * — for example to a player's own guilds — without duplicating the
+     * stripping or sorting logic.
+     */
     fun suggestions(guildService: GuildService, filter: (Guild) -> Boolean = { true }): List<String> {
         return guildService.getAllGuilds()
             .asSequence()

--- a/src/test/kotlin/net/lumalyte/lg/utils/GuildResolverNormalizeTest.kt
+++ b/src/test/kotlin/net/lumalyte/lg/utils/GuildResolverNormalizeTest.kt
@@ -44,4 +44,21 @@ class GuildResolverNormalizeTest {
         assertEquals("", GuildResolver.normalize("   "))
         assertEquals("", GuildResolver.normalize("<red></red>"))
     }
+
+    @Test
+    fun `mixed minimessage and legacy codes`() {
+        assertEquals("knights", GuildResolver.normalize("<red>&cKnights</red>"))
+        assertEquals("knights", GuildResolver.normalize("&l§cKnights"))
+    }
+
+    @Test
+    fun `same normalized form for different formattings`() {
+        // Property the resolver relies on: differently-formatted spellings
+        // of the same plain word collapse to the same key.
+        val a = GuildResolver.normalize("&cKnights")
+        val b = GuildResolver.normalize("<gradient:red:gold>Knights</gradient>")
+        val c = GuildResolver.normalize("knights")
+        assertEquals(a, b)
+        assertEquals(b, c)
+    }
 }

--- a/src/test/kotlin/net/lumalyte/lg/utils/GuildResolverNormalizeTest.kt
+++ b/src/test/kotlin/net/lumalyte/lg/utils/GuildResolverNormalizeTest.kt
@@ -1,0 +1,47 @@
+package net.lumalyte.lg.utils
+
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Test
+
+/**
+ * Pure-Kotlin tests for [GuildResolver.normalize]. The other resolver methods
+ * touch Bukkit and are exercised in-game.
+ */
+class GuildResolverNormalizeTest {
+
+    @Test
+    fun `lowercases plain input`() {
+        assertEquals("knights", GuildResolver.normalize("Knights"))
+        assertEquals("knights", GuildResolver.normalize("KNIGHTS"))
+    }
+
+    @Test
+    fun `strips minimessage tags`() {
+        assertEquals("knights", GuildResolver.normalize("<gradient:red:gold>Knights</gradient>"))
+        assertEquals("knights", GuildResolver.normalize("<red>Knights</red>"))
+    }
+
+    @Test
+    fun `strips legacy ampersand codes`() {
+        assertEquals("knights", GuildResolver.normalize("&cKnights"))
+        assertEquals("knights", GuildResolver.normalize("&6&lKnights"))
+    }
+
+    @Test
+    fun `strips section codes`() {
+        assertEquals("knights", GuildResolver.normalize("§cKnights"))
+    }
+
+    @Test
+    fun `strips whitespace and punctuation`() {
+        assertEquals("kingsguard", GuildResolver.normalize("King's Guard"))
+        assertEquals("teamtwo", GuildResolver.normalize("Team-Two"))
+    }
+
+    @Test
+    fun `blank input normalizes to empty string`() {
+        assertEquals("", GuildResolver.normalize(""))
+        assertEquals("", GuildResolver.normalize("   "))
+        assertEquals("", GuildResolver.normalize("<red></red>"))
+    }
+}


### PR DESCRIPTION
## Summary

Centralizes guild name/player-name lookup behind a new `GuildResolver` utility and fixes the missing tab-complete on `/g home`. Removes duplicated `.equals(name, ignoreCase = true)` / `getByName` patterns scattered across commands and admin tools.

## Issues addressed

1. **`/g home` had no autocomplete.** Root cause: missing `@CommandCompletion` annotation on the subcommand. The `@guildhomes` completion provider already existed and is now wired up.
2. **Guild resolution was inconsistent.** Each command did its own `getByName` or `find { it.name.equals(..., ignoreCase = true) }`. No single place defined what counts as a match.
3. **`/g info` could not resolve by player name.** Players had to know the exact guild name; `/g info Steve` did nothing useful.
4. **`/g accept` did not exist.** Users typing the natural alias for `/g join` got an unknown-command error.
5. **`/g decline` only matched on exact case-insensitive equality** against pending invites. No tolerance for whitespace, color codes, or stripped names.
6. **Admin tab completions were stubs.** `/lg disband`, `/vaultremove`, `/vaultrollback` returned `emptyList()` for guild-name suggestions.
7. **Closed-guild `/g join` passed raw user input** to the invite lookup rather than the canonical resolved `guild.name`.

`Guild.name` is already validated as plain text on creation (the `onCreate` regex rejects `<>`), so the user-perceived “I have to type MiniMessage” problem turns out to be confusion between `Guild.tag` (the colored display) and `Guild.name` (the plain identifier). The resolver still strips MiniMessage / legacy `&` codes / section `§` codes defensively so any legacy or imported data with embedded formatting still resolves correctly.

## Design

New `net.lumalyte.lg.utils.GuildResolver`:

| Method | Purpose |
| --- | --- |
| `normalize(input)` | Strip MiniMessage tags, legacy `&` codes, section codes; drop non-alphanumerics; lowercase. Used as the normalized index key for both stored names and user input. |
| `displayName(guild)` | Plain-text strip for suggestions and messages. |
| `resolveGuildByName(input, svc)` | Exact (case-insensitive) → normalized fallback. |
| `resolveGuildByPlayerName(input, svc)` | Online (`getPlayerExact`) → cached offline (`getOfflinePlayerIfCached`). Never blocks on a Mojang API call. |
| `resolve(input, svc)` | Guild name first, then player name. |
| `suggestions(svc, filter)` | Sorted plain-text tab-completion list. |

`Bukkit.getOfflinePlayerIfCached` (Paper API) returns `null` for uncached names without issuing a synchronous web lookup, so command handlers stay off the network on the main thread.

## Changes

### `GuildCommand.kt`
- `@Subcommand("join|accept")` — `accept` is now an alias of `join`.
- `@CommandCompletion("@guildhomes")` added to `/g home`.
- `/g info`: resolves by guild name **or** player name; completion switched to `@guildsorplayers`.
- `/g decline`: completion switched to `@pendinginvites`; matching uses exact-then-normalized comparison over the player's pending invites.
- `/g join` (closed guilds): invite lookup now uses canonical `guild.name` (was raw user input).
- `/g ally | enemy | truce | neutral`: replaced `guildRepository.getByName(...)` with `GuildResolver.resolve(...)`.

### `LumaGuilds.kt`
- `@guilds` completion now emits MiniMessage-stripped plain names via `GuildResolver.suggestions`.
- New `@pendinginvites` completion (per-player) — used by `/g decline`.
- New `@guildsorplayers` completion — guilds plus online player names, used by `/g info`.

### Admin commands
- `LumaGuildsCommand` (`/lg disband`): suggestions now backed by `GuildResolver.suggestions`; lookup uses the resolver.
- `RemoveVaultCommand`, `VaultRollbackCommand`: tab completion no longer returns `emptyList()` for the guild-name argument; lookup uses the resolver.

### Tests
- `GuildResolverNormalizeTest`: pure Kotlin coverage for MiniMessage stripping, legacy `&` codes, section codes, punctuation/whitespace handling, and blank inputs. The Bukkit-bound paths are intentionally not unit-tested here (no headless harness in the repo) and are exercised in-game.

## What this PR does NOT touch

- **No schema or persistence changes.** No migration risk.
- **No changes to `Guild`, `GuildRepository`, or `GuildService` contracts.** `getGuildByName` is still there; only call sites changed.
- **Bedrock menu sites that call `getGuildByName`** with system-supplied (already canonical) names are left alone — refactoring them would be churn without a user-visible benefit.

## Deferred / follow-up

- Permission-filtered `@guilds` (e.g., exclude own guild for relation commands) — left as a global list to keep this PR focused.
- Folding normalization into `GuildInvitationManager.getInviteByGuildName` itself as defense-in-depth (callers now pass canonical names, so it is not currently a bug).
- Tightening the `Guild.name` regex: it allows `&`, which collides with legacy color escapes if any consumer renders a name through `LegacyComponentSerializer.legacyAmpersand`.

## Test plan

- [ ] `./gradlew test` — verifies `GuildResolverNormalizeTest` (CI provides RoseChat jar that the repo's `.gitignore`d `libs/` directory does not).
- [ ] In-game: `/g home <TAB>` lists guild homes.
- [ ] In-game: `/g info <TAB>` lists guilds and online players; `/g info <PlayerName>` opens that player's guild info menu.
- [ ] In-game: `/g accept <Guild>` succeeds when an invite is pending (alias works).
- [ ] In-game: `/g decline <TAB>` lists only the player's pending invites; typing the stripped/lowercased form still resolves.
- [ ] In-game: `/g ally|enemy|truce|neutral <PlayerName>` resolves to that player's guild.
- [ ] In-game: `/lg disband <TAB>`, `/vaultremove <TAB>`, `/vaultrollback list <TAB>` all surface guild-name suggestions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an "accept" alias for the guild join command.
  * Centralized guild/name/player resolution to improve ambiguous lookups.

* **Improvements**
  * More robust guild name matching (strips formatting, normalizes input).
  * Improved and expanded command completion suggestions for guild-related commands.

* **Tests**
  * Added normalization tests to ensure consistent name matching.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/BadgersMC/LumaGuilds/pull/40)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->