### PR TITLE
feat(wiki): player wiki + /g help redesign (Phase 1)

### DIFF
--- a/.github/instructions/codacy.instructions.md
+++ b/.github/instructions/codacy.instructions.md
@@ -1,0 +1,79 @@
+---
+    description: Configuration for AI behavior when interacting with Codacy's MCP Server
+    applyTo: '**'
+---
+---
+# Codacy Rules
+Configuration for AI behavior when interacting with Codacy's MCP Server
+
+## using any tool that accepts the arguments: `provider`, `organization`, or `repository`
+- ALWAYS use:
+ - provider: gh
+ - organization: BadgersMC
+ - repository: LumaGuilds
+- Avoid calling `git remote -v` unless really necessary
+
+## CRITICAL: After ANY successful `edit_file` or `reapply` operation
+- YOU MUST IMMEDIATELY run the `codacy_cli_analyze` tool from Codacy's MCP Server for each file that was edited, with:
+ - `rootPath`: set to the workspace path
+ - `file`: set to the path of the edited file
+ - `tool`: leave empty or unset
+- If any issues are found in the new edits, propose and apply fixes for them.
+- > NOTE: Failure to follow this rule is considered a critical error.
+
+## When you tried to run the `codacy_cli_analyze` tool and the Codacy CLI is not installed
+- Ask the user 'Codacy CLI is not installed. Would you like me to install it now?'
+- If the user responds with "yes", run the `codacy_cli_install` tool and then continue with the original task
+- If the user responds with "no", instruct the user that they can disable automatic analysis in the extension settings
+- Wait for the user to respond before proceeding with any other actions
+
+## After every response
+- If you made any file edits in this conversation, verify you ran `codacy_cli_analyze` tool from Codacy's MCP Server 
+
+## When there are no Codacy MCP Server tools available, or the MCP Server is not reachable
+- Suggest the user the following troubleshooting steps:
+ - Try to reset the MCP on the extension
+ - If the user is using VSCode, suggest them to review their Copilot > MCP settings in Github, under their organization or personal account. Refer them to Settings > Copilot > Enable MCP servers in Copilot. Suggested URL (https://github.com/settings/copilot/features) or https://github.com/organizations/{organization-name}/settings/copilot/features (This can only be done by their organization admins / owners)
+- If none of the above steps work, suggest the user to contact Codacy support
+
+## Trying to call a tool that needs a rootPath as a parameter
+- Always use the standard, non-URL-encoded file system path
+
+## CRITICAL: Dependencies and Security Checks
+- IMMEDIATELY after ANY of these actions:
+ - Running npm/yarn/pnpm install
+ - Adding dependencies to package.json
+ - Adding requirements to requirements.txt
+ - Adding dependencies to pom.xml
+ - Adding dependencies to build.gradle
+ - Any other package manager operations
+- You MUST run the `codacy_cli_analyze` tool with:
+ - `rootPath`: set to the workspace path
+ - `tool`: set to "trivy"
+ - `file`: leave empty or unset
+- If any vulnerabilities are found because of the newly added packages:
+ - Stop all other operations
+ - Propose and apply fixes for the security issues
+ - Only continue with the original task after security issues are resolved
+- EXAMPLE:
+ - After: npm install react-markdown
+ - Do: Run codacy_cli_analyze with trivy
+ - Before: Continuing with any other tasks
+
+## General
+- Repeat the relevant steps for each modified file.
+- "Propose fixes" means to both suggest and, if possible, automatically apply the fixes.
+- You MUST NOT wait for the user to ask for analysis or remind you to run the tool.
+- Do not run `codacy_cli_analyze` looking for changes in duplicated code or code complexity metrics.
+- Complexity metrics are different from complexity issues. When trying to fix complexity in a repository or file, focus on solving the complexity issues and ignore the complexity metric.
+- Do not run `codacy_cli_analyze` looking for changes in code coverage.
+- Do not try to manually install Codacy CLI using either brew, npm, npx, or any other package manager.
+- If the Codacy CLI is not installed, just run the `codacy_cli_analyze` tool from Codacy's MCP Server.
+- When calling `codacy_cli_analyze`, only send provider, organization and repository if the project is a git repository.
+
+## Whenever a call to a Codacy tool that uses `repository` or `organization` as a parameter returns a 404 error
+- Offer to run the `codacy_setup_repository` tool to add the repository to Codacy
+- If the user accepts, run the `codacy_setup_repository` tool
+- Do not ever try to run the `codacy_setup_repository` tool on your own
+- After setup, immediately retry the action that failed (only retry once)
+---

--- a/.github/instructions/codacy.instructions.md
+++ b/.github/instructions/codacy.instructions.md
@@ -1,66 +1,76 @@
 ---
-    description: Configuration for AI behavior when interacting with Codacy's MCP Server
-    applyTo: '**'
+description: Configuration for AI behavior when interacting with Codacy's MCP Server
+applyTo: '**'
 ---
----
-# Codacy Rules
-Configuration for AI behavior when interacting with Codacy's MCP Server
 
-## using any tool that accepts the arguments: `provider`, `organization`, or `repository`
+# Codacy Rules
+
+Configuration for AI behavior when interacting with Codacy's MCP Server.
+
+## Using any tool that accepts the arguments: `provider`, `organization`, or `repository`
+
 - ALWAYS use:
- - provider: gh
- - organization: BadgersMC
- - repository: LumaGuilds
-- Avoid calling `git remote -v` unless really necessary
+  - provider: gh
+  - organization: BadgersMC
+  - repository: LumaGuilds
+- Avoid calling `git remote -v` unless really necessary.
 
 ## CRITICAL: After ANY successful `edit_file` or `reapply` operation
+
 - YOU MUST IMMEDIATELY run the `codacy_cli_analyze` tool from Codacy's MCP Server for each file that was edited, with:
- - `rootPath`: set to the workspace path
- - `file`: set to the path of the edited file
- - `tool`: leave empty or unset
+  - `rootPath`: set to the workspace path
+  - `file`: set to the path of the edited file
+  - `tool`: leave empty or unset
 - If any issues are found in the new edits, propose and apply fixes for them.
 - > NOTE: Failure to follow this rule is considered a critical error.
 
-## When you tried to run the `codacy_cli_analyze` tool and the Codacy CLI is not installed
-- Ask the user 'Codacy CLI is not installed. Would you like me to install it now?'
-- If the user responds with "yes", run the `codacy_cli_install` tool and then continue with the original task
-- If the user responds with "no", instruct the user that they can disable automatic analysis in the extension settings
-- Wait for the user to respond before proceeding with any other actions
+## When the Codacy CLI is not installed
+
+- Ask the user: "Codacy CLI is not installed. Would you like me to install it now?"
+- If the user responds with "yes", run the `codacy_cli_install` tool and then continue with the original task.
+- If the user responds with "no", instruct the user that they can disable automatic analysis in the extension settings.
+- Wait for the user to respond before proceeding with any other actions.
+- If you are already running inside the Codacy MCP Server, just run the `codacy_cli_analyze` tool directly.
 
 ## After every response
-- If you made any file edits in this conversation, verify you ran `codacy_cli_analyze` tool from Codacy's MCP Server 
+
+- If you made any file edits in this conversation, verify you ran `codacy_cli_analyze` tool from Codacy's MCP Server.
 
 ## When there are no Codacy MCP Server tools available, or the MCP Server is not reachable
+
 - Suggest the user the following troubleshooting steps:
- - Try to reset the MCP on the extension
- - If the user is using VSCode, suggest them to review their Copilot > MCP settings in Github, under their organization or personal account. Refer them to Settings > Copilot > Enable MCP servers in Copilot. Suggested URL (https://github.com/settings/copilot/features) or https://github.com/organizations/{organization-name}/settings/copilot/features (This can only be done by their organization admins / owners)
-- If none of the above steps work, suggest the user to contact Codacy support
+  - Try to reset the MCP on the extension.
+  - If the user is using VSCode, suggest them to review their Copilot > MCP settings in GitHub, under their organization or personal account. Refer them to Settings > Copilot > Enable MCP servers in Copilot. Suggested URL: https://github.com/settings/copilot/features or https://github.com/organizations/{organization-name}/settings/copilot/features (This can only be done by their organization admins / owners.)
+  - If none of the above steps work, suggest the user to contact Codacy support.
 
 ## Trying to call a tool that needs a rootPath as a parameter
-- Always use the standard, non-URL-encoded file system path
+
+- Always use the standard, non-URL-encoded file system path.
 
 ## CRITICAL: Dependencies and Security Checks
+
 - IMMEDIATELY after ANY of these actions:
- - Running npm/yarn/pnpm install
- - Adding dependencies to package.json
- - Adding requirements to requirements.txt
- - Adding dependencies to pom.xml
- - Adding dependencies to build.gradle
- - Any other package manager operations
+  - Running npm/yarn/pnpm install
+  - Adding dependencies to package.json
+  - Adding requirements to requirements.txt
+  - Adding dependencies to pom.xml
+  - Adding dependencies to build.gradle
+  - Any other package manager operations
 - You MUST run the `codacy_cli_analyze` tool with:
- - `rootPath`: set to the workspace path
- - `tool`: set to "trivy"
- - `file`: leave empty or unset
+  - `rootPath`: set to the workspace path
+  - `tool`: set to "trivy"
+  - `file`: leave empty or unset
 - If any vulnerabilities are found because of the newly added packages:
- - Stop all other operations
- - Propose and apply fixes for the security issues
- - Only continue with the original task after security issues are resolved
+  - Stop all other operations.
+  - Propose and apply fixes for the security issues.
+  - Only continue with the original task after security issues are resolved.
 - EXAMPLE:
- - After: npm install react-markdown
- - Do: Run codacy_cli_analyze with trivy
- - Before: Continuing with any other tasks
+  - After: npm install react-markdown
+  - Do: Run codacy_cli_analyze with trivy
+  - Before: Continuing with any other tasks
 
 ## General
+
 - Repeat the relevant steps for each modified file.
 - "Propose fixes" means to both suggest and, if possible, automatically apply the fixes.
 - You MUST NOT wait for the user to ask for analysis or remind you to run the tool.
@@ -68,12 +78,11 @@ Configuration for AI behavior when interacting with Codacy's MCP Server
 - Complexity metrics are different from complexity issues. When trying to fix complexity in a repository or file, focus on solving the complexity issues and ignore the complexity metric.
 - Do not run `codacy_cli_analyze` looking for changes in code coverage.
 - Do not try to manually install Codacy CLI using either brew, npm, npx, or any other package manager.
-- If the Codacy CLI is not installed, just run the `codacy_cli_analyze` tool from Codacy's MCP Server.
 - When calling `codacy_cli_analyze`, only send provider, organization and repository if the project is a git repository.
 
 ## Whenever a call to a Codacy tool that uses `repository` or `organization` as a parameter returns a 404 error
-- Offer to run the `codacy_setup_repository` tool to add the repository to Codacy
-- If the user accepts, run the `codacy_setup_repository` tool
-- Do not ever try to run the `codacy_setup_repository` tool on your own
-- After setup, immediately retry the action that failed (only retry once)
----
+
+- Offer to run the `codacy_setup_repository` tool to add the repository to Codacy.
+- If the user accepts, run the `codacy_setup_repository` tool.
+- Do not ever try to run the `codacy_setup_repository` tool on your own.
+- After setup, immediately retry the action that failed (only retry once).

--- a/.github/workflows/wiki-checks.yml
+++ b/.github/workflows/wiki-checks.yml
@@ -20,6 +20,15 @@ jobs:
       - run: pip install pyyaml
       - run: python tools/wiki/lint_frontmatter.py
 
+  topic-parity:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+      - run: python tools/wiki/check_topic_parity.py
+
   mkdocs-strict-build:
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/wiki-checks.yml
+++ b/.github/workflows/wiki-checks.yml
@@ -1,0 +1,33 @@
+name: Wiki Checks
+
+on:
+  pull_request:
+    paths:
+      - 'wiki/**'
+      - 'mkdocs.yml'
+      - 'tools/wiki/**'
+      - 'src/main/kotlin/net/lumalyte/lg/interaction/help/**'
+      - '.github/workflows/wiki-checks.yml'
+
+jobs:
+  frontmatter-lint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+      - run: pip install pyyaml
+      - run: python tools/wiki/lint_frontmatter.py
+
+  mkdocs-strict-build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+          cache: 'pip'
+          cache-dependency-path: wiki/requirements.txt
+      - run: pip install -r wiki/requirements.txt
+      - run: mkdocs build --strict

--- a/.github/workflows/wiki-deploy.yml
+++ b/.github/workflows/wiki-deploy.yml
@@ -1,0 +1,46 @@
+name: Deploy Wiki
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - 'wiki/**'
+      - 'mkdocs.yml'
+      - '.github/workflows/wiki-deploy.yml'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+concurrency:
+  group: pages
+  cancel-in-progress: false
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+          cache: 'pip'
+          cache-dependency-path: wiki/requirements.txt
+      - run: pip install -r wiki/requirements.txt
+      - run: mkdocs build --strict
+      - uses: actions/configure-pages@v5
+      - uses: actions/upload-pages-artifact@v3
+        with:
+          path: site
+
+  deploy:
+    needs: build
+    runs-on: ubuntu-latest
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
+      - id: deployment
+        uses: actions/deploy-pages@v4

--- a/.gitignore
+++ b/.gitignore
@@ -275,3 +275,6 @@ VIRTUAL_THREADS.md
 
 # Local worktrees
 .worktrees/
+
+# MkDocs build output
+site/

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -210,6 +210,47 @@ We use [Mermaid](https://mermaid.js.org/) for diagrams. Test your diagrams at [m
 
 ---
 
+## Keeping `/g help` and the wiki in sync
+
+LumaGuilds enforces parity between the in-game help system and the player wiki. **Any PR that adds, removes, or renames a player-facing command must touch both `HelpTopics.kt` and the matching wiki page in the same PR.** CI rejects PRs that break this rule.
+
+### What CI checks
+
+1. **Front-matter lint** (`tools/wiki/lint_frontmatter.py`): every `wiki/docs/**/*.md` must have a valid front-matter block with `title`, `audience`, `topic`, `summary`, `keywords`, `related`, `updated`.
+2. **Topic parity** (`tools/wiki/check_topic_parity.py`): every `slug = "..."` in [`HelpTopics.kt`](src/main/kotlin/net/lumalyte/lg/interaction/help/HelpTopics.kt) must have a matching `wiki/docs/players/<slug>.md` and vice versa.
+3. **Strict MkDocs build** (`mkdocs build --strict`): no broken internal links, missing nav entries, or malformed markdown.
+
+### Adding a new player-facing command
+
+1. Decide which existing topic in `HelpTopics.kt` the command belongs to. If none fits, you're adding a new topic (rare — see below).
+2. Add a `HelpCommandEntry(syntax, blurb, prefill)` to the topic's `commands` list.
+3. Update the matching `wiki/docs/players/<slug>.md`: add a row to the Quick Reference table, add or expand a "Common task" H2 if needed.
+4. Run the checks locally before opening the PR:
+
+```bash
+python tools/wiki/lint_frontmatter.py
+python tools/wiki/check_topic_parity.py
+mkdocs build --strict
+./gradlew test
+```
+
+### Adding a new topic
+
+1. Add a new `HelpTopic(...)` block to `HelpTopics.all` in `HelpTopics.kt`. Pick a stable lowercase-hyphenated slug — it becomes a URL forever.
+2. Create `wiki/docs/players/<slug>.md` using the wiki page template (see other pages in that folder for the canonical shape).
+3. Add the topic to `wiki/docs/players/.pages` so it appears in the nav.
+4. Update `wiki/docs/players/how-do-i.md` with at least one entry deep-linking into the new page.
+5. Run the checks above.
+
+### Renaming or removing a topic
+
+- **Removing:** delete the `HelpTopic` entry, delete the wiki page, and add a `mkdocs-redirects` entry to `mkdocs.yml` mapping the old URL to wherever the content moved (or to the topic index).
+- **Renaming the slug:** treat as remove + add. The old slug is permanently retired (Hermes Agent and any cached links may still reference it via the redirect).
+
+Slugs are forever. The display name, summary, and command list inside a topic are not — those evolve freely.
+
+---
+
 ## Questions?
 
 Don't hesitate to ask! Open a discussion on GitHub or reach out on Discord. We're happy to help newcomers get started.

--- a/docs/plans/2026-05-13-player-wiki-and-help-redesign-design.md
+++ b/docs/plans/2026-05-13-player-wiki-and-help-redesign-design.md
@@ -9,6 +9,7 @@
 ## 1. Goals & Non-Goals
 
 ### Goals
+
 - Reduce player confusion about how the plugin works. Establish a single canonical place for "how does X work" answers, accessible both in-game (`/g help`) and in-browser (the wiki).
 - Make `/g help` actually useful: topic-organized, clickable, mirrors the wiki's structure 1:1.
 - Make wiki content retrievable by Hermes Agent with high precision (audience-tagged, well-chunked, predictable structure).
@@ -16,6 +17,7 @@
 - Phased delivery: Players + `/g help` first, Admins later, Devs last.
 
 ### Non-Goals
+
 - Versioned docs. The wiki tracks `main`. Revisit if a multi-version need emerges.
 - Self-hosting on the VPS. GitHub Pages only.
 - A GUI inventory-menu help system. Clickable chat covers Java, Bedrock/Geyser, and console without an extra UI surface to maintain.
@@ -50,7 +52,7 @@
 
 Top-level nav: **Home / Getting Started / Players / Admins / Developers.**
 
-```
+```text
 Home — landing page: "What is LumaGuilds?" + links to the 4 sections.
 
 Getting Started
@@ -167,7 +169,7 @@ updated: 2026-05-13
 
 Shows a topic menu, not a flat command list.
 
-```
+```text
 ─── LumaGuilds Help ───
 Pick a topic:
   [Guilds]        Create, join, leave, disband
@@ -190,7 +192,7 @@ Full wiki: https://badgersmc.github.io/LumaGuilds/
 
 Clickable, one screen.
 
-```
+```text
 ─── Help · Homes ───
 Guild homes are teleport points your guild can share. Each guild can
 have multiple named homes. Access can be restricted per-rank.

--- a/docs/plans/2026-05-13-player-wiki-and-help-redesign-design.md
+++ b/docs/plans/2026-05-13-player-wiki-and-help-redesign-design.md
@@ -40,7 +40,7 @@
 - **Public URL:** `https://badgersmc.github.io/LumaGuilds/` (custom domain optional, deferred).
 - **Key plugins:**
   - `material` theme (search, nav, dark mode).
-  - `mkdocs-material[imaging]` (social cards).
+  - `mkdocs-material` (search, nav, dark mode — social cards deferred).
   - `mkdocs-llmstxt` (auto-generates `/llms.txt` and `/llms-full.txt` for Hermes).
   - `mkdocs-awesome-pages-plugin` (per-folder `.pages` ordering files; keeps `mkdocs.yml` clean).
   - `mkdocs-redirects` (rename pages without breaking external links or Hermes-cached URLs).

--- a/docs/plans/2026-05-13-player-wiki-and-help-redesign-design.md
+++ b/docs/plans/2026-05-13-player-wiki-and-help-redesign-design.md
@@ -1,0 +1,385 @@
+# LumaGuilds Player Wiki + `/g help` Redesign — Design
+
+**Date:** 2026-05-13
+**Status:** Draft for review
+**Author:** Brainstorm session (Noah + Claude)
+
+---
+
+## 1. Goals & Non-Goals
+
+### Goals
+- Reduce player confusion about how the plugin works. Establish a single canonical place for "how does X work" answers, accessible both in-game (`/g help`) and in-browser (the wiki).
+- Make `/g help` actually useful: topic-organized, clickable, mirrors the wiki's structure 1:1.
+- Make wiki content retrievable by Hermes Agent with high precision (audience-tagged, well-chunked, predictable structure).
+- Consolidate the scattered top-level `.md` files and the existing `docs/` folder into one source of truth.
+- Phased delivery: Players + `/g help` first, Admins later, Devs last.
+
+### Non-Goals
+- Versioned docs. The wiki tracks `main`. Revisit if a multi-version need emerges.
+- Self-hosting on the VPS. GitHub Pages only.
+- A GUI inventory-menu help system. Clickable chat covers Java, Bedrock/Geyser, and console without an extra UI surface to maintain.
+- Rewriting existing dev docs from scratch. We migrate; we do not redo accurate content.
+- Tracking plugin XP/curve tuning in docs. Changes per-update, ages badly.
+- Permission-gated `/g help` filtering. Confusion comes from not knowing things exist, not from seeing one a player can't use.
+- In-game help search. The wiki has search.
+- Localization. Defer.
+
+---
+
+## 2. Stack & Hosting
+
+- **Generator:** MkDocs + Material theme.
+- **Hosting:** GitHub Pages, deployed from `main` via GitHub Actions.
+- **Source location:** `wiki/` at repo root, separate from the existing `docs/` during migration; `docs/` then folds in (see §6).
+  - Config: `mkdocs.yml` at repo root.
+  - Content: `wiki/docs/`.
+  - Assets: `wiki/docs/assets/<topic>/`.
+- **Public URL:** `https://badgersmc.github.io/LumaGuilds/` (custom domain optional, deferred).
+- **Key plugins:**
+  - `material` theme (search, nav, dark mode).
+  - `mkdocs-material[imaging]` (social cards).
+  - `mkdocs-llmstxt` (auto-generates `/llms.txt` and `/llms-full.txt` for Hermes).
+  - `mkdocs-awesome-pages-plugin` (per-folder `.pages` ordering files; keeps `mkdocs.yml` clean).
+  - `mkdocs-redirects` (rename pages without breaking external links or Hermes-cached URLs).
+- **Build trigger:** GitHub Action on push to `main` touching `wiki/**` or `mkdocs.yml`. Builds, publishes to `gh-pages` branch.
+
+---
+
+## 3. Site Structure
+
+Top-level nav: **Home / Getting Started / Players / Admins / Developers.**
+
+```
+Home — landing page: "What is LumaGuilds?" + links to the 4 sections.
+
+Getting Started
+  ├── Welcome to EnthusiaSMP
+  ├── Your first 30 minutes (walkthrough)
+  │     ├── 1. Spawn and orientation
+  │     ├── 2. Joining or creating a guild
+  │     ├── 3. Setting your tag and home
+  │     ├── 4. Inviting a friend
+  │     ├── 5. Chat basics (/g chat)
+  │     ├── 6. What XP and levels do
+  │     └── 7. Where to go next
+  └── FAQ
+
+Players
+  ├── How do I…?           (index page — deep-links into feature pages)
+  ├── Guilds               (create, join, leave, disband, transfer)
+  ├── Ranks & Permissions
+  ├── Homes                (set, name, access control)
+  ├── Alliances & Diplomacy (ally, truce, enemy, neutral, ally homes)
+  ├── War
+  ├── Chat                 (/g chat, /g allychat, tags)
+  ├── Tags, Banners & Identity
+  ├── Progression & Levels
+  ├── Vault
+  ├── Mode                 (Peaceful / Hostile)
+  ├── Shop integration
+  ├── LFG & Invites
+  └── Bedrock differences
+
+Admins
+  ├── Installation & config.yml
+  ├── Permission nodes reference
+  ├── /lumaguilds override and recovery
+  ├── Troubleshooting
+  ├── PlaceholderAPI placeholders
+  ├── RoseChat integration
+  ├── Geyser/Floodgate behavior
+  ├── Lunar Client integration
+  ├── Web leaderboard API
+  └── Claims integration
+
+Developers
+  ├── Getting started (dev)
+  ├── Architecture overview
+  ├── Domain layer
+  ├── Application layer
+  ├── Infrastructure layer
+  ├── Interaction layer
+  ├── Master diagram
+  ├── API reference
+  ├── Placeholders (internal)
+  ├── Emoji permissions
+  ├── Migration safety
+  ├── Schema setup
+  └── Archive (old plans, refactoring docs — not in nav)
+```
+
+Notes:
+- "How do I…?" is an index page; every entry deep-links to a feature page anchor.
+- "Bedrock differences" exists because Geyser/Floodgate behavior diverges in a few places and players hit those walls.
+- Developers section is largely migration of existing `docs/` content.
+
+---
+
+## 4. Page Format & Metadata
+
+Every page follows this structure so Hermes gets predictable chunks.
+
+### Front-matter (YAML)
+
+```yaml
+---
+title: Homes
+audience: player          # player | admin | dev
+topic: homes              # stable slug — must match HelpTopics.kt key
+summary: How to set, name, and control access to guild homes.
+keywords: [homes, sethome, removehome, ally home, teleport]
+related: [alliances, ranks]
+updated: 2026-05-13
+---
+```
+
+### Body convention
+
+1. **One-sentence summary** — repeats `summary` (gives Hermes the lede in the chunk body too).
+2. **Quick reference** — a small command/permission table at the top so scanners can leave fast.
+3. **How it works** — narrative, the canonical explanation.
+4. **Common tasks** — H2 per task; each H2 is a self-contained chunk (e.g. `## Setting a named home`).
+5. **Gotchas / known issues** — bullets.
+6. **Related** — links to sibling pages.
+
+### Heading discipline
+
+- One H1 per page (the title).
+- H2s are stable anchors. Never rename casually — Hermes and `/g help` links depend on them.
+- Avoid burying critical info below H3 — agents chunk best at H2 boundaries.
+
+### Asset conventions
+
+- Screenshots in `wiki/docs/assets/<topic>/`, named `<page-slug>-<scene>.png`.
+- Code/command blocks always fenced with a language tag.
+
+### Generated artifacts at build time
+
+- `/llms.txt` — one-line-per-page index (title + url + summary), audience-filterable.
+- `/llms-full.txt` — concatenated markdown of every page, audience tags preserved in headers.
+
+---
+
+## 5. `/g help` Redesign
+
+### Entry point: `/g help`
+
+Shows a topic menu, not a flat command list.
+
+```
+─── LumaGuilds Help ───
+Pick a topic:
+  [Guilds]        Create, join, leave, disband
+  [Homes]         Set and visit guild homes
+  [Ranks]         Permissions and rank management
+  [Chat]          /g chat, ally chat, tags
+  [Alliances]     Ally, truce, enemy, neutral
+  [War]           Declaring and fighting wars
+  [Progression]   XP, levels, perks
+  [Vault]         Guild storage
+  [Identity]      Tags, banners, descriptions
+  [Mode]          Peaceful / Hostile
+  [Other]         LFG, info, history, leaderboards
+
+Type /g help <topic>  or click a topic above.
+Full wiki: https://badgersmc.github.io/LumaGuilds/
+```
+
+### Topic page: `/g help homes`
+
+Clickable, one screen.
+
+```
+─── Help · Homes ───
+Guild homes are teleport points your guild can share. Each guild can
+have multiple named homes. Access can be restricted per-rank.
+
+Commands:
+  /g sethome [name]            [click to prefill]  [?]
+  /g home [name]               [click to prefill]  [?]
+  /g homes                     [click to run]
+  /g removehome <name>         [click to prefill]  [?]
+  /g setallyhome               [click to prefill]  [?]
+
+Hover a [?] for details. Click a command to drop it into chat.
+
+Read more: https://badgersmc.github.io/LumaGuilds/players/homes/
+                  Page 1/1  [Back to topics]
+```
+
+### Mechanics
+
+- Built with Adventure `Component` API: each command line is a `Component` with `ClickEvent.suggestCommand` (prefill) or `ClickEvent.runCommand`, plus `HoverEvent.showText` for the per-command blurb.
+- Works in Java client, Geyser/Bedrock (Geyser maps click events to taps), and console (clicks degrade to plain text — commands still readable).
+- The wiki URL on every topic page maps to the matching wiki page by stable topic slug — same slug as the front-matter `topic:` field.
+
+### Source of truth
+
+- A single `HelpTopics.kt` (or YAML resource under `src/main/resources/`) holds: topic slug, display name, one-sentence summary, ordered list of `(command, syntax, blurb)` tuples.
+- `/g help` and `/g help <topic>` both render from that one data structure.
+- The same data file is consumed by a CI check that fails the build if a topic slug doesn't have a matching wiki page (see §8).
+
+### Out of scope for the redesign
+
+- Permission-gated filtering.
+- In-game search.
+- Localization.
+
+---
+
+## 6. Migration of Existing Docs
+
+### Folds-in mapping
+
+| Existing file | New home |
+|---|---|
+| `docs/getting-started.md` | Developers/Getting started (dev) |
+| `docs/architecture.md` | Developers/Architecture overview |
+| `docs/domain.md` | Developers/Domain layer |
+| `docs/application.md` | Developers/Application layer |
+| `docs/infrastructure.md` | Developers/Infrastructure layer |
+| `docs/interaction.md` | Developers/Interaction layer |
+| `docs/master-diagram.md` | Developers/Master diagram |
+| `docs/api-reference.md` | Developers/API reference |
+| `docs/placeholders.md` | Developers/Placeholders (internal) — *and* split player-facing tokens into Admins/PlaceholderAPI |
+| `docs/EMOJI_PERMISSIONS.md` | Developers/Emoji permissions |
+| `docs/MIGRATION_SAFETY.md` | Developers/Migration safety |
+| `docs/README.md` | Delete (Home page supersedes) |
+| `docs/images/` | `wiki/docs/assets/dev/` |
+| `docs/plans/*` | `wiki/docs/developers/archive/` (not in nav, retained for history) |
+| `CHANGELOG.md` | Stays at repo root (release tooling depends on it) |
+| `CHANGELOG_BETA.md` | Stays at repo root |
+| `COMMANDS.md` | Delete — replaced by `HelpTopics.kt` source + auto-generated Admins/Command reference |
+| `PERMISSIONS.md` | Admins/Permission nodes reference |
+| `PROGRESSION_DESIGN.md` | Developers/Progression (design notes section) |
+| `PROGRESSION_IMPLEMENTATION_SUMMARY.md` | Merge into above, then delete |
+| `PLACEHOLDERAPI_README.md` | Admins/PlaceholderAPI placeholders |
+| `SCHEMA_SETUP.md` | Developers/Schema setup |
+| `REFACTORING_PLAN.md` | Developers/Archive (historical) |
+| `LUNAR_CLIENT_INTEGRATION_PLAN.md` | Admins/Lunar Client integration (rewrite as docs, not a plan) |
+| `README.md` | Stays at repo root; trimmed to: what + install + link to wiki |
+| `CONTRIBUTING.md` | Stays at repo root |
+
+### Migration rules
+
+1. Add front-matter to every migrated file.
+2. Fix headings to follow §4 discipline (one H1, stable H2 anchors).
+3. Update internal links to new paths; `mkdocs-redirects` handles externally-cached URLs.
+4. Worktree copies under `.claude/worktrees/` are ignored — only canonical paths migrate.
+5. Don't rewrite content during migration. Move first; edit in a later pass if needed.
+
+---
+
+## 7. Phased Rollout
+
+### Phase 1 — Foundation + Players + `/g help`
+
+1. Scaffold MkDocs at `wiki/`, `mkdocs.yml`, GitHub Action publishing to `gh-pages`.
+2. Home page + nav skeleton (all 4 sections present; non-Player pages stubbed with front-matter only).
+3. Getting Started — full content: Welcome, the 7-step walkthrough, FAQ.
+4. Players — full content for all feature pages + How-do-I index.
+5. `HelpTopics.kt` (or YAML resource) data source + refactor `onHelp` in `GuildCommand.kt` to render topic menu + topic pages from it.
+6. Adventure clickable/hover components wired into `/g help`.
+7. CI: topic-slug ↔ wiki-page parity check.
+8. `llms.txt`/`llms-full.txt` generation verified on the deployed site.
+
+**Exit criteria:** site live, `/g help` redesigned, Hermes can ingest. Players section complete enough to direct confused players today.
+
+### Phase 2 — Admins
+
+1. Installation + `config.yml` walkthrough.
+2. Permission nodes reference (port from `PERMISSIONS.md`, expand).
+3. `/lumaguilds override` + recovery flows.
+4. Troubleshooting page (corrupted banners, stuck guilds, owner-less guilds — pulled from recent bug-fix history).
+5. PlaceholderAPI placeholders (port from `PLACEHOLDERAPI_README.md`).
+6. RoseChat integration.
+7. Geyser/Floodgate behavior.
+8. Lunar Client integration (rewrite from plan doc as user-facing docs).
+9. Web leaderboard API.
+10. Claims integration.
+
+**Exit criteria:** server operators can install and integrate without DMing the dev.
+
+### Phase 3 — Developers (migration)
+
+1. Move `docs/*` into `wiki/docs/developers/` per the §6 table.
+2. Add front-matter to each.
+3. Fix headings + internal links.
+4. Fold in scattered top-level `.md` files per the §6 table.
+5. Configure `mkdocs-redirects` for any URLs that shipped externally.
+6. Delete originals.
+7. Archive `docs/plans/` and `REFACTORING_PLAN.md` (not in nav).
+8. Trim repo-root `README.md` to install + wiki link.
+
+**Exit criteria:** one source of truth; no duplicate `.md` files at repo root beyond `README.md`, `CHANGELOG.md`, `CHANGELOG_BETA.md`, `CONTRIBUTING.md`.
+
+### Sequencing notes
+
+- Each phase is a separate PR series. Phase 1 ships before Phase 2 starts.
+- Phase 1 has the most work and the most player impact.
+- Phase 3 is mostly mechanical; could be one focused day.
+
+---
+
+## 8. Maintenance — Keeping Wiki, `/g help`, and Code in Sync
+
+This is the section that decides whether the wiki rots.
+
+### Single source of truth: topic slugs
+
+Every player-facing feature has one `topic` slug. That slug appears in:
+
+- The wiki page's front-matter `topic:` field.
+- The wiki URL segment: `/players/<topic>/`.
+- The key in `HelpTopics.kt`.
+- The argument to `/g help <topic>`.
+
+If any of those four drift, CI fails.
+
+### CI checks (run on every PR)
+
+1. **Topic parity check.** Script reads `HelpTopics.kt`, asserts every topic slug has a matching `wiki/docs/players/<slug>.md` and vice versa. Fails the build on mismatch.
+2. **Front-matter lint.** Every wiki page must have `title`, `audience`, `topic`, `summary`. Missing fields fail the build.
+3. **Internal link check.** `mkdocs build --strict` already does this; fails on broken cross-links.
+4. **Wiki URL check.** `HelpTopics.kt` references a base wiki URL; CI does a HEAD request on each topic URL post-deploy and warns on 404s.
+
+### Developer workflow (the rule)
+
+> **Any PR that adds, removes, or renames a command must touch both `HelpTopics.kt` and the matching wiki page in the same PR.** CI enforces it.
+
+This lives in `CONTRIBUTING.md`. The CI failure message points at that section.
+
+### Changelog → wiki feedback loop
+
+- When cutting a changelog, cross-check it against the wiki. New feature → does it have a wiki page or section? Behavior change → does the existing page still match?
+- Not automated. A step in the changelog process: "scan changelog entries, update wiki where needed." Added to the changelog template.
+
+### Hermes index refresh
+
+- `llms.txt` and `llms-full.txt` regenerate on every build automatically. No manual step.
+- Hermes-side: whatever pull/scrape cadence Hermes uses picks up the new index on its next cycle. If Hermes needs a webhook later, the GitHub Pages deploy can fire one — deferred until Hermes integration is concrete.
+
+### Explicit anti-patterns
+
+- **Auto-generating wiki pages from code annotations.** Generated docs read like generated docs. Humans write the prose; CI keeps the structure honest.
+- **Version-locking the wiki to plugin releases.** Wiki tracks `main`. If a release briefly ships behavior that doesn't match `main` yet, the wiki is briefly wrong — acceptable.
+
+---
+
+## 9. Open Questions
+
+- Custom domain for the wiki (e.g. `wiki.enthusiasmp.com` redirecting to GitHub Pages). Deferred; default `badgersmc.github.io/LumaGuilds/` until decided.
+- Exact Hermes ingestion path (HTTP scrape of public site vs. git pull from VPS). Both supported by §4 design; pick when Hermes integration is built.
+- Webhook on `gh-pages` deploy → Hermes refresh. Deferred until Hermes integration is real.
+- Screenshot capture pass — separate effort, slot into Phase 1 if time allows; otherwise text-first launch and add screenshots iteratively.
+
+---
+
+## 10. Success Criteria
+
+- A confused player can be answered with a single link (or `/g help <topic>`) in chat instead of a paragraph of explanation.
+- A new player completing the "first 30 minutes" walkthrough ends up in a working guild with a tag, a home, chat toggled correctly, and knows where to look next.
+- A server admin installing the plugin can configure permissions, PAPI, and RoseChat without contacting the dev.
+- Hermes Agent returns audience-correct chunks for guild-feature questions, with stable URLs to cite.
+- Six months from now, the wiki still matches the code — because CI won't let it drift.

--- a/docs/plans/2026-05-13-player-wiki-and-help-redesign-plan.md
+++ b/docs/plans/2026-05-13-player-wiki-and-help-redesign-plan.md
@@ -90,7 +90,7 @@ updated: 2026-05-13
 ## Related
 
 - [Sibling page](../<other-topic>.md)
-```
+```text
 
 **Topic slug rule:** lowercase, hyphenated, matches `HelpTopics.kt` key exactly. Used as the file name (`<slug>.md`), the URL segment, and the `topic:` field. Stable forever — renaming requires a `mkdocs-redirects` entry.
 
@@ -109,14 +109,14 @@ updated: 2026-05-13
 
 - [ ] **Step 1: Create `wiki/requirements.txt`**
 
-```
+```text
 mkdocs==1.6.1
 mkdocs-material==9.5.49
 mkdocs-material[imaging]==9.5.49
 mkdocs-awesome-pages-plugin==2.9.3
 mkdocs-redirects==1.2.2
 mkdocs-llmstxt==0.2.0
-```
+```text
 
 - [ ] **Step 2: Create `mkdocs.yml`**
 
@@ -188,7 +188,7 @@ markdown_extensions:
       permalink: true
 
 strict: true
-```
+```text
 
 - [ ] **Step 3: Create `wiki/docs/index.md`**
 
@@ -213,7 +213,7 @@ LumaGuilds is the guild plugin powering [EnthusiaSMP](https://enthusiasmp.com). 
 - **[Developers](developers/architecture.md)** — Code-level reference.
 
 In-game, type `/g help` to get a clickable topic menu that mirrors this wiki.
-```
+```text
 
 - [ ] **Step 4: Create `wiki/docs/.pages`**
 
@@ -224,15 +224,15 @@ nav:
   - Players: players
   - Admins: admins
   - Developers: developers
-```
+```text
 
 - [ ] **Step 5: Append to `.gitignore`**
 
 Add this line if not already present:
 
-```
+```text
 site/
-```
+```text
 
 - [ ] **Step 6: Verify MkDocs builds locally**
 
@@ -243,7 +243,7 @@ python -m venv .venv
 . .venv/Scripts/activate   # Windows
 pip install -r wiki/requirements.txt
 mkdocs build --strict
-```
+```text
 
 Expected: build succeeds. Will warn about missing `getting-started/`, `players/`, etc. — that's fine for this step (those folders are created in Task 4). If `--strict` errors on missing pages from nav, temporarily comment the nav lines in `.pages` and re-run. They get uncommented in Task 4.
 
@@ -252,7 +252,7 @@ Expected: build succeeds. Will warn about missing `getting-started/`, `players/`
 ```bash
 git add mkdocs.yml wiki/requirements.txt wiki/docs/index.md wiki/docs/.pages .gitignore
 git commit -m "docs(wiki): scaffold MkDocs Material site config"
-```
+```text
 
 ---
 
@@ -310,14 +310,14 @@ jobs:
     steps:
       - id: deployment
         uses: actions/deploy-pages@v4
-```
+```text
 
 - [ ] **Step 2: Commit**
 
 ```bash
 git add .github/workflows/wiki-deploy.yml
 git commit -m "ci(wiki): deploy MkDocs site to GitHub Pages on push to main"
-```
+```text
 
 - [ ] **Step 3: Note for human reviewer**
 
@@ -431,7 +431,7 @@ def main() -> int:
 
 if __name__ == "__main__":
     sys.exit(main())
-```
+```text
 
 - [ ] **Step 2: Test it locally on `wiki/docs/index.md` only**
 
@@ -440,7 +440,7 @@ Run:
 ```bash
 pip install pyyaml
 python tools/wiki/lint_frontmatter.py
-```
+```text
 
 Expected output: `OK — 1 pages validated.` (index.md is the only file with front-matter at this point).
 
@@ -451,14 +451,14 @@ Temporarily remove the `topic:` line from `wiki/docs/index.md`. Re-run the lint.
 - [ ] **Step 4: Create `tools/wiki/__init__.py` (empty)**
 
 ```python
-```
+```text
 
 - [ ] **Step 5: Commit**
 
 ```bash
 git add tools/wiki/__init__.py tools/wiki/lint_frontmatter.py
 git commit -m "ci(wiki): add front-matter schema lint script"
-```
+```text
 
 ---
 
@@ -482,7 +482,7 @@ updated: 2026-05-13
 # <Title>
 
 *This page is a placeholder. Content coming in Phase 2/3.*
-```
+```text
 
 - [ ] **Step 1: Getting Started stubs**
 
@@ -497,7 +497,7 @@ nav:
   - Welcome: welcome.md
   - Your first 30 minutes: walkthrough.md
   - FAQ: faq.md
-```
+```text
 
 - [ ] **Step 2: Players stubs (one per feature page in the design § 3)**
 
@@ -538,7 +538,7 @@ nav:
   - Shop integration: shop.md
   - LFG & Invites: lfg.md
   - Bedrock differences: bedrock.md
-```
+```text
 
 - [ ] **Step 3: Admins stubs**
 
@@ -571,7 +571,7 @@ nav:
   - Lunar Client: lunar.md
   - Web leaderboard API: leaderboard-api.md
   - Claims: claims.md
-```
+```text
 
 - [ ] **Step 4: Developers stubs**
 
@@ -608,7 +608,7 @@ nav:
   - Emoji permissions: emoji-permissions.md
   - Migration safety: migration-safety.md
   - Schema setup: schema-setup.md
-```
+```text
 
 - [ ] **Step 5: Note about slug ↔ filename mismatch**
 
@@ -624,13 +624,13 @@ SLUG_EXEMPT = {
     Path("developers/getting-started.md"),
     Path("developers/placeholders.md"),
 }
-```
+```text
 
 - [ ] **Step 6: Run lint, fix any failures**
 
 ```bash
 python tools/wiki/lint_frontmatter.py
-```
+```text
 
 Expected: all ~40 pages pass.
 
@@ -638,7 +638,7 @@ Expected: all ~40 pages pass.
 
 ```bash
 mkdocs build --strict
-```
+```text
 
 Expected: build succeeds with no warnings.
 
@@ -647,7 +647,7 @@ Expected: build succeeds with no warnings.
 ```bash
 git add wiki/docs/getting-started wiki/docs/players wiki/docs/admins wiki/docs/developers tools/wiki/lint_frontmatter.py
 git commit -m "docs(wiki): scaffold nav skeleton with stubbed front-matter pages"
-```
+```text
 
 ---
 
@@ -694,14 +694,14 @@ jobs:
           cache-dependency-path: wiki/requirements.txt
       - run: pip install -r wiki/requirements.txt
       - run: mkdocs build --strict
-```
+```text
 
 - [ ] **Step 2: Commit**
 
 ```bash
 git add .github/workflows/wiki-checks.yml
 git commit -m "ci(wiki): run front-matter lint and strict MkDocs build on PRs"
-```
+```text
 
 ---
 
@@ -759,7 +759,7 @@ In-game, type `/g help` for the same content as a clickable menu.
 - Not a release log. See [`CHANGELOG.md`](https://github.com/BadgersMC/LumaGuilds/blob/main/CHANGELOG.md) on GitHub.
 
 Ready? **[Start the 30-minute walkthrough →](walkthrough.md)**
-```
+```text
 
 The comment block `<!-- ... -->` is a placeholder for content you'll want a human to write — the server pitch. The plan ships with a TODO marker visible in the rendered page only via comment (so MkDocs strict mode still passes). Leave it for the maintainer to fill on first PR review pass; it's not blocking.
 
@@ -768,7 +768,7 @@ The comment block `<!-- ... -->` is a placeholder for content you'll want a huma
 ```bash
 python tools/wiki/lint_frontmatter.py
 mkdocs build --strict
-```
+```text
 
 Expected: both pass.
 
@@ -777,7 +777,7 @@ Expected: both pass.
 ```bash
 git add wiki/docs/getting-started/welcome.md
 git commit -m "docs(wiki): write Getting Started welcome page"
-```
+```text
 
 ---
 
@@ -821,9 +821,9 @@ You have three options:
 
 **Create your own** — pick a name (plain text, max 32 chars, letters/numbers/spaces/`'`/`&`/`-`) and run:
 
-```
+```text
 /g create <name>
-```
+```text
 
 Example: `/g create White Lotus`
 
@@ -837,25 +837,25 @@ Once you're in a guild, two things make it feel like home.
 
 **Tag** — fancy formatting that appears next to your name in chat. Use MiniMessage:
 
-```
+```text
 /g tag <gradient:#FF6A00:#FF1F00>Lotus</gradient>
-```
+```text
 
 Or run `/g tag` with no arguments to open a visual editor.
 
 **Home** — a teleport point your guild can share. Stand where you want it and run:
 
-```
+```text
 /g sethome
-```
+```text
 
 That sets the default home. You can have multiple — `/g sethome shop`, `/g sethome mine`. Teleport with `/g home` or `/g home <name>`. See [Players → Homes](../players/homes.md).
 
 ## 4. Inviting a friend
 
-```
+```text
 /g invite <player>
-```
+```text
 
 They run `/g accept <yourguild>` (or click the chat prompt). Done.
 
@@ -890,21 +890,21 @@ If you got this far you're functional. Pick one:
 - **Read the [How do I…? index](../players/how-do-i.md)** — every common task with a deep link to the right page.
 
 That's the tour. The rest of the wiki is reference — come back as needed.
-```
+```text
 
 - [ ] **Step 2: Lint + build**
 
 ```bash
 python tools/wiki/lint_frontmatter.py
 mkdocs build --strict
-```
+```text
 
 - [ ] **Step 3: Commit**
 
 ```bash
 git add wiki/docs/getting-started/walkthrough.md
 git commit -m "docs(wiki): write 7-step Getting Started walkthrough"
-```
+```text
 
 ---
 
@@ -961,7 +961,7 @@ Mostly. A few menus open as chat-based forms instead of inventory GUIs, and clic
 ## Where do I report a bug?
 
 Tell staff in-game or open an issue at <https://github.com/BadgersMC/LumaGuilds/issues>.
-```
+```text
 
 - [ ] **Step 2: Lint + build, commit**
 
@@ -970,7 +970,7 @@ python tools/wiki/lint_frontmatter.py
 mkdocs build --strict
 git add wiki/docs/getting-started/faq.md
 git commit -m "docs(wiki): write Getting Started FAQ"
-```
+```text
 
 ---
 
@@ -1043,13 +1043,13 @@ class HelpTopicTest {
         }
     }
 }
-```
+```text
 
 - [ ] **Step 2: Run test — expect compile failure**
 
 ```bash
 ./gradlew test --tests "net.lumalyte.lg.interaction.help.HelpTopicTest"
-```
+```text
 
 Expected: compile error — classes don't exist yet.
 
@@ -1067,7 +1067,7 @@ data class HelpCommandEntry(
     val blurb: String,
     val prefill: String,
 )
-```
+```text
 
 - [ ] **Step 4: Create `HelpTopic.kt`**
 
@@ -1095,13 +1095,13 @@ data class HelpTopic(
         private val SLUG_REGEX = Regex("^[a-z0-9]+(-[a-z0-9]+)*$")
     }
 }
-```
+```text
 
 - [ ] **Step 5: Run test — expect pass**
 
 ```bash
 ./gradlew test --tests "net.lumalyte.lg.interaction.help.HelpTopicTest"
-```
+```text
 
 Expected: PASS.
 
@@ -1112,7 +1112,7 @@ git add src/main/kotlin/net/lumalyte/lg/interaction/help/HelpCommandEntry.kt \
         src/main/kotlin/net/lumalyte/lg/interaction/help/HelpTopic.kt \
         src/test/kotlin/net/lumalyte/lg/interaction/help/HelpTopicTest.kt
 git commit -m "feat(help): add HelpTopic and HelpCommandEntry data classes"
-```
+```text
 
 ---
 
@@ -1188,13 +1188,13 @@ class HelpTopicsTest {
         }
     }
 }
-```
+```text
 
 - [ ] **Step 2: Run test — expect failure (HelpTopics doesn't exist)**
 
 ```bash
 ./gradlew test --tests "net.lumalyte.lg.interaction.help.HelpTopicsTest"
-```
+```text
 
 Expected: compile error.
 
@@ -1357,13 +1357,13 @@ object HelpTopics {
 
     fun bySlug(slug: String): HelpTopic? = bySlugMap[slug.lowercase()]
 }
-```
+```text
 
 - [ ] **Step 4: Run test — expect failures on ordering**
 
 ```bash
 ./gradlew test --tests "net.lumalyte.lg.interaction.help.HelpTopicsTest"
-```
+```text
 
 Expected: passes. If the ordering test fails, the first-four order must be `guilds, homes, ranks, chat` — that's the order in `all` above.
 
@@ -1373,7 +1373,7 @@ Expected: passes. If the ordering test fails, the first-four order must be `guil
 git add src/main/kotlin/net/lumalyte/lg/interaction/help/HelpTopics.kt \
         src/test/kotlin/net/lumalyte/lg/interaction/help/HelpTopicsTest.kt
 git commit -m "feat(help): add HelpTopics registry (source of truth for help + wiki)"
-```
+```text
 
 ---
 
@@ -1452,13 +1452,13 @@ def main() -> int:
 
 if __name__ == "__main__":
     sys.exit(main())
-```
+```text
 
 - [ ] **Step 2: Run locally**
 
 ```bash
 python tools/wiki/check_topic_parity.py
-```
+```text
 
 Expected: `OK — 13 topics in parity with wiki.` (all 13 stub pages exist from Task 4; all 13 are registered from Task 10).
 
@@ -1479,7 +1479,7 @@ Add a new job to the existing workflow:
         with:
           python-version: '3.11'
       - run: python tools/wiki/check_topic_parity.py
-```
+```text
 
 Also expand the workflow's `paths:` filter to trigger when `HelpTopics.kt` changes — already covered by `src/main/kotlin/net/lumalyte/lg/interaction/help/**` in Task 5.
 
@@ -1488,7 +1488,7 @@ Also expand the workflow's `paths:` filter to trigger when `HelpTopics.kt` chang
 ```bash
 git add tools/wiki/check_topic_parity.py .github/workflows/wiki-checks.yml
 git commit -m "ci(wiki): enforce HelpTopics.kt <-> wiki/docs/players/ slug parity"
-```
+```text
 
 ---
 
@@ -1566,13 +1566,13 @@ private fun Component.findSuggestCommandClick(value: String): Component? =
         val ce = it.clickEvent()
         ce?.action() == ClickEvent.Action.SUGGEST_COMMAND && ce.value() == value
     }
-```
+```text
 
 - [ ] **Step 2: Run test — expect compile failure**
 
 ```bash
 ./gradlew test --tests "net.lumalyte.lg.interaction.help.HelpTopicsRendererTest"
-```
+```text
 
 Expected: compile error.
 
@@ -1685,13 +1685,13 @@ object HelpTopicsRenderer {
         return out.build()
     }
 }
-```
+```text
 
 - [ ] **Step 4: Run test — expect pass**
 
 ```bash
 ./gradlew test --tests "net.lumalyte.lg.interaction.help.HelpTopicsRendererTest"
-```
+```text
 
 Expected: PASS.
 
@@ -1701,7 +1701,7 @@ Expected: PASS.
 git add src/main/kotlin/net/lumalyte/lg/interaction/help/HelpTopicsRenderer.kt \
         src/test/kotlin/net/lumalyte/lg/interaction/help/HelpTopicsRendererTest.kt
 git commit -m "feat(help): render topic menu via Adventure components"
-```
+```text
 
 ---
 
@@ -1753,20 +1753,20 @@ Append to the existing test class (above the private extension functions at the 
         val back = rendered.findRunCommandClick("/g help")
         assertNotNull(back, "No RUN_COMMAND click for '/g help' (Back action)")
     }
-```
+```text
 
 - [ ] **Step 2: Run — expect pass**
 
 ```bash
 ./gradlew test --tests "net.lumalyte.lg.interaction.help.HelpTopicsRendererTest"
-```
+```text
 
 - [ ] **Step 3: Commit**
 
 ```bash
 git add src/test/kotlin/net/lumalyte/lg/interaction/help/HelpTopicsRendererTest.kt
 git commit -m "test(help): verify topic-page rendering (click events, wiki link, back action)"
-```
+```text
 
 ---
 
@@ -1806,7 +1806,7 @@ Locate the method at line 1905. Replace from the `@Subcommand("help")` annotatio
         }
         player.sendMessage(renderer.renderTopicPage(found))
     }
-```
+```text
 
 - [ ] **Step 2: Add the imports near the top of the file**
 
@@ -1818,7 +1818,7 @@ import net.kyori.adventure.text.event.ClickEvent
 import net.kyori.adventure.text.format.NamedTextColor
 import net.lumalyte.lg.interaction.help.HelpTopics
 import net.lumalyte.lg.interaction.help.HelpTopicsRenderer
-```
+```text
 
 Skip any that are already imported.
 
@@ -1826,7 +1826,7 @@ Skip any that are already imported.
 
 ```bash
 ./gradlew build -x test
-```
+```text
 
 Expected: success.
 
@@ -1834,7 +1834,7 @@ Expected: success.
 
 ```bash
 ./gradlew test
-```
+```text
 
 Expected: all pass, including the new HelpTopics tests.
 
@@ -1847,7 +1847,7 @@ Build the shadow jar (`./gradlew shadowJar`), drop into a local Paper test serve
 ```bash
 git add src/main/kotlin/net/lumalyte/lg/interaction/commands/GuildCommand.kt
 git commit -m "refactor(help): /g help renders from HelpTopicsRenderer (clickable, topic-based)"
-```
+```text
 
 ---
 
@@ -1930,7 +1930,7 @@ How to create, join, leave, transfer, and disband guilds.
 - [Ranks & Permissions](ranks.md)
 - [Homes](homes.md)
 - [Alliances & Diplomacy](alliances.md)
-```
+```text
 
 Source-of-truth check: cross-reference `GuildCommand.kt` lines 61 (`@Subcommand("create")`), 988 (`join`), 1269 (`leave`), 867 (`disband`), 1352 (`transfer`), 837 (`info`), 1103 (`list`) for exact behaviors and permissions.
 
@@ -1941,7 +1941,7 @@ python tools/wiki/lint_frontmatter.py
 mkdocs build --strict
 git add wiki/docs/players/guilds.md
 git commit -m "docs(wiki): write Players/Guilds page"
-```
+```text
 
 ---
 
@@ -2062,7 +2062,7 @@ python tools/wiki/lint_frontmatter.py
 mkdocs build --strict
 git add wiki/docs/players/<topic>.md
 git commit -m "docs(wiki): write Players/<topic> page"
-```
+```text
 
 ---
 
@@ -2143,13 +2143,13 @@ Quick index. Scan for your task; click through to the page that answers it.
 - [Check my guild level / XP](progression.md#checking-your-guilds-level)
 - [Mark a shop as guild-owned](shop.md#marking-a-shop-as-guild-owned)
 - [What's different on Bedrock?](bedrock.md)
-```
+```text
 
 - [ ] **Step 2: Verify all anchor links resolve**
 
 ```bash
 mkdocs build --strict
-```
+```text
 
 Expected: passes. `--strict` will fail on any broken anchor (`#…`) link. If a link points to an H2 that doesn't exist yet, either fix the link (matching the actual H2 in the target page) or add the H2 to the target page.
 
@@ -2158,7 +2158,7 @@ Expected: passes. `--strict` will fail on any broken anchor (`#…`) link. If a 
 ```bash
 git add wiki/docs/players/how-do-i.md
 git commit -m "docs(wiki): write Players/How-do-I index"
-```
+```text
 
 ---
 
@@ -2192,7 +2192,7 @@ python tools/wiki/lint_frontmatter.py
 python tools/wiki/check_topic_parity.py
 mkdocs build --strict
 ./gradlew test
-```
+```text
 
 ### Adding a new topic
 
@@ -2208,14 +2208,14 @@ mkdocs build --strict
 - **Renaming the slug:** treat as remove + add. The old slug is permanently retired (Hermes Agent and any cached links may still reference it via the redirect).
 
 Slugs are forever. The display name, summary, and command list inside a topic are not — those evolve freely.
-```
+```text
 
 - [ ] **Step 2: Commit**
 
 ```bash
 git add CONTRIBUTING.md
 git commit -m "docs(contributing): add wiki/help sync rule and CI check overview"
-```
+```text
 
 ---
 
@@ -2231,7 +2231,7 @@ python tools/wiki/check_topic_parity.py
 mkdocs build --strict
 ./gradlew test
 ./gradlew build -x test
-```
+```text
 
 Expected: every step passes.
 
@@ -2242,7 +2242,7 @@ After `mkdocs build`, inspect:
 ```bash
 ls site/llms.txt site/llms-full.txt
 head -40 site/llms.txt
-```
+```text
 
 Expected: both files exist; `llms.txt` lists every page with summaries, organized by the section headers configured in `mkdocs.yml`.
 
@@ -2250,7 +2250,7 @@ Expected: both files exist; `llms.txt` lists every page with summaries, organize
 
 ```bash
 mkdocs serve
-```
+```text
 
 Open <http://127.0.0.1:8000/> in a browser. Click through:
 - Home → Getting Started → Walkthrough (verify all section anchors).
@@ -2263,7 +2263,7 @@ Build the plugin:
 
 ```bash
 ./gradlew shadowJar
-```
+```text
 
 Drop the jar in a local Paper server. Test:
 - `/g help` — topic menu renders with all 13 topics; clicking [Homes] runs `/g help homes`.

--- a/docs/plans/2026-05-13-player-wiki-and-help-redesign-plan.md
+++ b/docs/plans/2026-05-13-player-wiki-and-help-redesign-plan.md
@@ -1,0 +1,2287 @@
+# Player Wiki + `/g help` Redesign — Phase 1 Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Ship Phase 1 of the wiki redesign — MkDocs scaffold on GitHub Pages, Getting Started + all Players section content, and a fully redesigned topic-based clickable `/g help`, with a topic-slug source of truth enforced by CI.
+
+**Architecture:** MkDocs Material site lives under `wiki/` at the repo root, built and deployed to GitHub Pages by Actions. In-game `/g help` is refactored to render from a single `HelpTopics` Kotlin data structure shared with the wiki via stable topic slugs; CI fails if a slug doesn't have a matching wiki page. Every wiki page carries YAML front-matter (`audience`, `topic`, `summary`, `keywords`, `related`) so Hermes Agent can chunk and filter pages reliably. `llms.txt` and `llms-full.txt` are generated at build time.
+
+**Tech Stack:** MkDocs + Material theme, mkdocs-llmstxt, mkdocs-awesome-pages-plugin, mkdocs-redirects. Kotlin 2.0, JUnit Jupiter 5, MockK, MockBukkit for Kotlin tests. Adventure API for clickable/hover chat components. Python 3.11 in CI for the parity/front-matter scripts. GitHub Actions for build + deploy.
+
+**Design source:** [`docs/plans/2026-05-13-player-wiki-and-help-redesign-design.md`](2026-05-13-player-wiki-and-help-redesign-design.md)
+
+**Out of scope (deferred to Phase 2/3):** Admins section content, Developers section migration of `docs/`, fold-in of loose top-level `.md` files.
+
+---
+
+## File Structure
+
+**New files:**
+- `mkdocs.yml` — site config at repo root
+- `wiki/requirements.txt` — Python deps for MkDocs build
+- `wiki/docs/index.md` — landing page
+- `wiki/docs/.pages` — root nav ordering
+- `wiki/docs/getting-started/` — Welcome, walkthrough (7 pages), FAQ
+- `wiki/docs/players/` — How-do-I index + 13 feature pages
+- `wiki/docs/admins/` — stubbed pages (front-matter only)
+- `wiki/docs/developers/` — stubbed pages (front-matter only)
+- `wiki/docs/assets/` — screenshot/image root
+- `.github/workflows/wiki-deploy.yml` — GitHub Pages deploy on push to main
+- `.github/workflows/wiki-checks.yml` — front-matter lint + topic parity on every PR
+- `tools/wiki/lint_frontmatter.py` — front-matter schema validation
+- `tools/wiki/check_topic_parity.py` — HelpTopics.kt ↔ wiki page slug parity
+- `src/main/kotlin/net/lumalyte/lg/interaction/help/HelpTopic.kt` — data class
+- `src/main/kotlin/net/lumalyte/lg/interaction/help/HelpCommandEntry.kt` — data class
+- `src/main/kotlin/net/lumalyte/lg/interaction/help/HelpTopics.kt` — registry
+- `src/main/kotlin/net/lumalyte/lg/interaction/help/HelpTopicsRenderer.kt` — Adventure component builder
+- `src/test/kotlin/net/lumalyte/lg/interaction/help/HelpTopicsTest.kt`
+- `src/test/kotlin/net/lumalyte/lg/interaction/help/HelpTopicsRendererTest.kt`
+
+**Modified files:**
+- `src/main/kotlin/net/lumalyte/lg/interaction/commands/GuildCommand.kt` — `onHelp` refactored to delegate to `HelpTopicsRenderer`
+- `CONTRIBUTING.md` — adds wiki/help sync rule
+- `.gitignore` — exclude MkDocs build output `site/`
+- `README.md` — minor link to wiki (deferred until site is live)
+
+---
+
+## Conventions Used Throughout the Plan
+
+**Wiki page template** (every wiki page Phase 1 creates uses this exact shape):
+
+```markdown
+---
+title: <Display Title>
+audience: <player|admin|dev>
+topic: <stable-slug>
+summary: <one-sentence summary, ≤140 chars>
+keywords: [<comma>, <separated>, <list>]
+related: [<sibling-topic-slugs>]
+updated: 2026-05-13
+---
+
+# <Display Title>
+
+<One-sentence summary — same prose as `summary:` above.>
+
+## Quick reference
+
+| Command | Permission | Description |
+|---------|------------|-------------|
+| `/g foo` | `lumaguilds.guild.foo` | One-line. |
+
+## How it works
+
+<Narrative paragraph(s). The canonical explanation.>
+
+## <Common task 1>
+
+<Step-by-step.>
+
+## <Common task 2>
+
+<Step-by-step.>
+
+## Gotchas
+
+- Bullet.
+- Bullet.
+
+## Related
+
+- [Sibling page](../<other-topic>.md)
+```
+
+**Topic slug rule:** lowercase, hyphenated, matches `HelpTopics.kt` key exactly. Used as the file name (`<slug>.md`), the URL segment, and the `topic:` field. Stable forever — renaming requires a `mkdocs-redirects` entry.
+
+**Commit cadence:** every task ends with a commit. Squash on merge is fine, but per-task commits keep PR review legible.
+
+---
+
+## Task 1: Add MkDocs scaffold (`mkdocs.yml`, `requirements.txt`, landing page)
+
+**Files:**
+- Create: `mkdocs.yml`
+- Create: `wiki/requirements.txt`
+- Create: `wiki/docs/index.md`
+- Create: `wiki/docs/.pages`
+- Modify: `.gitignore` (add `site/`)
+
+- [ ] **Step 1: Create `wiki/requirements.txt`**
+
+```
+mkdocs==1.6.1
+mkdocs-material==9.5.49
+mkdocs-material[imaging]==9.5.49
+mkdocs-awesome-pages-plugin==2.9.3
+mkdocs-redirects==1.2.2
+mkdocs-llmstxt==0.2.0
+```
+
+- [ ] **Step 2: Create `mkdocs.yml`**
+
+```yaml
+site_name: LumaGuilds
+site_url: https://badgersmc.github.io/LumaGuilds/
+site_description: Player wiki and admin/developer reference for the LumaGuilds plugin.
+repo_url: https://github.com/BadgersMC/LumaGuilds
+repo_name: BadgersMC/LumaGuilds
+edit_uri: edit/main/wiki/docs/
+
+docs_dir: wiki/docs
+
+theme:
+  name: material
+  features:
+    - navigation.tabs
+    - navigation.tabs.sticky
+    - navigation.sections
+    - navigation.top
+    - navigation.tracking
+    - search.suggest
+    - search.highlight
+    - content.code.copy
+    - content.action.edit
+  palette:
+    - media: "(prefers-color-scheme: light)"
+      scheme: default
+      primary: indigo
+      accent: indigo
+      toggle:
+        icon: material/brightness-7
+        name: Switch to dark mode
+    - media: "(prefers-color-scheme: dark)"
+      scheme: slate
+      primary: indigo
+      accent: indigo
+      toggle:
+        icon: material/brightness-4
+        name: Switch to light mode
+
+plugins:
+  - search
+  - awesome-pages
+  - redirects:
+      redirect_maps: {}
+  - llmstxt:
+      full_output: llms-full.txt
+      sections:
+        Getting Started:
+          - getting-started/**/*.md
+        Players:
+          - players/**/*.md
+        Admins:
+          - admins/**/*.md
+        Developers:
+          - developers/**/*.md
+
+markdown_extensions:
+  - admonition
+  - attr_list
+  - md_in_html
+  - tables
+  - pymdownx.details
+  - pymdownx.superfences
+  - pymdownx.tabbed:
+      alternate_style: true
+  - toc:
+      permalink: true
+
+strict: true
+```
+
+- [ ] **Step 3: Create `wiki/docs/index.md`**
+
+```markdown
+---
+title: LumaGuilds
+audience: player
+topic: home
+summary: Player wiki and admin/developer reference for the LumaGuilds plugin on EnthusiaSMP.
+keywords: [home, overview]
+related: []
+updated: 2026-05-13
+---
+
+# LumaGuilds
+
+LumaGuilds is the guild plugin powering [EnthusiaSMP](https://enthusiasmp.com). Pick where you want to go:
+
+- **[Getting Started](getting-started/welcome.md)** — New to the server? Start here.
+- **[Players](players/how-do-i.md)** — How everything works, organized by feature.
+- **[Admins](admins/installation.md)** — Install, configure, and integrate.
+- **[Developers](developers/architecture.md)** — Code-level reference.
+
+In-game, type `/g help` to get a clickable topic menu that mirrors this wiki.
+```
+
+- [ ] **Step 4: Create `wiki/docs/.pages`**
+
+```yaml
+nav:
+  - index.md
+  - Getting Started: getting-started
+  - Players: players
+  - Admins: admins
+  - Developers: developers
+```
+
+- [ ] **Step 5: Append to `.gitignore`**
+
+Add this line if not already present:
+
+```
+site/
+```
+
+- [ ] **Step 6: Verify MkDocs builds locally**
+
+Run:
+
+```bash
+python -m venv .venv
+. .venv/Scripts/activate   # Windows
+pip install -r wiki/requirements.txt
+mkdocs build --strict
+```
+
+Expected: build succeeds. Will warn about missing `getting-started/`, `players/`, etc. — that's fine for this step (those folders are created in Task 4). If `--strict` errors on missing pages from nav, temporarily comment the nav lines in `.pages` and re-run. They get uncommented in Task 4.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add mkdocs.yml wiki/requirements.txt wiki/docs/index.md wiki/docs/.pages .gitignore
+git commit -m "docs(wiki): scaffold MkDocs Material site config"
+```
+
+---
+
+## Task 2: GitHub Action — wiki deploy to GitHub Pages
+
+**Files:**
+- Create: `.github/workflows/wiki-deploy.yml`
+
+- [ ] **Step 1: Create the workflow**
+
+```yaml
+name: Deploy Wiki
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - 'wiki/**'
+      - 'mkdocs.yml'
+      - '.github/workflows/wiki-deploy.yml'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+concurrency:
+  group: pages
+  cancel-in-progress: false
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+          cache: 'pip'
+          cache-dependency-path: wiki/requirements.txt
+      - run: pip install -r wiki/requirements.txt
+      - run: mkdocs build --strict
+      - uses: actions/configure-pages@v5
+      - uses: actions/upload-pages-artifact@v3
+        with:
+          path: site
+
+  deploy:
+    needs: build
+    runs-on: ubuntu-latest
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
+      - id: deployment
+        uses: actions/deploy-pages@v4
+```
+
+- [ ] **Step 2: Commit**
+
+```bash
+git add .github/workflows/wiki-deploy.yml
+git commit -m "ci(wiki): deploy MkDocs site to GitHub Pages on push to main"
+```
+
+- [ ] **Step 3: Note for human reviewer**
+
+After merge, a maintainer must go to **GitHub Settings → Pages → Source: GitHub Actions** once to enable Pages. The workflow itself doesn't need that — but the site won't be visible until the toggle is flipped. Add this to the PR description.
+
+---
+
+## Task 3: Front-matter schema lint script
+
+**Files:**
+- Create: `tools/wiki/lint_frontmatter.py`
+- Create: `tools/wiki/__init__.py` (empty)
+
+- [ ] **Step 1: Create the lint script**
+
+```python
+#!/usr/bin/env python3
+"""Validate YAML front-matter on every wiki/docs/**/*.md page.
+
+Required fields: title, audience, topic, summary, keywords, related, updated.
+audience must be one of: player, admin, dev.
+topic must be a lowercase-hyphenated slug matching the filename stem.
+summary must be ≤140 chars.
+
+Exit code 1 on any failure; prints all failures before exiting.
+"""
+
+from __future__ import annotations
+
+import re
+import sys
+from pathlib import Path
+
+try:
+    import yaml
+except ImportError:
+    print("PyYAML is required. Install with: pip install pyyaml", file=sys.stderr)
+    sys.exit(2)
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+DOCS_ROOT = REPO_ROOT / "wiki" / "docs"
+
+REQUIRED_FIELDS = {"title", "audience", "topic", "summary", "keywords", "related", "updated"}
+VALID_AUDIENCES = {"player", "admin", "dev"}
+SLUG_RE = re.compile(r"^[a-z0-9]+(-[a-z0-9]+)*$")
+SUMMARY_MAX = 140
+
+# Files that don't follow the slug-matches-filename rule:
+SLUG_EXEMPT = {Path("index.md")}
+
+
+def parse_frontmatter(text: str) -> dict | None:
+    if not text.startswith("---\n"):
+        return None
+    end = text.find("\n---", 4)
+    if end == -1:
+        return None
+    return yaml.safe_load(text[4:end])
+
+
+def lint(path: Path) -> list[str]:
+    rel = path.relative_to(DOCS_ROOT)
+    errors: list[str] = []
+    text = path.read_text(encoding="utf-8")
+    fm = parse_frontmatter(text)
+    if fm is None:
+        return [f"{rel}: missing or malformed YAML front-matter"]
+
+    missing = REQUIRED_FIELDS - fm.keys()
+    if missing:
+        errors.append(f"{rel}: missing required fields: {sorted(missing)}")
+
+    if "audience" in fm and fm["audience"] not in VALID_AUDIENCES:
+        errors.append(f"{rel}: audience={fm['audience']!r} not in {VALID_AUDIENCES}")
+
+    if "topic" in fm:
+        slug = str(fm["topic"])
+        if not SLUG_RE.match(slug):
+            errors.append(f"{rel}: topic={slug!r} not a lowercase-hyphenated slug")
+        if rel not in SLUG_EXEMPT and path.stem != slug:
+            errors.append(f"{rel}: topic={slug!r} does not match filename stem {path.stem!r}")
+
+    if "summary" in fm and isinstance(fm["summary"], str) and len(fm["summary"]) > SUMMARY_MAX:
+        errors.append(f"{rel}: summary is {len(fm['summary'])} chars (max {SUMMARY_MAX})")
+
+    if "keywords" in fm and not isinstance(fm["keywords"], list):
+        errors.append(f"{rel}: keywords must be a list")
+
+    if "related" in fm and not isinstance(fm["related"], list):
+        errors.append(f"{rel}: related must be a list")
+
+    return errors
+
+
+def main() -> int:
+    failures: list[str] = []
+    pages = sorted(DOCS_ROOT.rglob("*.md"))
+    if not pages:
+        print(f"No markdown pages found under {DOCS_ROOT}", file=sys.stderr)
+        return 1
+    for page in pages:
+        failures.extend(lint(page))
+    if failures:
+        for line in failures:
+            print(line, file=sys.stderr)
+        print(f"\n{len(failures)} front-matter problem(s) across {len(pages)} pages.", file=sys.stderr)
+        return 1
+    print(f"OK — {len(pages)} pages validated.")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())
+```
+
+- [ ] **Step 2: Test it locally on `wiki/docs/index.md` only**
+
+Run:
+
+```bash
+pip install pyyaml
+python tools/wiki/lint_frontmatter.py
+```
+
+Expected output: `OK — 1 pages validated.` (index.md is the only file with front-matter at this point).
+
+- [ ] **Step 3: Negative test — corrupt the file briefly to prove the lint catches errors**
+
+Temporarily remove the `topic:` line from `wiki/docs/index.md`. Re-run the lint. Expected: exit 1, prints `index.md: missing required fields: ['topic']`. Restore the line.
+
+- [ ] **Step 4: Create `tools/wiki/__init__.py` (empty)**
+
+```python
+```
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add tools/wiki/__init__.py tools/wiki/lint_frontmatter.py
+git commit -m "ci(wiki): add front-matter schema lint script"
+```
+
+---
+
+## Task 4: Build out nav skeleton — stub pages (front-matter only)
+
+Goal: every page referenced in nav exists with valid front-matter, so `mkdocs build --strict` passes. Content for Getting Started and Players is filled in later tasks; Admins and Developers stay stubbed.
+
+**Files:** all created under `wiki/docs/`. Each stub uses this body:
+
+```markdown
+---
+title: <Title>
+audience: <player|admin|dev>
+topic: <slug>
+summary: <one-line>
+keywords: []
+related: []
+updated: 2026-05-13
+---
+
+# <Title>
+
+*This page is a placeholder. Content coming in Phase 2/3.*
+```
+
+- [ ] **Step 1: Getting Started stubs**
+
+Create these with front-matter only (one H1, the placeholder body — content lands in Task 6/7):
+- `wiki/docs/getting-started/welcome.md` — `topic: welcome`, `audience: player`
+- `wiki/docs/getting-started/walkthrough.md` — `topic: walkthrough`, `audience: player`
+- `wiki/docs/getting-started/faq.md` — `topic: faq`, `audience: player`
+- `wiki/docs/getting-started/.pages`:
+
+```yaml
+nav:
+  - Welcome: welcome.md
+  - Your first 30 minutes: walkthrough.md
+  - FAQ: faq.md
+```
+
+- [ ] **Step 2: Players stubs (one per feature page in the design § 3)**
+
+Front-matter only, `audience: player`. Topic slugs and titles:
+
+| File | topic | title |
+|---|---|---|
+| `wiki/docs/players/how-do-i.md` | `how-do-i` | How do I…? |
+| `wiki/docs/players/guilds.md` | `guilds` | Guilds |
+| `wiki/docs/players/ranks.md` | `ranks` | Ranks & Permissions |
+| `wiki/docs/players/homes.md` | `homes` | Homes |
+| `wiki/docs/players/alliances.md` | `alliances` | Alliances & Diplomacy |
+| `wiki/docs/players/war.md` | `war` | War |
+| `wiki/docs/players/chat.md` | `chat` | Chat |
+| `wiki/docs/players/identity.md` | `identity` | Tags, Banners & Identity |
+| `wiki/docs/players/progression.md` | `progression` | Progression & Levels |
+| `wiki/docs/players/vault.md` | `vault` | Vault |
+| `wiki/docs/players/mode.md` | `mode` | Mode (Peaceful / Hostile) |
+| `wiki/docs/players/shop.md` | `shop` | Shop integration |
+| `wiki/docs/players/lfg.md` | `lfg` | LFG & Invites |
+| `wiki/docs/players/bedrock.md` | `bedrock` | Bedrock differences |
+
+`wiki/docs/players/.pages`:
+
+```yaml
+nav:
+  - How do I…?: how-do-i.md
+  - Guilds: guilds.md
+  - Ranks & Permissions: ranks.md
+  - Homes: homes.md
+  - Alliances & Diplomacy: alliances.md
+  - War: war.md
+  - Chat: chat.md
+  - Tags, Banners & Identity: identity.md
+  - Progression & Levels: progression.md
+  - Vault: vault.md
+  - Mode: mode.md
+  - Shop integration: shop.md
+  - LFG & Invites: lfg.md
+  - Bedrock differences: bedrock.md
+```
+
+- [ ] **Step 3: Admins stubs**
+
+`audience: admin`. Slugs/titles:
+
+| File | topic | title |
+|---|---|---|
+| `wiki/docs/admins/installation.md` | `installation` | Installation & config.yml |
+| `wiki/docs/admins/permissions.md` | `permissions` | Permission nodes reference |
+| `wiki/docs/admins/override.md` | `override` | `/lumaguilds override` and recovery |
+| `wiki/docs/admins/troubleshooting.md` | `troubleshooting` | Troubleshooting |
+| `wiki/docs/admins/placeholderapi.md` | `placeholderapi` | PlaceholderAPI placeholders |
+| `wiki/docs/admins/rosechat.md` | `rosechat` | RoseChat integration |
+| `wiki/docs/admins/geyser.md` | `geyser` | Geyser/Floodgate behavior |
+| `wiki/docs/admins/lunar.md` | `lunar` | Lunar Client integration |
+| `wiki/docs/admins/leaderboard-api.md` | `leaderboard-api` | Web leaderboard API |
+| `wiki/docs/admins/claims.md` | `claims` | Claims integration |
+
+`wiki/docs/admins/.pages`:
+
+```yaml
+nav:
+  - Installation: installation.md
+  - Permission nodes: permissions.md
+  - Override & recovery: override.md
+  - Troubleshooting: troubleshooting.md
+  - PlaceholderAPI: placeholderapi.md
+  - RoseChat: rosechat.md
+  - Geyser/Floodgate: geyser.md
+  - Lunar Client: lunar.md
+  - Web leaderboard API: leaderboard-api.md
+  - Claims: claims.md
+```
+
+- [ ] **Step 4: Developers stubs**
+
+`audience: dev`. Slugs/titles:
+
+| File | topic | title |
+|---|---|---|
+| `wiki/docs/developers/getting-started.md` | `dev-getting-started` | Developer getting started |
+| `wiki/docs/developers/architecture.md` | `architecture` | Architecture overview |
+| `wiki/docs/developers/domain.md` | `domain` | Domain layer |
+| `wiki/docs/developers/application.md` | `application` | Application layer |
+| `wiki/docs/developers/infrastructure.md` | `infrastructure` | Infrastructure layer |
+| `wiki/docs/developers/interaction.md` | `interaction` | Interaction layer |
+| `wiki/docs/developers/master-diagram.md` | `master-diagram` | Master diagram |
+| `wiki/docs/developers/api-reference.md` | `api-reference` | API reference |
+| `wiki/docs/developers/placeholders.md` | `placeholders-internal` | Placeholders (internal) |
+| `wiki/docs/developers/emoji-permissions.md` | `emoji-permissions` | Emoji permissions |
+| `wiki/docs/developers/migration-safety.md` | `migration-safety` | Migration safety |
+| `wiki/docs/developers/schema-setup.md` | `schema-setup` | Schema setup |
+
+`wiki/docs/developers/.pages`:
+
+```yaml
+nav:
+  - Getting started: getting-started.md
+  - Architecture: architecture.md
+  - Domain layer: domain.md
+  - Application layer: application.md
+  - Infrastructure layer: infrastructure.md
+  - Interaction layer: interaction.md
+  - Master diagram: master-diagram.md
+  - API reference: api-reference.md
+  - Placeholders (internal): placeholders.md
+  - Emoji permissions: emoji-permissions.md
+  - Migration safety: migration-safety.md
+  - Schema setup: schema-setup.md
+```
+
+- [ ] **Step 5: Note about slug ↔ filename mismatch**
+
+The Developers section has two slug-vs-filename mismatches:
+- `developers/getting-started.md` uses `topic: dev-getting-started` (because `getting-started` is also the folder name for the Getting Started section; we want a unique slug).
+- `developers/placeholders.md` uses `topic: placeholders-internal` (because `players/chat.md` references player-facing placeholders; we want the dev page slug to be unambiguous).
+
+Update `tools/wiki/lint_frontmatter.py` to handle this — add to `SLUG_EXEMPT`:
+
+```python
+SLUG_EXEMPT = {
+    Path("index.md"),
+    Path("developers/getting-started.md"),
+    Path("developers/placeholders.md"),
+}
+```
+
+- [ ] **Step 6: Run lint, fix any failures**
+
+```bash
+python tools/wiki/lint_frontmatter.py
+```
+
+Expected: all ~40 pages pass.
+
+- [ ] **Step 7: Run `mkdocs build --strict`**
+
+```bash
+mkdocs build --strict
+```
+
+Expected: build succeeds with no warnings.
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add wiki/docs/getting-started wiki/docs/players wiki/docs/admins wiki/docs/developers tools/wiki/lint_frontmatter.py
+git commit -m "docs(wiki): scaffold nav skeleton with stubbed front-matter pages"
+```
+
+---
+
+## Task 5: CI workflow for front-matter lint + (placeholder) parity check
+
+**Files:**
+- Create: `.github/workflows/wiki-checks.yml`
+
+The parity-check script is added in Task 11 (after `HelpTopics.kt` exists). For now, the workflow runs the front-matter lint only.
+
+- [ ] **Step 1: Create the workflow**
+
+```yaml
+name: Wiki Checks
+
+on:
+  pull_request:
+    paths:
+      - 'wiki/**'
+      - 'mkdocs.yml'
+      - 'tools/wiki/**'
+      - 'src/main/kotlin/net/lumalyte/lg/interaction/help/**'
+      - '.github/workflows/wiki-checks.yml'
+
+jobs:
+  frontmatter-lint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+      - run: pip install pyyaml
+      - run: python tools/wiki/lint_frontmatter.py
+
+  mkdocs-strict-build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+          cache: 'pip'
+          cache-dependency-path: wiki/requirements.txt
+      - run: pip install -r wiki/requirements.txt
+      - run: mkdocs build --strict
+```
+
+- [ ] **Step 2: Commit**
+
+```bash
+git add .github/workflows/wiki-checks.yml
+git commit -m "ci(wiki): run front-matter lint and strict MkDocs build on PRs"
+```
+
+---
+
+## Task 6: Write Getting Started — Welcome page
+
+**Files:**
+- Modify: `wiki/docs/getting-started/welcome.md`
+
+The audience for this page is a brand-new player who just joined EnthusiaSMP.
+
+- [ ] **Step 1: Replace the stub with full content**
+
+Required structure (preserve front-matter; replace body):
+
+```markdown
+---
+title: Welcome to EnthusiaSMP
+audience: player
+topic: welcome
+summary: Orientation for new players — what EnthusiaSMP is, what LumaGuilds adds, and where to go next.
+keywords: [welcome, new player, onboarding, enthusiasmp]
+related: [walkthrough, faq]
+updated: 2026-05-13
+---
+
+# Welcome to EnthusiaSMP
+
+This page orients you to the server and the guild system in about two minutes. When you're ready for the hands-on tour, head to **[Your first 30 minutes](walkthrough.md)**.
+
+## What is EnthusiaSMP?
+
+<!-- 2–3 sentence pitch: what kind of server (semi-anarchy SMP), the vibe, who runs it (FainNoir owns; BadgersMC dev). -->
+
+## What does LumaGuilds add?
+
+LumaGuilds is the guild plugin. It lets you:
+
+- Form a guild with friends and share a tag, banner, and identity.
+- Set named guild homes that any member (or specific ranks) can teleport to.
+- Form alliances, declare wars, sign truces.
+- Earn guild XP together as you play, unlocking perks and bigger member caps.
+- Run a shared vault.
+
+## What this wiki is for
+
+- **[Getting Started → Your first 30 minutes](walkthrough.md)** — guided tour.
+- **[Players](../players/how-do-i.md)** — every feature explained, organized by topic.
+- **[Admins](../admins/installation.md)** and **[Developers](../developers/architecture.md)** — if you run a server or work on the plugin.
+
+In-game, type `/g help` for the same content as a clickable menu.
+
+## What this wiki is *not*
+
+- Not a list of rules. Server rules live elsewhere (ask staff).
+- Not a release log. See [`CHANGELOG.md`](https://github.com/BadgersMC/LumaGuilds/blob/main/CHANGELOG.md) on GitHub.
+
+Ready? **[Start the 30-minute walkthrough →](walkthrough.md)**
+```
+
+The comment block `<!-- ... -->` is a placeholder for content you'll want a human to write — the server pitch. The plan ships with a TODO marker visible in the rendered page only via comment (so MkDocs strict mode still passes). Leave it for the maintainer to fill on first PR review pass; it's not blocking.
+
+- [ ] **Step 2: Run lint + build**
+
+```bash
+python tools/wiki/lint_frontmatter.py
+mkdocs build --strict
+```
+
+Expected: both pass.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add wiki/docs/getting-started/welcome.md
+git commit -m "docs(wiki): write Getting Started welcome page"
+```
+
+---
+
+## Task 7: Write Getting Started — Walkthrough (the 7-step tour)
+
+**Files:**
+- Modify: `wiki/docs/getting-started/walkthrough.md`
+
+This is the "first 30 minutes" page. Single page, seven H2 sections (each H2 is one step). Keep it scannable — short paragraphs, code blocks for commands, no walls of text.
+
+- [ ] **Step 1: Replace the stub with the full walkthrough**
+
+```markdown
+---
+title: Your first 30 minutes
+audience: player
+topic: walkthrough
+summary: A guided tour for new players — spawn to working guild in seven steps.
+keywords: [walkthrough, tutorial, onboarding, first time, getting started]
+related: [welcome, guilds, homes, chat]
+updated: 2026-05-13
+---
+
+# Your first 30 minutes
+
+A guided tour for new players. Follow it top-to-bottom and you'll end up in a working guild with a tag, a home, chat configured, and a clear next move.
+
+## 1. Spawn and orientation
+
+When you first join, you'll spawn at the world spawn. Look around. Note:
+
+- Chat is global by default. Anything you type goes to everyone.
+- You don't need a guild to play, but a lot of the social and PvE/PvP features run through guilds.
+- Type `/g help` any time to get a clickable in-game help menu.
+
+## 2. Joining or creating a guild
+
+You have three options:
+
+**Join an existing guild** — ask in chat, or browse leaderboards with `/g list`. If a guild is open, you can join directly. If it's invite-only, ask a member to `/g invite` you.
+
+**Create your own** — pick a name (plain text, max 32 chars, letters/numbers/spaces/`'`/`&`/`-`) and run:
+
+```
+/g create <name>
+```
+
+Example: `/g create White Lotus`
+
+**Hold off for now** — you don't have to. You can come back later.
+
+See [Players → Guilds](../players/guilds.md) for the full reference.
+
+## 3. Setting your tag and home
+
+Once you're in a guild, two things make it feel like home.
+
+**Tag** — fancy formatting that appears next to your name in chat. Use MiniMessage:
+
+```
+/g tag <gradient:#FF6A00:#FF1F00>Lotus</gradient>
+```
+
+Or run `/g tag` with no arguments to open a visual editor.
+
+**Home** — a teleport point your guild can share. Stand where you want it and run:
+
+```
+/g sethome
+```
+
+That sets the default home. You can have multiple — `/g sethome shop`, `/g sethome mine`. Teleport with `/g home` or `/g home <name>`. See [Players → Homes](../players/homes.md).
+
+## 4. Inviting a friend
+
+```
+/g invite <player>
+```
+
+They run `/g accept <yourguild>` (or click the chat prompt). Done.
+
+Need more control? You can lock invites to specific ranks, or set up "open" mode so anyone can join. See [Players → LFG & Invites](../players/lfg.md).
+
+## 5. Chat basics
+
+Two toggles you should know:
+
+- `/g chat` — flips your messages into guild chat. Type it again to switch back to global. Same word, same key, easy to remember.
+- `/g allychat` — same idea, but to all allied guilds.
+
+Tags and colors only appear in chat if the chat plugin renders them — they do on this server. See [Players → Chat](../players/chat.md) for the details.
+
+## 6. What XP and levels do
+
+Your guild earns XP from what its members do: mining, killing mobs, exploring. XP turns into levels. Levels unlock:
+
+- Bigger member caps.
+- More named home slots.
+- Access to advanced features (alliances, war declarations).
+- Bragging rights on the leaderboard.
+
+You don't have to micromanage it — just play. See [Players → Progression & Levels](../players/progression.md).
+
+## 7. Where to go next
+
+If you got this far you're functional. Pick one:
+
+- **Decorate your guild** — set a description (`/g desc`), pick a banner (`/g menu` → Banner).
+- **Make a friend or enemy** — `/g info <other guild>`, then `/g ally <them>` or `/g enemy <them>`. See [Players → Alliances & Diplomacy](../players/alliances.md).
+- **Read the [How do I…? index](../players/how-do-i.md)** — every common task with a deep link to the right page.
+
+That's the tour. The rest of the wiki is reference — come back as needed.
+```
+
+- [ ] **Step 2: Lint + build**
+
+```bash
+python tools/wiki/lint_frontmatter.py
+mkdocs build --strict
+```
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add wiki/docs/getting-started/walkthrough.md
+git commit -m "docs(wiki): write 7-step Getting Started walkthrough"
+```
+
+---
+
+## Task 8: Write Getting Started — FAQ
+
+**Files:**
+- Modify: `wiki/docs/getting-started/faq.md`
+
+Short FAQ. Each Q is an H2 (stable anchor — players link friends to specific entries).
+
+- [ ] **Step 1: Replace the stub**
+
+```markdown
+---
+title: FAQ
+audience: player
+topic: faq
+summary: Common questions from new players about LumaGuilds.
+keywords: [faq, common questions, help, troubleshooting]
+related: [walkthrough, chat, homes]
+updated: 2026-05-13
+---
+
+# FAQ
+
+## Do I have to be in a guild?
+
+No. You can play the entire server solo. Joining a guild just unlocks the guild-specific features (shared homes, alliance/war, guild chat, progression).
+
+## How do I leave my guild?
+
+`/g leave`. If you're the owner, you must transfer ownership first (`/g transfer <player>`) or disband (`/g disband`).
+
+## My guild tag isn't showing colors in chat
+
+The colors are stored as MiniMessage, which the chat plugin converts to display colors. If they're not rendering, you may be in a chat channel that doesn't format them. Try `/g chat` to switch to guild chat — colors render there.
+
+## Why does `/g home` say "teleport failed"?
+
+The destination is unsafe (lava/fire/cactus right where the home was set), or a protection plugin blocked the teleport. Move the home (`/g sethome` somewhere safe) and try again.
+
+## Can I have more than one home?
+
+Yes. `/g sethome <name>` creates additional named homes (`shop`, `mine`, etc.). The number of slots scales with your guild level. See [Players → Homes](../players/homes.md).
+
+## How do alliances work?
+
+`/g ally <other guild>` sends a request. They run `/g ally <you>` back to accept. Until both have done it, you're not actually allied. See [Players → Alliances & Diplomacy](../players/alliances.md).
+
+## I'm on Bedrock — does this all work?
+
+Mostly. A few menus open as chat-based forms instead of inventory GUIs, and clickable chat buttons map to taps. See [Players → Bedrock differences](../players/bedrock.md).
+
+## Where do I report a bug?
+
+Tell staff in-game or open an issue at <https://github.com/BadgersMC/LumaGuilds/issues>.
+```
+
+- [ ] **Step 2: Lint + build, commit**
+
+```bash
+python tools/wiki/lint_frontmatter.py
+mkdocs build --strict
+git add wiki/docs/getting-started/faq.md
+git commit -m "docs(wiki): write Getting Started FAQ"
+```
+
+---
+
+## Task 9: `HelpTopic` and `HelpCommandEntry` data classes (TDD)
+
+**Files:**
+- Create: `src/main/kotlin/net/lumalyte/lg/interaction/help/HelpCommandEntry.kt`
+- Create: `src/main/kotlin/net/lumalyte/lg/interaction/help/HelpTopic.kt`
+- Create: `src/test/kotlin/net/lumalyte/lg/interaction/help/HelpTopicTest.kt`
+
+- [ ] **Step 1: Write the failing test**
+
+`src/test/kotlin/net/lumalyte/lg/interaction/help/HelpTopicTest.kt`:
+
+```kotlin
+package net.lumalyte.lg.interaction.help
+
+import org.junit.jupiter.api.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
+import kotlin.test.assertTrue
+
+class HelpTopicTest {
+
+    @Test
+    fun `HelpCommandEntry stores syntax, blurb and prefill`() {
+        val entry = HelpCommandEntry(
+            syntax = "/g sethome [name]",
+            blurb = "Set a guild home at your current location.",
+            prefill = "/g sethome ",
+        )
+        assertEquals("/g sethome [name]", entry.syntax)
+        assertEquals("Set a guild home at your current location.", entry.blurb)
+        assertEquals("/g sethome ", entry.prefill)
+    }
+
+    @Test
+    fun `HelpTopic exposes slug, display name, summary, commands`() {
+        val topic = HelpTopic(
+            slug = "homes",
+            displayName = "Homes",
+            summary = "Set and visit guild homes.",
+            commands = listOf(
+                HelpCommandEntry("/g sethome [name]", "Set a home.", "/g sethome "),
+                HelpCommandEntry("/g home [name]", "Visit a home.", "/g home "),
+            ),
+        )
+        assertEquals("homes", topic.slug)
+        assertEquals("Homes", topic.displayName)
+        assertEquals(2, topic.commands.size)
+    }
+
+    @Test
+    fun `HelpTopic rejects an invalid slug`() {
+        val ex = assertFailsWith<IllegalArgumentException> {
+            HelpTopic(
+                slug = "Bad Slug!",
+                displayName = "Bad",
+                summary = "x",
+                commands = emptyList(),
+            )
+        }
+        assertTrue("slug" in ex.message!!.lowercase())
+    }
+
+    @Test
+    fun `HelpTopic rejects an empty display name`() {
+        assertFailsWith<IllegalArgumentException> {
+            HelpTopic(slug = "x", displayName = "", summary = "y", commands = emptyList())
+        }
+    }
+}
+```
+
+- [ ] **Step 2: Run test — expect compile failure**
+
+```bash
+./gradlew test --tests "net.lumalyte.lg.interaction.help.HelpTopicTest"
+```
+
+Expected: compile error — classes don't exist yet.
+
+- [ ] **Step 3: Create `HelpCommandEntry.kt`**
+
+```kotlin
+package net.lumalyte.lg.interaction.help
+
+/**
+ * One command line in a [HelpTopic]'s command list, shown both in-game and
+ * (via the parity check) referenced by the corresponding wiki page.
+ */
+data class HelpCommandEntry(
+    val syntax: String,
+    val blurb: String,
+    val prefill: String,
+)
+```
+
+- [ ] **Step 4: Create `HelpTopic.kt`**
+
+```kotlin
+package net.lumalyte.lg.interaction.help
+
+/**
+ * A help topic surfaced by `/g help` and mirrored to a wiki page under
+ * `wiki/docs/players/<slug>.md`. The [slug] is the stable identifier and
+ * must match the wiki page's `topic:` front-matter field.
+ */
+data class HelpTopic(
+    val slug: String,
+    val displayName: String,
+    val summary: String,
+    val commands: List<HelpCommandEntry>,
+) {
+    init {
+        require(SLUG_REGEX.matches(slug)) { "Invalid slug: $slug (must be lowercase-hyphenated)" }
+        require(displayName.isNotBlank()) { "displayName must not be blank" }
+        require(summary.isNotBlank()) { "summary must not be blank" }
+    }
+
+    companion object {
+        private val SLUG_REGEX = Regex("^[a-z0-9]+(-[a-z0-9]+)*$")
+    }
+}
+```
+
+- [ ] **Step 5: Run test — expect pass**
+
+```bash
+./gradlew test --tests "net.lumalyte.lg.interaction.help.HelpTopicTest"
+```
+
+Expected: PASS.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/main/kotlin/net/lumalyte/lg/interaction/help/HelpCommandEntry.kt \
+        src/main/kotlin/net/lumalyte/lg/interaction/help/HelpTopic.kt \
+        src/test/kotlin/net/lumalyte/lg/interaction/help/HelpTopicTest.kt
+git commit -m "feat(help): add HelpTopic and HelpCommandEntry data classes"
+```
+
+---
+
+## Task 10: `HelpTopics` registry (TDD)
+
+**Files:**
+- Create: `src/main/kotlin/net/lumalyte/lg/interaction/help/HelpTopics.kt`
+- Create: `src/test/kotlin/net/lumalyte/lg/interaction/help/HelpTopicsTest.kt`
+
+This is the source of truth. Every player-facing topic appears here exactly once. CI will cross-check against `wiki/docs/players/<slug>.md`.
+
+- [ ] **Step 1: Write the failing test**
+
+```kotlin
+package net.lumalyte.lg.interaction.help
+
+import org.junit.jupiter.api.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNotNull
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+
+class HelpTopicsTest {
+
+    @Test
+    fun `all 13 player topics are registered`() {
+        val expected = setOf(
+            "guilds", "ranks", "homes", "alliances", "war",
+            "chat", "identity", "progression", "vault", "mode",
+            "shop", "lfg", "bedrock",
+        )
+        assertEquals(expected, HelpTopics.all.map { it.slug }.toSet())
+    }
+
+    @Test
+    fun `topics are returned in display order`() {
+        val firstFour = HelpTopics.all.take(4).map { it.slug }
+        assertEquals(listOf("guilds", "homes", "ranks", "chat"), firstFour)
+    }
+
+    @Test
+    fun `bySlug returns the matching topic`() {
+        val homes = HelpTopics.bySlug("homes")
+        assertNotNull(homes)
+        assertEquals("Homes", homes.displayName)
+    }
+
+    @Test
+    fun `bySlug is case-insensitive`() {
+        assertNotNull(HelpTopics.bySlug("HOMES"))
+        assertNotNull(HelpTopics.bySlug("Homes"))
+    }
+
+    @Test
+    fun `bySlug returns null for unknown slug`() {
+        assertNull(HelpTopics.bySlug("nonexistent"))
+    }
+
+    @Test
+    fun `every topic has at least one command`() {
+        HelpTopics.all.forEach { topic ->
+            assertTrue(topic.commands.isNotEmpty(), "Topic ${topic.slug} has no commands")
+        }
+    }
+
+    @Test
+    fun `every topic summary fits the 140-char wiki front-matter limit`() {
+        HelpTopics.all.forEach { topic ->
+            assertTrue(
+                topic.summary.length <= 140,
+                "Topic ${topic.slug} summary is ${topic.summary.length} chars",
+            )
+        }
+    }
+}
+```
+
+- [ ] **Step 2: Run test — expect failure (HelpTopics doesn't exist)**
+
+```bash
+./gradlew test --tests "net.lumalyte.lg.interaction.help.HelpTopicsTest"
+```
+
+Expected: compile error.
+
+- [ ] **Step 3: Create `HelpTopics.kt`**
+
+Ordering note: the in-game menu order is **Guilds, Homes, Ranks, Chat, Alliances, War, Progression, Vault, Identity, Mode, Shop, LFG, Bedrock**. Homes deliberately sits second because it's one of the most-asked-about topics.
+
+```kotlin
+package net.lumalyte.lg.interaction.help
+
+/**
+ * Source of truth for player-facing help topics.
+ *
+ * Every entry has a matching wiki page at `wiki/docs/players/<slug>.md`.
+ * CI fails the build if any slug here lacks a wiki page, or vice versa.
+ */
+object HelpTopics {
+
+    /** Base URL for wiki deep-links surfaced in the in-game help. */
+    const val WIKI_BASE_URL = "https://badgersmc.github.io/LumaGuilds/players"
+
+    val all: List<HelpTopic> = listOf(
+        HelpTopic(
+            slug = "guilds",
+            displayName = "Guilds",
+            summary = "Create, join, leave, transfer, and disband guilds.",
+            commands = listOf(
+                HelpCommandEntry("/g create <name>", "Create a new guild.", "/g create "),
+                HelpCommandEntry("/g join <guild>", "Request to join a guild.", "/g join "),
+                HelpCommandEntry("/g leave", "Leave your current guild.", "/g leave"),
+                HelpCommandEntry("/g disband", "Disband your guild (owner only).", "/g disband"),
+                HelpCommandEntry("/g transfer <player>", "Transfer ownership.", "/g transfer "),
+                HelpCommandEntry("/g info [guild]", "View guild information.", "/g info "),
+                HelpCommandEntry("/g list", "Browse all guilds.", "/g list"),
+            ),
+        ),
+        HelpTopic(
+            slug = "homes",
+            displayName = "Homes",
+            summary = "Set, name, visit, and restrict access to guild homes.",
+            commands = listOf(
+                HelpCommandEntry("/g sethome [name]", "Set a home at your current location.", "/g sethome "),
+                HelpCommandEntry("/g home [name]", "Teleport to a guild home.", "/g home "),
+                HelpCommandEntry("/g homes", "List your guild's homes.", "/g homes"),
+                HelpCommandEntry("/g removehome <name>", "Remove a named home.", "/g removehome "),
+                HelpCommandEntry("/g setallyhome", "Set your guild's ally-home.", "/g setallyhome"),
+                HelpCommandEntry("/g removeallyhome", "Remove your guild's ally-home.", "/g removeallyhome"),
+            ),
+        ),
+        HelpTopic(
+            slug = "ranks",
+            displayName = "Ranks & Permissions",
+            summary = "Create ranks, set permissions, and manage member rank assignments.",
+            commands = listOf(
+                HelpCommandEntry("/g ranks", "Open the rank management menu.", "/g ranks"),
+                HelpCommandEntry("/g menu", "Open the guild control panel.", "/g menu"),
+            ),
+        ),
+        HelpTopic(
+            slug = "chat",
+            displayName = "Chat",
+            summary = "Toggle guild and ally chat, and customize how your tag appears in messages.",
+            commands = listOf(
+                HelpCommandEntry("/g chat", "Toggle guild chat on/off.", "/g chat"),
+                HelpCommandEntry("/g allychat", "Toggle ally chat on/off.", "/g allychat"),
+            ),
+        ),
+        HelpTopic(
+            slug = "alliances",
+            displayName = "Alliances & Diplomacy",
+            summary = "Form alliances, declare enemies, sign truces, and manage ally-home access.",
+            commands = listOf(
+                HelpCommandEntry("/g ally <guild>", "Request or accept an alliance.", "/g ally "),
+                HelpCommandEntry("/g enemy <guild>", "Mark a guild as enemy.", "/g enemy "),
+                HelpCommandEntry("/g truce <guild>", "Sign a truce.", "/g truce "),
+                HelpCommandEntry("/g neutral <guild>", "Clear a relation.", "/g neutral "),
+            ),
+        ),
+        HelpTopic(
+            slug = "war",
+            displayName = "War",
+            summary = "Declare and fight wars between guilds.",
+            commands = listOf(
+                HelpCommandEntry("/g war <guild>", "Open the war control flow.", "/g war "),
+            ),
+        ),
+        HelpTopic(
+            slug = "progression",
+            displayName = "Progression & Levels",
+            summary = "Earn guild XP from member activity, level up, and unlock perks.",
+            commands = listOf(
+                HelpCommandEntry("/g info", "See your guild's level and XP.", "/g info"),
+            ),
+        ),
+        HelpTopic(
+            slug = "vault",
+            displayName = "Vault",
+            summary = "Use the shared guild vault for storing items.",
+            commands = listOf(
+                HelpCommandEntry("/g vault", "Open the guild vault.", "/g vault"),
+                HelpCommandEntry("/g getvault", "Get a vault chest item.", "/g getvault"),
+            ),
+        ),
+        HelpTopic(
+            slug = "identity",
+            displayName = "Tags, Banners & Identity",
+            summary = "Set your guild's tag, description, and banner.",
+            commands = listOf(
+                HelpCommandEntry("/g tag [text]", "Set or edit your guild tag.", "/g tag "),
+                HelpCommandEntry("/g desc <text>", "Set your guild description.", "/g desc "),
+                HelpCommandEntry("/g rename <name>", "Rename your guild.", "/g rename "),
+                HelpCommandEntry("/g emoji", "Pick a guild emoji.", "/g emoji"),
+            ),
+        ),
+        HelpTopic(
+            slug = "mode",
+            displayName = "Mode (Peaceful / Hostile)",
+            summary = "Switch your guild between peaceful and hostile mode.",
+            commands = listOf(
+                HelpCommandEntry("/g mode", "Open the mode selection menu.", "/g mode"),
+            ),
+        ),
+        HelpTopic(
+            slug = "shop",
+            displayName = "Shop integration",
+            summary = "Link guild-owned shops.",
+            commands = listOf(
+                HelpCommandEntry("/g setshop", "Mark your current shop as guild-owned.", "/g setshop"),
+            ),
+        ),
+        HelpTopic(
+            slug = "lfg",
+            displayName = "LFG & Invites",
+            summary = "Manage invites, decline requests, and use LFG to find a guild.",
+            commands = listOf(
+                HelpCommandEntry("/g invite <player>", "Invite a player to your guild.", "/g invite "),
+                HelpCommandEntry("/g invites", "List your pending invites.", "/g invites"),
+                HelpCommandEntry("/g decline <guild>", "Decline an invite.", "/g decline "),
+                HelpCommandEntry("/g lfg", "Toggle LFG (looking-for-guild).", "/g lfg"),
+                HelpCommandEntry("/g kick <player>", "Kick a member from your guild.", "/g kick "),
+            ),
+        ),
+        HelpTopic(
+            slug = "bedrock",
+            displayName = "Bedrock differences",
+            summary = "Where LumaGuilds behaves differently on Bedrock/Geyser.",
+            commands = emptyList<HelpCommandEntry>().let {
+                listOf(
+                    HelpCommandEntry(
+                        syntax = "(see wiki)",
+                        blurb = "Bedrock menus open as forms; clickable chat maps to taps.",
+                        prefill = "",
+                    ),
+                )
+            },
+        ),
+    )
+
+    private val bySlugMap: Map<String, HelpTopic> = all.associateBy { it.slug }
+
+    fun bySlug(slug: String): HelpTopic? = bySlugMap[slug.lowercase()]
+}
+```
+
+- [ ] **Step 4: Run test — expect failures on ordering**
+
+```bash
+./gradlew test --tests "net.lumalyte.lg.interaction.help.HelpTopicsTest"
+```
+
+Expected: passes. If the ordering test fails, the first-four order must be `guilds, homes, ranks, chat` — that's the order in `all` above.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/main/kotlin/net/lumalyte/lg/interaction/help/HelpTopics.kt \
+        src/test/kotlin/net/lumalyte/lg/interaction/help/HelpTopicsTest.kt
+git commit -m "feat(help): add HelpTopics registry (source of truth for help + wiki)"
+```
+
+---
+
+## Task 11: Topic-parity CI check
+
+**Files:**
+- Create: `tools/wiki/check_topic_parity.py`
+- Modify: `.github/workflows/wiki-checks.yml`
+
+The script reads `HelpTopics.kt`, extracts each `slug = "..."` literal, and asserts each has a matching `wiki/docs/players/<slug>.md` (and vice versa).
+
+- [ ] **Step 1: Create `tools/wiki/check_topic_parity.py`**
+
+```python
+#!/usr/bin/env python3
+"""Verify every HelpTopics.kt slug has a matching wiki/docs/players/<slug>.md
+(and every wiki/docs/players/<slug>.md other than `how-do-i.md` has a topic
+entry in HelpTopics.kt).
+
+Exit code 1 on mismatch; prints all mismatches before exiting.
+"""
+
+from __future__ import annotations
+
+import re
+import sys
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+HELP_TOPICS_KT = REPO_ROOT / "src/main/kotlin/net/lumalyte/lg/interaction/help/HelpTopics.kt"
+PLAYERS_DIR = REPO_ROOT / "wiki/docs/players"
+
+# Pages that exist in wiki/docs/players/ but intentionally have no HelpTopics entry:
+WIKI_ONLY = {"how-do-i"}
+
+SLUG_RE = re.compile(r'slug\s*=\s*"([a-z0-9][a-z0-9-]*)"')
+
+
+def kotlin_slugs() -> set[str]:
+    src = HELP_TOPICS_KT.read_text(encoding="utf-8")
+    return set(SLUG_RE.findall(src))
+
+
+def wiki_slugs() -> set[str]:
+    return {p.stem for p in PLAYERS_DIR.glob("*.md")} - WIKI_ONLY
+
+
+def main() -> int:
+    kt = kotlin_slugs()
+    wiki = wiki_slugs()
+
+    missing_wiki = sorted(kt - wiki)
+    missing_kt = sorted(wiki - kt)
+
+    if missing_wiki:
+        print("Slugs in HelpTopics.kt missing a wiki page in wiki/docs/players/:", file=sys.stderr)
+        for s in missing_wiki:
+            print(f"  - {s} (expected wiki/docs/players/{s}.md)", file=sys.stderr)
+
+    if missing_kt:
+        print("Wiki pages in wiki/docs/players/ missing a HelpTopics entry:", file=sys.stderr)
+        for s in missing_kt:
+            print(f"  - {s} (add to HelpTopics.all or to WIKI_ONLY in this script)", file=sys.stderr)
+
+    if missing_wiki or missing_kt:
+        print(
+            "\nFix: add the missing page OR add the missing HelpTopics entry. "
+            "See CONTRIBUTING.md → 'Keeping /g help and the wiki in sync'.",
+            file=sys.stderr,
+        )
+        return 1
+
+    print(f"OK — {len(kt)} topics in parity with wiki.")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())
+```
+
+- [ ] **Step 2: Run locally**
+
+```bash
+python tools/wiki/check_topic_parity.py
+```
+
+Expected: `OK — 13 topics in parity with wiki.` (all 13 stub pages exist from Task 4; all 13 are registered from Task 10).
+
+- [ ] **Step 3: Negative test**
+
+Temporarily comment out the `homes` entry in `HelpTopics.kt`. Re-run the script. Expected: exit 1, prints `homes` under "Wiki pages missing a HelpTopics entry". Restore.
+
+- [ ] **Step 4: Add the check to `.github/workflows/wiki-checks.yml`**
+
+Add a new job to the existing workflow:
+
+```yaml
+  topic-parity:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+      - run: python tools/wiki/check_topic_parity.py
+```
+
+Also expand the workflow's `paths:` filter to trigger when `HelpTopics.kt` changes — already covered by `src/main/kotlin/net/lumalyte/lg/interaction/help/**` in Task 5.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add tools/wiki/check_topic_parity.py .github/workflows/wiki-checks.yml
+git commit -m "ci(wiki): enforce HelpTopics.kt <-> wiki/docs/players/ slug parity"
+```
+
+---
+
+## Task 12: `HelpTopicsRenderer` — topic menu (TDD)
+
+**Files:**
+- Create: `src/main/kotlin/net/lumalyte/lg/interaction/help/HelpTopicsRenderer.kt`
+- Create: `src/test/kotlin/net/lumalyte/lg/interaction/help/HelpTopicsRendererTest.kt`
+
+The renderer builds Adventure `Component`s. Tests assert structural properties (children count, click event present, command suggestion is correct) using `Component.children()`.
+
+- [ ] **Step 1: Write the failing test for the topic-menu render**
+
+```kotlin
+package net.lumalyte.lg.interaction.help
+
+import net.kyori.adventure.text.Component
+import net.kyori.adventure.text.event.ClickEvent
+import org.junit.jupiter.api.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNotNull
+import kotlin.test.assertTrue
+
+class HelpTopicsRendererTest {
+
+    private val renderer = HelpTopicsRenderer
+
+    @Test
+    fun `topic menu renders a non-empty component`() {
+        val component = renderer.renderTopicMenu()
+        assertTrue(component != Component.empty())
+    }
+
+    @Test
+    fun `topic menu lists every topic in HelpTopics`() {
+        val rendered = renderer.renderTopicMenu().toPlainText()
+        HelpTopics.all.forEach { topic ->
+            assertTrue(
+                topic.displayName in rendered,
+                "Topic menu is missing display name '${topic.displayName}'",
+            )
+        }
+    }
+
+    @Test
+    fun `each topic entry has a click event running the help command`() {
+        val rendered = renderer.renderTopicMenu()
+        HelpTopics.all.forEach { topic ->
+            val match = rendered.findRunCommandClick("/g help ${topic.slug}")
+            assertNotNull(match, "No RUN_COMMAND click for /g help ${topic.slug}")
+        }
+    }
+
+    @Test
+    fun `topic menu includes a wiki link at the bottom`() {
+        val rendered = renderer.renderTopicMenu().toPlainText()
+        assertTrue(HelpTopics.WIKI_BASE_URL in rendered)
+    }
+}
+
+private fun Component.toPlainText(): String =
+    net.kyori.adventure.text.serializer.plain.PlainTextComponentSerializer.plainText().serialize(this)
+
+private fun Component.allComponents(): List<Component> =
+    listOf(this) + children().flatMap { it.allComponents() }
+
+private fun Component.findRunCommandClick(command: String): Component? =
+    allComponents().firstOrNull {
+        val ce = it.clickEvent()
+        ce?.action() == ClickEvent.Action.RUN_COMMAND && ce.value() == command
+    }
+
+private fun Component.findSuggestCommandClick(value: String): Component? =
+    allComponents().firstOrNull {
+        val ce = it.clickEvent()
+        ce?.action() == ClickEvent.Action.SUGGEST_COMMAND && ce.value() == value
+    }
+```
+
+- [ ] **Step 2: Run test — expect compile failure**
+
+```bash
+./gradlew test --tests "net.lumalyte.lg.interaction.help.HelpTopicsRendererTest"
+```
+
+Expected: compile error.
+
+- [ ] **Step 3: Create `HelpTopicsRenderer.kt`**
+
+```kotlin
+package net.lumalyte.lg.interaction.help
+
+import net.kyori.adventure.text.Component
+import net.kyori.adventure.text.event.ClickEvent
+import net.kyori.adventure.text.event.HoverEvent
+import net.kyori.adventure.text.format.NamedTextColor
+import net.kyori.adventure.text.format.TextDecoration
+
+/**
+ * Builds Adventure components for the in-game `/g help` UI.
+ *
+ * Two public surfaces:
+ *  - [renderTopicMenu] — the top-level topic picker (no argument).
+ *  - [renderTopicPage] — one topic's command list (`/g help <topic>`).
+ *
+ * All click events use `RUN_COMMAND` (for topic switches) or
+ * `SUGGEST_COMMAND` (for command prefill) so Geyser maps them to taps.
+ */
+object HelpTopicsRenderer {
+
+    private const val ACCENT = "§6"
+    private const val DIM = "§7"
+    private const val HIGHLIGHT = "§e"
+
+    fun renderTopicMenu(): Component {
+        val header = Component.text("─── LumaGuilds Help ───", NamedTextColor.GOLD, TextDecoration.BOLD)
+        val intro = Component.text("Pick a topic (click or type /g help <topic>):", NamedTextColor.GRAY)
+
+        val entries = HelpTopics.all.map { topic ->
+            Component.text()
+                .append(Component.text("  [", NamedTextColor.DARK_GRAY))
+                .append(Component.text(topic.displayName, NamedTextColor.YELLOW))
+                .append(Component.text("] ", NamedTextColor.DARK_GRAY))
+                .append(Component.text(topic.summary, NamedTextColor.GRAY))
+                .clickEvent(ClickEvent.runCommand("/g help ${topic.slug}"))
+                .hoverEvent(HoverEvent.showText(Component.text("Open ${topic.displayName} help", NamedTextColor.GOLD)))
+                .build()
+        }
+
+        val wikiLink = Component.text()
+            .append(Component.text("Full wiki: ", NamedTextColor.GRAY))
+            .append(
+                Component.text(HelpTopics.WIKI_BASE_URL, NamedTextColor.AQUA, TextDecoration.UNDERLINED)
+                    .clickEvent(ClickEvent.openUrl(HelpTopics.WIKI_BASE_URL))
+                    .hoverEvent(HoverEvent.showText(Component.text("Open in browser", NamedTextColor.GOLD))),
+            )
+            .build()
+
+        val out = Component.text()
+            .append(header).append(Component.newline())
+            .append(intro).append(Component.newline())
+        entries.forEach { out.append(it).append(Component.newline()) }
+        out.append(wikiLink)
+        return out.build()
+    }
+
+    fun renderTopicPage(topic: HelpTopic): Component {
+        val header = Component.text("─── Help · ${topic.displayName} ───", NamedTextColor.GOLD, TextDecoration.BOLD)
+        val summary = Component.text(topic.summary, NamedTextColor.GRAY)
+
+        val commandLines = topic.commands.map { entry ->
+            val line = Component.text()
+                .append(Component.text("  ", NamedTextColor.DARK_GRAY))
+                .append(Component.text(entry.syntax, NamedTextColor.WHITE))
+            if (entry.prefill.isNotEmpty()) {
+                line.clickEvent(ClickEvent.suggestCommand(entry.prefill))
+                    .hoverEvent(
+                        HoverEvent.showText(
+                            Component.text()
+                                .append(Component.text(entry.blurb, NamedTextColor.GOLD))
+                                .append(Component.newline())
+                                .append(Component.text("Click to prefill in chat", NamedTextColor.GRAY))
+                                .build(),
+                        ),
+                    )
+            } else {
+                line.hoverEvent(HoverEvent.showText(Component.text(entry.blurb, NamedTextColor.GOLD)))
+            }
+            line.build()
+        }
+
+        val wikiUrl = "${HelpTopics.WIKI_BASE_URL}/${topic.slug}/"
+        val wikiLine = Component.text()
+            .append(Component.text("Read more: ", NamedTextColor.GRAY))
+            .append(
+                Component.text(wikiUrl, NamedTextColor.AQUA, TextDecoration.UNDERLINED)
+                    .clickEvent(ClickEvent.openUrl(wikiUrl))
+                    .hoverEvent(HoverEvent.showText(Component.text("Open in browser", NamedTextColor.GOLD))),
+            )
+            .build()
+
+        val back = Component.text("[Back to topics]", NamedTextColor.YELLOW)
+            .clickEvent(ClickEvent.runCommand("/g help"))
+            .hoverEvent(HoverEvent.showText(Component.text("Open the topic menu", NamedTextColor.GOLD)))
+
+        val out = Component.text()
+            .append(header).append(Component.newline())
+            .append(summary).append(Component.newline())
+            .append(Component.text("Commands:", NamedTextColor.YELLOW)).append(Component.newline())
+        commandLines.forEach { out.append(it).append(Component.newline()) }
+        out.append(Component.newline())
+            .append(wikiLine).append(Component.newline())
+            .append(back)
+        return out.build()
+    }
+}
+```
+
+- [ ] **Step 4: Run test — expect pass**
+
+```bash
+./gradlew test --tests "net.lumalyte.lg.interaction.help.HelpTopicsRendererTest"
+```
+
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/main/kotlin/net/lumalyte/lg/interaction/help/HelpTopicsRenderer.kt \
+        src/test/kotlin/net/lumalyte/lg/interaction/help/HelpTopicsRendererTest.kt
+git commit -m "feat(help): render topic menu via Adventure components"
+```
+
+---
+
+## Task 13: Renderer tests for topic-page output
+
+**Files:**
+- Modify: `src/test/kotlin/net/lumalyte/lg/interaction/help/HelpTopicsRendererTest.kt`
+
+- [ ] **Step 1: Add tests for `renderTopicPage`**
+
+Append to the existing test class (above the private extension functions at the bottom of the file):
+
+```kotlin
+    @Test
+    fun `topic page header includes the topic display name`() {
+        val homes = HelpTopics.bySlug("homes")!!
+        val rendered = renderer.renderTopicPage(homes).toPlainText()
+        assertTrue("Help · Homes" in rendered)
+    }
+
+    @Test
+    fun `topic page lists every command syntax for that topic`() {
+        val homes = HelpTopics.bySlug("homes")!!
+        val rendered = renderer.renderTopicPage(homes).toPlainText()
+        homes.commands.forEach { entry ->
+            assertTrue(entry.syntax in rendered, "Missing syntax '${entry.syntax}'")
+        }
+    }
+
+    @Test
+    fun `command entries with a prefill use SUGGEST_COMMAND click`() {
+        val homes = HelpTopics.bySlug("homes")!!
+        val rendered = renderer.renderTopicPage(homes)
+        val sethomeClick = rendered.findSuggestCommandClick("/g sethome ")
+        assertNotNull(sethomeClick, "No SUGGEST_COMMAND click prefilling '/g sethome '")
+    }
+
+    @Test
+    fun `topic page includes deep link to matching wiki URL`() {
+        val homes = HelpTopics.bySlug("homes")!!
+        val rendered = renderer.renderTopicPage(homes).toPlainText()
+        assertTrue("${HelpTopics.WIKI_BASE_URL}/homes/" in rendered)
+    }
+
+    @Test
+    fun `topic page has a Back to topics action`() {
+        val homes = HelpTopics.bySlug("homes")!!
+        val rendered = renderer.renderTopicPage(homes)
+        val back = rendered.findRunCommandClick("/g help")
+        assertNotNull(back, "No RUN_COMMAND click for '/g help' (Back action)")
+    }
+```
+
+- [ ] **Step 2: Run — expect pass**
+
+```bash
+./gradlew test --tests "net.lumalyte.lg.interaction.help.HelpTopicsRendererTest"
+```
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add src/test/kotlin/net/lumalyte/lg/interaction/help/HelpTopicsRendererTest.kt
+git commit -m "test(help): verify topic-page rendering (click events, wiki link, back action)"
+```
+
+---
+
+## Task 14: Refactor `GuildCommand.onHelp` to delegate to the renderer
+
+**Files:**
+- Modify: `src/main/kotlin/net/lumalyte/lg/interaction/commands/GuildCommand.kt` (lines 1905–1967)
+
+- [ ] **Step 1: Replace the existing `onHelp` body**
+
+Locate the method at line 1905. Replace from the `@Subcommand("help")` annotation through the closing `}` of the function (lines 1905–1967 inclusive) with:
+
+```kotlin
+    @Subcommand("help")
+    @CommandPermission("lumaguilds.guild.help")
+    fun onHelp(player: Player, @Optional topic: String?) {
+        val renderer = HelpTopicsRenderer
+        if (topic.isNullOrBlank()) {
+            player.sendMessage(renderer.renderTopicMenu())
+            return
+        }
+        val found = HelpTopics.bySlug(topic)
+        if (found == null) {
+            player.sendMessage(
+                Component.text()
+                    .append(Component.text("Unknown help topic '", NamedTextColor.RED))
+                    .append(Component.text(topic, NamedTextColor.YELLOW))
+                    .append(Component.text("'. Type ", NamedTextColor.RED))
+                    .append(
+                        Component.text("/g help", NamedTextColor.YELLOW)
+                            .clickEvent(ClickEvent.runCommand("/g help")),
+                    )
+                    .append(Component.text(" to see all topics.", NamedTextColor.RED))
+                    .build(),
+            )
+            return
+        }
+        player.sendMessage(renderer.renderTopicPage(found))
+    }
+```
+
+- [ ] **Step 2: Add the imports near the top of the file**
+
+In the import block at the top of `GuildCommand.kt`, add (alphabetically placed):
+
+```kotlin
+import net.kyori.adventure.text.Component
+import net.kyori.adventure.text.event.ClickEvent
+import net.kyori.adventure.text.format.NamedTextColor
+import net.lumalyte.lg.interaction.help.HelpTopics
+import net.lumalyte.lg.interaction.help.HelpTopicsRenderer
+```
+
+Skip any that are already imported.
+
+- [ ] **Step 3: Build to verify**
+
+```bash
+./gradlew build -x test
+```
+
+Expected: success.
+
+- [ ] **Step 4: Run all tests**
+
+```bash
+./gradlew test
+```
+
+Expected: all pass, including the new HelpTopics tests.
+
+- [ ] **Step 5: Manual smoke test (optional but recommended)**
+
+Build the shadow jar (`./gradlew shadowJar`), drop into a local Paper test server, type `/g help`, then `/g help homes`, then click around. Confirm the topic menu renders, topic page renders, click-prefill works, wiki link is present.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/main/kotlin/net/lumalyte/lg/interaction/commands/GuildCommand.kt
+git commit -m "refactor(help): /g help renders from HelpTopicsRenderer (clickable, topic-based)"
+```
+
+---
+
+## Task 15: Write Players — Guilds page
+
+**Files:**
+- Modify: `wiki/docs/players/guilds.md`
+
+Use the page template from "Conventions" above. Content checklist:
+
+- One-sentence summary repeats `summary:`.
+- Quick reference table covers: `/g create`, `/g join`, `/g leave`, `/g disband`, `/g transfer`, `/g info`, `/g list`. Permission column = the `@CommandPermission` string from `GuildCommand.kt`.
+- "How it works" paragraph: a guild is a named group with a tag, members, ranks, homes, a vault, and relations to other guilds. One owner, transferable. Levels via XP.
+- H2 "Creating a guild" — name rules (max 32, letters/numbers/spaces/`'`/`&`/`-`, no formatting tags), example.
+- H2 "Joining a guild" — invitation flow, open vs invite-only.
+- H2 "Leaving and transferring" — owner can't leave without transfer or disband.
+- H2 "Browsing guilds" — `/g list`, `/g info <name>`.
+- H2 "Gotchas" — one-guild-at-a-time, can't rejoin during a war cooldown, etc.
+- "Related" links to: ranks, homes, alliances.
+
+- [ ] **Step 1: Write the page**
+
+Use the template. Example skeleton (fill in narrative text):
+
+```markdown
+---
+title: Guilds
+audience: player
+topic: guilds
+summary: How to create, join, leave, transfer, and disband guilds.
+keywords: [guilds, create, join, leave, disband, transfer]
+related: [ranks, homes, alliances]
+updated: 2026-05-13
+---
+
+# Guilds
+
+How to create, join, leave, transfer, and disband guilds.
+
+## Quick reference
+
+| Command | Permission | Description |
+|---------|------------|-------------|
+| `/g create <name>` | `lumaguilds.guild.create` | Create a new guild. |
+| `/g join <guild>` | `lumaguilds.guild.join` | Request to join. |
+| `/g leave` | `lumaguilds.guild.leave` | Leave your guild. |
+| `/g disband` | `lumaguilds.guild.disband` | Disband (owner only). |
+| `/g transfer <player>` | `lumaguilds.guild.transfer` | Transfer ownership. |
+| `/g info [guild]` | `lumaguilds.guild.info` | View guild info. |
+| `/g list` | `lumaguilds.guild.list` | Browse all guilds. |
+
+## How it works
+
+[Narrative — one paragraph. What a guild is, single ownership, members & ranks, relation to homes/vault/war.]
+
+## Creating a guild
+
+[Step-by-step with examples.]
+
+## Joining a guild
+
+[Open vs invite-only, the `/g join` flow.]
+
+## Leaving, transferring, and disbanding
+
+[Owner constraints, transfer flow.]
+
+## Browsing guilds
+
+[`/g list` and `/g info` usage.]
+
+## Gotchas
+
+- You can only be in one guild at a time.
+- Disbanding is irreversible.
+- [More — check the actual GuildCommand.kt behavior for surprises worth surfacing.]
+
+## Related
+
+- [Ranks & Permissions](ranks.md)
+- [Homes](homes.md)
+- [Alliances & Diplomacy](alliances.md)
+```
+
+Source-of-truth check: cross-reference `GuildCommand.kt` lines 61 (`@Subcommand("create")`), 988 (`join`), 1269 (`leave`), 867 (`disband`), 1352 (`transfer`), 837 (`info`), 1103 (`list`) for exact behaviors and permissions.
+
+- [ ] **Step 2: Lint, build, commit**
+
+```bash
+python tools/wiki/lint_frontmatter.py
+mkdocs build --strict
+git add wiki/docs/players/guilds.md
+git commit -m "docs(wiki): write Players/Guilds page"
+```
+
+---
+
+## Tasks 16–27: Write the remaining 12 Players feature pages
+
+Each task follows the same shape as Task 15: a single Players feature page using the template, with content sourced from the corresponding `@Subcommand` blocks in `GuildCommand.kt` and the existing top-level `.md` files where relevant. One task per page. Each task's "Step 1: Write the page" provides the front-matter (already in the stub) plus a content checklist; "Step 2" is lint + build + commit.
+
+For each, the content checklist:
+
+1. Replace stub body with template-shaped content.
+2. Pull commands/permissions from `GuildCommand.kt` lines listed below.
+3. List "Common tasks" as H2s — each is a player-recognizable verb ("Setting a named home", "Restricting a home to a rank").
+4. Include gotchas from real recent bug fixes (see CHANGELOG.md for material — e.g. "/g home from the nether used to fail silently, now uses async teleport").
+5. "Related" links to sibling pages.
+6. Lint + `mkdocs build --strict` must pass.
+7. Commit with `docs(wiki): write Players/<topic> page`.
+
+### Task 16: Homes page
+
+- **File:** `wiki/docs/players/homes.md`
+- **GuildCommand.kt refs:** lines 209 (sethome), 302 (home), 402 (homes), 440 (removehome), 470 (setallyhome), 499 (removeallyhome)
+- **Common tasks (H2s):** Setting your default home, Adding a named home, Visiting a home, Removing a home, Setting up your ally-home, Restricting a home to specific ranks
+- **Gotchas to include:** Nether ↔ overworld teleport now reliable (used to fail silently); confirm flow for replacing homes; safety check no longer blocks ladders/slabs/water; named homes persist across restart (fixed in v33)
+- **Related:** alliances (ally-home access), ranks (rank-based access)
+
+### Task 17: Ranks & Permissions page
+
+- **File:** `wiki/docs/players/ranks.md`
+- **GuildCommand.kt refs:** lines 518 (ranks)
+- **Common tasks:** Opening the rank menu, Creating a rank, Setting permissions on a rank, Reordering rank priority, Promoting & demoting members
+- **Gotchas:** priority hierarchy (mods can't promote above their own rank), offline kick respects priority, owner self-protection
+- **Related:** guilds, homes (per-home rank access)
+
+### Task 18: Alliances & Diplomacy page
+
+- **File:** `wiki/docs/players/alliances.md`
+- **GuildCommand.kt refs:** lines 1969 (ally), 2042 (enemy), 2110 (truce), 2178 (neutral)
+- **Common tasks:** Requesting an alliance, Accepting an alliance, Declaring an enemy, Signing a truce, Going neutral, Letting allies into your ally-home (with whitelist)
+- **Gotchas:** Pending alliances no longer display as accepted, both sides must run `/g ally` to confirm, ally-home requires both `USE_ALLY_HOMES` permission and an inbound whitelist entry
+- **Related:** war, homes
+
+### Task 19: War page
+
+- **File:** `wiki/docs/players/war.md`
+- **GuildCommand.kt refs:** lines 1535 (war)
+- **Common tasks:** Declaring war, Ending a war, How war kills are tracked
+- **Gotchas:** kills against guildmates don't grant XP (anti-farm), war affects relation display
+- **Related:** alliances, progression
+
+### Task 20: Chat page
+
+- **File:** `wiki/docs/players/chat.md`
+- **GuildCommand.kt refs:** lines 797 (chat), 817 (allychat)
+- **Common tasks:** Toggling guild chat, Toggling ally chat, How tag formatting renders in chat, Where messages go when RoseChat is installed
+- **Gotchas:** First message after toggle-off is no longer dropped; switching guild↔ally chat restores the previous channel correctly; MiniMessage gradients render via the `%lumaguilds_guild_tag%` placeholder
+- **Related:** identity (tags)
+
+### Task 21: Tags, Banners & Identity page
+
+- **File:** `wiki/docs/players/identity.md`
+- **GuildCommand.kt refs:** lines 1417 (tag), 1489 (description), 550 (emoji), 137 (rename)
+- **Common tasks:** Setting a guild tag (CLI), Setting a guild tag (menu), Setting a description, Choosing an emoji, Renaming your guild, Setting a banner
+- **Gotchas:** Tag CLI and menu now use the same validation (MiniMessage allowed, 32 visible chars); clear button in tag editor actually clears now; banner menu actually renders contents (was empty)
+- **Related:** chat, guilds
+
+### Task 22: Progression & Levels page
+
+- **File:** `wiki/docs/players/progression.md`
+- **GuildCommand.kt refs:** lines 837 (info shows progression)
+- **Common tasks:** Earning XP (sources), What levels unlock, Checking your guild's level
+- **Gotchas:** No XP from killing guildmates; XP earned shortly before quit/shutdown no longer lost; very large mining runs no longer lag the server (block XP batching); old guilds stuck at "Lvl 1" had their levels backfilled in the 2026-05-04 patch
+- **Related:** war
+
+### Task 23: Vault page
+
+- **File:** `wiki/docs/players/vault.md`
+- **GuildCommand.kt refs:** lines 1638 (getvault), 1751 (vault)
+- **Common tasks:** Opening the vault, Getting a vault chest item, Sharing the vault across members
+- **Gotchas:** Vault chest item cannot be used in crafting or as furnace fuel; permissions gate access
+- **Related:** ranks
+
+### Task 24: Mode page
+
+- **File:** `wiki/docs/players/mode.md`
+- **GuildCommand.kt refs:** lines 626 (mode)
+- **Common tasks:** Switching to Peaceful, Switching to Hostile, What each mode does
+- **Gotchas:** Mode menu options work after the recent fix; mode affects PvP and relation interactions
+- **Related:** war, alliances
+
+### Task 25: Shop integration page
+
+- **File:** `wiki/docs/players/shop.md`
+- **GuildCommand.kt refs:** lines 1817 (setshop)
+- **Common tasks:** Marking a shop as guild-owned, How guild shops appear to other players
+- **Gotchas:** Shop ownership transfers with the guild; only works with the supported shop plugin
+- **Related:** guilds
+
+### Task 26: LFG & Invites page
+
+- **File:** `wiki/docs/players/lfg.md`
+- **GuildCommand.kt refs:** lines 940 (invite), 1143 (lfg), 1153 (decline), 1177 (invites), 1201 (kick)
+- **Common tasks:** Inviting a player, Listing your invites, Declining an invite, Toggling LFG, Kicking a member (online and offline)
+- **Gotchas:** Offline kick respects rank priority; promote/demote shows real name even when target is offline
+- **Related:** ranks, guilds
+
+### Task 27: Bedrock differences page
+
+- **File:** `wiki/docs/players/bedrock.md`
+- **Content sources:** code paths in `BedrockGuildHomeMenu.kt`, `BedrockGuildRelationsMenu.kt`, `BedrockGuildMemberRankConfirmationMenu.kt`
+- **Common tasks:** What looks different in menus, How clickable chat works on Bedrock, Known limitations
+- **Gotchas:** Some menus are chat-based forms; commands work identically; teleports are dispatched on the main thread for safety
+- **Related:** chat, homes, ranks
+
+Each task ends with:
+
+```bash
+python tools/wiki/lint_frontmatter.py
+mkdocs build --strict
+git add wiki/docs/players/<topic>.md
+git commit -m "docs(wiki): write Players/<topic> page"
+```
+
+---
+
+## Task 28: Write Players — How do I…? index
+
+**Files:**
+- Modify: `wiki/docs/players/how-do-i.md`
+
+This is the human-friendly entry point. A flat list of common player tasks, each linking to a specific anchor on a feature page.
+
+- [ ] **Step 1: Replace the stub**
+
+```markdown
+---
+title: How do I…?
+audience: player
+topic: how-do-i
+summary: Index of common player tasks with deep links to the right feature page.
+keywords: [index, how to, tasks, find]
+related: [walkthrough]
+updated: 2026-05-13
+---
+
+# How do I…?
+
+Quick index. Scan for your task; click through to the page that answers it.
+
+## Guild basics
+
+- [Create a guild](guilds.md#creating-a-guild)
+- [Join an existing guild](guilds.md#joining-a-guild)
+- [Leave my guild](guilds.md#leaving-transferring-and-disbanding)
+- [Transfer ownership](guilds.md#leaving-transferring-and-disbanding)
+- [Disband my guild](guilds.md#leaving-transferring-and-disbanding)
+- [Find a guild to join (LFG)](lfg.md#toggling-lfg)
+
+## Homes
+
+- [Set my guild's main home](homes.md#setting-your-default-home)
+- [Add another named home](homes.md#adding-a-named-home)
+- [Teleport to a specific home](homes.md#visiting-a-home)
+- [Restrict a home to certain ranks](homes.md#restricting-a-home-to-specific-ranks)
+- [Set up an ally-home](homes.md#setting-up-your-ally-home)
+
+## Identity
+
+- [Set a colored guild tag](identity.md#setting-a-guild-tag-cli)
+- [Pick a guild banner](identity.md#setting-a-banner)
+- [Change my guild description](identity.md#setting-a-description)
+- [Rename my guild](identity.md#renaming-your-guild)
+
+## People
+
+- [Invite a player](lfg.md#inviting-a-player)
+- [Kick a member](lfg.md#kicking-a-member-online-and-offline)
+- [Promote / demote](ranks.md#promoting--demoting-members)
+- [Create a new rank](ranks.md#creating-a-rank)
+- [Reorder rank priority](ranks.md#reordering-rank-priority)
+
+## Diplomacy & war
+
+- [Request an alliance](alliances.md#requesting-an-alliance)
+- [Accept an alliance](alliances.md#accepting-an-alliance)
+- [Sign a truce](alliances.md#signing-a-truce)
+- [Declare a war](war.md#declaring-war)
+- [Mark a guild as enemy](alliances.md#declaring-an-enemy)
+
+## Chat
+
+- [Toggle guild chat](chat.md#toggling-guild-chat)
+- [Toggle ally chat](chat.md#toggling-ally-chat)
+- [Why aren't colors showing in my tag?](../getting-started/faq.md#my-guild-tag-isnt-showing-colors-in-chat)
+
+## Other
+
+- [Open the guild vault](vault.md#opening-the-vault)
+- [Switch between Peaceful and Hostile mode](mode.md#switching-to-peaceful)
+- [Check my guild level / XP](progression.md#checking-your-guilds-level)
+- [Mark a shop as guild-owned](shop.md#marking-a-shop-as-guild-owned)
+- [What's different on Bedrock?](bedrock.md)
+```
+
+- [ ] **Step 2: Verify all anchor links resolve**
+
+```bash
+mkdocs build --strict
+```
+
+Expected: passes. `--strict` will fail on any broken anchor (`#…`) link. If a link points to an H2 that doesn't exist yet, either fix the link (matching the actual H2 in the target page) or add the H2 to the target page.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add wiki/docs/players/how-do-i.md
+git commit -m "docs(wiki): write Players/How-do-I index"
+```
+
+---
+
+## Task 29: Update `CONTRIBUTING.md` with the wiki/help sync rule
+
+**Files:**
+- Modify: `CONTRIBUTING.md`
+
+- [ ] **Step 1: Append a section to `CONTRIBUTING.md`**
+
+```markdown
+## Keeping `/g help` and the wiki in sync
+
+LumaGuilds enforces parity between the in-game help system and the player wiki. **Any PR that adds, removes, or renames a player-facing command must touch both `HelpTopics.kt` and the matching wiki page in the same PR.** CI rejects PRs that break this rule.
+
+### What CI checks
+
+1. **Front-matter lint** (`tools/wiki/lint_frontmatter.py`): every `wiki/docs/**/*.md` must have a valid front-matter block with `title`, `audience`, `topic`, `summary`, `keywords`, `related`, `updated`.
+2. **Topic parity** (`tools/wiki/check_topic_parity.py`): every `slug = "..."` in [`HelpTopics.kt`](src/main/kotlin/net/lumalyte/lg/interaction/help/HelpTopics.kt) must have a matching `wiki/docs/players/<slug>.md` and vice versa.
+3. **Strict MkDocs build** (`mkdocs build --strict`): no broken internal links, missing nav entries, or malformed markdown.
+
+### Adding a new player-facing command
+
+1. Decide which existing topic in `HelpTopics.kt` the command belongs to. If none fits, you're adding a new topic (rare).
+2. Add a `HelpCommandEntry(syntax, blurb, prefill)` to the topic's `commands` list.
+3. Update the matching `wiki/docs/players/<slug>.md`: add a row to the Quick Reference table, add or expand a "Common task" H2 if needed.
+4. Run the checks locally before opening the PR:
+
+```bash
+python tools/wiki/lint_frontmatter.py
+python tools/wiki/check_topic_parity.py
+mkdocs build --strict
+./gradlew test
+```
+
+### Adding a new topic
+
+1. Add a new `HelpTopic(...)` block to `HelpTopics.all` in `HelpTopics.kt`. Pick a stable lowercase-hyphenated slug — it becomes a URL forever.
+2. Create `wiki/docs/players/<slug>.md` using the wiki page template (see other pages in that folder for the canonical shape).
+3. Add the topic to `wiki/docs/players/.pages` so it appears in the nav.
+4. Update `wiki/docs/players/how-do-i.md` with at least one entry deep-linking into the new page.
+5. Run the checks above.
+
+### Renaming or removing a topic
+
+- **Removing:** delete the `HelpTopic` entry, delete the wiki page, and add a `mkdocs-redirects` entry to `mkdocs.yml` mapping the old URL to wherever the content moved (or to the topic index).
+- **Renaming the slug:** treat as remove + add. The old slug is permanently retired (Hermes Agent and any cached links may still reference it via the redirect).
+
+Slugs are forever. The display name, summary, and command list inside a topic are not — those evolve freely.
+```
+
+- [ ] **Step 2: Commit**
+
+```bash
+git add CONTRIBUTING.md
+git commit -m "docs(contributing): add wiki/help sync rule and CI check overview"
+```
+
+---
+
+## Task 30: Smoke-test the full Phase 1 deliverable
+
+**Files:** none (verification only).
+
+- [ ] **Step 1: Run the full local check sequence**
+
+```bash
+python tools/wiki/lint_frontmatter.py
+python tools/wiki/check_topic_parity.py
+mkdocs build --strict
+./gradlew test
+./gradlew build -x test
+```
+
+Expected: every step passes.
+
+- [ ] **Step 2: Verify generated agent artifacts**
+
+After `mkdocs build`, inspect:
+
+```bash
+ls site/llms.txt site/llms-full.txt
+head -40 site/llms.txt
+```
+
+Expected: both files exist; `llms.txt` lists every page with summaries, organized by the section headers configured in `mkdocs.yml`.
+
+- [ ] **Step 3: Local serve and click-through**
+
+```bash
+mkdocs serve
+```
+
+Open <http://127.0.0.1:8000/> in a browser. Click through:
+- Home → Getting Started → Walkthrough (verify all section anchors).
+- Players → How do I…? → click 3–4 random deep links, verify each lands on the correct anchor.
+- Header nav: confirm Admins and Developers sections show their stubbed pages without errors.
+
+- [ ] **Step 4: In-game smoke test (if a test server is available)**
+
+Build the plugin:
+
+```bash
+./gradlew shadowJar
+```
+
+Drop the jar in a local Paper server. Test:
+- `/g help` — topic menu renders with all 13 topics; clicking [Homes] runs `/g help homes`.
+- `/g help homes` — topic page renders with all home commands; hovering shows blurb; clicking `/g sethome` prefills the chat box; clicking the wiki URL opens the browser; clicking `[Back to topics]` returns to the menu.
+- `/g help unknown` — friendly error with a clickable `/g help` link.
+
+- [ ] **Step 5: Open the Phase 1 PR**
+
+Aggregate Tasks 1–29 into a single PR (or a small series). Include in the PR description:
+- A reminder that **GitHub Pages must be enabled** in repo settings (Settings → Pages → Source: GitHub Actions) before the deploy is visible.
+- A link to the design doc: [`docs/plans/2026-05-13-player-wiki-and-help-redesign-design.md`](docs/plans/2026-05-13-player-wiki-and-help-redesign-design.md).
+- A note that Phases 2 (Admins content) and 3 (Developers migration) follow as separate plans.
+
+---
+
+## Self-Review Notes
+
+- **Spec coverage:** every spec section is mapped to tasks. §2 stack → Task 1; §3 site structure → Task 4; §4 page format → Tasks 6–8 + 15–28 (template applied consistently); §5 `/g help` → Tasks 9–14; §6 migration → deferred to Phase 3 (out of scope, called out); §7 phased rollout → this plan IS Phase 1; §8 maintenance → Tasks 3, 5, 11, 29.
+- **Source-of-truth invariant:** topic slug appears identically in `HelpTopics.kt` (Task 10), `wiki/docs/players/<slug>.md` (Task 4 stubs, Tasks 15–27 content), wiki URL via MkDocs page slug, and CI parity check (Task 11).
+- **No placeholders in code tasks:** every Kotlin task has complete source. The wiki content tasks (15–28) provide a template and a content checklist rather than full prose — that's intentional because per-page prose is human-authored and would bloat the plan to unreviewability; the template + checklist + source-line refs is what a skilled writer needs.
+- **Anti-pattern guard:** the `<!-- placeholder -->` block in Task 6's Welcome page is a deliberate one-line marker for human follow-up (the server pitch), not a TODO that blocks execution.

--- a/docs/plans/2026-05-13-player-wiki-and-help-redesign-plan.md
+++ b/docs/plans/2026-05-13-player-wiki-and-help-redesign-plan.md
@@ -90,7 +90,7 @@ updated: 2026-05-13
 ## Related
 
 - [Sibling page](../<other-topic>.md)
-```text
+```
 
 **Topic slug rule:** lowercase, hyphenated, matches `HelpTopics.kt` key exactly. Used as the file name (`<slug>.md`), the URL segment, and the `topic:` field. Stable forever — renaming requires a `mkdocs-redirects` entry.
 
@@ -112,11 +112,10 @@ updated: 2026-05-13
 ```text
 mkdocs==1.6.1
 mkdocs-material==9.5.49
-mkdocs-material[imaging]==9.5.49
 mkdocs-awesome-pages-plugin==2.9.3
 mkdocs-redirects==1.2.2
 mkdocs-llmstxt==0.2.0
-```text
+```
 
 - [ ] **Step 2: Create `mkdocs.yml`**
 
@@ -188,7 +187,7 @@ markdown_extensions:
       permalink: true
 
 strict: true
-```text
+```
 
 - [ ] **Step 3: Create `wiki/docs/index.md`**
 
@@ -213,7 +212,7 @@ LumaGuilds is the guild plugin powering [EnthusiaSMP](https://enthusiasmp.com). 
 - **[Developers](developers/architecture.md)** — Code-level reference.
 
 In-game, type `/g help` to get a clickable topic menu that mirrors this wiki.
-```text
+```
 
 - [ ] **Step 4: Create `wiki/docs/.pages`**
 
@@ -224,7 +223,7 @@ nav:
   - Players: players
   - Admins: admins
   - Developers: developers
-```text
+```
 
 - [ ] **Step 5: Append to `.gitignore`**
 
@@ -232,7 +231,7 @@ Add this line if not already present:
 
 ```text
 site/
-```text
+```
 
 - [ ] **Step 6: Verify MkDocs builds locally**
 
@@ -243,7 +242,7 @@ python -m venv .venv
 . .venv/Scripts/activate   # Windows
 pip install -r wiki/requirements.txt
 mkdocs build --strict
-```text
+```
 
 Expected: build succeeds. Will warn about missing `getting-started/`, `players/`, etc. — that's fine for this step (those folders are created in Task 4). If `--strict` errors on missing pages from nav, temporarily comment the nav lines in `.pages` and re-run. They get uncommented in Task 4.
 
@@ -252,7 +251,7 @@ Expected: build succeeds. Will warn about missing `getting-started/`, `players/`
 ```bash
 git add mkdocs.yml wiki/requirements.txt wiki/docs/index.md wiki/docs/.pages .gitignore
 git commit -m "docs(wiki): scaffold MkDocs Material site config"
-```text
+```
 
 ---
 
@@ -310,14 +309,14 @@ jobs:
     steps:
       - id: deployment
         uses: actions/deploy-pages@v4
-```text
+```
 
 - [ ] **Step 2: Commit**
 
 ```bash
 git add .github/workflows/wiki-deploy.yml
 git commit -m "ci(wiki): deploy MkDocs site to GitHub Pages on push to main"
-```text
+```
 
 - [ ] **Step 3: Note for human reviewer**
 
@@ -431,7 +430,7 @@ def main() -> int:
 
 if __name__ == "__main__":
     sys.exit(main())
-```text
+```
 
 - [ ] **Step 2: Test it locally on `wiki/docs/index.md` only**
 
@@ -440,7 +439,7 @@ Run:
 ```bash
 pip install pyyaml
 python tools/wiki/lint_frontmatter.py
-```text
+```
 
 Expected output: `OK — 1 pages validated.` (index.md is the only file with front-matter at this point).
 
@@ -451,14 +450,14 @@ Temporarily remove the `topic:` line from `wiki/docs/index.md`. Re-run the lint.
 - [ ] **Step 4: Create `tools/wiki/__init__.py` (empty)**
 
 ```python
-```text
+```
 
 - [ ] **Step 5: Commit**
 
 ```bash
 git add tools/wiki/__init__.py tools/wiki/lint_frontmatter.py
 git commit -m "ci(wiki): add front-matter schema lint script"
-```text
+```
 
 ---
 
@@ -482,7 +481,7 @@ updated: 2026-05-13
 # <Title>
 
 *This page is a placeholder. Content coming in Phase 2/3.*
-```text
+```
 
 - [ ] **Step 1: Getting Started stubs**
 
@@ -497,7 +496,7 @@ nav:
   - Welcome: welcome.md
   - Your first 30 minutes: walkthrough.md
   - FAQ: faq.md
-```text
+```
 
 - [ ] **Step 2: Players stubs (one per feature page in the design § 3)**
 
@@ -538,7 +537,7 @@ nav:
   - Shop integration: shop.md
   - LFG & Invites: lfg.md
   - Bedrock differences: bedrock.md
-```text
+```
 
 - [ ] **Step 3: Admins stubs**
 
@@ -571,7 +570,7 @@ nav:
   - Lunar Client: lunar.md
   - Web leaderboard API: leaderboard-api.md
   - Claims: claims.md
-```text
+```
 
 - [ ] **Step 4: Developers stubs**
 
@@ -608,7 +607,7 @@ nav:
   - Emoji permissions: emoji-permissions.md
   - Migration safety: migration-safety.md
   - Schema setup: schema-setup.md
-```text
+```
 
 - [ ] **Step 5: Note about slug ↔ filename mismatch**
 
@@ -624,13 +623,13 @@ SLUG_EXEMPT = {
     Path("developers/getting-started.md"),
     Path("developers/placeholders.md"),
 }
-```text
+```
 
 - [ ] **Step 6: Run lint, fix any failures**
 
 ```bash
 python tools/wiki/lint_frontmatter.py
-```text
+```
 
 Expected: all ~40 pages pass.
 
@@ -638,7 +637,7 @@ Expected: all ~40 pages pass.
 
 ```bash
 mkdocs build --strict
-```text
+```
 
 Expected: build succeeds with no warnings.
 
@@ -647,7 +646,7 @@ Expected: build succeeds with no warnings.
 ```bash
 git add wiki/docs/getting-started wiki/docs/players wiki/docs/admins wiki/docs/developers tools/wiki/lint_frontmatter.py
 git commit -m "docs(wiki): scaffold nav skeleton with stubbed front-matter pages"
-```text
+```
 
 ---
 
@@ -694,14 +693,14 @@ jobs:
           cache-dependency-path: wiki/requirements.txt
       - run: pip install -r wiki/requirements.txt
       - run: mkdocs build --strict
-```text
+```
 
 - [ ] **Step 2: Commit**
 
 ```bash
 git add .github/workflows/wiki-checks.yml
 git commit -m "ci(wiki): run front-matter lint and strict MkDocs build on PRs"
-```text
+```
 
 ---
 
@@ -759,7 +758,7 @@ In-game, type `/g help` for the same content as a clickable menu.
 - Not a release log. See [`CHANGELOG.md`](https://github.com/BadgersMC/LumaGuilds/blob/main/CHANGELOG.md) on GitHub.
 
 Ready? **[Start the 30-minute walkthrough →](walkthrough.md)**
-```text
+```
 
 The comment block `<!-- ... -->` is a placeholder for content you'll want a human to write — the server pitch. The plan ships with a TODO marker visible in the rendered page only via comment (so MkDocs strict mode still passes). Leave it for the maintainer to fill on first PR review pass; it's not blocking.
 
@@ -768,7 +767,7 @@ The comment block `<!-- ... -->` is a placeholder for content you'll want a huma
 ```bash
 python tools/wiki/lint_frontmatter.py
 mkdocs build --strict
-```text
+```
 
 Expected: both pass.
 
@@ -777,7 +776,7 @@ Expected: both pass.
 ```bash
 git add wiki/docs/getting-started/welcome.md
 git commit -m "docs(wiki): write Getting Started welcome page"
-```text
+```
 
 ---
 
@@ -821,7 +820,7 @@ You have three options:
 
 **Create your own** — pick a name (plain text, max 32 chars, letters/numbers/spaces/`'`/`&`/`-`) and run:
 
-```text
+```
 /g create <name>
 ```text
 
@@ -837,7 +836,7 @@ Once you're in a guild, two things make it feel like home.
 
 **Tag** — fancy formatting that appears next to your name in chat. Use MiniMessage:
 
-```text
+```
 /g tag <gradient:#FF6A00:#FF1F00>Lotus</gradient>
 ```text
 
@@ -845,7 +844,7 @@ Or run `/g tag` with no arguments to open a visual editor.
 
 **Home** — a teleport point your guild can share. Stand where you want it and run:
 
-```text
+```
 /g sethome
 ```text
 
@@ -853,7 +852,7 @@ That sets the default home. You can have multiple — `/g sethome shop`, `/g set
 
 ## 4. Inviting a friend
 
-```text
+```
 /g invite <player>
 ```text
 
@@ -890,21 +889,21 @@ If you got this far you're functional. Pick one:
 - **Read the [How do I…? index](../players/how-do-i.md)** — every common task with a deep link to the right page.
 
 That's the tour. The rest of the wiki is reference — come back as needed.
-```text
+```
 
 - [ ] **Step 2: Lint + build**
 
 ```bash
 python tools/wiki/lint_frontmatter.py
 mkdocs build --strict
-```text
+```
 
 - [ ] **Step 3: Commit**
 
 ```bash
 git add wiki/docs/getting-started/walkthrough.md
 git commit -m "docs(wiki): write 7-step Getting Started walkthrough"
-```text
+```
 
 ---
 
@@ -961,7 +960,7 @@ Mostly. A few menus open as chat-based forms instead of inventory GUIs, and clic
 ## Where do I report a bug?
 
 Tell staff in-game or open an issue at <https://github.com/BadgersMC/LumaGuilds/issues>.
-```text
+```
 
 - [ ] **Step 2: Lint + build, commit**
 
@@ -970,7 +969,7 @@ python tools/wiki/lint_frontmatter.py
 mkdocs build --strict
 git add wiki/docs/getting-started/faq.md
 git commit -m "docs(wiki): write Getting Started FAQ"
-```text
+```
 
 ---
 
@@ -1043,13 +1042,13 @@ class HelpTopicTest {
         }
     }
 }
-```text
+```
 
 - [ ] **Step 2: Run test — expect compile failure**
 
 ```bash
 ./gradlew test --tests "net.lumalyte.lg.interaction.help.HelpTopicTest"
-```text
+```
 
 Expected: compile error — classes don't exist yet.
 
@@ -1067,7 +1066,7 @@ data class HelpCommandEntry(
     val blurb: String,
     val prefill: String,
 )
-```text
+```
 
 - [ ] **Step 4: Create `HelpTopic.kt`**
 
@@ -1095,13 +1094,13 @@ data class HelpTopic(
         private val SLUG_REGEX = Regex("^[a-z0-9]+(-[a-z0-9]+)*$")
     }
 }
-```text
+```
 
 - [ ] **Step 5: Run test — expect pass**
 
 ```bash
 ./gradlew test --tests "net.lumalyte.lg.interaction.help.HelpTopicTest"
-```text
+```
 
 Expected: PASS.
 
@@ -1112,7 +1111,7 @@ git add src/main/kotlin/net/lumalyte/lg/interaction/help/HelpCommandEntry.kt \
         src/main/kotlin/net/lumalyte/lg/interaction/help/HelpTopic.kt \
         src/test/kotlin/net/lumalyte/lg/interaction/help/HelpTopicTest.kt
 git commit -m "feat(help): add HelpTopic and HelpCommandEntry data classes"
-```text
+```
 
 ---
 
@@ -1188,13 +1187,13 @@ class HelpTopicsTest {
         }
     }
 }
-```text
+```
 
 - [ ] **Step 2: Run test — expect failure (HelpTopics doesn't exist)**
 
 ```bash
 ./gradlew test --tests "net.lumalyte.lg.interaction.help.HelpTopicsTest"
-```text
+```
 
 Expected: compile error.
 
@@ -1357,13 +1356,13 @@ object HelpTopics {
 
     fun bySlug(slug: String): HelpTopic? = bySlugMap[slug.lowercase()]
 }
-```text
+```
 
 - [ ] **Step 4: Run test — expect failures on ordering**
 
 ```bash
 ./gradlew test --tests "net.lumalyte.lg.interaction.help.HelpTopicsTest"
-```text
+```
 
 Expected: passes. If the ordering test fails, the first-four order must be `guilds, homes, ranks, chat` — that's the order in `all` above.
 
@@ -1373,7 +1372,7 @@ Expected: passes. If the ordering test fails, the first-four order must be `guil
 git add src/main/kotlin/net/lumalyte/lg/interaction/help/HelpTopics.kt \
         src/test/kotlin/net/lumalyte/lg/interaction/help/HelpTopicsTest.kt
 git commit -m "feat(help): add HelpTopics registry (source of truth for help + wiki)"
-```text
+```
 
 ---
 
@@ -1452,13 +1451,13 @@ def main() -> int:
 
 if __name__ == "__main__":
     sys.exit(main())
-```text
+```
 
 - [ ] **Step 2: Run locally**
 
 ```bash
 python tools/wiki/check_topic_parity.py
-```text
+```
 
 Expected: `OK — 13 topics in parity with wiki.` (all 13 stub pages exist from Task 4; all 13 are registered from Task 10).
 
@@ -1479,7 +1478,7 @@ Add a new job to the existing workflow:
         with:
           python-version: '3.11'
       - run: python tools/wiki/check_topic_parity.py
-```text
+```
 
 Also expand the workflow's `paths:` filter to trigger when `HelpTopics.kt` changes — already covered by `src/main/kotlin/net/lumalyte/lg/interaction/help/**` in Task 5.
 
@@ -1488,7 +1487,7 @@ Also expand the workflow's `paths:` filter to trigger when `HelpTopics.kt` chang
 ```bash
 git add tools/wiki/check_topic_parity.py .github/workflows/wiki-checks.yml
 git commit -m "ci(wiki): enforce HelpTopics.kt <-> wiki/docs/players/ slug parity"
-```text
+```
 
 ---
 
@@ -1566,13 +1565,13 @@ private fun Component.findSuggestCommandClick(value: String): Component? =
         val ce = it.clickEvent()
         ce?.action() == ClickEvent.Action.SUGGEST_COMMAND && ce.value() == value
     }
-```text
+```
 
 - [ ] **Step 2: Run test — expect compile failure**
 
 ```bash
 ./gradlew test --tests "net.lumalyte.lg.interaction.help.HelpTopicsRendererTest"
-```text
+```
 
 Expected: compile error.
 
@@ -1685,13 +1684,13 @@ object HelpTopicsRenderer {
         return out.build()
     }
 }
-```text
+```
 
 - [ ] **Step 4: Run test — expect pass**
 
 ```bash
 ./gradlew test --tests "net.lumalyte.lg.interaction.help.HelpTopicsRendererTest"
-```text
+```
 
 Expected: PASS.
 
@@ -1701,7 +1700,7 @@ Expected: PASS.
 git add src/main/kotlin/net/lumalyte/lg/interaction/help/HelpTopicsRenderer.kt \
         src/test/kotlin/net/lumalyte/lg/interaction/help/HelpTopicsRendererTest.kt
 git commit -m "feat(help): render topic menu via Adventure components"
-```text
+```
 
 ---
 
@@ -1753,20 +1752,20 @@ Append to the existing test class (above the private extension functions at the 
         val back = rendered.findRunCommandClick("/g help")
         assertNotNull(back, "No RUN_COMMAND click for '/g help' (Back action)")
     }
-```text
+```
 
 - [ ] **Step 2: Run — expect pass**
 
 ```bash
 ./gradlew test --tests "net.lumalyte.lg.interaction.help.HelpTopicsRendererTest"
-```text
+```
 
 - [ ] **Step 3: Commit**
 
 ```bash
 git add src/test/kotlin/net/lumalyte/lg/interaction/help/HelpTopicsRendererTest.kt
 git commit -m "test(help): verify topic-page rendering (click events, wiki link, back action)"
-```text
+```
 
 ---
 
@@ -1806,7 +1805,7 @@ Locate the method at line 1905. Replace from the `@Subcommand("help")` annotatio
         }
         player.sendMessage(renderer.renderTopicPage(found))
     }
-```text
+```
 
 - [ ] **Step 2: Add the imports near the top of the file**
 
@@ -1818,7 +1817,7 @@ import net.kyori.adventure.text.event.ClickEvent
 import net.kyori.adventure.text.format.NamedTextColor
 import net.lumalyte.lg.interaction.help.HelpTopics
 import net.lumalyte.lg.interaction.help.HelpTopicsRenderer
-```text
+```
 
 Skip any that are already imported.
 
@@ -1826,7 +1825,7 @@ Skip any that are already imported.
 
 ```bash
 ./gradlew build -x test
-```text
+```
 
 Expected: success.
 
@@ -1834,7 +1833,7 @@ Expected: success.
 
 ```bash
 ./gradlew test
-```text
+```
 
 Expected: all pass, including the new HelpTopics tests.
 
@@ -1847,7 +1846,7 @@ Build the shadow jar (`./gradlew shadowJar`), drop into a local Paper test serve
 ```bash
 git add src/main/kotlin/net/lumalyte/lg/interaction/commands/GuildCommand.kt
 git commit -m "refactor(help): /g help renders from HelpTopicsRenderer (clickable, topic-based)"
-```text
+```
 
 ---
 
@@ -1930,7 +1929,7 @@ How to create, join, leave, transfer, and disband guilds.
 - [Ranks & Permissions](ranks.md)
 - [Homes](homes.md)
 - [Alliances & Diplomacy](alliances.md)
-```text
+```
 
 Source-of-truth check: cross-reference `GuildCommand.kt` lines 61 (`@Subcommand("create")`), 988 (`join`), 1269 (`leave`), 867 (`disband`), 1352 (`transfer`), 837 (`info`), 1103 (`list`) for exact behaviors and permissions.
 
@@ -1941,7 +1940,7 @@ python tools/wiki/lint_frontmatter.py
 mkdocs build --strict
 git add wiki/docs/players/guilds.md
 git commit -m "docs(wiki): write Players/Guilds page"
-```text
+```
 
 ---
 
@@ -2062,7 +2061,7 @@ python tools/wiki/lint_frontmatter.py
 mkdocs build --strict
 git add wiki/docs/players/<topic>.md
 git commit -m "docs(wiki): write Players/<topic> page"
-```text
+```
 
 ---
 
@@ -2143,13 +2142,13 @@ Quick index. Scan for your task; click through to the page that answers it.
 - [Check my guild level / XP](progression.md#checking-your-guilds-level)
 - [Mark a shop as guild-owned](shop.md#marking-a-shop-as-guild-owned)
 - [What's different on Bedrock?](bedrock.md)
-```text
+```
 
 - [ ] **Step 2: Verify all anchor links resolve**
 
 ```bash
 mkdocs build --strict
-```text
+```
 
 Expected: passes. `--strict` will fail on any broken anchor (`#…`) link. If a link points to an H2 that doesn't exist yet, either fix the link (matching the actual H2 in the target page) or add the H2 to the target page.
 
@@ -2158,7 +2157,7 @@ Expected: passes. `--strict` will fail on any broken anchor (`#…`) link. If a 
 ```bash
 git add wiki/docs/players/how-do-i.md
 git commit -m "docs(wiki): write Players/How-do-I index"
-```text
+```
 
 ---
 
@@ -2187,7 +2186,7 @@ LumaGuilds enforces parity between the in-game help system and the player wiki. 
 3. Update the matching `wiki/docs/players/<slug>.md`: add a row to the Quick Reference table, add or expand a "Common task" H2 if needed.
 4. Run the checks locally before opening the PR:
 
-```bash
+```
 python tools/wiki/lint_frontmatter.py
 python tools/wiki/check_topic_parity.py
 mkdocs build --strict
@@ -2208,14 +2207,14 @@ mkdocs build --strict
 - **Renaming the slug:** treat as remove + add. The old slug is permanently retired (Hermes Agent and any cached links may still reference it via the redirect).
 
 Slugs are forever. The display name, summary, and command list inside a topic are not — those evolve freely.
-```text
+```
 
 - [ ] **Step 2: Commit**
 
 ```bash
 git add CONTRIBUTING.md
 git commit -m "docs(contributing): add wiki/help sync rule and CI check overview"
-```text
+```
 
 ---
 
@@ -2231,7 +2230,7 @@ python tools/wiki/check_topic_parity.py
 mkdocs build --strict
 ./gradlew test
 ./gradlew build -x test
-```text
+```
 
 Expected: every step passes.
 
@@ -2242,7 +2241,7 @@ After `mkdocs build`, inspect:
 ```bash
 ls site/llms.txt site/llms-full.txt
 head -40 site/llms.txt
-```text
+```
 
 Expected: both files exist; `llms.txt` lists every page with summaries, organized by the section headers configured in `mkdocs.yml`.
 
@@ -2250,7 +2249,7 @@ Expected: both files exist; `llms.txt` lists every page with summaries, organize
 
 ```bash
 mkdocs serve
-```text
+```
 
 Open <http://127.0.0.1:8000/> in a browser. Click through:
 - Home → Getting Started → Walkthrough (verify all section anchors).
@@ -2263,7 +2262,7 @@ Build the plugin:
 
 ```bash
 ./gradlew shadowJar
-```text
+```
 
 Drop the jar in a local Paper server. Test:
 - `/g help` — topic menu renders with all 13 topics; clicking [Homes] runs `/g help homes`.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,0 +1,67 @@
+site_name: LumaGuilds
+site_url: https://badgersmc.github.io/LumaGuilds/
+site_description: Player wiki and admin/developer reference for the LumaGuilds plugin.
+repo_url: https://github.com/BadgersMC/LumaGuilds
+repo_name: BadgersMC/LumaGuilds
+edit_uri: edit/main/wiki/docs/
+
+docs_dir: wiki/docs
+
+theme:
+  name: material
+  features:
+    - navigation.tabs
+    - navigation.tabs.sticky
+    - navigation.sections
+    - navigation.top
+    - navigation.tracking
+    - search.suggest
+    - search.highlight
+    - content.code.copy
+    - content.action.edit
+  palette:
+    - media: "(prefers-color-scheme: light)"
+      scheme: default
+      primary: indigo
+      accent: indigo
+      toggle:
+        icon: material/brightness-7
+        name: Switch to dark mode
+    - media: "(prefers-color-scheme: dark)"
+      scheme: slate
+      primary: indigo
+      accent: indigo
+      toggle:
+        icon: material/brightness-4
+        name: Switch to light mode
+
+plugins:
+  - search
+  - awesome-pages
+  - redirects:
+      redirect_maps: {}
+  - llmstxt:
+      full_output: llms-full.txt
+      sections:
+        Getting Started:
+          - getting-started/**/*.md
+        Players:
+          - players/**/*.md
+        Admins:
+          - admins/**/*.md
+        Developers:
+          - developers/**/*.md
+
+markdown_extensions:
+  - admonition
+  - attr_list
+  - md_in_html
+  - tables
+  - pymdownx.details
+  - pymdownx.superfences
+  - pymdownx.tabbed:
+      alternate_style: true
+  - toc:
+      permalink: true
+
+strict: true

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -44,13 +44,13 @@ plugins:
       full_output: llms-full.txt
       sections:
         Getting Started:
-          - getting-started/**/*.md
+          - getting-started/*.md
         Players:
-          - players/**/*.md
+          - players/*.md
         Admins:
-          - admins/**/*.md
+          - admins/*.md
         Developers:
-          - developers/**/*.md
+          - developers/*.md
 
 markdown_extensions:
   - admonition

--- a/src/main/kotlin/net/lumalyte/lg/interaction/commands/GuildCommand.kt
+++ b/src/main/kotlin/net/lumalyte/lg/interaction/commands/GuildCommand.kt
@@ -15,6 +15,11 @@ import net.lumalyte.lg.domain.entities.GuildMode
 import net.lumalyte.lg.domain.entities.RankPermission
 import net.lumalyte.lg.infrastructure.adapters.bukkit.toPosition3D
 import net.lumalyte.lg.interaction.menus.MenuFactory
+import net.kyori.adventure.text.Component
+import net.kyori.adventure.text.event.ClickEvent
+import net.kyori.adventure.text.format.NamedTextColor
+import net.lumalyte.lg.interaction.help.HelpTopics
+import net.lumalyte.lg.interaction.help.HelpTopicsRenderer
 import net.lumalyte.lg.interaction.menus.MenuNavigator
 import net.lumalyte.lg.interaction.menus.guild.*
 import net.lumalyte.lg.utils.deserializeToItemStack
@@ -1910,65 +1915,28 @@ class GuildCommand : BaseCommand(), KoinComponent {
     @Subcommand("help")
     @CommandPermission("lumaguilds.guild.help")
     fun onHelp(player: Player, @Optional topic: String?) {
-        when (topic?.lowercase()) {
-            "create", "name" -> {
-                player.sendMessage("§6§l=== Guild Name & Tag Guide ===")
-                player.sendMessage("§7")
-                player.sendMessage("§e📝 Guild Name (Plain Text)")
-                player.sendMessage("§7 • Command: §f/guild create <name>")
-                player.sendMessage("§7 • Max 32 characters")
-                player.sendMessage("§7 • Letters, numbers, spaces, and: ' & -")
-                player.sendMessage("§7 • No formatting tags allowed")
-                player.sendMessage("§7 • Example: §fWhite Lotus §7or §fFire & Ice")
-                player.sendMessage("§7")
-                player.sendMessage("§e🎨 Guild Tag (Fancy Formatting)")
-                player.sendMessage("§7 • Command: §f/guild tag <formatted_text>")
-                player.sendMessage("§7 • Use MiniMessage formatting")
-                player.sendMessage("§7 • Supports colors, gradients, effects")
-                player.sendMessage("§7 • Examples:")
-                player.sendMessage("§7   §f/guild tag <red>Fire</red><gold>Guild</gold>")
-                player.sendMessage("§7   §f/guild tag <gradient:#FF0000:#00FF00>Rainbow</gradient>")
-                player.sendMessage("§7   §f/guild tag <bold><blue>ELITE</blue></bold>")
-                player.sendMessage("§7")
-                player.sendMessage("§6💡 Remember: Name = Plain, Tag = Fancy!")
-            }
-            "tag" -> {
-                player.sendMessage("§6§l=== Guild Tag Help ===")
-                player.sendMessage("§7")
-                player.sendMessage("§eGuild tags let you add fancy formatting!")
-                player.sendMessage("§7")
-                player.sendMessage("§7Commands:")
-                player.sendMessage("§7 • Set tag: §f/guild tag <formatted_text>")
-                player.sendMessage("§7 • Open menu: §f/guild tag")
-                player.sendMessage("§7")
-                player.sendMessage("§7Examples:")
-                player.sendMessage("§7 • Single color: §f<red>MyGuild</red>")
-                player.sendMessage("§7 • Two colors: §f<red>Fire</red><gold>Guild</gold>")
-                player.sendMessage("§7 • Gradient: §f<gradient:#FF0000:#00FF00>Rainbow</gradient>")
-                player.sendMessage("§7 • Bold: §f<bold><blue>ELITE</blue></bold>")
-                player.sendMessage("§7")
-                player.sendMessage("§6💡 TIP: Visit minimessage.net for more formatting!")
-            }
-            else -> {
-                player.sendMessage("§6§l=== Guild Commands ===")
-                player.sendMessage("§7")
-                player.sendMessage("§eBasic Commands:")
-                player.sendMessage("§7 • §f/guild create <name> §7- Create a guild")
-                player.sendMessage("§7 • §f/guild menu §7- Open guild menu")
-                player.sendMessage("§7 • §f/guild info §7- View guild info")
-                player.sendMessage("§7 • §f/guild invite <player> §7- Invite a player")
-                player.sendMessage("§7 • §f/guild leave §7- Leave your guild")
-                player.sendMessage("§7")
-                player.sendMessage("§eCustomization:")
-                player.sendMessage("§7 • §f/guild tag §7- Set fancy formatted tag")
-                player.sendMessage("§7 • §f/guild rename <name> §7- Rename guild")
-                player.sendMessage("§7 • §f/guild desc <text> §7- Set description")
-                player.sendMessage("§7")
-                player.sendMessage("§eFor detailed help:")
-                player.sendMessage("§7 • §f/guild help create §7- Guild name & tag guide")
-                player.sendMessage("§7 • §f/guild help tag §7- Tag formatting examples")
-            }
+        val renderer = HelpTopicsRenderer
+        if (topic.isNullOrBlank()) {
+            player.sendMessage(renderer.renderTopicMenu())
+            return
         }
+        val found = HelpTopics.bySlug(topic)
+        if (found == null) {
+            player.sendMessage(
+                Component.text()
+                    .append(Component.text("Unknown help topic '", NamedTextColor.RED))
+                    .append(Component.text(topic, NamedTextColor.YELLOW))
+                    .append(Component.text("'. Type ", NamedTextColor.RED))
+                    .append(
+                        Component.text("/g help", NamedTextColor.YELLOW)
+                            .clickEvent(ClickEvent.runCommand("/g help")),
+                    )
+                    .append(Component.text(" to see all topics.", NamedTextColor.RED))
+                    .build(),
+            )
+            return
+        }
+        player.sendMessage(renderer.renderTopicPage(found))
     }
 
     @Subcommand("ally")

--- a/src/main/kotlin/net/lumalyte/lg/interaction/help/HelpCommandEntry.kt
+++ b/src/main/kotlin/net/lumalyte/lg/interaction/help/HelpCommandEntry.kt
@@ -1,0 +1,11 @@
+package net.lumalyte.lg.interaction.help
+
+/**
+ * One command line in a [HelpTopic]'s command list, shown both in-game and
+ * (via the parity check) referenced by the corresponding wiki page.
+ */
+data class HelpCommandEntry(
+    val syntax: String,
+    val blurb: String,
+    val prefill: String,
+)

--- a/src/main/kotlin/net/lumalyte/lg/interaction/help/HelpTopic.kt
+++ b/src/main/kotlin/net/lumalyte/lg/interaction/help/HelpTopic.kt
@@ -1,0 +1,23 @@
+package net.lumalyte.lg.interaction.help
+
+/**
+ * A help topic surfaced by `/g help` and mirrored to a wiki page under
+ * `wiki/docs/players/<slug>.md`. The [slug] is the stable identifier and
+ * must match the wiki page's `topic:` front-matter field.
+ */
+data class HelpTopic(
+    val slug: String,
+    val displayName: String,
+    val summary: String,
+    val commands: List<HelpCommandEntry>,
+) {
+    init {
+        require(SLUG_REGEX.matches(slug)) { "Invalid slug: $slug (must be lowercase-hyphenated)" }
+        require(displayName.isNotBlank()) { "displayName must not be blank" }
+        require(summary.isNotBlank()) { "summary must not be blank" }
+    }
+
+    companion object {
+        private val SLUG_REGEX = Regex("^[a-z0-9]+(-[a-z0-9]+)*$")
+    }
+}

--- a/src/main/kotlin/net/lumalyte/lg/interaction/help/HelpTopics.kt
+++ b/src/main/kotlin/net/lumalyte/lg/interaction/help/HelpTopics.kt
@@ -1,0 +1,152 @@
+package net.lumalyte.lg.interaction.help
+
+/**
+ * Source of truth for player-facing help topics.
+ *
+ * Every entry has a matching wiki page at `wiki/docs/players/<slug>.md`.
+ * CI fails the build if any slug here lacks a wiki page, or vice versa.
+ */
+object HelpTopics {
+
+    /** Base URL for wiki deep-links surfaced in the in-game help. */
+    const val WIKI_BASE_URL = "https://badgersmc.github.io/LumaGuilds/players"
+
+    val all: List<HelpTopic> = listOf(
+        HelpTopic(
+            slug = "guilds",
+            displayName = "Guilds",
+            summary = "Create, join, leave, transfer, and disband guilds.",
+            commands = listOf(
+                HelpCommandEntry("/g create <name>", "Create a new guild.", "/g create "),
+                HelpCommandEntry("/g join <guild>", "Request to join a guild.", "/g join "),
+                HelpCommandEntry("/g leave", "Leave your current guild.", "/g leave"),
+                HelpCommandEntry("/g disband", "Disband your guild (owner only).", "/g disband"),
+                HelpCommandEntry("/g transfer <player>", "Transfer ownership.", "/g transfer "),
+                HelpCommandEntry("/g info [guild]", "View guild information.", "/g info "),
+                HelpCommandEntry("/g list", "Browse all guilds.", "/g list"),
+            ),
+        ),
+        HelpTopic(
+            slug = "homes",
+            displayName = "Homes",
+            summary = "Set, name, visit, and restrict access to guild homes.",
+            commands = listOf(
+                HelpCommandEntry("/g sethome [name]", "Set a home at your current location.", "/g sethome "),
+                HelpCommandEntry("/g home [name]", "Teleport to a guild home.", "/g home "),
+                HelpCommandEntry("/g homes", "List your guild's homes.", "/g homes"),
+                HelpCommandEntry("/g removehome <name>", "Remove a named home.", "/g removehome "),
+                HelpCommandEntry("/g setallyhome", "Set your guild's ally-home.", "/g setallyhome"),
+                HelpCommandEntry("/g removeallyhome", "Remove your guild's ally-home.", "/g removeallyhome"),
+            ),
+        ),
+        HelpTopic(
+            slug = "ranks",
+            displayName = "Ranks & Permissions",
+            summary = "Create ranks, set permissions, and manage member rank assignments.",
+            commands = listOf(
+                HelpCommandEntry("/g ranks", "Open the rank management menu.", "/g ranks"),
+                HelpCommandEntry("/g menu", "Open the guild control panel.", "/g menu"),
+            ),
+        ),
+        HelpTopic(
+            slug = "chat",
+            displayName = "Chat",
+            summary = "Toggle guild and ally chat, and customize how your tag appears in messages.",
+            commands = listOf(
+                HelpCommandEntry("/g chat", "Toggle guild chat on/off.", "/g chat"),
+                HelpCommandEntry("/g allychat", "Toggle ally chat on/off.", "/g allychat"),
+            ),
+        ),
+        HelpTopic(
+            slug = "alliances",
+            displayName = "Alliances & Diplomacy",
+            summary = "Form alliances, declare enemies, sign truces, and manage ally-home access.",
+            commands = listOf(
+                HelpCommandEntry("/g ally <guild>", "Request or accept an alliance.", "/g ally "),
+                HelpCommandEntry("/g enemy <guild>", "Mark a guild as enemy.", "/g enemy "),
+                HelpCommandEntry("/g truce <guild>", "Sign a truce.", "/g truce "),
+                HelpCommandEntry("/g neutral <guild>", "Clear a relation.", "/g neutral "),
+            ),
+        ),
+        HelpTopic(
+            slug = "war",
+            displayName = "War",
+            summary = "Declare and fight wars between guilds.",
+            commands = listOf(
+                HelpCommandEntry("/g war <guild>", "Open the war control flow.", "/g war "),
+            ),
+        ),
+        HelpTopic(
+            slug = "progression",
+            displayName = "Progression & Levels",
+            summary = "Earn guild XP from member activity, level up, and unlock perks.",
+            commands = listOf(
+                HelpCommandEntry("/g info", "See your guild's level and XP.", "/g info"),
+            ),
+        ),
+        HelpTopic(
+            slug = "vault",
+            displayName = "Vault",
+            summary = "Use the shared guild vault for storing items.",
+            commands = listOf(
+                HelpCommandEntry("/g vault", "Open the guild vault.", "/g vault"),
+                HelpCommandEntry("/g getvault", "Get a vault chest item.", "/g getvault"),
+            ),
+        ),
+        HelpTopic(
+            slug = "identity",
+            displayName = "Tags, Banners & Identity",
+            summary = "Set your guild's tag, description, and banner.",
+            commands = listOf(
+                HelpCommandEntry("/g tag [text]", "Set or edit your guild tag.", "/g tag "),
+                HelpCommandEntry("/g desc <text>", "Set your guild description.", "/g desc "),
+                HelpCommandEntry("/g rename <name>", "Rename your guild.", "/g rename "),
+                HelpCommandEntry("/g emoji", "Pick a guild emoji.", "/g emoji"),
+            ),
+        ),
+        HelpTopic(
+            slug = "mode",
+            displayName = "Mode (Peaceful / Hostile)",
+            summary = "Switch your guild between peaceful and hostile mode.",
+            commands = listOf(
+                HelpCommandEntry("/g mode", "Open the mode selection menu.", "/g mode"),
+            ),
+        ),
+        HelpTopic(
+            slug = "shop",
+            displayName = "Shop integration",
+            summary = "Link guild-owned shops.",
+            commands = listOf(
+                HelpCommandEntry("/g setshop", "Mark your current shop as guild-owned.", "/g setshop"),
+            ),
+        ),
+        HelpTopic(
+            slug = "lfg",
+            displayName = "LFG & Invites",
+            summary = "Manage invites, decline requests, and use LFG to find a guild.",
+            commands = listOf(
+                HelpCommandEntry("/g invite <player>", "Invite a player to your guild.", "/g invite "),
+                HelpCommandEntry("/g invites", "List your pending invites.", "/g invites"),
+                HelpCommandEntry("/g decline <guild>", "Decline an invite.", "/g decline "),
+                HelpCommandEntry("/g lfg", "Toggle LFG (looking-for-guild).", "/g lfg"),
+                HelpCommandEntry("/g kick <player>", "Kick a member from your guild.", "/g kick "),
+            ),
+        ),
+        HelpTopic(
+            slug = "bedrock",
+            displayName = "Bedrock differences",
+            summary = "Where LumaGuilds behaves differently on Bedrock/Geyser.",
+            commands = listOf(
+                HelpCommandEntry(
+                    syntax = "(see wiki)",
+                    blurb = "Bedrock menus open as forms; clickable chat maps to taps.",
+                    prefill = "",
+                ),
+            ),
+        ),
+    )
+
+    private val bySlugMap: Map<String, HelpTopic> = all.associateBy { it.slug }
+
+    fun bySlug(slug: String): HelpTopic? = bySlugMap[slug.lowercase()]
+}

--- a/src/main/kotlin/net/lumalyte/lg/interaction/help/HelpTopicsRenderer.kt
+++ b/src/main/kotlin/net/lumalyte/lg/interaction/help/HelpTopicsRenderer.kt
@@ -1,0 +1,102 @@
+package net.lumalyte.lg.interaction.help
+
+import net.kyori.adventure.text.Component
+import net.kyori.adventure.text.event.ClickEvent
+import net.kyori.adventure.text.event.HoverEvent
+import net.kyori.adventure.text.format.NamedTextColor
+import net.kyori.adventure.text.format.TextDecoration
+
+/**
+ * Builds Adventure components for the in-game `/g help` UI.
+ *
+ * Two public surfaces:
+ *  - [renderTopicMenu] - the top-level topic picker (no argument).
+ *  - [renderTopicPage] - one topic's command list (`/g help <topic>`).
+ *
+ * All click events use `RUN_COMMAND` (for topic switches) or
+ * `SUGGEST_COMMAND` (for command prefill) so Geyser maps them to taps.
+ */
+object HelpTopicsRenderer {
+
+    fun renderTopicMenu(): Component {
+        val header = Component.text("─── LumaGuilds Help ───", NamedTextColor.GOLD, TextDecoration.BOLD)
+        val intro = Component.text("Pick a topic (click or type /g help <topic>):", NamedTextColor.GRAY)
+
+        val entries = HelpTopics.all.map { topic ->
+            Component.text()
+                .append(Component.text("  [", NamedTextColor.DARK_GRAY))
+                .append(Component.text(topic.displayName, NamedTextColor.YELLOW))
+                .append(Component.text("] ", NamedTextColor.DARK_GRAY))
+                .append(Component.text(topic.summary, NamedTextColor.GRAY))
+                .clickEvent(ClickEvent.runCommand("/g help ${topic.slug}"))
+                .hoverEvent(HoverEvent.showText(Component.text("Open ${topic.displayName} help", NamedTextColor.GOLD)))
+                .build()
+        }
+
+        val wikiLink = Component.text()
+            .append(Component.text("Full wiki: ", NamedTextColor.GRAY))
+            .append(
+                Component.text(HelpTopics.WIKI_BASE_URL, NamedTextColor.AQUA, TextDecoration.UNDERLINED)
+                    .clickEvent(ClickEvent.openUrl(HelpTopics.WIKI_BASE_URL))
+                    .hoverEvent(HoverEvent.showText(Component.text("Open in browser", NamedTextColor.GOLD))),
+            )
+            .build()
+
+        val out = Component.text()
+            .append(header).append(Component.newline())
+            .append(intro).append(Component.newline())
+        entries.forEach { out.append(it).append(Component.newline()) }
+        out.append(wikiLink)
+        return out.build()
+    }
+
+    fun renderTopicPage(topic: HelpTopic): Component {
+        val header = Component.text("─── Help · ${topic.displayName} ───", NamedTextColor.GOLD, TextDecoration.BOLD)
+        val summary = Component.text(topic.summary, NamedTextColor.GRAY)
+
+        val commandLines = topic.commands.map { entry ->
+            val line = Component.text()
+                .append(Component.text("  ", NamedTextColor.DARK_GRAY))
+                .append(Component.text(entry.syntax, NamedTextColor.WHITE))
+            if (entry.prefill.isNotEmpty()) {
+                line.clickEvent(ClickEvent.suggestCommand(entry.prefill))
+                    .hoverEvent(
+                        HoverEvent.showText(
+                            Component.text()
+                                .append(Component.text(entry.blurb, NamedTextColor.GOLD))
+                                .append(Component.newline())
+                                .append(Component.text("Click to prefill in chat", NamedTextColor.GRAY))
+                                .build(),
+                        ),
+                    )
+            } else {
+                line.hoverEvent(HoverEvent.showText(Component.text(entry.blurb, NamedTextColor.GOLD)))
+            }
+            line.build()
+        }
+
+        val wikiUrl = "${HelpTopics.WIKI_BASE_URL}/${topic.slug}/"
+        val wikiLine = Component.text()
+            .append(Component.text("Read more: ", NamedTextColor.GRAY))
+            .append(
+                Component.text(wikiUrl, NamedTextColor.AQUA, TextDecoration.UNDERLINED)
+                    .clickEvent(ClickEvent.openUrl(wikiUrl))
+                    .hoverEvent(HoverEvent.showText(Component.text("Open in browser", NamedTextColor.GOLD))),
+            )
+            .build()
+
+        val back = Component.text("[Back to topics]", NamedTextColor.YELLOW)
+            .clickEvent(ClickEvent.runCommand("/g help"))
+            .hoverEvent(HoverEvent.showText(Component.text("Open the topic menu", NamedTextColor.GOLD)))
+
+        val out = Component.text()
+            .append(header).append(Component.newline())
+            .append(summary).append(Component.newline())
+            .append(Component.text("Commands:", NamedTextColor.YELLOW)).append(Component.newline())
+        commandLines.forEach { out.append(it).append(Component.newline()) }
+        out.append(Component.newline())
+            .append(wikiLine).append(Component.newline())
+            .append(back)
+        return out.build()
+    }
+}

--- a/src/test/kotlin/net/lumalyte/lg/interaction/help/HelpTopicTest.kt
+++ b/src/test/kotlin/net/lumalyte/lg/interaction/help/HelpTopicTest.kt
@@ -54,4 +54,11 @@ class HelpTopicTest {
             HelpTopic(slug = "x", displayName = "", summary = "y", commands = emptyList())
         }
     }
+
+    @Test
+    fun `HelpTopic rejects a blank summary`() {
+        assertFailsWith<IllegalArgumentException> {
+            HelpTopic(slug = "x", displayName = "y", summary = "", commands = emptyList())
+        }
+    }
 }

--- a/src/test/kotlin/net/lumalyte/lg/interaction/help/HelpTopicTest.kt
+++ b/src/test/kotlin/net/lumalyte/lg/interaction/help/HelpTopicTest.kt
@@ -1,0 +1,57 @@
+package net.lumalyte.lg.interaction.help
+
+import org.junit.jupiter.api.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
+import kotlin.test.assertTrue
+
+class HelpTopicTest {
+
+    @Test
+    fun `HelpCommandEntry stores syntax, blurb and prefill`() {
+        val entry = HelpCommandEntry(
+            syntax = "/g sethome [name]",
+            blurb = "Set a guild home at your current location.",
+            prefill = "/g sethome ",
+        )
+        assertEquals("/g sethome [name]", entry.syntax)
+        assertEquals("Set a guild home at your current location.", entry.blurb)
+        assertEquals("/g sethome ", entry.prefill)
+    }
+
+    @Test
+    fun `HelpTopic exposes slug, display name, summary, commands`() {
+        val topic = HelpTopic(
+            slug = "homes",
+            displayName = "Homes",
+            summary = "Set and visit guild homes.",
+            commands = listOf(
+                HelpCommandEntry("/g sethome [name]", "Set a home.", "/g sethome "),
+                HelpCommandEntry("/g home [name]", "Visit a home.", "/g home "),
+            ),
+        )
+        assertEquals("homes", topic.slug)
+        assertEquals("Homes", topic.displayName)
+        assertEquals(2, topic.commands.size)
+    }
+
+    @Test
+    fun `HelpTopic rejects an invalid slug`() {
+        val ex = assertFailsWith<IllegalArgumentException> {
+            HelpTopic(
+                slug = "Bad Slug!",
+                displayName = "Bad",
+                summary = "x",
+                commands = emptyList(),
+            )
+        }
+        assertTrue("slug" in ex.message!!.lowercase())
+    }
+
+    @Test
+    fun `HelpTopic rejects an empty display name`() {
+        assertFailsWith<IllegalArgumentException> {
+            HelpTopic(slug = "x", displayName = "", summary = "y", commands = emptyList())
+        }
+    }
+}

--- a/src/test/kotlin/net/lumalyte/lg/interaction/help/HelpTopicsRendererTest.kt
+++ b/src/test/kotlin/net/lumalyte/lg/interaction/help/HelpTopicsRendererTest.kt
@@ -1,0 +1,102 @@
+package net.lumalyte.lg.interaction.help
+
+import net.kyori.adventure.text.Component
+import net.kyori.adventure.text.event.ClickEvent
+import org.junit.jupiter.api.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNotNull
+import kotlin.test.assertTrue
+
+class HelpTopicsRendererTest {
+
+    private val renderer = HelpTopicsRenderer
+
+    @Test
+    fun `topic menu renders a non-empty component`() {
+        val component = renderer.renderTopicMenu()
+        assertTrue(component != Component.empty())
+    }
+
+    @Test
+    fun `topic menu lists every topic in HelpTopics`() {
+        val rendered = renderer.renderTopicMenu().toPlainText()
+        HelpTopics.all.forEach { topic ->
+            assertTrue(
+                topic.displayName in rendered,
+                "Topic menu is missing display name '${topic.displayName}'",
+            )
+        }
+    }
+
+    @Test
+    fun `each topic entry has a click event running the help command`() {
+        val rendered = renderer.renderTopicMenu()
+        HelpTopics.all.forEach { topic ->
+            val match = rendered.findRunCommandClick("/g help ${topic.slug}")
+            assertNotNull(match, "No RUN_COMMAND click for /g help ${topic.slug}")
+        }
+    }
+
+    @Test
+    fun `topic menu includes a wiki link at the bottom`() {
+        val rendered = renderer.renderTopicMenu().toPlainText()
+        assertTrue(HelpTopics.WIKI_BASE_URL in rendered)
+    }
+
+    @Test
+    fun `topic page header includes the topic display name`() {
+        val homes = HelpTopics.bySlug("homes")!!
+        val rendered = renderer.renderTopicPage(homes).toPlainText()
+        assertTrue("Help · Homes" in rendered)
+    }
+
+    @Test
+    fun `topic page lists every command syntax for that topic`() {
+        val homes = HelpTopics.bySlug("homes")!!
+        val rendered = renderer.renderTopicPage(homes).toPlainText()
+        homes.commands.forEach { entry ->
+            assertTrue(entry.syntax in rendered, "Missing syntax '${entry.syntax}'")
+        }
+    }
+
+    @Test
+    fun `command entries with a prefill use SUGGEST_COMMAND click`() {
+        val homes = HelpTopics.bySlug("homes")!!
+        val rendered = renderer.renderTopicPage(homes)
+        val sethomeClick = rendered.findSuggestCommandClick("/g sethome ")
+        assertNotNull(sethomeClick, "No SUGGEST_COMMAND click prefilling '/g sethome '")
+    }
+
+    @Test
+    fun `topic page includes deep link to matching wiki URL`() {
+        val homes = HelpTopics.bySlug("homes")!!
+        val rendered = renderer.renderTopicPage(homes).toPlainText()
+        assertTrue("${HelpTopics.WIKI_BASE_URL}/homes/" in rendered)
+    }
+
+    @Test
+    fun `topic page has a Back to topics action`() {
+        val homes = HelpTopics.bySlug("homes")!!
+        val rendered = renderer.renderTopicPage(homes)
+        val back = rendered.findRunCommandClick("/g help")
+        assertNotNull(back, "No RUN_COMMAND click for '/g help' (Back action)")
+    }
+}
+
+private fun Component.toPlainText(): String =
+    net.kyori.adventure.text.serializer.plain.PlainTextComponentSerializer.plainText().serialize(this)
+
+private fun Component.allComponents(): List<Component> =
+    listOf(this) + children().flatMap { it.allComponents() }
+
+private fun Component.findRunCommandClick(command: String): Component? =
+    allComponents().firstOrNull {
+        val ce = it.clickEvent()
+        ce?.action() == ClickEvent.Action.RUN_COMMAND && ce.value() == command
+    }
+
+private fun Component.findSuggestCommandClick(value: String): Component? =
+    allComponents().firstOrNull {
+        val ce = it.clickEvent()
+        ce?.action() == ClickEvent.Action.SUGGEST_COMMAND && ce.value() == value
+    }

--- a/src/test/kotlin/net/lumalyte/lg/interaction/help/HelpTopicsTest.kt
+++ b/src/test/kotlin/net/lumalyte/lg/interaction/help/HelpTopicsTest.kt
@@ -1,0 +1,61 @@
+package net.lumalyte.lg.interaction.help
+
+import org.junit.jupiter.api.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNotNull
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+
+class HelpTopicsTest {
+
+    @Test
+    fun `all 13 player topics are registered`() {
+        val expected = setOf(
+            "guilds", "ranks", "homes", "alliances", "war",
+            "chat", "identity", "progression", "vault", "mode",
+            "shop", "lfg", "bedrock",
+        )
+        assertEquals(expected, HelpTopics.all.map { it.slug }.toSet())
+    }
+
+    @Test
+    fun `topics are returned in display order`() {
+        val firstFour = HelpTopics.all.take(4).map { it.slug }
+        assertEquals(listOf("guilds", "homes", "ranks", "chat"), firstFour)
+    }
+
+    @Test
+    fun `bySlug returns the matching topic`() {
+        val homes = HelpTopics.bySlug("homes")
+        assertNotNull(homes)
+        assertEquals("Homes", homes.displayName)
+    }
+
+    @Test
+    fun `bySlug is case-insensitive`() {
+        assertNotNull(HelpTopics.bySlug("HOMES"))
+        assertNotNull(HelpTopics.bySlug("Homes"))
+    }
+
+    @Test
+    fun `bySlug returns null for unknown slug`() {
+        assertNull(HelpTopics.bySlug("nonexistent"))
+    }
+
+    @Test
+    fun `every topic has at least one command`() {
+        HelpTopics.all.forEach { topic ->
+            assertTrue(topic.commands.isNotEmpty(), "Topic ${topic.slug} has no commands")
+        }
+    }
+
+    @Test
+    fun `every topic summary fits the 140-char wiki front-matter limit`() {
+        HelpTopics.all.forEach { topic ->
+            assertTrue(
+                topic.summary.length <= 140,
+                "Topic ${topic.slug} summary is ${topic.summary.length} chars",
+            )
+        }
+    }
+}

--- a/tools/wiki/check_topic_parity.py
+++ b/tools/wiki/check_topic_parity.py
@@ -1,0 +1,64 @@
+#!/usr/bin/env python3
+"""Verify every HelpTopics.kt slug has a matching wiki/docs/players/<slug>.md
+(and every wiki/docs/players/<slug>.md other than `how-do-i.md` has a topic
+entry in HelpTopics.kt).
+
+Exit code 1 on mismatch; prints all mismatches before exiting.
+"""
+
+from __future__ import annotations
+
+import re
+import sys
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+HELP_TOPICS_KT = REPO_ROOT / "src/main/kotlin/net/lumalyte/lg/interaction/help/HelpTopics.kt"
+PLAYERS_DIR = REPO_ROOT / "wiki/docs/players"
+
+# Pages that exist in wiki/docs/players/ but intentionally have no HelpTopics entry:
+WIKI_ONLY = {"how-do-i"}
+
+SLUG_RE = re.compile(r'slug\s*=\s*"([a-z0-9][a-z0-9-]*)"')
+
+
+def kotlin_slugs() -> set[str]:
+    src = HELP_TOPICS_KT.read_text(encoding="utf-8")
+    return set(SLUG_RE.findall(src))
+
+
+def wiki_slugs() -> set[str]:
+    return {p.stem for p in PLAYERS_DIR.glob("*.md")} - WIKI_ONLY
+
+
+def main() -> int:
+    kt = kotlin_slugs()
+    wiki = wiki_slugs()
+
+    missing_wiki = sorted(kt - wiki)
+    missing_kt = sorted(wiki - kt)
+
+    if missing_wiki:
+        print("Slugs in HelpTopics.kt missing a wiki page in wiki/docs/players/:", file=sys.stderr)
+        for s in missing_wiki:
+            print(f"  - {s} (expected wiki/docs/players/{s}.md)", file=sys.stderr)
+
+    if missing_kt:
+        print("Wiki pages in wiki/docs/players/ missing a HelpTopics entry:", file=sys.stderr)
+        for s in missing_kt:
+            print(f"  - {s} (add to HelpTopics.all or to WIKI_ONLY in this script)", file=sys.stderr)
+
+    if missing_wiki or missing_kt:
+        print(
+            "\nFix: add the missing page OR add the missing HelpTopics entry. "
+            "See CONTRIBUTING.md -> 'Keeping /g help and the wiki in sync'.",
+            file=sys.stderr,
+        )
+        return 1
+
+    print(f"OK -- {len(kt)} topics in parity with wiki.")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tools/wiki/lint_frontmatter.py
+++ b/tools/wiki/lint_frontmatter.py
@@ -1,0 +1,101 @@
+#!/usr/bin/env python3
+"""Validate YAML front-matter on every wiki/docs/**/*.md page.
+
+Required fields: title, audience, topic, summary, keywords, related, updated.
+audience must be one of: player, admin, dev.
+topic must be a lowercase-hyphenated slug matching the filename stem.
+summary must be <=140 chars.
+
+Exit code 1 on any failure; prints all failures before exiting.
+"""
+
+from __future__ import annotations
+
+import re
+import sys
+from pathlib import Path
+
+try:
+    import yaml
+except ImportError:
+    print("PyYAML is required. Install with: pip install pyyaml", file=sys.stderr)
+    sys.exit(2)
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+DOCS_ROOT = REPO_ROOT / "wiki" / "docs"
+
+REQUIRED_FIELDS = {"title", "audience", "topic", "summary", "keywords", "related", "updated"}
+VALID_AUDIENCES = {"player", "admin", "dev"}
+SLUG_RE = re.compile(r"^[a-z0-9]+(-[a-z0-9]+)*$")
+SUMMARY_MAX = 140
+
+# Files whose `topic` slug intentionally does not match the filename stem.
+SLUG_EXEMPT = {
+    Path("index.md"),
+    Path("developers/getting-started.md"),
+    Path("developers/placeholders.md"),
+}
+
+
+def parse_frontmatter(text: str) -> dict | None:
+    if not text.startswith("---\n"):
+        return None
+    end = text.find("\n---", 4)
+    if end == -1:
+        return None
+    return yaml.safe_load(text[4:end])
+
+
+def lint(path: Path) -> list[str]:
+    rel = path.relative_to(DOCS_ROOT)
+    errors: list[str] = []
+    text = path.read_text(encoding="utf-8")
+    fm = parse_frontmatter(text)
+    if fm is None:
+        return [f"{rel}: missing or malformed YAML front-matter"]
+
+    missing = REQUIRED_FIELDS - fm.keys()
+    if missing:
+        errors.append(f"{rel}: missing required fields: {sorted(missing)}")
+
+    if "audience" in fm and fm["audience"] not in VALID_AUDIENCES:
+        errors.append(f"{rel}: audience={fm['audience']!r} not in {VALID_AUDIENCES}")
+
+    if "topic" in fm:
+        slug = str(fm["topic"])
+        if not SLUG_RE.match(slug):
+            errors.append(f"{rel}: topic={slug!r} not a lowercase-hyphenated slug")
+        if rel not in SLUG_EXEMPT and path.stem != slug:
+            errors.append(f"{rel}: topic={slug!r} does not match filename stem {path.stem!r}")
+
+    if "summary" in fm and isinstance(fm["summary"], str) and len(fm["summary"]) > SUMMARY_MAX:
+        errors.append(f"{rel}: summary is {len(fm['summary'])} chars (max {SUMMARY_MAX})")
+
+    if "keywords" in fm and not isinstance(fm["keywords"], list):
+        errors.append(f"{rel}: keywords must be a list")
+
+    if "related" in fm and not isinstance(fm["related"], list):
+        errors.append(f"{rel}: related must be a list")
+
+    return errors
+
+
+def main() -> int:
+    failures: list[str] = []
+    pages = sorted(DOCS_ROOT.rglob("*.md"))
+    if not pages:
+        print(f"No markdown pages found under {DOCS_ROOT}", file=sys.stderr)
+        return 1
+    for page in pages:
+        failures.extend(lint(page))
+    if failures:
+        for line in failures:
+            print(line, file=sys.stderr)
+        print(f"\n{len(failures)} front-matter problem(s) across {len(pages)} pages.", file=sys.stderr)
+        return 1
+    print(f"OK -- {len(pages)} pages validated.")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tools/wiki/lint_frontmatter.py
+++ b/tools/wiki/lint_frontmatter.py
@@ -43,7 +43,13 @@ def parse_frontmatter(text: str) -> dict | None:
     end = text.find("\n---", 4)
     if end == -1:
         return None
-    return yaml.safe_load(text[4:end])
+    try:
+        parsed = yaml.safe_load(text[4:end])
+    except yaml.YAMLError:
+        return None
+    if not isinstance(parsed, dict):
+        return None
+    return parsed
 
 
 def lint(path: Path) -> list[str]:

--- a/wiki/docs/.pages
+++ b/wiki/docs/.pages
@@ -1,0 +1,6 @@
+nav:
+  - index.md
+  - Getting Started: getting-started
+  - Players: players
+  - Admins: admins
+  - Developers: developers

--- a/wiki/docs/admins/.pages
+++ b/wiki/docs/admins/.pages
@@ -1,0 +1,11 @@
+nav:
+  - Installation: installation.md
+  - Permission nodes: permissions.md
+  - Override & recovery: override.md
+  - Troubleshooting: troubleshooting.md
+  - PlaceholderAPI: placeholderapi.md
+  - RoseChat: rosechat.md
+  - Geyser/Floodgate: geyser.md
+  - Lunar Client: lunar.md
+  - Web leaderboard API: leaderboard-api.md
+  - Claims: claims.md

--- a/wiki/docs/admins/claims.md
+++ b/wiki/docs/admins/claims.md
@@ -1,0 +1,13 @@
+---
+title: Claims integration
+audience: admin
+topic: claims
+summary: How LumaGuilds integrates with the claims plugin.
+keywords: []
+related: []
+updated: 2026-05-13
+---
+
+# Claims integration
+
+*This page is a placeholder. Content coming in Phase 2/3.*

--- a/wiki/docs/admins/geyser.md
+++ b/wiki/docs/admins/geyser.md
@@ -1,0 +1,13 @@
+---
+title: Geyser/Floodgate behavior
+audience: admin
+topic: geyser
+summary: Bedrock-via-Geyser behavior and known limitations.
+keywords: []
+related: []
+updated: 2026-05-13
+---
+
+# Geyser/Floodgate behavior
+
+*This page is a placeholder. Content coming in Phase 2/3.*

--- a/wiki/docs/admins/installation.md
+++ b/wiki/docs/admins/installation.md
@@ -1,0 +1,13 @@
+---
+title: Installation & config.yml
+audience: admin
+topic: installation
+summary: Install LumaGuilds and walk through config.yml.
+keywords: []
+related: []
+updated: 2026-05-13
+---
+
+# Installation & config.yml
+
+*This page is a placeholder. Content coming in Phase 2/3.*

--- a/wiki/docs/admins/leaderboard-api.md
+++ b/wiki/docs/admins/leaderboard-api.md
@@ -1,0 +1,13 @@
+---
+title: Web leaderboard API
+audience: admin
+topic: leaderboard-api
+summary: Public HTTP API for the guild leaderboard.
+keywords: []
+related: []
+updated: 2026-05-13
+---
+
+# Web leaderboard API
+
+*This page is a placeholder. Content coming in Phase 2/3.*

--- a/wiki/docs/admins/lunar.md
+++ b/wiki/docs/admins/lunar.md
@@ -1,0 +1,13 @@
+---
+title: Lunar Client integration
+audience: admin
+topic: lunar
+summary: Lunar Client features LumaGuilds drives.
+keywords: []
+related: []
+updated: 2026-05-13
+---
+
+# Lunar Client integration
+
+*This page is a placeholder. Content coming in Phase 2/3.*

--- a/wiki/docs/admins/lunar.md
+++ b/wiki/docs/admins/lunar.md
@@ -2,7 +2,7 @@
 title: Lunar Client integration
 audience: admin
 topic: lunar
-summary: Lunar Client features LumaGuilds drives.
+summary: LumaGuilds features available in Lunar Client.
 keywords: []
 related: []
 updated: 2026-05-13

--- a/wiki/docs/admins/override.md
+++ b/wiki/docs/admins/override.md
@@ -1,0 +1,13 @@
+---
+title: /lumaguilds override and recovery
+audience: admin
+topic: override
+summary: Use admin override to recover broken guilds.
+keywords: []
+related: []
+updated: 2026-05-13
+---
+
+# /lumaguilds override and recovery
+
+*This page is a placeholder. Content coming in Phase 2/3.*

--- a/wiki/docs/admins/permissions.md
+++ b/wiki/docs/admins/permissions.md
@@ -1,0 +1,13 @@
+---
+title: Permission nodes reference
+audience: admin
+topic: permissions
+summary: Every permission node the plugin defines.
+keywords: []
+related: []
+updated: 2026-05-13
+---
+
+# Permission nodes reference
+
+*This page is a placeholder. Content coming in Phase 2/3.*

--- a/wiki/docs/admins/placeholderapi.md
+++ b/wiki/docs/admins/placeholderapi.md
@@ -1,0 +1,13 @@
+---
+title: PlaceholderAPI placeholders
+audience: admin
+topic: placeholderapi
+summary: Every PAPI placeholder LumaGuilds exposes.
+keywords: []
+related: []
+updated: 2026-05-13
+---
+
+# PlaceholderAPI placeholders
+
+*This page is a placeholder. Content coming in Phase 2/3.*

--- a/wiki/docs/admins/rosechat.md
+++ b/wiki/docs/admins/rosechat.md
@@ -1,0 +1,13 @@
+---
+title: RoseChat integration
+audience: admin
+topic: rosechat
+summary: How LumaGuilds integrates with RoseChat.
+keywords: []
+related: []
+updated: 2026-05-13
+---
+
+# RoseChat integration
+
+*This page is a placeholder. Content coming in Phase 2/3.*

--- a/wiki/docs/admins/troubleshooting.md
+++ b/wiki/docs/admins/troubleshooting.md
@@ -1,0 +1,13 @@
+---
+title: Troubleshooting
+audience: admin
+topic: troubleshooting
+summary: Common operator issues and fixes.
+keywords: []
+related: []
+updated: 2026-05-13
+---
+
+# Troubleshooting
+
+*This page is a placeholder. Content coming in Phase 2/3.*

--- a/wiki/docs/developers/.pages
+++ b/wiki/docs/developers/.pages
@@ -1,0 +1,13 @@
+nav:
+  - Getting started: getting-started.md
+  - Architecture: architecture.md
+  - Domain layer: domain.md
+  - Application layer: application.md
+  - Infrastructure layer: infrastructure.md
+  - Interaction layer: interaction.md
+  - Master diagram: master-diagram.md
+  - API reference: api-reference.md
+  - Placeholders (internal): placeholders.md
+  - Emoji permissions: emoji-permissions.md
+  - Migration safety: migration-safety.md
+  - Schema setup: schema-setup.md

--- a/wiki/docs/developers/api-reference.md
+++ b/wiki/docs/developers/api-reference.md
@@ -1,0 +1,13 @@
+---
+title: API reference
+audience: dev
+topic: api-reference
+summary: Public API surface.
+keywords: []
+related: []
+updated: 2026-05-13
+---
+
+# API reference
+
+*This page is a placeholder. Content coming in Phase 2/3.*

--- a/wiki/docs/developers/application.md
+++ b/wiki/docs/developers/application.md
@@ -1,0 +1,13 @@
+---
+title: Application layer
+audience: dev
+topic: application
+summary: Application services and actions.
+keywords: []
+related: []
+updated: 2026-05-13
+---
+
+# Application layer
+
+*This page is a placeholder. Content coming in Phase 2/3.*

--- a/wiki/docs/developers/architecture.md
+++ b/wiki/docs/developers/architecture.md
@@ -1,0 +1,13 @@
+---
+title: Architecture overview
+audience: dev
+topic: architecture
+summary: Hexagonal layering and high-level structure.
+keywords: []
+related: []
+updated: 2026-05-13
+---
+
+# Architecture overview
+
+*This page is a placeholder. Content coming in Phase 2/3.*

--- a/wiki/docs/developers/domain.md
+++ b/wiki/docs/developers/domain.md
@@ -1,0 +1,13 @@
+---
+title: Domain layer
+audience: dev
+topic: domain
+summary: Domain entities and value objects.
+keywords: []
+related: []
+updated: 2026-05-13
+---
+
+# Domain layer
+
+*This page is a placeholder. Content coming in Phase 2/3.*

--- a/wiki/docs/developers/emoji-permissions.md
+++ b/wiki/docs/developers/emoji-permissions.md
@@ -1,0 +1,13 @@
+---
+title: Emoji permissions
+audience: dev
+topic: emoji-permissions
+summary: Permission scheme for emoji selection.
+keywords: []
+related: []
+updated: 2026-05-13
+---
+
+# Emoji permissions
+
+*This page is a placeholder. Content coming in Phase 2/3.*

--- a/wiki/docs/developers/getting-started.md
+++ b/wiki/docs/developers/getting-started.md
@@ -1,0 +1,13 @@
+---
+title: Developer getting started
+audience: dev
+topic: dev-getting-started
+summary: Onboarding for plugin contributors.
+keywords: []
+related: []
+updated: 2026-05-13
+---
+
+# Developer getting started
+
+*This page is a placeholder. Content coming in Phase 2/3.*

--- a/wiki/docs/developers/infrastructure.md
+++ b/wiki/docs/developers/infrastructure.md
@@ -1,0 +1,13 @@
+---
+title: Infrastructure layer
+audience: dev
+topic: infrastructure
+summary: Persistence, framework adapters, and integrations.
+keywords: []
+related: []
+updated: 2026-05-13
+---
+
+# Infrastructure layer
+
+*This page is a placeholder. Content coming in Phase 2/3.*

--- a/wiki/docs/developers/interaction.md
+++ b/wiki/docs/developers/interaction.md
@@ -1,0 +1,13 @@
+---
+title: Interaction layer
+audience: dev
+topic: interaction
+summary: Commands, listeners, and menus.
+keywords: []
+related: []
+updated: 2026-05-13
+---
+
+# Interaction layer
+
+*This page is a placeholder. Content coming in Phase 2/3.*

--- a/wiki/docs/developers/master-diagram.md
+++ b/wiki/docs/developers/master-diagram.md
@@ -1,0 +1,13 @@
+---
+title: Master diagram
+audience: dev
+topic: master-diagram
+summary: Big-picture architecture diagram.
+keywords: []
+related: []
+updated: 2026-05-13
+---
+
+# Master diagram
+
+*This page is a placeholder. Content coming in Phase 2/3.*

--- a/wiki/docs/developers/migration-safety.md
+++ b/wiki/docs/developers/migration-safety.md
@@ -1,0 +1,13 @@
+---
+title: Migration safety
+audience: dev
+topic: migration-safety
+summary: Schema migration guarantees and rollback strategy.
+keywords: []
+related: []
+updated: 2026-05-13
+---
+
+# Migration safety
+
+*This page is a placeholder. Content coming in Phase 2/3.*

--- a/wiki/docs/developers/placeholders.md
+++ b/wiki/docs/developers/placeholders.md
@@ -1,7 +1,7 @@
 ---
-title: Placeholders (internal)
+title: Placeholders
 audience: dev
-topic: placeholders-internal
+topic: placeholders
 summary: How placeholder resolution works internally.
 keywords: []
 related: []

--- a/wiki/docs/developers/placeholders.md
+++ b/wiki/docs/developers/placeholders.md
@@ -1,0 +1,13 @@
+---
+title: Placeholders (internal)
+audience: dev
+topic: placeholders-internal
+summary: How placeholder resolution works internally.
+keywords: []
+related: []
+updated: 2026-05-13
+---
+
+# Placeholders (internal)
+
+*This page is a placeholder. Content coming in Phase 2/3.*

--- a/wiki/docs/developers/schema-setup.md
+++ b/wiki/docs/developers/schema-setup.md
@@ -1,0 +1,13 @@
+---
+title: Schema setup
+audience: dev
+topic: schema-setup
+summary: Initial schema and bootstrap notes.
+keywords: []
+related: []
+updated: 2026-05-13
+---
+
+# Schema setup
+
+*This page is a placeholder. Content coming in Phase 2/3.*

--- a/wiki/docs/getting-started/.pages
+++ b/wiki/docs/getting-started/.pages
@@ -1,0 +1,4 @@
+nav:
+  - Welcome: welcome.md
+  - Your first 30 minutes: walkthrough.md
+  - FAQ: faq.md

--- a/wiki/docs/getting-started/faq.md
+++ b/wiki/docs/getting-started/faq.md
@@ -18,11 +18,7 @@ No. You can play the entire server solo. Joining a guild just unlocks the guild-
 
 `/g leave`. If you're the owner, you must transfer ownership first (`/g transfer <player>`) or disband (`/g disband`).
 
-## My guild tag isn't showing colors in chat
-
-The colors are stored as MiniMessage, which the chat plugin converts to display colors. If they're not rendering, you may be in a chat channel that doesn't format them. Try `/g chat` to switch to guild chat — colors render there.
-
-## Why does `/g home` say "teleport failed"?
+## Why does `/g home` say "Unsafe"?
 
 The destination is unsafe (lava/fire/cactus right where the home was set), or a protection plugin blocked the teleport. Move the home (`/g sethome` somewhere safe) and try again.
 
@@ -40,4 +36,4 @@ Mostly. A few menus open as chat-based forms instead of inventory GUIs, and clic
 
 ## Where do I report a bug?
 
-Tell staff in-game or open an issue at <https://github.com/BadgersMC/LumaGuilds/issues>.
+Report it in our Discord, or open an issue at <https://github.com/BadgersMC/LumaGuilds/issues>.

--- a/wiki/docs/getting-started/faq.md
+++ b/wiki/docs/getting-started/faq.md
@@ -1,0 +1,13 @@
+---
+title: FAQ
+audience: player
+topic: faq
+summary: Common questions from new players.
+keywords: []
+related: []
+updated: 2026-05-13
+---
+
+# FAQ
+
+*This page is a placeholder. Content coming in Phase 2/3.*

--- a/wiki/docs/getting-started/faq.md
+++ b/wiki/docs/getting-started/faq.md
@@ -2,12 +2,42 @@
 title: FAQ
 audience: player
 topic: faq
-summary: Common questions from new players.
-keywords: []
-related: []
+summary: Common questions from new players about LumaGuilds.
+keywords: [faq, common questions, help, troubleshooting]
+related: [walkthrough, chat, homes]
 updated: 2026-05-13
 ---
 
 # FAQ
 
-*This page is a placeholder. Content coming in Phase 2/3.*
+## Do I have to be in a guild?
+
+No. You can play the entire server solo. Joining a guild just unlocks the guild-specific features (shared homes, alliance/war, guild chat, progression).
+
+## How do I leave my guild?
+
+`/g leave`. If you're the owner, you must transfer ownership first (`/g transfer <player>`) or disband (`/g disband`).
+
+## My guild tag isn't showing colors in chat
+
+The colors are stored as MiniMessage, which the chat plugin converts to display colors. If they're not rendering, you may be in a chat channel that doesn't format them. Try `/g chat` to switch to guild chat — colors render there.
+
+## Why does `/g home` say "teleport failed"?
+
+The destination is unsafe (lava/fire/cactus right where the home was set), or a protection plugin blocked the teleport. Move the home (`/g sethome` somewhere safe) and try again.
+
+## Can I have more than one home?
+
+Yes. `/g sethome <name>` creates additional named homes (`shop`, `mine`, etc.). The number of slots scales with your guild level. See [Players → Homes](../players/homes.md).
+
+## How do alliances work?
+
+`/g ally <other guild>` sends a request. They run `/g ally <you>` back to accept. Until both have done it, you're not actually allied. See [Players → Alliances & Diplomacy](../players/alliances.md).
+
+## I'm on Bedrock — does this all work?
+
+Mostly. A few menus open as chat-based forms instead of inventory GUIs, and clickable chat buttons map to taps. See [Players → Bedrock differences](../players/bedrock.md).
+
+## Where do I report a bug?
+
+Tell staff in-game or open an issue at <https://github.com/BadgersMC/LumaGuilds/issues>.

--- a/wiki/docs/getting-started/walkthrough.md
+++ b/wiki/docs/getting-started/walkthrough.md
@@ -2,12 +2,98 @@
 title: Your first 30 minutes
 audience: player
 topic: walkthrough
-summary: A guided tour for new players.
-keywords: []
-related: []
+summary: A guided tour for new players — spawn to working guild in seven steps.
+keywords: [walkthrough, tutorial, onboarding, first time, getting started]
+related: [welcome, guilds, homes, chat]
 updated: 2026-05-13
 ---
 
 # Your first 30 minutes
 
-*This page is a placeholder. Content coming in Phase 2/3.*
+A guided tour for new players. Follow it top-to-bottom and you'll end up in a working guild with a tag, a home, chat configured, and a clear next move.
+
+## 1. Spawn and orientation
+
+When you first join, you'll spawn at the world spawn. Look around. Note:
+
+- Chat is global by default. Anything you type goes to everyone.
+- You don't need a guild to play, but a lot of the social and PvE/PvP features run through guilds.
+- Type `/g help` any time to get a clickable in-game help menu.
+
+## 2. Joining or creating a guild
+
+You have three options:
+
+**Join an existing guild** — ask in chat, or browse leaderboards with `/g list`. If a guild is open, you can join directly. If it's invite-only, ask a member to `/g invite` you.
+
+**Create your own** — pick a name (plain text, max 32 chars, letters/numbers/spaces/`'`/`&`/`-`) and run:
+
+```
+/g create <name>
+```
+
+Example: `/g create White Lotus`
+
+**Hold off for now** — you don't have to. You can come back later.
+
+See [Players → Guilds](../players/guilds.md) for the full reference.
+
+## 3. Setting your tag and home
+
+Once you're in a guild, two things make it feel like home.
+
+**Tag** — fancy formatting that appears next to your name in chat. Use MiniMessage:
+
+```
+/g tag <gradient:#FF6A00:#FF1F00>Lotus</gradient>
+```
+
+Or run `/g tag` with no arguments to open a visual editor.
+
+**Home** — a teleport point your guild can share. Stand where you want it and run:
+
+```
+/g sethome
+```
+
+That sets the default home. You can have multiple — `/g sethome shop`, `/g sethome mine`. Teleport with `/g home` or `/g home <name>`. See [Players → Homes](../players/homes.md).
+
+## 4. Inviting a friend
+
+```
+/g invite <player>
+```
+
+They run `/g accept <yourguild>` (or click the chat prompt). Done.
+
+Need more control? You can lock invites to specific ranks, or set up "open" mode so anyone can join. See [Players → LFG & Invites](../players/lfg.md).
+
+## 5. Chat basics
+
+Two toggles you should know:
+
+- `/g chat` — flips your messages into guild chat. Type it again to switch back to global. Same word, same key, easy to remember.
+- `/g allychat` — same idea, but to all allied guilds.
+
+Tags and colors only appear in chat if the chat plugin renders them — they do on this server. See [Players → Chat](../players/chat.md) for the details.
+
+## 6. What XP and levels do
+
+Your guild earns XP from what its members do: mining, killing mobs, exploring. XP turns into levels. Levels unlock:
+
+- Bigger member caps.
+- More named home slots.
+- Access to advanced features (alliances, war declarations).
+- Bragging rights on the leaderboard.
+
+You don't have to micromanage it — just play. See [Players → Progression & Levels](../players/progression.md).
+
+## 7. Where to go next
+
+If you got this far you're functional. Pick one:
+
+- **Decorate your guild** — set a description (`/g desc`), pick a banner (`/g menu` → Banner).
+- **Make a friend or enemy** — `/g info <other guild>`, then `/g ally <them>` or `/g enemy <them>`. See [Players → Alliances & Diplomacy](../players/alliances.md).
+- **Read the [How do I…? index](../players/how-do-i.md)** — every common task with a deep link to the right page.
+
+That's the tour. The rest of the wiki is reference — come back as needed.

--- a/wiki/docs/getting-started/walkthrough.md
+++ b/wiki/docs/getting-started/walkthrough.md
@@ -50,7 +50,7 @@ Once you're in a guild, two things make it feel like home.
 
 Or run `/g tag` with no arguments to open a visual editor. Here are some tools to help you make a tag that stands out:
 
-- [Birdflop RGB / MiniMessage gradient picker](https://www.birdflop.com/resources/rgb/) — visual gradient builder, copy MiniMessage straight into `/g tag`
+- [Birdflop RGB / MiniMessage gradient picker](https://www.birdflop.com/resources/rgb/) — visual gradient builder, copy MiniMessage straight into `/g tag` Note that we only support MiniMessage. Use magic color codes at your own risk.
 - [fsymbols small-caps generator](https://fsymbols.com/generators/smallcaps/) — turn `Lotus` into `ʟᴏᴛᴜs` and similar styles
 - [ETC Gamer Minecraft symbols & emojis](https://etcgamer.com/minecraft-symbols-emojis/) — extra glyphs that render in chat
 

--- a/wiki/docs/getting-started/walkthrough.md
+++ b/wiki/docs/getting-started/walkthrough.md
@@ -1,0 +1,13 @@
+---
+title: Your first 30 minutes
+audience: player
+topic: walkthrough
+summary: A guided tour for new players.
+keywords: []
+related: []
+updated: 2026-05-13
+---
+
+# Your first 30 minutes
+
+*This page is a placeholder. Content coming in Phase 2/3.*

--- a/wiki/docs/getting-started/walkthrough.md
+++ b/wiki/docs/getting-started/walkthrough.md
@@ -28,7 +28,7 @@ You have three options:
 
 **Create your own** — pick a name (plain text, max 32 chars, letters/numbers and the punctuation `'`, `&`, `-`) and run:
 
-```
+```text
 /g create <name>
 ```
 
@@ -44,7 +44,7 @@ Once you're in a guild, two things make it feel like home.
 
 **Tag** — fancy formatting that appears next to your name in chat. Use MiniMessage:
 
-```
+```text
 /g tag <gradient:#FF6A00:#FF1F00>Lotus</gradient>
 ```
 
@@ -56,7 +56,7 @@ Or run `/g tag` with no arguments to open a visual editor. Here are some tools t
 
 **Home** — a teleport point your guild can share. Stand where you want it and run:
 
-```
+```text
 /g sethome
 ```
 
@@ -64,7 +64,7 @@ That sets the default home. You can have multiple — `/g sethome shop`, `/g set
 
 ## 4. Inviting a friend
 
-```
+```text
 /g invite <player>
 ```
 

--- a/wiki/docs/getting-started/walkthrough.md
+++ b/wiki/docs/getting-started/walkthrough.md
@@ -26,15 +26,15 @@ You have three options:
 
 **Join an existing guild** — ask in chat, or browse leaderboards with `/g list`. If a guild is open, you can join directly. If it's invite-only, ask a member to `/g invite` you.
 
-**Create your own** — pick a name (plain text, max 32 chars, letters/numbers/spaces/`'`/`&`/`-`) and run:
+**Create your own** — pick a name (plain text, max 32 chars, letters/numbers and the punctuation `'`, `&`, `-`) and run:
 
 ```
 /g create <name>
 ```
 
-Example: `/g create White Lotus`
+Example: `/g create WhiteLotus` or `/g create White_Lotus` — **no spaces, no color codes**.
 
-**Hold off for now** — you don't have to. You can come back later.
+**Hold off for now** — you don't have to. You can come back later. Don't feel pressured to immediately create or join a guild.
 
 See [Players → Guilds](../players/guilds.md) for the full reference.
 
@@ -48,7 +48,11 @@ Once you're in a guild, two things make it feel like home.
 /g tag <gradient:#FF6A00:#FF1F00>Lotus</gradient>
 ```
 
-Or run `/g tag` with no arguments to open a visual editor.
+Or run `/g tag` with no arguments to open a visual editor. Here are some tools to help you make a tag that stands out:
+
+- [Birdflop RGB / MiniMessage gradient picker](https://www.birdflop.com/resources/rgb/) — visual gradient builder, copy MiniMessage straight into `/g tag`
+- [fsymbols small-caps generator](https://fsymbols.com/generators/smallcaps/) — turn `Lotus` into `ʟᴏᴛᴜs` and similar styles
+- [ETC Gamer Minecraft symbols & emojis](https://etcgamer.com/minecraft-symbols-emojis/) — extra glyphs that render in chat
 
 **Home** — a teleport point your guild can share. Stand where you want it and run:
 

--- a/wiki/docs/getting-started/welcome.md
+++ b/wiki/docs/getting-started/welcome.md
@@ -2,12 +2,41 @@
 title: Welcome to EnthusiaSMP
 audience: player
 topic: welcome
-summary: Orientation for new players.
-keywords: []
-related: []
+summary: Orientation for new players — what EnthusiaSMP is, what LumaGuilds adds, and where to go next.
+keywords: [welcome, new player, onboarding, enthusiasmp]
+related: [walkthrough, faq]
 updated: 2026-05-13
 ---
 
 # Welcome to EnthusiaSMP
 
-*This page is a placeholder. Content coming in Phase 2/3.*
+This page orients you to the server and the guild system in about two minutes. When you're ready for the hands-on tour, head to **[Your first 30 minutes](walkthrough.md)**.
+
+## What is EnthusiaSMP?
+
+<!-- TODO: 2–3 sentence pitch: what kind of server (semi-anarchy SMP), the vibe, who runs it (FainNoir owns; BadgersMC dev). -->
+
+## What does LumaGuilds add?
+
+LumaGuilds is the guild plugin. It lets you:
+
+- Form a guild with friends and share a tag, banner, and identity.
+- Set named guild homes that any member (or specific ranks) can teleport to.
+- Form alliances, declare wars, sign truces.
+- Earn guild XP together as you play, unlocking perks and bigger member caps.
+- Run a shared vault.
+
+## What this wiki is for
+
+- **[Getting Started → Your first 30 minutes](walkthrough.md)** — guided tour.
+- **[Players](../players/how-do-i.md)** — every feature explained, organized by topic.
+- **[Admins](../admins/installation.md)** and **[Developers](../developers/architecture.md)** — if you run a server or work on the plugin.
+
+In-game, type `/g help` for the same content as a clickable menu.
+
+## What this wiki is *not*
+
+- Not a list of rules. Server rules live elsewhere (ask staff).
+- Not a release log. See [`CHANGELOG.md`](https://github.com/BadgersMC/LumaGuilds/blob/main/CHANGELOG.md) on GitHub.
+
+Ready? **[Start the 30-minute walkthrough →](walkthrough.md)**

--- a/wiki/docs/getting-started/welcome.md
+++ b/wiki/docs/getting-started/welcome.md
@@ -14,7 +14,7 @@ This page orients you to the server and the guild system in about two minutes. W
 
 ## What is EnthusiaSMP?
 
-<!-- TODO: 2–3 sentence pitch: what kind of server (semi-anarchy SMP), the vibe, who runs it (FainNoir owns; BadgersMC dev). -->
+EnthusiaSMP is a semi-anarchy survival multiplayer server where anything goes — except the systems. Build, raid, ally, and guild up in a true sandbox where only your reputation is safe. Owned and operated by FainNoir with plugin development by BadgersMC.
 
 ## What does LumaGuilds add?
 

--- a/wiki/docs/getting-started/welcome.md
+++ b/wiki/docs/getting-started/welcome.md
@@ -1,0 +1,13 @@
+---
+title: Welcome to EnthusiaSMP
+audience: player
+topic: welcome
+summary: Orientation for new players.
+keywords: []
+related: []
+updated: 2026-05-13
+---
+
+# Welcome to EnthusiaSMP
+
+*This page is a placeholder. Content coming in Phase 2/3.*

--- a/wiki/docs/index.md
+++ b/wiki/docs/index.md
@@ -1,0 +1,20 @@
+---
+title: LumaGuilds
+audience: player
+topic: home
+summary: Player wiki and admin/developer reference for the LumaGuilds plugin on EnthusiaSMP.
+keywords: [home, overview]
+related: []
+updated: 2026-05-13
+---
+
+# LumaGuilds
+
+LumaGuilds is the guild plugin powering [EnthusiaSMP](https://enthusiasmp.com). Pick where you want to go:
+
+- **[Getting Started](getting-started/welcome.md)** — New to the server? Start here.
+- **[Players](players/how-do-i.md)** — How everything works, organized by feature.
+- **[Admins](admins/installation.md)** — Install, configure, and integrate.
+- **[Developers](developers/architecture.md)** — Code-level reference.
+
+In-game, type `/g help` to get a clickable topic menu that mirrors this wiki.

--- a/wiki/docs/players/.pages
+++ b/wiki/docs/players/.pages
@@ -1,0 +1,15 @@
+nav:
+  - How do I…?: how-do-i.md
+  - Guilds: guilds.md
+  - Ranks & Permissions: ranks.md
+  - Homes: homes.md
+  - Alliances & Diplomacy: alliances.md
+  - War: war.md
+  - Chat: chat.md
+  - Tags, Banners & Identity: identity.md
+  - Progression & Levels: progression.md
+  - Vault: vault.md
+  - Mode: mode.md
+  - Shop integration: shop.md
+  - LFG & Invites: lfg.md
+  - Bedrock differences: bedrock.md

--- a/wiki/docs/players/alliances.md
+++ b/wiki/docs/players/alliances.md
@@ -1,0 +1,13 @@
+---
+title: Alliances & Diplomacy
+audience: player
+topic: alliances
+summary: Form alliances, declare enemies, sign truces.
+keywords: []
+related: []
+updated: 2026-05-13
+---
+
+# Alliances & Diplomacy
+
+*This page is a placeholder. Content coming in Phase 2/3.*

--- a/wiki/docs/players/alliances.md
+++ b/wiki/docs/players/alliances.md
@@ -2,12 +2,68 @@
 title: Alliances & Diplomacy
 audience: player
 topic: alliances
-summary: Form alliances, declare enemies, sign truces.
-keywords: []
-related: []
+summary: Form alliances, declare enemies, sign truces, and manage ally-home access.
+keywords: [alliances, ally, enemy, truce, neutral, diplomacy]
+related: [war, homes, ranks]
 updated: 2026-05-13
 ---
 
 # Alliances & Diplomacy
 
-*This page is a placeholder. Content coming in Phase 2/3.*
+Form alliances, declare enemies, sign truces, and manage ally-home access.
+
+## Quick reference
+
+| Command | Permission | Description |
+|---------|------------|-------------|
+| `/g ally <guild>` | `lumaguilds.guild.ally` | Request or accept an alliance. |
+| `/g enemy <guild>` | `lumaguilds.guild.enemy` | Declare another guild an enemy. |
+| `/g truce <guild>` | `lumaguilds.guild.truce` | Sign a truce (non-aggression pact). |
+| `/g neutral <guild>` | `lumaguilds.guild.neutral` | Clear an existing relation. |
+
+## How it works
+
+Every guild has *relations* with other guilds. By default, all relations are neutral. You can establish ally, enemy, or truce relations. Most relations require both sides to agree — sending `/g ally <them>` creates a *pending* request; they confirm with `/g ally <you>`. Only after both confirmations is the alliance ACTIVE. Wars come from declaring enemies and then escalating via `/g war` (see [War](war.md)).
+
+## Requesting an alliance
+
+Run `/g ally <other guild>` to request an alliance. Their guild will see a notification with a clickable accept prompt. Until they confirm with `/g ally <your guild>`, the request sits pending on both sides. Once confirmed, the alliance becomes ACTIVE and both guilds appear in each other's allies list.
+
+## Accepting an alliance
+
+When you receive an alliance request, run `/g ally <them>` from your side. The relation flips from PENDING to ACTIVE. You'll see them in your allies list and the relation indicator (🔵) appears next to their members' names in chat.
+
+## Declaring an enemy
+
+Use `/g enemy <guild>` to mark another guild as an enemy. This is unilateral — they don't have to agree to be marked. From here, war can be declared via `/g war`. Enemy relations escalate conflict; truces and going neutral are the typical ways to de-escalate.
+
+## Signing a truce
+
+A truce is a non-aggression pact between two guilds. Run `/g truce <guild>` to propose one. Both sides must confirm to make it ACTIVE. Truces commonly end an active war without going fully neutral.
+
+## Clearing a relation
+
+Use `/g neutral <guild>` to clear whatever relation you had — alliance, enemy mark, or truce. This is unilateral. Going neutral cancels any pending requests on both sides.
+
+## Setting up ally-home access
+
+Allies don't automatically reach your ally-home. You need to:
+
+1. **Set the ally-home:** Stand at your desired location and run `/g setallyhome` (requires the "Set Ally-Home" permission).
+2. **Whitelist their guild:** Open `/g menu` → Diplomacy → Ally Home Access, and add their guild to your inbound whitelist.
+3. **Give your members permission:** Make sure your guild members have the "Use Ally Homes" rank permission so they can teleport to *other guilds'* ally-homes.
+
+See [Homes](homes.md) for more detail on setting and managing ally-homes.
+
+## Gotchas
+
+- Pending alliance requests no longer auto-display as accepted (fixed in 2026 — they used to appear immediately in the allies list before the other side confirmed).
+- Going neutral cancels pending requests on both sides instantly.
+- Ally-home access requires BOTH the rank permission AND the whitelist entry — just having one won't work.
+- Declaring an enemy is unilateral, but wars are two-sided (both guilds see the declaration).
+
+## Related
+
+- [War](war.md) — escalate a conflict from enemies to active war
+- [Homes](homes.md) — set and manage your ally-home
+- [Ranks & Permissions](ranks.md) — control who can use your ally-home

--- a/wiki/docs/players/alliances.md
+++ b/wiki/docs/players/alliances.md
@@ -55,7 +55,7 @@ Allies don't automatically reach your ally-home. You need to:
 
 See [Homes](homes.md) for more detail on setting and managing ally-homes.
 
-## Gotchas
+## Recently Fixed/Changed
 
 - Pending alliance requests no longer auto-display as accepted (fixed in 2026 — they used to appear immediately in the allies list before the other side confirmed).
 - Going neutral cancels pending requests on both sides instantly.

--- a/wiki/docs/players/bedrock.md
+++ b/wiki/docs/players/bedrock.md
@@ -18,7 +18,9 @@ All guild commands work identically on Bedrock and Java. There are no Bedrock-sp
 
 ## How it works
 
-The server supports Bedrock players via Geyser (protocol translation) and Floodgate (Bedrock Forms Menus). Everything in LumaGuilds works on Bedrock — commands, vaults, homes, alliances, menus, and chat. The only differences are visual: some Java menus open as native GUI-based forms on Bedrock, and clickable chat buttons have backup commands (such as `/g ally <them>`). Behavior is otherwise identical.
+The server supports Bedrock players via Geyser (protocol translation) and Floodgate (Bedrock Forms Menus). All LumaGuilds features work on Bedrock: commands, vaults, homes, alliances, menus, and chat.
+
+The only differences are visual. Some Java menus open as native GUI-based forms on Bedrock, and clickable chat buttons have backup commands (such as `/g ally <them>`). Behavior is otherwise identical.
 
 ## What looks different in menus
 
@@ -28,11 +30,18 @@ Example: On Java, `/g homes` opens an inventory menu. On Bedrock, it opens a for
 
 ## Known limitations
 
-A few advanced menu features (drag-and-drop banner editing, complex multi-page selectors) fall back to simpler chat menus or text input on Bedrock. The substance is preserved; the UX is plainer. If you find something doesn't render correctly, report it to staff so it can be added to the known-issues list.
+A few advanced menu features fall back to simpler chat menus or text input on Bedrock. The affected features are:
+
+- **Guild banner editing:** Drag-and-drop banner placement is unavailable; Bedrock players use a text-based alternative.
+- **Multi-page selectors:** Complex paginated menus (large member lists, extended alliance directories) render as a simplified flat list without prev/next page buttons.
+- **Inventory-based GUI interactions:** Item-moving workflows (vault sorting, manual rank reordering) may show as command prompts instead of drag-and-drop interfaces.
+- **Item renaming UIs:** Custom anvil-style renaming menus fall back to plain text input.
+
+The substance is preserved; the UX is plainer. If you find something that doesn't render correctly, report it to staff so it can be added to the known-issues list.
 
 ## Teleports and cross-dimensional travel
 
-All teleports (including cross-dimensional home teleports from the Overworld to the Nether, or to the End) are dispatched safely on the main thread for Bedrock players. Floodgate threading quirks are handled correctly — you won't see "teleport rejected" or timeout errors (fixed in 2026).
+All teleports (including cross-dimensional home teleports from the Overworld to the Nether, or to the End) are dispatched safely on the main thread for Bedrock players. Floodgate threading quirks are handled correctly — you won't see "teleport rejected" or timeout errors (fixed in v2.4.0, commit 7a3f2e1, 2026-05-01).
 
 ## Recently Fixed/Changed
 

--- a/wiki/docs/players/bedrock.md
+++ b/wiki/docs/players/bedrock.md
@@ -45,7 +45,7 @@ All teleports (including cross-dimensional home teleports from the Overworld to 
 
 ## Recently Fixed/Changed
 
-Nothing For Now!
+Nothing for now!
 
 ## Related
 

--- a/wiki/docs/players/bedrock.md
+++ b/wiki/docs/players/bedrock.md
@@ -18,17 +18,13 @@ All guild commands work identically on Bedrock and Java. There are no Bedrock-sp
 
 ## How it works
 
-The server supports Bedrock players via Geyser (protocol translation) and Floodgate (account linking). Everything in LumaGuilds works on Bedrock — commands, vaults, homes, alliances, menus, and chat. The only differences are visual: some Java menus open as chat-based forms on Bedrock, and clickable chat buttons render as taps. Behavior is otherwise identical.
+The server supports Bedrock players via Geyser (protocol translation) and Floodgate (Bedrock Forms Menus). Everything in LumaGuilds works on Bedrock — commands, vaults, homes, alliances, menus, and chat. The only differences are visual: some Java menus open as native GUI-based forms on Bedrock, and clickable chat buttons have backup commands (such as `/g ally <them>`). Behavior is otherwise identical.
 
 ## What looks different in menus
 
 Some Java menus (the guild member rank confirmation, the ally-home access editor, the home selection on `/g homes`) open as Floodgate form dialogs on Bedrock instead of inventory GUIs. The functionality is identical — pick options, confirm, done. The UX is slightly different, but you get the same result.
 
 Example: On Java, `/g homes` opens an inventory menu. On Bedrock, it opens a form dialog with the same homes listed and the same buttons to teleport.
-
-## How clickable chat works on Bedrock
-
-Clickable text (in `/g help`, in invite prompts, in confirmation messages) maps to taps on Bedrock. Tapping a `[link]` or button runs the same command a Java player would get from clicking. Hover-for-detail tooltips don't appear on Bedrock — the blurb text shows immediately as part of the message.
 
 ## Known limitations
 
@@ -38,12 +34,9 @@ A few advanced menu features (drag-and-drop banner editing, complex multi-page s
 
 All teleports (including cross-dimensional home teleports from the Overworld to the Nether, or to the End) are dispatched safely on the main thread for Bedrock players. Floodgate threading quirks are handled correctly — you won't see "teleport rejected" or timeout errors (fixed in 2026).
 
-## Gotchas
+## Recently Fixed/Changed
 
-- Commands work identically on Bedrock — no special syntax needed.
-- If a menu doesn't render right, check if it's a known Bedrock limitation (listed above). If not, report it.
-- Chat message length limits still apply (256 characters on both Java and Bedrock).
-- Server-side rank permissions are enforced identically — you can't use Bedrock to bypass restrictions.
+Nothing For Now!
 
 ## Related
 

--- a/wiki/docs/players/bedrock.md
+++ b/wiki/docs/players/bedrock.md
@@ -2,12 +2,51 @@
 title: Bedrock differences
 audience: player
 topic: bedrock
-summary: Where the plugin behaves differently on Bedrock/Geyser.
-keywords: []
-related: []
+summary: Where LumaGuilds behaves differently on Bedrock Edition via Geyser/Floodgate.
+keywords: [bedrock, geyser, floodgate, cross-play]
+related: [homes, chat, ranks]
 updated: 2026-05-13
 ---
 
 # Bedrock differences
 
-*This page is a placeholder. Content coming in Phase 2/3.*
+Where LumaGuilds behaves differently on Bedrock Edition via Geyser/Floodgate.
+
+## Quick reference
+
+All guild commands work identically on Bedrock and Java. There are no Bedrock-specific commands — the differences are visual and UX-focused only.
+
+## How it works
+
+The server supports Bedrock players via Geyser (protocol translation) and Floodgate (account linking). Everything in LumaGuilds works on Bedrock — commands, vaults, homes, alliances, menus, and chat. The only differences are visual: some Java menus open as chat-based forms on Bedrock, and clickable chat buttons render as taps. Behavior is otherwise identical.
+
+## What looks different in menus
+
+Some Java menus (the guild member rank confirmation, the ally-home access editor, the home selection on `/g homes`) open as Floodgate form dialogs on Bedrock instead of inventory GUIs. The functionality is identical — pick options, confirm, done. The UX is slightly different, but you get the same result.
+
+Example: On Java, `/g homes` opens an inventory menu. On Bedrock, it opens a form dialog with the same homes listed and the same buttons to teleport.
+
+## How clickable chat works on Bedrock
+
+Clickable text (in `/g help`, in invite prompts, in confirmation messages) maps to taps on Bedrock. Tapping a `[link]` or button runs the same command a Java player would get from clicking. Hover-for-detail tooltips don't appear on Bedrock — the blurb text shows immediately as part of the message.
+
+## Known limitations
+
+A few advanced menu features (drag-and-drop banner editing, complex multi-page selectors) fall back to simpler chat menus or text input on Bedrock. The substance is preserved; the UX is plainer. If you find something doesn't render correctly, report it to staff so it can be added to the known-issues list.
+
+## Teleports and cross-dimensional travel
+
+All teleports (including cross-dimensional home teleports from the Overworld to the Nether, or to the End) are dispatched safely on the main thread for Bedrock players. Floodgate threading quirks are handled correctly — you won't see "teleport rejected" or timeout errors (fixed in 2026).
+
+## Gotchas
+
+- Commands work identically on Bedrock — no special syntax needed.
+- If a menu doesn't render right, check if it's a known Bedrock limitation (listed above). If not, report it.
+- Chat message length limits still apply (256 characters on both Java and Bedrock).
+- Server-side rank permissions are enforced identically — you can't use Bedrock to bypass restrictions.
+
+## Related
+
+- [Homes](homes.md) — set and teleport to guild homes
+- [Chat](chat.md) — guild chat and messaging
+- [Ranks & Permissions](ranks.md) — guild rank system and permissions

--- a/wiki/docs/players/bedrock.md
+++ b/wiki/docs/players/bedrock.md
@@ -1,0 +1,13 @@
+---
+title: Bedrock differences
+audience: player
+topic: bedrock
+summary: Where the plugin behaves differently on Bedrock/Geyser.
+keywords: []
+related: []
+updated: 2026-05-13
+---
+
+# Bedrock differences
+
+*This page is a placeholder. Content coming in Phase 2/3.*

--- a/wiki/docs/players/chat.md
+++ b/wiki/docs/players/chat.md
@@ -2,12 +2,51 @@
 title: Chat
 audience: player
 topic: chat
-summary: Guild chat, ally chat, tag formatting.
-keywords: []
-related: []
+summary: Toggle guild and ally chat, and customize how your tag appears in messages.
+keywords: [chat, guild chat, ally chat, tag, rosechat]
+related: [identity, alliances]
 updated: 2026-05-13
 ---
 
 # Chat
 
-*This page is a placeholder. Content coming in Phase 2/3.*
+Toggle guild and ally chat, and customize how your tag appears in messages.
+
+## Quick reference
+
+| Command | Permission | Description |
+|---------|------------|-------------|
+| `/g chat` | `lumaguilds.guild.chat` | Toggle guild chat on/off. |
+| `/g allychat` | `lumaguilds.guild.allychat` | Toggle ally chat on/off. |
+
+## How it works
+
+By default your messages go to global chat. `/g chat` flips you into guild chat — anything you type goes only to your guildmates until you toggle it off. `/g allychat` does the same but the audience is all guilds you have an ACTIVE alliance with. Tags and colors render in chat via the server's chat plugin (RoseChat on EnthusiaSMP).
+
+## Toggling guild chat
+
+Run `/g chat` once to enter guild chat. Type your messages. Run `/g chat` again to return to global. Same command, same key — no juggling needed. A prefix or indicator in chat shows you which channel is active.
+
+## Toggling ally chat
+
+Use `/g allychat` to enter ally chat. Same on/off behavior as guild chat. Only members of guilds you have an ACTIVE alliance with can read your messages. Useful for coordinating with allied guilds without spamming global.
+
+## How tag formatting renders
+
+Your guild tag (set via `/g tag`) can include MiniMessage formatting like `<gradient:#FF0000:#00FF00>Rainbow</gradient>`. RoseChat parses that and renders the colors. If you don't see colors in chat, the chat channel you're in may not be configured to format them — try `/g chat` to switch to guild chat, where formatting always renders.
+
+## Where messages go with RoseChat
+
+LumaGuilds hands guild chat off to RoseChat as a dedicated channel. RoseChat owns formatting, delivery, and recipients. From a player's perspective, nothing changes — `/g chat` still flips you in and out. Internally, your channel is being switched. See [Identity](identity.md) for how to set and customize your tag.
+
+## Gotchas
+
+- Switching between guild chat and ally chat preserves your original channel (e.g. global), so toggling off returns you to where you started, not to the last guild/ally channel you used.
+- The first message after toggling guild chat off is no longer dropped (fixed in 2026 — there was a stale-marker bug).
+- MiniMessage in tags renders correctly in chat — both colors and gradients work.
+- Ally chat only reaches guilds with an ACTIVE alliance; pending or neutral relations don't count.
+
+## Related
+
+- [Identity](identity.md) — set your guild tag and customize your appearance
+- [Alliances & Diplomacy](alliances.md) — who hears ally chat

--- a/wiki/docs/players/chat.md
+++ b/wiki/docs/players/chat.md
@@ -39,7 +39,7 @@ Your guild tag (set via `/g tag`) can include MiniMessage formatting like `<grad
 
 LumaGuilds hands guild chat off to RoseChat as a dedicated channel. RoseChat owns formatting, delivery, and recipients. From a player's perspective, nothing changes — `/g chat` still flips you in and out. Internally, your channel is being switched. See [Identity](identity.md) for how to set and customize your tag.
 
-## Gotchas
+## Recently Fixed/Changed
 
 - Switching between guild chat and ally chat preserves your original channel (e.g. global), so toggling off returns you to where you started, not to the last guild/ally channel you used.
 - The first message after toggling guild chat off is no longer dropped (fixed in 2026 — there was a stale-marker bug).

--- a/wiki/docs/players/chat.md
+++ b/wiki/docs/players/chat.md
@@ -1,0 +1,13 @@
+---
+title: Chat
+audience: player
+topic: chat
+summary: Guild chat, ally chat, tag formatting.
+keywords: []
+related: []
+updated: 2026-05-13
+---
+
+# Chat
+
+*This page is a placeholder. Content coming in Phase 2/3.*

--- a/wiki/docs/players/guilds.md
+++ b/wiki/docs/players/guilds.md
@@ -32,10 +32,10 @@ A guild is a named group of players with one owner, optional ranks, shared homes
 
 Pick a name and run `/g create <name>`. Names are plain text only — max 32 characters, using letters, numbers, and the punctuation `'`, `&`, `-`. **No spaces, no color codes, no MiniMessage tags** (colors and gradients go in your *tag* instead — see the [Identity](identity.md) page). Use `_` or `CamelCase` for multi-word names. Examples:
 
-```
+```text
 /g create WhiteLotus
 /g create White_Lotus
-```
+```text
 
 You'll become the owner automatically. Your new guild starts at level 1 with one home slot and basic vault access.
 
@@ -43,9 +43,9 @@ You'll become the owner automatically. Your new guild starts at level 1 with one
 
 For open guilds, just run `/g join <name>`. For invite-only guilds, a member with permission must run `/g invite <you>` first. You'll see a chat prompt or notification; accept it with `/g join <them>` or click the prompt button.
 
-```
+```text
 /g join WhiteLotus
-```
+```text
 
 You can only be in one guild at a time.
 
@@ -60,15 +60,15 @@ Anyone can leave at any time with `/g leave`. If you're the owner, you can't lea
 
 Use `/g list` to see all open guilds... This will be changed to show all guilds. A seperate `/guild lfg` command will take on open guild browsing.
 
-```
+```text
 /g list
-```
+```text
 
 Use `/g info [guild]` to zoom into one guild's details — members, homes, relations, and level.
 
-```
+```text
 /g info WhiteLotus
-```
+```text
 
 ## Gotchas
 

--- a/wiki/docs/players/guilds.md
+++ b/wiki/docs/players/guilds.md
@@ -2,12 +2,82 @@
 title: Guilds
 audience: player
 topic: guilds
-summary: Create, join, leave, and disband guilds.
-keywords: []
-related: []
+summary: How to create, join, leave, transfer, and disband guilds.
+keywords: [guilds, create, join, leave, disband, transfer]
+related: [ranks, homes, alliances]
 updated: 2026-05-13
 ---
 
 # Guilds
 
-*This page is a placeholder. Content coming in Phase 2/3.*
+How to create, join, leave, transfer, and disband guilds.
+
+## Quick reference
+
+| Command | Permission | Description |
+|---------|------------|-------------|
+| `/g create <name>` | `lumaguilds.guild.create` | Create a new guild. |
+| `/g join <guild>` | `lumaguilds.guild.join` | Request to join a guild. |
+| `/g leave` | `lumaguilds.guild.leave` | Leave your current guild. |
+| `/g disband` | `lumaguilds.guild.disband` | Disband your guild (owner only). |
+| `/g transfer <player>` | `lumaguilds.guild.transfer` | Transfer ownership. |
+| `/g info [guild]` | `lumaguilds.guild.info` | View guild info. |
+| `/g list` | `lumaguilds.guild.list` | Browse all guilds. |
+
+## How it works
+
+A guild is a named group of players with one owner, optional ranks, shared homes, a shared vault, and relations (allies/enemies/truces) with other guilds. You can be in one guild at a time. Guilds earn XP from member activity and level up to unlock perks like additional home slots and vault space.
+
+## Creating a guild
+
+Pick a name and run `/g create <name>`. Names are plain text only — max 32 characters, using letters, numbers, spaces, and the punctuation `'`, `&`, `-`. No MiniMessage tags (those go in your tag; see the Identity page). Example:
+
+```
+/g create White Lotus
+```
+
+You'll become the owner automatically. Your new guild starts at level 1 with one home slot and basic vault access.
+
+## Joining a guild
+
+For open guilds, just run `/g join <name>`. For invite-only guilds, a member with permission must run `/g invite <you>` first. You'll see a chat prompt or notification; accept it with `/g join <them>` or click the prompt button.
+
+```
+/g join White Lotus
+```
+
+You can only be in one guild at a time.
+
+## Leaving, transferring, and disbanding
+
+Anyone can leave at any time with `/g leave`. If you're the owner, you can't leave directly — you have two options:
+
+- **Transfer ownership:** `/g transfer <player>` hands off the guild to someone else. They become the new owner, and you become a regular member (or leave immediately after).
+- **Disband:** `/g disband` dissolves the guild entirely. This is irreversible. All homes, vault, and guild data are lost.
+
+## Browsing guilds
+
+Use `/g list` to see all guilds on the server with member counts and levels.
+
+```
+/g list
+```
+
+Use `/g info [guild]` to zoom into one guild's details — members, homes, relations, and level.
+
+```
+/g info White Lotus
+```
+
+## Gotchas
+
+- You can only be in one guild at a time. Leaving one guild to join another happens instantly.
+- Disbanding is irreversible — double-check before running `/g disband`.
+- The owner role is single and cannot be transferred except via `/g transfer`. If the owner goes inactive and you're a mod, you cannot promote yourself to owner.
+- Guild XP comes from member activity — the more active your members are, the faster you level.
+
+## Related
+
+- [Ranks & Permissions](ranks.md) — set up roles and permissions
+- [Homes](homes.md) — create shared teleport points
+- [Alliances](alliances.md) — declare allies, enemies, and truces

--- a/wiki/docs/players/guilds.md
+++ b/wiki/docs/players/guilds.md
@@ -35,7 +35,7 @@ Pick a name and run `/g create <name>`. Names are plain text only — max 32 cha
 ```text
 /g create WhiteLotus
 /g create White_Lotus
-```text
+```
 
 You'll become the owner automatically. Your new guild starts at level 1 with one home slot and basic vault access.
 
@@ -45,7 +45,7 @@ For open guilds, just run `/g join <name>`. For invite-only guilds, a member wit
 
 ```text
 /g join WhiteLotus
-```text
+```
 
 You can only be in one guild at a time.
 
@@ -62,13 +62,13 @@ Use `/g list` to see all open guilds... This will be changed to show all guilds.
 
 ```text
 /g list
-```text
+```
 
 Use `/g info [guild]` to zoom into one guild's details — members, homes, relations, and level.
 
 ```text
 /g info WhiteLotus
-```text
+```
 
 ## Gotchas
 

--- a/wiki/docs/players/guilds.md
+++ b/wiki/docs/players/guilds.md
@@ -1,0 +1,13 @@
+---
+title: Guilds
+audience: player
+topic: guilds
+summary: Create, join, leave, and disband guilds.
+keywords: []
+related: []
+updated: 2026-05-13
+---
+
+# Guilds
+
+*This page is a placeholder. Content coming in Phase 2/3.*

--- a/wiki/docs/players/guilds.md
+++ b/wiki/docs/players/guilds.md
@@ -58,7 +58,7 @@ Anyone can leave at any time with `/g leave`. If you're the owner, you can't lea
 
 ## Browsing guilds
 
-Use `/g list` to see all guilds on the server with member counts and levels.
+Use `/g list` to see all open guilds... This will be changed to show all guilds. A seperate `/guild lfg` command will take on open guild browsing.
 
 ```
 /g list
@@ -74,7 +74,7 @@ Use `/g info [guild]` to zoom into one guild's details — members, homes, relat
 
 - You can only be in one guild at a time. Leaving one guild to join another happens instantly.
 - Disbanding is irreversible — double-check before running `/g disband`.
-- The owner role is single and cannot be transferred except via `/g transfer`. If the owner goes inactive and you're a mod, you cannot promote yourself to owner.
+- The owner role is single and cannot be transferred except via `/g transfer`. If the owner goes inactive and you're a mod, you cannot promote yourself to owner. Contact staff if this is an issue.
 - Guild XP comes from member activity — the more active your members are, the faster you level.
 
 ## Related

--- a/wiki/docs/players/guilds.md
+++ b/wiki/docs/players/guilds.md
@@ -30,10 +30,11 @@ A guild is a named group of players with one owner, optional ranks, shared homes
 
 ## Creating a guild
 
-Pick a name and run `/g create <name>`. Names are plain text only — max 32 characters, using letters, numbers, spaces, and the punctuation `'`, `&`, `-`. No MiniMessage tags (those go in your tag; see the Identity page). Example:
+Pick a name and run `/g create <name>`. Names are plain text only — max 32 characters, using letters, numbers, and the punctuation `'`, `&`, `-`. **No spaces, no color codes, no MiniMessage tags** (colors and gradients go in your *tag* instead — see the [Identity](identity.md) page). Use `_` or `CamelCase` for multi-word names. Examples:
 
 ```
-/g create White Lotus
+/g create WhiteLotus
+/g create White_Lotus
 ```
 
 You'll become the owner automatically. Your new guild starts at level 1 with one home slot and basic vault access.
@@ -43,7 +44,7 @@ You'll become the owner automatically. Your new guild starts at level 1 with one
 For open guilds, just run `/g join <name>`. For invite-only guilds, a member with permission must run `/g invite <you>` first. You'll see a chat prompt or notification; accept it with `/g join <them>` or click the prompt button.
 
 ```
-/g join White Lotus
+/g join WhiteLotus
 ```
 
 You can only be in one guild at a time.
@@ -66,7 +67,7 @@ Use `/g list` to see all guilds on the server with member counts and levels.
 Use `/g info [guild]` to zoom into one guild's details — members, homes, relations, and level.
 
 ```
-/g info White Lotus
+/g info WhiteLotus
 ```
 
 ## Gotchas

--- a/wiki/docs/players/homes.md
+++ b/wiki/docs/players/homes.md
@@ -31,9 +31,9 @@ Homes are teleport points your guild can share. Each guild starts with one home 
 
 Stand where you want it and run `/g sethome`. This creates or overwrites the `main` home:
 
-```
+```text
 /g sethome
-```
+```text
 
 Your guild members can now teleport there with `/g home`.
 
@@ -41,11 +41,11 @@ Your guild members can now teleport there with `/g home`.
 
 Once you unlock additional home slots (by leveling your guild), you can create named homes for different purposes:
 
-```
+```text
 /g sethome spawner
 /g sethome mine
 /g sethome goldfarm
-```
+```text
 
 Use `/g homes` to list all homes your guild has set.
 
@@ -53,10 +53,10 @@ Use `/g homes` to list all homes your guild has set.
 
 Teleport to your main home with `/g home`. For a named home, use `/g home <name>`:
 
-```
+```text
 /g home
 /g home spawner
-```
+```text
 
 There's a short countdown — don't move or the teleport cancels. The destination must be safe (not lava, fire, or cactus right at the spot). Safe blocks like ladders, slabs, and water work fine.
 
@@ -64,9 +64,9 @@ There's a short countdown — don't move or the teleport cancels. The destinatio
 
 Use `/g removehome <name>` to delete a named home:
 
-```
+```text
 /g removehome spawner
-```
+```text
 
 You'll get a confirmation prompt. The slot opens up for a new home.
 
@@ -74,9 +74,9 @@ You'll get a confirmation prompt. The slot opens up for a new home.
 
 Your ally-home is separate from regular homes — it's a spot allied guilds can teleport to if they have permission and are on your whitelist. Stand where you want it and run:
 
-```
+```text
 /g setallyhome
-```
+```text
 
 Only members with the "Set Ally-Home" permission can do this. Use `/g removeallyhome` to remove it.
 
@@ -88,7 +88,7 @@ Homes without rank restrictions are accessible to all guild members.
 
 ## Recently Fixed/Changed
 
-- Nether ↔ Overworld teleports are reliable (fixed in 2026).
+- Nether ↔ Overworld teleports are reliable (fixed in May 2026).
 - The destination block must be safe — if a protection plugin still cancels your teleport, contact staff.
 - Named homes persist across server restarts (used to be wiped — fixed in May 2026).
 - Ally-homes are completely separate from regular homes — your regular homes stay private to your guild.

--- a/wiki/docs/players/homes.md
+++ b/wiki/docs/players/homes.md
@@ -1,0 +1,13 @@
+---
+title: Homes
+audience: player
+topic: homes
+summary: Set, name, and access-control guild homes.
+keywords: []
+related: []
+updated: 2026-05-13
+---
+
+# Homes
+
+*This page is a placeholder. Content coming in Phase 2/3.*

--- a/wiki/docs/players/homes.md
+++ b/wiki/docs/players/homes.md
@@ -33,7 +33,7 @@ Stand where you want it and run `/g sethome`. This creates or overwrites the `ma
 
 ```text
 /g sethome
-```text
+```
 
 Your guild members can now teleport there with `/g home`.
 
@@ -45,7 +45,7 @@ Once you unlock additional home slots (by leveling your guild), you can create n
 /g sethome spawner
 /g sethome mine
 /g sethome goldfarm
-```text
+```
 
 Use `/g homes` to list all homes your guild has set.
 
@@ -56,7 +56,7 @@ Teleport to your main home with `/g home`. For a named home, use `/g home <name>
 ```text
 /g home
 /g home spawner
-```text
+```
 
 There's a short countdown — don't move or the teleport cancels. The destination must be safe (not lava, fire, or cactus right at the spot). Safe blocks like ladders, slabs, and water work fine.
 
@@ -66,7 +66,7 @@ Use `/g removehome <name>` to delete a named home:
 
 ```text
 /g removehome spawner
-```text
+```
 
 You'll get a confirmation prompt. The slot opens up for a new home.
 
@@ -76,7 +76,7 @@ Your ally-home is separate from regular homes — it's a spot allied guilds can 
 
 ```text
 /g setallyhome
-```text
+```
 
 Only members with the "Set Ally-Home" permission can do this. Use `/g removeallyhome` to remove it.
 

--- a/wiki/docs/players/homes.md
+++ b/wiki/docs/players/homes.md
@@ -42,9 +42,9 @@ Your guild members can now teleport there with `/g home`.
 Once you unlock additional home slots (by leveling your guild), you can create named homes for different purposes:
 
 ```
-/g sethome shop
+/g sethome spawner
 /g sethome mine
-/g sethome enderfarm
+/g sethome goldfarm
 ```
 
 Use `/g homes` to list all homes your guild has set.
@@ -55,7 +55,7 @@ Teleport to your main home with `/g home`. For a named home, use `/g home <name>
 
 ```
 /g home
-/g home shop
+/g home spawner
 ```
 
 There's a short countdown — don't move or the teleport cancels. The destination must be safe (not lava, fire, or cactus right at the spot). Safe blocks like ladders, slabs, and water work fine.
@@ -65,7 +65,7 @@ There's a short countdown — don't move or the teleport cancels. The destinatio
 Use `/g removehome <name>` to delete a named home:
 
 ```
-/g removehome shop
+/g removehome spawner
 ```
 
 You'll get a confirmation prompt. The slot opens up for a new home.
@@ -86,7 +86,7 @@ Open `/g menu` → Homes → pick a home → Access. Choose which ranks can use 
 
 Homes without rank restrictions are accessible to all guild members.
 
-## Gotchas
+## Recently Fixed/Changed
 
 - Nether ↔ Overworld teleports are reliable (fixed in 2026).
 - The destination block must be safe — if a protection plugin still cancels your teleport, contact staff.

--- a/wiki/docs/players/homes.md
+++ b/wiki/docs/players/homes.md
@@ -2,12 +2,99 @@
 title: Homes
 audience: player
 topic: homes
-summary: Set, name, and access-control guild homes.
-keywords: []
-related: []
+summary: Set, name, visit, and restrict access to guild homes.
+keywords: [homes, sethome, removehome, ally home, teleport]
+related: [ranks, alliances]
 updated: 2026-05-13
 ---
 
 # Homes
 
-*This page is a placeholder. Content coming in Phase 2/3.*
+Set, name, visit, and restrict access to guild homes.
+
+## Quick reference
+
+| Command | Permission | Description |
+|---------|------------|-------------|
+| `/g sethome [name]` | `lumaguilds.guild.sethome` | Set a home at your location. |
+| `/g home [name]` | `lumaguilds.guild.home` | Teleport to a guild home. |
+| `/g homes` | `lumaguilds.guild.homes` | List your guild's homes. |
+| `/g removehome <name>` | `lumaguilds.guild.removehome` | Remove a named home. |
+| `/g setallyhome` | `lumaguilds.guild.setallyhome` | Set your ally-home. |
+| `/g removeallyhome` | `lumaguilds.guild.removeallyhome` | Remove your ally-home. |
+
+## How it works
+
+Homes are teleport points your guild can share. Each guild starts with one home slot (`main`) and unlocks more as it levels up. Homes can be restricted per-rank — only members at a chosen rank or above can teleport to them. There's also a separate "ally-home" that allied guilds can reach if they have permission and are whitelisted.
+
+## Setting your default home
+
+Stand where you want it and run `/g sethome`. This creates or overwrites the `main` home:
+
+```
+/g sethome
+```
+
+Your guild members can now teleport there with `/g home`.
+
+## Adding named homes
+
+Once you unlock additional home slots (by leveling your guild), you can create named homes for different purposes:
+
+```
+/g sethome shop
+/g sethome mine
+/g sethome enderfarm
+```
+
+Use `/g homes` to list all homes your guild has set.
+
+## Visiting a home
+
+Teleport to your main home with `/g home`. For a named home, use `/g home <name>`:
+
+```
+/g home
+/g home shop
+```
+
+There's a short countdown — don't move or the teleport cancels. The destination must be safe (not lava, fire, or cactus right at the spot). Safe blocks like ladders, slabs, and water work fine.
+
+## Removing a home
+
+Use `/g removehome <name>` to delete a named home:
+
+```
+/g removehome shop
+```
+
+You'll get a confirmation prompt. The slot opens up for a new home.
+
+## Setting up your ally-home
+
+Your ally-home is separate from regular homes — it's a spot allied guilds can teleport to if they have permission and are on your whitelist. Stand where you want it and run:
+
+```
+/g setallyhome
+```
+
+Only members with the "Set Ally-Home" permission can do this. Use `/g removeallyhome` to remove it.
+
+## Restricting a home to specific ranks
+
+Open `/g menu` → Homes → pick a home → Access. Choose which ranks can use it. By default, only the owner can access newly-created homes.
+
+Homes without rank restrictions are accessible to all guild members.
+
+## Gotchas
+
+- Nether ↔ Overworld teleports are reliable (fixed in 2026).
+- The destination block must be safe — if a protection plugin still cancels your teleport, contact staff.
+- Named homes persist across server restarts (used to be wiped — fixed in May 2026).
+- Ally-homes are completely separate from regular homes — your regular homes stay private to your guild.
+- You need the right rank to teleport to restricted homes; mods can't override rank restrictions.
+
+## Related
+
+- [Ranks & Permissions](ranks.md) — set per-home rank access
+- [Alliances](alliances.md) — establish allies and manage their home access

--- a/wiki/docs/players/how-do-i.md
+++ b/wiki/docs/players/how-do-i.md
@@ -59,7 +59,7 @@ Quick index. Scan for your task; click through to the page that answers it.
 
 - [Toggle guild chat](chat.md#toggling-guild-chat)
 - [Toggle ally chat](chat.md#toggling-ally-chat)
-- [Why aren't colors showing in my tag?](../getting-started/faq.md#my-guild-tag-isnt-showing-colors-in-chat)
+- [How tag formatting renders](chat.md#how-tag-formatting-renders)
 
 ## Other
 

--- a/wiki/docs/players/how-do-i.md
+++ b/wiki/docs/players/how-do-i.md
@@ -2,12 +2,69 @@
 title: How do I…?
 audience: player
 topic: how-do-i
-summary: Index of common player tasks.
-keywords: []
-related: []
+summary: Index of common player tasks with deep links to the right feature page.
+keywords: [index, how to, tasks, find]
+related: [walkthrough]
 updated: 2026-05-13
 ---
 
 # How do I…?
 
-*This page is a placeholder. Content coming in Phase 2/3.*
+Quick index. Scan for your task; click through to the page that answers it.
+
+## Guild basics
+
+- [Create a guild](guilds.md#creating-a-guild)
+- [Join an existing guild](guilds.md#joining-a-guild)
+- [Leave my guild](guilds.md#leaving-transferring-and-disbanding)
+- [Transfer ownership](guilds.md#leaving-transferring-and-disbanding)
+- [Disband my guild](guilds.md#leaving-transferring-and-disbanding)
+- [Find a guild to join (LFG)](lfg.md#toggling-looking-for-guild)
+
+## Homes
+
+- [Set my guild's main home](homes.md#setting-your-default-home)
+- [Add another named home](homes.md#adding-named-homes)
+- [Teleport to a specific home](homes.md#visiting-a-home)
+- [Restrict a home to certain ranks](homes.md#restricting-a-home-to-specific-ranks)
+- [Set up an ally-home](homes.md#setting-up-your-ally-home)
+
+## Identity
+
+- [Set a colored guild tag](identity.md#setting-a-guild-tag-cli)
+- [Pick a guild banner](identity.md#setting-a-banner)
+- [Change my guild description](identity.md#setting-a-description)
+- [Rename my guild](identity.md#renaming-your-guild)
+- [Pick a guild emoji](identity.md#choosing-an-emoji)
+
+## People
+
+- [Invite a player](lfg.md#inviting-a-player)
+- [Kick a member](lfg.md#kicking-a-member-online-and-offline)
+- [Promote / demote](ranks.md#promoting-and-demoting-members)
+- [Create a new rank](ranks.md#creating-a-rank)
+- [Reorder rank priority](ranks.md#reordering-rank-priority)
+
+## Diplomacy & war
+
+- [Request an alliance](alliances.md#requesting-an-alliance)
+- [Accept an alliance](alliances.md#accepting-an-alliance)
+- [Sign a truce](alliances.md#signing-a-truce)
+- [Declare a war](war.md#declaring-war)
+- [End a war](war.md#ending-a-war)
+- [Mark a guild as enemy](alliances.md#declaring-an-enemy)
+- [Clear a guild relation](alliances.md#clearing-a-relation)
+
+## Chat
+
+- [Toggle guild chat](chat.md#toggling-guild-chat)
+- [Toggle ally chat](chat.md#toggling-ally-chat)
+- [Why aren't colors showing in my tag?](../getting-started/faq.md#my-guild-tag-isnt-showing-colors-in-chat)
+
+## Other
+
+- [Open the guild vault](vault.md#opening-the-vault)
+- [Switch between Peaceful and Hostile mode](mode.md#switching-to-peaceful)
+- [Check my guild level / XP](progression.md#checking-your-guilds-level)
+- [Mark a shop as guild-owned](shop.md#marking-a-shop-as-guild-owned)
+- [What's different on Bedrock?](bedrock.md)

--- a/wiki/docs/players/how-do-i.md
+++ b/wiki/docs/players/how-do-i.md
@@ -1,0 +1,13 @@
+---
+title: How do I…?
+audience: player
+topic: how-do-i
+summary: Index of common player tasks.
+keywords: []
+related: []
+updated: 2026-05-13
+---
+
+# How do I…?
+
+*This page is a placeholder. Content coming in Phase 2/3.*

--- a/wiki/docs/players/identity.md
+++ b/wiki/docs/players/identity.md
@@ -33,7 +33,7 @@ Run `/g tag <text>` directly with MiniMessage formatting. Examples:
 /g tag <red>FireGuild</red>
 /g tag <gradient:#FF0000:#00FF00>Rainbow</gradient>
 /g tag <bold><blue>ELITE</blue></bold>
-```text
+```
 
 Max 32 visible characters (formatting tags don't count toward the limit).
 
@@ -47,7 +47,7 @@ Use `/g desc <text>` — appears on your guild's info card and in directory list
 
 ```text
 /g desc A relaxed community for builders and redstoners
-```text
+```
 
 ## Choosing an emoji
 
@@ -59,13 +59,13 @@ Use `/g rename <name>` (owner-only typically — check your rank's permissions).
 
 ```text
 /g rename MyGuild
-```text
+```
 
 Renaming doesn't change your tag — those are independent.
 
 ## Setting a banner
 
-Open `/g menu` → Banner. Click to enter the banner selection menu, where you can drag your custom banner design into the menu, and show off your desgins. The banner is shown in your info card, alliance menus, and on guild-owned shops. 
+Open `/g menu` → Banner. Click to enter the banner selection menu, where you can drag your custom banner design into the menu, and show off your designs. The banner is shown in your info card, alliance menus, and on guild-owned shops. 
 
 ## Gotchas
 

--- a/wiki/docs/players/identity.md
+++ b/wiki/docs/players/identity.md
@@ -65,13 +65,14 @@ Renaming doesn't change your tag — those are independent.
 
 ## Setting a banner
 
-Open `/g menu` → Banner. Click to enter the banner selection menu, where you can pattern your banner using Minecraft's standard banner mechanics. The banner is shown in your info card, alliance menus, and on guild-owned shops.
+Open `/g menu` → Banner. Click to enter the banner selection menu, where you can drag your custom banner design into the menu, and show off your desgins. The banner is shown in your info card, alliance menus, and on guild-owned shops. 
 
 ## Gotchas
 
 - The `/g tag` CLI accepts MiniMessage formatting (used to be stricter than the menu — fixed in 2026).
 - The "Clear" button in the tag editor now properly clears the tag (used to silently undo on save).
 - The Guild Banner menu renders correctly (used to open empty — fixed).
+- The Glass Pane can no longer be removed from the menu (sorry toxik)
 - If your colored tag isn't rendering in chat, you may be in a chat channel that doesn't format MiniMessage — try `/g chat` to switch to guild chat.
 
 ## Related

--- a/wiki/docs/players/identity.md
+++ b/wiki/docs/players/identity.md
@@ -29,11 +29,11 @@ Four pieces give your guild personality: the *name* (plain text, what shows in `
 
 Run `/g tag <text>` directly with MiniMessage formatting. Examples:
 
-```
+```text
 /g tag <red>FireGuild</red>
 /g tag <gradient:#FF0000:#00FF00>Rainbow</gradient>
 /g tag <bold><blue>ELITE</blue></bold>
-```
+```text
 
 Max 32 visible characters (formatting tags don't count toward the limit).
 
@@ -45,9 +45,9 @@ Run `/g tag` with no arguments to open the visual Tag Editor. You can type your 
 
 Use `/g desc <text>` — appears on your guild's info card and in directory listings. Keep it short and descriptive:
 
-```
+```text
 /g desc A relaxed community for builders and redstoners
-```
+```text
 
 ## Choosing an emoji
 
@@ -55,11 +55,11 @@ Run `/g emoji` to open an emoji picker. The chosen emoji appears in menus, leade
 
 ## Renaming your guild
 
-Use `/g rename <name>` (owner-only typically — check your rank's permissions). Same rules as creation: max 32 plain-text chars, no MiniMessage:
+Use `/g rename <name>` (owner-only typically — check your rank's permissions). Same rules as creation: max 32 characters, using letters, numbers, and the punctuation `'`, `&`, `-` (no MiniMessage):
 
-```
+```text
 /g rename MyGuild
-```
+```text
 
 Renaming doesn't change your tag — those are independent.
 

--- a/wiki/docs/players/identity.md
+++ b/wiki/docs/players/identity.md
@@ -1,0 +1,13 @@
+---
+title: Tags, Banners & Identity
+audience: player
+topic: identity
+summary: Set tags, descriptions, banners, emoji.
+keywords: []
+related: []
+updated: 2026-05-13
+---
+
+# Tags, Banners & Identity
+
+*This page is a placeholder. Content coming in Phase 2/3.*

--- a/wiki/docs/players/identity.md
+++ b/wiki/docs/players/identity.md
@@ -2,12 +2,79 @@
 title: Tags, Banners & Identity
 audience: player
 topic: identity
-summary: Set tags, descriptions, banners, emoji.
-keywords: []
-related: []
+summary: Set your guild's tag, description, banner, and emoji to give it personality.
+keywords: [tag, banner, description, emoji, identity, rename, minimessage]
+related: [chat, guilds]
 updated: 2026-05-13
 ---
 
 # Tags, Banners & Identity
 
-*This page is a placeholder. Content coming in Phase 2/3.*
+Set your guild's tag, description, banner, and emoji to give it personality.
+
+## Quick reference
+
+| Command | Permission | Description |
+|---------|------------|-------------|
+| `/g tag [text]` | `lumaguilds.guild.tag` | Set or open the tag editor. |
+| `/g desc <text>` | `lumaguilds.guild.desc` | Set your guild description. |
+| `/g rename <name>` | `lumaguilds.guild.rename` | Rename your guild. |
+| `/g emoji` | `lumaguilds.guild.emoji` | Pick a guild emoji. |
+
+## How it works
+
+Four pieces give your guild personality: the *name* (plain text, what shows in `/g list`), the *tag* (fancy formatted prefix shown next to members' names in chat), the *description* (a short blurb in your info card), the *banner* (a Minecraft banner pattern), and the *emoji* (an icon shown in menus). Tags use MiniMessage formatting and can include colors and gradients.
+
+## Setting a guild tag (CLI)
+
+Run `/g tag <text>` directly with MiniMessage formatting. Examples:
+
+```
+/g tag <red>FireGuild</red>
+/g tag <gradient:#FF0000:#00FF00>Rainbow</gradient>
+/g tag <bold><blue>ELITE</blue></bold>
+```
+
+Max 32 visible characters (formatting tags don't count toward the limit).
+
+## Setting a guild tag (menu)
+
+Run `/g tag` with no arguments to open the visual Tag Editor. You can type your tag, preview formatting, clear it, and save. Same validation as the CLI.
+
+## Setting a description
+
+Use `/g desc <text>` — appears on your guild's info card and in directory listings. Keep it short and descriptive:
+
+```
+/g desc A relaxed community for builders and redstoners
+```
+
+## Choosing an emoji
+
+Run `/g emoji` to open an emoji picker. The chosen emoji appears in menus, leaderboards, and some chat contexts. Emoji selection is gated by your guild level — more options unlock as you level up.
+
+## Renaming your guild
+
+Use `/g rename <name>` (owner-only typically — check your rank's permissions). Same rules as creation: max 32 plain-text chars, no MiniMessage:
+
+```
+/g rename MyGuild
+```
+
+Renaming doesn't change your tag — those are independent.
+
+## Setting a banner
+
+Open `/g menu` → Banner. Click to enter the banner selection menu, where you can pattern your banner using Minecraft's standard banner mechanics. The banner is shown in your info card, alliance menus, and on guild-owned shops.
+
+## Gotchas
+
+- The `/g tag` CLI accepts MiniMessage formatting (used to be stricter than the menu — fixed in 2026).
+- The "Clear" button in the tag editor now properly clears the tag (used to silently undo on save).
+- The Guild Banner menu renders correctly (used to open empty — fixed).
+- If your colored tag isn't rendering in chat, you may be in a chat channel that doesn't format MiniMessage — try `/g chat` to switch to guild chat.
+
+## Related
+
+- [Chat](chat.md) — where your tag is rendered
+- [Guilds](guilds.md) — name vs tag distinction

--- a/wiki/docs/players/lfg.md
+++ b/wiki/docs/players/lfg.md
@@ -32,7 +32,7 @@ Run `/g invite <player>` to send them an invite:
 
 ```text
 /g invite Steve
-```text
+```
 
 They receive a clickable message. Clicking accept automatically runs `/g join` for them. The invite persists until they accept or decline.
 
@@ -42,7 +42,7 @@ Use `/g invites` to see every guild that has invited you:
 
 ```text
 /g invites
-```text
+```
 
 The list shows clickable accept and decline buttons for each invite.
 
@@ -52,7 +52,7 @@ Click the accept button in your invites list, or manually run `/g join <guild>`:
 
 ```text
 /g join Dragons
-```text
+```
 
 You're now a member of that guild. See [Guilds](guilds.md) for details.
 
@@ -62,7 +62,7 @@ Use `/g decline <guild>` to reject an invite:
 
 ```text
 /g decline Dragons
-```text
+```
 
 The invite is removed. You can re-accept later if the guild invites you again.
 
@@ -72,7 +72,7 @@ Run `/g lfg` to toggle your recruitment status:
 
 ```text
 /g lfg
-```text
+```
 
 While on, your name appears in guild leaders' recruitment lists (if the server supports LFG discovery). Toggle it off once you find a guild.
 
@@ -82,7 +82,7 @@ Run `/g kick <player>` to remove them from your guild:
 
 ```text
 /g kick Steve
-```text
+```
 
 This works whether they're online or offline. Your rank must outrank theirs — otherwise the kick is refused. (See [Ranks & Permissions](ranks.md) for rank hierarchy.)
 

--- a/wiki/docs/players/lfg.md
+++ b/wiki/docs/players/lfg.md
@@ -2,12 +2,98 @@
 title: LFG & Invites
 audience: player
 topic: lfg
-summary: Manage invites and LFG.
-keywords: []
-related: []
+summary: Manage guild invites, decline requests, find guilds via LFG, and kick members.
+keywords: [lfg, invite, accept, decline, kick, invites]
+related: [guilds, ranks]
 updated: 2026-05-13
 ---
 
 # LFG & Invites
 
-*This page is a placeholder. Content coming in Phase 2/3.*
+Manage guild invites, decline requests, find guilds via LFG, and kick members.
+
+## Quick reference
+
+| Command | Permission | Description |
+|---------|------------|-------------|
+| `/g invite <player>` | `lumaguilds.guild.invite` | Invite a player to your guild. |
+| `/g invites` | `lumaguilds.guild.invites` | List your pending invites. |
+| `/g decline <guild>` | `lumaguilds.guild.decline` | Decline an invite from a guild. |
+| `/g lfg` | `lumaguilds.guild.lfg` | Toggle "looking for guild" status. |
+| `/g kick <player>` | `lumaguilds.guild.kick` | Kick a member from your guild. |
+
+## How it works
+
+Invites move players into guilds. A guild member with permission sends an invite; the target sees a notification and can accept or decline. On the flip side, players can broadcast "looking for guild" via `/g lfg` so guild leaders know to recruit them. Kicks remove members from your guild — they work on both online and offline players, subject to rank priority.
+
+## Inviting a player
+
+Run `/g invite <player>` to send them an invite:
+
+```
+/g invite Steve
+```
+
+They receive a clickable message. Clicking accept automatically runs `/g join` for them. The invite persists until they accept or decline.
+
+## Listing your pending invites
+
+Use `/g invites` to see every guild that has invited you:
+
+```
+/g invites
+```
+
+The list shows clickable accept and decline buttons for each invite.
+
+## Accepting an invite
+
+Click the accept button in your invites list, or manually run `/g join <guild>`:
+
+```
+/g join Dragons
+```
+
+You're now a member of that guild. See [Guilds](guilds.md) for details.
+
+## Declining an invite
+
+Use `/g decline <guild>` to reject an invite:
+
+```
+/g decline Dragons
+```
+
+The invite is removed. You can re-accept later if the guild invites you again.
+
+## Toggling "looking for guild"
+
+Run `/g lfg` to toggle your recruitment status:
+
+```
+/g lfg
+```
+
+While on, your name appears in guild leaders' recruitment lists (if the server supports LFG discovery). Toggle it off once you find a guild.
+
+## Kicking a member (online and offline)
+
+Run `/g kick <player>` to remove them from your guild:
+
+```
+/g kick Steve
+```
+
+This works whether they're online or offline. Your rank must outrank theirs — otherwise the kick is refused. (See [Ranks & Permissions](ranks.md) for rank hierarchy.)
+
+## Gotchas
+
+- Offline kicks now respect rank priority (used to let mods kick anyone offline — fixed in 2026).
+- The promote/demote confirmation menu shows the real player name even when the target is offline (used to say "Unknown Player" — fixed in 2026).
+- Open vs invite-only is a guild-level setting; even with `/g lfg` on, you can't auto-join an invite-only guild.
+- If a player has pending invites when they join another guild, those invites are cleared.
+
+## Related
+
+- [Guilds](guilds.md) — creating, joining, leaving guilds
+- [Ranks & Permissions](ranks.md) — managing member ranks and kick priority

--- a/wiki/docs/players/lfg.md
+++ b/wiki/docs/players/lfg.md
@@ -30,9 +30,9 @@ Invites move players into guilds. A guild member with permission sends an invite
 
 Run `/g invite <player>` to send them an invite:
 
-```
+```text
 /g invite Steve
-```
+```text
 
 They receive a clickable message. Clicking accept automatically runs `/g join` for them. The invite persists until they accept or decline.
 
@@ -40,9 +40,9 @@ They receive a clickable message. Clicking accept automatically runs `/g join` f
 
 Use `/g invites` to see every guild that has invited you:
 
-```
+```text
 /g invites
-```
+```text
 
 The list shows clickable accept and decline buttons for each invite.
 
@@ -50,9 +50,9 @@ The list shows clickable accept and decline buttons for each invite.
 
 Click the accept button in your invites list, or manually run `/g join <guild>`:
 
-```
+```text
 /g join Dragons
-```
+```text
 
 You're now a member of that guild. See [Guilds](guilds.md) for details.
 
@@ -60,9 +60,9 @@ You're now a member of that guild. See [Guilds](guilds.md) for details.
 
 Use `/g decline <guild>` to reject an invite:
 
-```
+```text
 /g decline Dragons
-```
+```text
 
 The invite is removed. You can re-accept later if the guild invites you again.
 
@@ -70,9 +70,9 @@ The invite is removed. You can re-accept later if the guild invites you again.
 
 Run `/g lfg` to toggle your recruitment status:
 
-```
+```text
 /g lfg
-```
+```text
 
 While on, your name appears in guild leaders' recruitment lists (if the server supports LFG discovery). Toggle it off once you find a guild.
 
@@ -80,9 +80,9 @@ While on, your name appears in guild leaders' recruitment lists (if the server s
 
 Run `/g kick <player>` to remove them from your guild:
 
-```
+```text
 /g kick Steve
-```
+```text
 
 This works whether they're online or offline. Your rank must outrank theirs — otherwise the kick is refused. (See [Ranks & Permissions](ranks.md) for rank hierarchy.)
 

--- a/wiki/docs/players/lfg.md
+++ b/wiki/docs/players/lfg.md
@@ -1,0 +1,13 @@
+---
+title: LFG & Invites
+audience: player
+topic: lfg
+summary: Manage invites and LFG.
+keywords: []
+related: []
+updated: 2026-05-13
+---
+
+# LFG & Invites
+
+*This page is a placeholder. Content coming in Phase 2/3.*

--- a/wiki/docs/players/mode.md
+++ b/wiki/docs/players/mode.md
@@ -22,6 +22,8 @@ Switch your guild between Peaceful and Hostile mode to control PvP and conflict 
 
 Every guild is either in **Peaceful** or **Hostile** mode. Peaceful guilds opt out of guild-vs-guild PvP and can't be enemies or be at war. Hostile guilds can be enemied and warred. Switching modes is reversible but may have cooldowns or restrictions configured by the server.
 
+**Note: This is purely for competitive/social purposes, and does not stop Guilds from killing your Guild.**
+
 ## Switching to Peaceful
 
 Run `/g mode`, then click the Peaceful option in the menu. Confirm the switch:

--- a/wiki/docs/players/mode.md
+++ b/wiki/docs/players/mode.md
@@ -28,11 +28,11 @@ Every guild is either in **Peaceful** or **Hostile** mode. Peaceful guilds opt o
 
 Run `/g mode`, then click the Peaceful option in the menu. Confirm the switch:
 
-```
+```text
 /g mode
 [Click: Peaceful]
 [Confirm]
-```
+```text
 
 Your guild's enemy relations and pending war declarations clear. Future enemy and war attempts will be blocked while you're peaceful.
 
@@ -40,11 +40,11 @@ Your guild's enemy relations and pending war declarations clear. Future enemy an
 
 Run `/g mode`, then click Hostile in the menu and confirm:
 
-```
+```text
 /g mode
 [Click: Hostile]
 [Confirm]
-```
+```text
 
 Now your guild can be enemied, declare wars, and engage in guild-vs-guild PvP.
 

--- a/wiki/docs/players/mode.md
+++ b/wiki/docs/players/mode.md
@@ -2,12 +2,63 @@
 title: Mode (Peaceful / Hostile)
 audience: player
 topic: mode
-summary: Switch between Peaceful and Hostile mode.
-keywords: []
-related: []
+summary: Switch your guild between Peaceful and Hostile mode to control PvP and conflict behavior.
+keywords: [mode, peaceful, hostile, pvp]
+related: [war, alliances]
 updated: 2026-05-13
 ---
 
 # Mode (Peaceful / Hostile)
 
-*This page is a placeholder. Content coming in Phase 2/3.*
+Switch your guild between Peaceful and Hostile mode to control PvP and conflict behavior.
+
+## Quick reference
+
+| Command | Permission | Description |
+|---------|------------|-------------|
+| `/g mode` | `lumaguilds.guild.mode` | Open the mode selection menu. |
+
+## How it works
+
+Every guild is either in **Peaceful** or **Hostile** mode. Peaceful guilds opt out of guild-vs-guild PvP and can't be enemies or be at war. Hostile guilds can be enemied and warred. Switching modes is reversible but may have cooldowns or restrictions configured by the server.
+
+## Switching to Peaceful
+
+Run `/g mode`, then click the Peaceful option in the menu. Confirm the switch:
+
+```
+/g mode
+[Click: Peaceful]
+[Confirm]
+```
+
+Your guild's enemy relations and pending war declarations clear. Future enemy and war attempts will be blocked while you're peaceful.
+
+## Switching to Hostile
+
+Run `/g mode`, then click Hostile in the menu and confirm:
+
+```
+/g mode
+[Click: Hostile]
+[Confirm]
+```
+
+Now your guild can be enemied, declare wars, and engage in guild-vs-guild PvP.
+
+## Understanding each mode
+
+**Peaceful:** Protects you from being declared an enemy and from being warred. Your members can still PvP individually under server-wide PvP rules, but those kills don't count toward guild war stats. You also can't declare yourself enemies or declare wars.
+
+**Hostile:** The default — fully engaged in the guild relationship system. You can be enemied, declare wars, declare other guilds as enemies, and PvP counts toward guild war progression.
+
+## Gotchas
+
+- The Mode menu options work properly after the recent fix (clicking Peaceful/Hostile used to throw errors — fixed in 2026).
+- Going Peaceful while at war may immediately end the war (server-dependent).
+- Some advanced features (declaring war, marking enemies) are gated to Hostile mode only.
+
+## Related
+
+- [War](war.md) — wage war with other guilds in Hostile mode
+- [Alliances](alliances.md) — establish peace and cooperation with allies

--- a/wiki/docs/players/mode.md
+++ b/wiki/docs/players/mode.md
@@ -32,7 +32,7 @@ Run `/g mode`, then click the Peaceful option in the menu. Confirm the switch:
 /g mode
 [Click: Peaceful]
 [Confirm]
-```text
+```
 
 Your guild's enemy relations and pending war declarations clear. Future enemy and war attempts will be blocked while you're peaceful.
 
@@ -44,7 +44,7 @@ Run `/g mode`, then click Hostile in the menu and confirm:
 /g mode
 [Click: Hostile]
 [Confirm]
-```text
+```
 
 Now your guild can be enemied, declare wars, and engage in guild-vs-guild PvP.
 

--- a/wiki/docs/players/mode.md
+++ b/wiki/docs/players/mode.md
@@ -1,0 +1,13 @@
+---
+title: Mode (Peaceful / Hostile)
+audience: player
+topic: mode
+summary: Switch between Peaceful and Hostile mode.
+keywords: []
+related: []
+updated: 2026-05-13
+---
+
+# Mode (Peaceful / Hostile)
+
+*This page is a placeholder. Content coming in Phase 2/3.*

--- a/wiki/docs/players/progression.md
+++ b/wiki/docs/players/progression.md
@@ -2,12 +2,53 @@
 title: Progression & Levels
 audience: player
 topic: progression
-summary: Earn XP, level up, unlock perks.
-keywords: []
-related: []
+summary: Earn guild XP from member activity, level up, and unlock perks.
+keywords: [progression, levels, xp, leveling, perks]
+related: [guilds, war, homes]
 updated: 2026-05-13
 ---
 
 # Progression & Levels
 
-*This page is a placeholder. Content coming in Phase 2/3.*
+Earn guild XP from member activity, level up, and unlock perks.
+
+## Quick reference
+
+| Command | Permission | Description |
+|---------|------------|-------------|
+| `/g info` | `lumaguilds.guild.info` | See your guild's current level and XP. |
+
+## How it works
+
+Your guild earns XP from what its members do — mining, killing mobs, completing certain activities. XP accumulates and your guild levels up automatically when it crosses thresholds. Each level unlocks something: more member slots, more home slots, access to advanced features (like declaring war), better leaderboard placement. You don't need to manage XP — just play, and your guild progresses.
+
+## Earning XP (sources)
+
+XP comes from typical Minecraft activity by guild members: breaking blocks, killing mobs, certain PvP kills. Most sources are passive — playing the game progresses your guild. There are no explicit "quests" to grind.
+
+## What levels unlock
+
+Higher levels unlock additional member capacity, named home slots, advanced features (declaring war, certain rank permissions), and emoji options. Run `/g info` to see your current level and what's available at the next level.
+
+## Checking your guild's level
+
+Run `/g info` — it shows:
+- Current level
+- Current XP
+- XP needed for the next level
+- Member count
+
+The leaderboard (in-game `/g list` and the web leaderboard) ranks guilds by level and XP.
+
+## Gotchas
+
+- Killing a member of your own guild no longer awards XP (anti-farm — fixed mid-2026).
+- XP earned in the seconds before you quit, the server shuts down, or a database flush fails is no longer lost (fixed mid-2026 — it now retries on the next flush cycle).
+- Large mining runs no longer overwhelm the server (block XP is now batched — fixed mid-2026).
+- Old guilds that displayed "Level 1" despite huge XP totals had their levels corrected on the May 2026 patch — `/g info` should now show the real level.
+
+## Related
+
+- [Guilds](guilds.md) — guild basics
+- [War](war.md) — declaring war requires a minimum guild level
+- [Homes](homes.md) — unlocking home slots through leveling

--- a/wiki/docs/players/progression.md
+++ b/wiki/docs/players/progression.md
@@ -1,0 +1,13 @@
+---
+title: Progression & Levels
+audience: player
+topic: progression
+summary: Earn XP, level up, unlock perks.
+keywords: []
+related: []
+updated: 2026-05-13
+---
+
+# Progression & Levels
+
+*This page is a placeholder. Content coming in Phase 2/3.*

--- a/wiki/docs/players/ranks.md
+++ b/wiki/docs/players/ranks.md
@@ -29,7 +29,7 @@ Use `/g ranks` or `/g menu` → Ranks to access rank management. From there you 
 
 ```text
 /g ranks
-```text
+```
 
 ## Creating a rank
 
@@ -60,7 +60,7 @@ Owner (priority 0)
 Moderator (priority 1)
   ▼
 Member (priority 2)
-```text
+```
 
 ## Promoting and demoting members
 
@@ -68,7 +68,7 @@ Open `/g menu` → Members. Click a member and select Promote or Demote. Both on
 
 ```text
 /g menu
-```text
+```
 
 The system will confirm the action before applying it. You can't promote someone above your own rank, and you can't demote the owner.
 

--- a/wiki/docs/players/ranks.md
+++ b/wiki/docs/players/ranks.md
@@ -27,9 +27,9 @@ Every member is assigned a rank. Ranks have a *priority* (0 = owner, higher numb
 
 Use `/g ranks` or `/g menu` → Ranks to access rank management. From there you can create, delete, rename, reorder, and set permissions on ranks.
 
-```
+```text
 /g ranks
-```
+```text
 
 ## Creating a rank
 
@@ -54,21 +54,21 @@ Only give permissions you trust members to use safely.
 
 In the rank menu, use the ▲ / ▼ buttons next to each rank to move it up or down. Higher priority = more trust. The owner rank (priority 0) can't move, and you can't move a rank above your own priority.
 
-```
+```text
 Owner (priority 0)
   ▼
 Moderator (priority 1)
   ▼
 Member (priority 2)
-```
+```text
 
 ## Promoting and demoting members
 
 Open `/g menu` → Members. Click a member and select Promote or Demote. Both online and offline members can be managed.
 
-```
+```text
 /g menu
-```
+```text
 
 The system will confirm the action before applying it. You can't promote someone above your own rank, and you can't demote the owner.
 

--- a/wiki/docs/players/ranks.md
+++ b/wiki/docs/players/ranks.md
@@ -1,0 +1,13 @@
+---
+title: Ranks & Permissions
+audience: player
+topic: ranks
+summary: Manage ranks and permissions.
+keywords: []
+related: []
+updated: 2026-05-13
+---
+
+# Ranks & Permissions
+
+*This page is a placeholder. Content coming in Phase 2/3.*

--- a/wiki/docs/players/ranks.md
+++ b/wiki/docs/players/ranks.md
@@ -2,12 +2,86 @@
 title: Ranks & Permissions
 audience: player
 topic: ranks
-summary: Manage ranks and permissions.
-keywords: []
-related: []
+summary: Create ranks, set permissions, and manage member rank assignments.
+keywords: [ranks, permissions, priority, promote, demote]
+related: [guilds, homes, lfg]
 updated: 2026-05-13
 ---
 
 # Ranks & Permissions
 
-*This page is a placeholder. Content coming in Phase 2/3.*
+Create ranks, set permissions, and manage member rank assignments.
+
+## Quick reference
+
+| Command | Permission | Description |
+|---------|------------|-------------|
+| `/g ranks` | `lumaguilds.guild.ranks` | Open the rank management menu. |
+| `/g menu` | `lumaguilds.guild.menu` | Open the guild control panel. |
+
+## How it works
+
+Every member is assigned a rank. Ranks have a *priority* (0 = owner, higher numbers = lower rank) and a set of *permissions*. To do anything privileged — invite, kick, manage homes, declare war — your rank needs the matching permission. You can never promote someone to or beyond your own priority, and you can never manage a member who outranks you.
+
+## Opening the rank menu
+
+Use `/g ranks` or `/g menu` → Ranks to access rank management. From there you can create, delete, rename, reorder, and set permissions on ranks.
+
+```
+/g ranks
+```
+
+## Creating a rank
+
+In the rank menu, click "Create". Pick a name, choose a display color, and assign permissions. New ranks default to the lowest priority — use the reorder buttons to lift them up.
+
+Example: Create a "Moderator" rank with permission to invite and kick members.
+
+## Setting permissions on a rank
+
+Open the rank in the menu and go to Permissions. Toggle each permission to enable or disable it. Permissions are grouped by area:
+
+- **Members:** invite, kick, promote, demote
+- **Homes:** create, set, remove, access (restricted homes)
+- **Vault:** deposit, withdraw, manage inventory
+- **War:** declare, accept, end
+- **Banner:** set guild banner/tag colors
+- And more.
+
+Only give permissions you trust members to use safely.
+
+## Reordering rank priority
+
+In the rank menu, use the ▲ / ▼ buttons next to each rank to move it up or down. Higher priority = more trust. The owner rank (priority 0) can't move, and you can't move a rank above your own priority.
+
+```
+Owner (priority 0)
+  ▼
+Moderator (priority 1)
+  ▼
+Member (priority 2)
+```
+
+## Promoting and demoting members
+
+Open `/g menu` → Members. Click a member and select Promote or Demote. Both online and offline members can be managed.
+
+```
+/g menu
+```
+
+The system will confirm the action before applying it. You can't promote someone above your own rank, and you can't demote the owner.
+
+## Gotchas
+
+- Mods with "Manage Members" can no longer manage co-owners or promote themselves above their rank (fixed mid-2026).
+- Offline kicks now respect priority — you can't kick someone above you just because they're offline.
+- Promote/demote confirmations show the real player name even when the target is offline (used to show "Unknown Player").
+- The owner role is fixed at priority 0 and has all permissions automatically. You can't create a rank equal to the owner.
+- If a member's rank is deleted, they're moved to the next-lowest rank.
+
+## Related
+
+- [Guilds](guilds.md) — create and manage your guild
+- [Homes](homes.md) — set per-home rank access
+- [LFG](lfg.md) — manage members and bans

--- a/wiki/docs/players/shop.md
+++ b/wiki/docs/players/shop.md
@@ -28,7 +28,7 @@ First, set up your shop normally with the shop plugin. Then stand near it (or lo
 
 ```text
 /g setshop
-```text
+```
 
 The shop is now linked to your guild.
 

--- a/wiki/docs/players/shop.md
+++ b/wiki/docs/players/shop.md
@@ -26,9 +26,9 @@ LumaGuilds integrates with the server's shop plugin. When a guild member runs `/
 
 First, set up your shop normally with the shop plugin. Then stand near it (or look at it, depending on plugin convention) and run `/g setshop`:
 
-```
+```text
 /g setshop
-```
+```text
 
 The shop is now linked to your guild.
 

--- a/wiki/docs/players/shop.md
+++ b/wiki/docs/players/shop.md
@@ -1,0 +1,13 @@
+---
+title: Shop integration
+audience: player
+topic: shop
+summary: Mark shops as guild-owned.
+keywords: []
+related: []
+updated: 2026-05-13
+---
+
+# Shop integration
+
+*This page is a placeholder. Content coming in Phase 2/3.*

--- a/wiki/docs/players/shop.md
+++ b/wiki/docs/players/shop.md
@@ -2,12 +2,52 @@
 title: Shop integration
 audience: player
 topic: shop
-summary: Mark shops as guild-owned.
-keywords: []
-related: []
+summary: Mark shops as guild-owned so the guild gets credit and visibility.
+keywords: [shop, setshop, guild shop, integration]
+related: [guilds, identity]
 updated: 2026-05-13
 ---
 
 # Shop integration
 
-*This page is a placeholder. Content coming in Phase 2/3.*
+Mark shops as guild-owned so the guild gets credit and visibility.
+
+## Quick reference
+
+| Command | Permission | Description |
+|---------|------------|-------------|
+| `/g setshop` | `lumaguilds.guild.setshop` | Mark your current shop as guild-owned. |
+
+## How it works
+
+LumaGuilds integrates with the server's shop plugin. When a guild member runs `/g setshop` at one of their own shops, that shop is tagged as guild-owned. Guild-owned shops display the guild name, tag, and banner to customers, and the guild gets visibility in shop listings (if your server supports them).
+
+## Marking a shop as guild-owned
+
+First, set up your shop normally with the shop plugin. Then stand near it (or look at it, depending on plugin convention) and run `/g setshop`:
+
+```
+/g setshop
+```
+
+The shop is now linked to your guild.
+
+## How guild shops appear to other players
+
+Customers browsing your shop see your guild's tag and (if configured) banner displayed with the shop. The shop may appear in guild-shop listings if your server has them enabled. Note: shop transactions don't automatically credit guild XP — that's configured separately by the server admin.
+
+## Removing a guild-owned shop
+
+If you need to unlink a shop from your guild, you'll typically need to reset it using the shop plugin's own tools, then re-run `/g setshop` with a different shop (or contact staff for guidance).
+
+## Gotchas
+
+- You must own the shop personally with the shop plugin before `/g setshop` can mark it for the guild.
+- Shop ownership stays with you — only the guild link changes.
+- If you leave the guild, the link may need to be reapplied by a member who owns the shop.
+- Only works with the supported shop plugin on this server — check with staff if it isn't behaving.
+
+## Related
+
+- [Guilds](guilds.md) — create and manage your guild
+- [Identity](identity.md) — customize your guild's tag and banner (displayed on shops)

--- a/wiki/docs/players/vault.md
+++ b/wiki/docs/players/vault.md
@@ -2,12 +2,58 @@
 title: Vault
 audience: player
 topic: vault
-summary: Shared guild storage.
-keywords: []
-related: []
+summary: Use the shared guild vault for storing items members can access together.
+keywords: [vault, storage, shared chest, getvault]
+related: [ranks, guilds]
 updated: 2026-05-13
 ---
 
 # Vault
 
-*This page is a placeholder. Content coming in Phase 2/3.*
+Use the shared guild vault for storing items members can access together.
+
+## Quick reference
+
+| Command | Permission | Description |
+|---------|------------|-------------|
+| `/g vault` | `lumaguilds.guild.vault` | Open the guild vault. |
+| `/g getvault` | `lumaguilds.guild.getvault` | Get a vault chest item. |
+
+## How it works
+
+The guild vault is a shared inventory all members can use, gated by rank permission. You can open it with the command, or place a special "vault chest" item somewhere and right-click it. The vault is a single shared inventory — putting items in lets your guildmates take them out, and vice versa.
+
+## Opening the vault
+
+Run `/g vault` from anywhere in the world (you must have the "Use Vault" rank permission). The vault inventory opens like a chest:
+
+```
+/g vault
+```
+
+Add items by right-clicking them into the vault, or take items that other members have put there.
+
+## Getting a vault chest item
+
+Use `/g getvault` to get a special chest item that, when placed and right-clicked, opens the guild vault from that location:
+
+```
+/g getvault
+```
+
+Place it in a dedicated vault room so members can access the vault without using the command. The item is tagged so it can't be repurposed.
+
+## Sharing the vault across members
+
+Anyone with the "Use Vault" rank permission can open the vault, regardless of where they are. Items added by any member are available to all. No permission is needed to *read* the vault — only to *open* it.
+
+## Gotchas
+
+- Vault chest items cannot be used in crafting (you can't craft a chest-boat, hopper, or trapped chest from one — fixed for anti-exploit).
+- Vault chest items cannot be burned as furnace fuel (also fixed for anti-exploit).
+- Vault access is governed by your rank — if you can't open it, check that your rank has "Use Vault" permission.
+
+## Related
+
+- [Ranks & Permissions](ranks.md) — vault permissions live on ranks
+- [Guilds](guilds.md) — guild basics

--- a/wiki/docs/players/vault.md
+++ b/wiki/docs/players/vault.md
@@ -29,7 +29,7 @@ Run `/g vault` from anywhere in the world (you must have the "Use Vault" rank pe
 
 ```text
 /g vault
-```text
+```
 
 Add items by right-clicking them into the vault, or take items that other members have put there.
 
@@ -39,7 +39,7 @@ Use `/g getvault` to get a special chest item that, when placed and right-clicke
 
 ```text
 /g getvault
-```text
+```
 
 Place it in a dedicated vault room so members can access the vault without using the command. The item is tagged so it can't be repurposed.
 

--- a/wiki/docs/players/vault.md
+++ b/wiki/docs/players/vault.md
@@ -1,0 +1,13 @@
+---
+title: Vault
+audience: player
+topic: vault
+summary: Shared guild storage.
+keywords: []
+related: []
+updated: 2026-05-13
+---
+
+# Vault
+
+*This page is a placeholder. Content coming in Phase 2/3.*

--- a/wiki/docs/players/vault.md
+++ b/wiki/docs/players/vault.md
@@ -27,9 +27,9 @@ The guild vault is a shared inventory all members can use, gated by rank permiss
 
 Run `/g vault` from anywhere in the world (you must have the "Use Vault" rank permission). The vault inventory opens like a chest:
 
-```
+```text
 /g vault
-```
+```text
 
 Add items by right-clicking them into the vault, or take items that other members have put there.
 
@@ -37,9 +37,9 @@ Add items by right-clicking them into the vault, or take items that other member
 
 Use `/g getvault` to get a special chest item that, when placed and right-clicked, opens the guild vault from that location:
 
-```
+```text
 /g getvault
-```
+```text
 
 Place it in a dedicated vault room so members can access the vault without using the command. The item is tagged so it can't be repurposed.
 

--- a/wiki/docs/players/war.md
+++ b/wiki/docs/players/war.md
@@ -1,0 +1,13 @@
+---
+title: War
+audience: player
+topic: war
+summary: Declare and fight wars.
+keywords: []
+related: []
+updated: 2026-05-13
+---
+
+# War
+
+*This page is a placeholder. Content coming in Phase 2/3.*

--- a/wiki/docs/players/war.md
+++ b/wiki/docs/players/war.md
@@ -2,12 +2,54 @@
 title: War
 audience: player
 topic: war
-summary: Declare and fight wars.
-keywords: []
-related: []
+summary: Declare and fight wars between guilds.
+keywords: [war, pvp, declare war, kills]
+related: [alliances, mode, progression]
 updated: 2026-05-13
 ---
 
 # War
 
-*This page is a placeholder. Content coming in Phase 2/3.*
+Declare and fight wars between guilds.
+
+## Quick reference
+
+| Command | Permission | Description |
+|---------|------------|-------------|
+| `/g war <guild>` | `lumaguilds.guild.war` | Open the war control flow. |
+
+## How it works
+
+War is the escalation of an enemy relation. Once two guilds are at war, kills between their members count toward war statistics and are tracked separately from normal PvP. Wars persist until one side surrenders, the other side accepts a truce, or relations are reset.
+
+## Declaring war
+
+First, mark the other guild as enemy using `/g enemy <them>`. Then run `/g war <them>`. A confirmation menu opens — confirm to start the war. Both guilds will see a server-wide announcement. From that point on, kills between the two warring guilds count toward war statistics.
+
+## Ending a war
+
+Either side can end a war by:
+
+- **Proposing a truce:** `/g truce <them>` offers a friendly resolution; both sides must confirm.
+- **Going neutral:** `/g neutral <them>` is unilateral and faster, but clears all relation data.
+
+## How kills are tracked
+
+Killing a member of a guild you're at war with awards your guild kill credit toward the war. The win goes to whichever guild accumulates the most kills (or however your server configures victory conditions — check with staff). Kill streaks and war statistics are displayed in your guild's war profile.
+
+## Guild Mode and war
+
+Your guild's Mode (peaceful/hostile) affects whether your guild can start wars at all. Peaceful guilds cannot declare war. Hostile guilds can. See [Mode](mode.md) for more detail.
+
+## Gotchas
+
+- You can't earn guild XP from killing a member of your own guild (anti-farm — fixed mid-2026).
+- War only enables PvP between the two warring guilds — your normal PvP rules with everyone else stay unchanged.
+- Pending ally requests are cancelled if you declare war on an ally.
+- Both sides must be at least enemy status before a war can be declared.
+
+## Related
+
+- [Alliances & Diplomacy](alliances.md) — manage enemy and ally relations
+- [Mode](mode.md) — peaceful vs. hostile guild alignment
+- [Progression](progression.md) — how XP and kill stats work

--- a/wiki/requirements.txt
+++ b/wiki/requirements.txt
@@ -4,3 +4,4 @@ mkdocs-material[imaging]==9.5.49
 mkdocs-awesome-pages-plugin==2.9.3
 mkdocs-redirects==1.2.2
 mkdocs-llmstxt==0.2.0
+pillow>=12.2.0

--- a/wiki/requirements.txt
+++ b/wiki/requirements.txt
@@ -1,0 +1,6 @@
+mkdocs==1.6.1
+mkdocs-material==9.5.49
+mkdocs-material[imaging]==9.5.49
+mkdocs-awesome-pages-plugin==2.9.3
+mkdocs-redirects==1.2.2
+mkdocs-llmstxt==0.2.0

--- a/wiki/requirements.txt
+++ b/wiki/requirements.txt
@@ -1,7 +1,5 @@
 mkdocs==1.6.1
 mkdocs-material==9.5.49
-mkdocs-material[imaging]==9.5.49
 mkdocs-awesome-pages-plugin==2.9.3
 mkdocs-redirects==1.2.2
 mkdocs-llmstxt==0.2.0
-pillow>=12.2.0


### PR DESCRIPTION
## Summary

Phase 1 of the wiki redesign — MkDocs Material site on GitHub Pages, Getting Started + Players content, fully redesigned topic-based clickable `/g help`, with a topic-slug source of truth enforced by CI.

- **MkDocs scaffold** at `wiki/`, deployed to GitHub Pages via Actions
- **Getting Started**: Welcome, 7-step walkthrough, FAQ
- **Players section**: 13 feature pages (Guilds, Homes, Ranks, Alliances, War, Chat, Identity, Progression, Vault, Mode, Shop, LFG, Bedrock) + How-do-I index
- **Admins + Developers**: stubbed with valid front-matter (Phase 2 + Phase 3 fill these in)
- **`/g help` refactored**: clickable Adventure-component topic menu mirroring the wiki, hover/click prefill, wiki deep-links, source-of-truth via `HelpTopics.kt`
- **CI gates**: front-matter lint, topic-slug parity (`HelpTopics.kt` ↔ wiki pages), `mkdocs build --strict`
- **Hermes Agent friendly**: every page has audience-tagged YAML front-matter; `llms.txt` + `llms-full.txt` generated at build time

Design: [`docs/plans/2026-05-13-player-wiki-and-help-redesign-design.md`](docs/plans/2026-05-13-player-wiki-and-help-redesign-design.md)
Plan: [`docs/plans/2026-05-13-player-wiki-and-help-redesign-plan.md`](docs/plans/2026-05-13-player-wiki-and-help-redesign-plan.md)

## ⚠ Action required after merge

The first deploy needs **Settings → Pages → Source: GitHub Actions** to be flipped on once. Until that's done, the deploy workflow runs but the site won't be visible at <https://badgersmc.github.io/LumaGuilds/>.

## Test plan

- [x] `python tools/wiki/lint_frontmatter.py` passes (40 pages)
- [x] `python tools/wiki/check_topic_parity.py` passes (13 topics)
- [x] `mkdocs build --strict` passes — no broken anchors or links
- [x] `./gradlew test` passes — all 20 new help-package tests green
- [x] `site/llms.txt` and `site/llms-full.txt` populated under each section
- [ ] After merge: enable GitHub Pages source = Actions
- [ ] After merge: smoke-test in-game with `/g help` and `/g help homes` on a test server

## Out of scope (deferred)

- **Phase 2 — Admins**: installation, permission nodes reference, override/recovery, troubleshooting, PlaceholderAPI, RoseChat, Geyser/Floodgate, Lunar, web leaderboard API, claims integration
- **Phase 3 — Developers migration**: move existing `docs/*.md` and scattered top-level `.md` files (PERMISSIONS.md, PROGRESSION_*.md, etc.) into `wiki/docs/developers/`

Each phase will get its own plan + PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Interactive in-game /g help with topic menu, clickable actions, and direct wiki deep-links.
  * Full player, admin, and developer wiki surfaced via GitHub Pages.

* **Documentation**
  * Comprehensive player guides: Getting Started, walkthrough, FAQ, Homes, Guilds, Alliances, War, Ranks, Progression, Chat, Shop, Vault, Bedrock notes, and more.
  * CONTRIBUTING updated with wiki/update workflow and sync guidance.

* **Chores**
  * CI workflows added to validate and deploy the wiki.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/BadgersMC/LumaGuilds/pull/42)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->