### PR TITLE
fix(banner): prevent drag-extraction of placeholder glass pane

### DIFF
--- a/src/main/kotlin/net/lumalyte/lg/interaction/listeners/BannerSelectionListener.kt
+++ b/src/main/kotlin/net/lumalyte/lg/interaction/listeners/BannerSelectionListener.kt
@@ -8,6 +8,7 @@ import org.bukkit.event.EventHandler
 import org.bukkit.event.Listener
 import org.bukkit.event.inventory.InventoryClickEvent
 import org.bukkit.event.inventory.InventoryCloseEvent
+import org.bukkit.event.inventory.InventoryDragEvent
 import org.bukkit.event.inventory.InventoryType
 import org.bukkit.event.player.PlayerQuitEvent
 import org.bukkit.inventory.ItemStack
@@ -25,9 +26,10 @@ class BannerSelectionListener : Listener, KoinComponent {
     fun onInventoryClick(event: InventoryClickEvent) {
         val player = event.whoClicked as? Player ?: return
 
-        // Identify the banner menu via the per-player tracker — InventoryFramework owns
-        // the inventory holder, so a custom InventoryHolder cannot be attached.
-        if (!GuildBannerMenu.activeViewers.contains(player.uniqueId)) return
+        // Verify this click is targeting the player's specific GuildBannerMenu inventory
+        // instance, not some other chest a different plugin opened.
+        val expectedInventory = GuildBannerMenu.activeMenus[player.uniqueId]
+        if (expectedInventory == null || event.view.topInventory != expectedInventory) return
 
         // Only handle clicks in the top inventory (menu)
         if (event.clickedInventory?.type != InventoryType.CHEST) return
@@ -84,14 +86,76 @@ class BannerSelectionListener : Listener, KoinComponent {
     }
 
     @EventHandler
+    fun onInventoryDrag(event: InventoryDragEvent) {
+        val player = event.whoClicked as? Player ?: return
+
+        // Verify this drag is targeting the player's specific GuildBannerMenu inventory
+        val expectedInventory = GuildBannerMenu.activeMenus[player.uniqueId]
+        if (expectedInventory == null || event.view.topInventory != expectedInventory) return
+
+        val topInventory = event.view.topInventory
+        val topSlots = event.rawSlots.filter { it < topInventory.size }
+
+        // Drag doesn't touch the menu — ignore
+        if (topSlots.isEmpty()) return
+
+        // Block any drag touching multiple menu slots
+        if (topSlots.size > 1) {
+            event.isCancelled = true
+            player.sendMessage("§c❌ Drag-clicking across multiple menu slots is disabled.")
+            return
+        }
+
+        // Only allow single-slot drag into slot 11 with a banner
+        val slot = topSlots.first()
+        if (slot != 11) {
+            event.isCancelled = true
+            return
+        }
+
+        val draggedItem = event.oldCursor
+        if (!isBanner(draggedItem.type)) {
+            event.isCancelled = true
+            return
+        }
+
+        val currentItem = topInventory.getItem(slot)
+        val isPlaceholder = currentItem?.type == Material.LIGHT_GRAY_STAINED_GLASS_PANE
+        val isEmpty = currentItem == null || currentItem.type == Material.AIR
+
+        if (!isPlaceholder && !isEmpty) {
+            event.isCancelled = true
+            return
+        }
+
+        // Valid banner placement via drag — cancel vanilla behavior and handle manually
+        event.isCancelled = true
+
+        val singleBanner = draggedItem.clone()
+        singleBanner.amount = 1
+        topInventory.setItem(slot, singleBanner)
+
+        // Remove 1 banner from cursor
+        if (draggedItem.amount > 1) {
+            val remaining = draggedItem.clone()
+            remaining.amount = draggedItem.amount - 1
+            player.setItemOnCursor(remaining)
+        } else {
+            player.setItemOnCursor(ItemStack.of(Material.AIR))
+        }
+
+        player.sendMessage("§7📍 Banner placed! Click '§a⏳ APPLY CHANGES§7' to save.")
+    }
+
+    @EventHandler
     fun onInventoryClose(event: InventoryCloseEvent) {
         val player = event.player as? Player ?: return
-        GuildBannerMenu.activeViewers.remove(player.uniqueId)
+        GuildBannerMenu.activeMenus.remove(player.uniqueId)
     }
 
     @EventHandler
     fun onPlayerQuit(event: PlayerQuitEvent) {
-        GuildBannerMenu.activeViewers.remove(event.player.uniqueId)
+        GuildBannerMenu.activeMenus.remove(event.player.uniqueId)
     }
 
     private fun isBanner(material: Material): Boolean {

--- a/src/main/kotlin/net/lumalyte/lg/interaction/menus/guild/GuildBannerMenu.kt
+++ b/src/main/kotlin/net/lumalyte/lg/interaction/menus/guild/GuildBannerMenu.kt
@@ -24,6 +24,7 @@ import org.koin.core.component.KoinComponent
 import org.koin.core.component.inject
 import java.util.UUID
 import java.util.concurrent.ConcurrentHashMap
+import org.bukkit.inventory.Inventory
 
 class GuildBannerMenu(private val menuNavigator: MenuNavigator, private val player: Player,
                      private var guild: Guild): Menu, KoinComponent {
@@ -35,15 +36,16 @@ class GuildBannerMenu(private val menuNavigator: MenuNavigator, private val play
     private val menuFactory: net.lumalyte.lg.interaction.menus.MenuFactory by inject()
 
     companion object {
-        // Tracks which players currently have the Java guild banner menu open. Used by
-        // BannerSelectionListener to identify banner-placement clicks without relying on
-        // InventoryHolder identity (InventoryFramework owns the holder) or the inventory
-        // title (deprecated and exploit-prone).
-        val activeViewers: MutableSet<UUID> = ConcurrentHashMap.newKeySet()
+        // Maps player UUID -> the specific Inventory instance of their currently-open
+        // GuildBannerMenu. Used by BannerSelectionListener to verify clicks are hitting
+        // THIS menu and not some other chest a different plugin opened.
+        val activeMenus: MutableMap<UUID, Inventory> = ConcurrentHashMap()
     }
 
     override fun open() {
-        activeViewers.add(player.uniqueId)
+        // Clean up any stale tracking for this player before opening a new instance.
+        // A player can only have one inventory open at a time; replaces stale entries.
+        activeMenus.remove(player.uniqueId)
 
         // Create a 3x9 GUI for banner selection
         val gui = ChestGui(3, "§6Guild Banner - ${guild.name}")
@@ -84,6 +86,10 @@ class GuildBannerMenu(private val menuNavigator: MenuNavigator, private val play
 
         gui.addPane(pane)
         gui.show(player)
+
+        // Record the specific inventory instance so BannerSelectionListener can
+        // distinguish THIS menu from any other chest the player might open.
+        activeMenus[player.uniqueId] = gui.getInventory()
     }
 
     private fun addCurrentBannerDisplay(pane: StaticPane, x: Int, y: Int) {


### PR DESCRIPTION
- Replace activeViewers UUID set with activeMenus instance tracking to prevent cross-plugin inventory contamination.
- Add InventoryDragEvent handler allowing banner placement into slot 11 while blocking extraction of placeholder glass pane or any placed banner.
- Block multi-slot drags and drags to non-banner slots.

Fixes: players could drag-click the LIGHT_GRAY_STAINED_GLASS_PANE placeholder out of the banner slot because InventoryDragEvent bypasses setOnTopClick and InventoryClickEvent handlers.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added drag-and-drop support for placing banners with single-slot restrictions and target validation.

* **Bug Fixes**
  * Improved menu instance tracking per player for more reliable interaction validation.
  * Enhanced inventory click and drag event handling to prevent unintended behavior.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/BadgersMC/LumaGuilds/pull/41)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->