### PR TITLE
feat: /g allyhome command + fix migrations under VirtualThreadSQLiteStorage

### DIFF
--- a/src/main/kotlin/net/lumalyte/lg/LumaGuilds.kt
+++ b/src/main/kotlin/net/lumalyte/lg/LumaGuilds.kt
@@ -695,6 +695,29 @@ class LumaGuilds : JavaPlugin() {
             (guildNames + playerNames).distinct().sorted()
         }
 
+        // Ally guilds whose ally-home the executing player can teleport to.
+        // Filters: target must be an active ALLY of player's guild, have ally-home set,
+        // and pass canUseAllyHome (rank perm + inbound whitelist).
+        commandManager.commandCompletions.registerAsyncCompletion("allyguilds") { context ->
+            val player = context.player ?: return@registerAsyncCompletion emptyList()
+            val guildService = get().get<net.lumalyte.lg.application.services.GuildService>()
+            val relationService = get().get<net.lumalyte.lg.application.services.RelationService>()
+            val guilds = guildService.getPlayerGuilds(player.uniqueId)
+            if (guilds.isEmpty()) return@registerAsyncCompletion emptyList()
+            val sourceGuild = guilds.first()
+            relationService
+                .getGuildRelationsByType(sourceGuild.id, net.lumalyte.lg.domain.entities.RelationType.ALLY)
+                .mapNotNull { rel ->
+                    val otherId = rel.getOtherGuild(sourceGuild.id)
+                    val other = guildService.getGuild(otherId) ?: return@mapNotNull null
+                    if (other.allyHome == null) return@mapNotNull null
+                    if (!guildService.canUseAllyHome(player.uniqueId, sourceGuild.id, other.id)) return@mapNotNull null
+                    other.name
+                }
+                .distinct()
+                .sorted()
+        }
+
         commandManager.commandCompletions.registerAsyncCompletion("guildhomes") { context ->
             val player = context.player ?: return@registerAsyncCompletion emptyList()
             val guildService = get().get<net.lumalyte.lg.application.services.GuildService>()

--- a/src/main/kotlin/net/lumalyte/lg/LumaGuilds.kt
+++ b/src/main/kotlin/net/lumalyte/lg/LumaGuilds.kt
@@ -319,7 +319,7 @@ class LumaGuilds : JavaPlugin() {
 
         try {
             when (storage) {
-                is SQLiteStorage -> {
+                is SQLiteStorage, is VirtualThreadSQLiteStorage -> {
                     logColored("🔄 Running SQLite migrations...")
 
                     try {

--- a/src/main/kotlin/net/lumalyte/lg/LumaGuilds.kt
+++ b/src/main/kotlin/net/lumalyte/lg/LumaGuilds.kt
@@ -335,7 +335,7 @@ class LumaGuilds : JavaPlugin() {
                         throw RuntimeException("Failed to run SQLite migrations - database error", e)
                     }
                 }
-                is MariaDBStorage -> {
+                is MariaDBStorage, is VirtualThreadMariaDBStorage -> {
                     logColored("🔄 Running MariaDB migrations...")
                     // Get MariaDB connection details from config for migration
                     val host = config.getString("mariadb.host", "localhost") ?: "localhost"

--- a/src/main/kotlin/net/lumalyte/lg/interaction/commands/GuildCommand.kt
+++ b/src/main/kotlin/net/lumalyte/lg/interaction/commands/GuildCommand.kt
@@ -521,85 +521,91 @@ class GuildCommand : BaseCommand(), KoinComponent {
     @CommandCompletion("@allyguilds")
     fun onAllyHome(player: Player, guildName: String, @Optional confirm: String?) {
         if (guildName.lowercase() == "confirm" || confirm?.lowercase() == "confirm") {
-            val pendingLocation = GuildHomeSafety.consumePending(player)
-            if (pendingLocation != null) {
-                teleportationService.startTeleport(player, pendingLocation) {
-                    lastHomeTeleport[player.uniqueId] = System.currentTimeMillis()
-                }
-                return
-            } else {
-                player.sendMessage("§cNo pending unsafe teleport to confirm, or confirmation expired.")
-                return
-            }
+            handleAllyHomeConfirm(player)
+            return
         }
 
-        val playerId = player.uniqueId
-
-        val guilds = guildService.getPlayerGuilds(playerId)
-        if (guilds.isEmpty()) {
+        val ownGuild = guildService.getPlayerGuilds(player.uniqueId).firstOrNull()
+        if (ownGuild == null) {
             player.sendMessage("§cYou are not in a guild.")
             return
         }
 
-        val guild = guilds.first()
+        val targetGuild = resolveAllyTarget(player, guildName, ownGuild) ?: return
+        val targetLocation = resolveAllyHomeLocation(player, ownGuild, targetGuild) ?: return
+        if (!checkAllyHomeCooldown(player, ownGuild.id)) return
 
+        val config = configService.loadConfig()
+        if (config.guild.homeTeleportSafetyCheck &&
+            !GuildHomeSafety.checkOrAskConfirm(player, targetLocation, "/guild allyhome ${targetGuild.id} confirm")) {
+            return
+        }
+
+        teleportationService.startTeleport(player, targetLocation) {
+            lastHomeTeleport[player.uniqueId] = System.currentTimeMillis()
+            player.sendMessage("§a✅ Teleported to §6${targetGuild.name}§a's ally home.")
+        }
+    }
+
+    private fun handleAllyHomeConfirm(player: Player) {
+        val pendingLocation = GuildHomeSafety.consumePending(player)
+        if (pendingLocation == null) {
+            player.sendMessage("§cNo pending unsafe teleport to confirm, or confirmation expired.")
+            return
+        }
+        teleportationService.startTeleport(player, pendingLocation) {
+            lastHomeTeleport[player.uniqueId] = System.currentTimeMillis()
+        }
+    }
+
+    private fun resolveAllyTarget(
+        player: Player,
+        guildName: String,
+        ownGuild: net.lumalyte.lg.domain.entities.Guild
+    ): net.lumalyte.lg.domain.entities.Guild? {
         val targetGuild = net.lumalyte.lg.utils.GuildResolver.resolve(guildName, guildService)
         if (targetGuild == null) {
             player.sendMessage("§cNo guild named '$guildName' found.")
-            return
+            return null
         }
-
-        if (targetGuild.id == guild.id) {
+        if (targetGuild.id == ownGuild.id) {
             player.sendMessage("§cUse §6/guild home §cfor your own guild's home.")
-            return
+            return null
         }
-
         val relationService: net.lumalyte.lg.application.services.RelationService by inject()
-        val relation = relationService.getRelationType(guild.id, targetGuild.id)
-        if (relation != net.lumalyte.lg.domain.entities.RelationType.ALLY) {
+        if (relationService.getRelationType(ownGuild.id, targetGuild.id)
+            != net.lumalyte.lg.domain.entities.RelationType.ALLY) {
             player.sendMessage("§c${targetGuild.name} is not an ally of your guild.")
-            return
+            return null
         }
+        return targetGuild
+    }
 
+    private fun resolveAllyHomeLocation(
+        player: Player,
+        ownGuild: net.lumalyte.lg.domain.entities.Guild,
+        targetGuild: net.lumalyte.lg.domain.entities.Guild
+    ): Location? {
         val allyHome = guildService.getAllyHome(targetGuild.id)
         if (allyHome == null) {
             player.sendMessage("§c${targetGuild.name} has no ally home set.")
-            return
+            return null
         }
-
-        if (!guildService.canUseAllyHome(playerId, guild.id, targetGuild.id)) {
+        if (!guildService.canUseAllyHome(player.uniqueId, ownGuild.id, targetGuild.id)) {
             player.sendMessage("§c❌ You don't have permission to use ${targetGuild.name}'s ally home.")
             player.sendMessage("§7Your rank may lack USE_ALLY_HOMES, or that guild has not granted access.")
-            return
+            return null
         }
-
-        if (teleportationService.hasActiveTeleport(playerId)) {
+        if (teleportationService.hasActiveTeleport(player.uniqueId)) {
             player.sendMessage("§cYou already have a teleport in progress. Please wait for it to complete.")
-            return
+            return null
         }
-
-        val config = configService.loadConfig()
-        val baseCooldownSeconds = config.guild.homeTeleportCooldownSeconds
-        val cooldownMultiplier = progressionService.getHomeCooldownMultiplier(guild.id)
-        val cooldownSeconds = (baseCooldownSeconds * cooldownMultiplier).toLong()
-
-        val lastTeleport = lastHomeTeleport[playerId]
-        if (lastTeleport != null) {
-            val elapsedSeconds = (System.currentTimeMillis() - lastTeleport) / 1000
-            if (elapsedSeconds < cooldownSeconds) {
-                val remainingSeconds = cooldownSeconds - elapsedSeconds
-                player.sendMessage("§c◷ Please wait ${remainingSeconds}s before teleporting again.")
-                return
-            }
-        }
-
         val world = player.server.getWorld(allyHome.worldId)
         if (world == null) {
             player.sendMessage("§cAlly guild home world is not available.")
-            return
+            return null
         }
-
-        val targetLocation = Location(
+        return Location(
             world,
             allyHome.position.x.toDouble() + 0.5,
             allyHome.position.y.toDouble(),
@@ -607,17 +613,20 @@ class GuildCommand : BaseCommand(), KoinComponent {
             player.location.yaw,
             player.location.pitch
         )
+    }
 
-        if (config.guild.homeTeleportSafetyCheck) {
-            if (!GuildHomeSafety.checkOrAskConfirm(player, targetLocation, "/guild allyhome ${targetGuild.id} confirm")) {
-                return
-            }
+    private fun checkAllyHomeCooldown(player: Player, ownGuildId: java.util.UUID): Boolean {
+        val config = configService.loadConfig()
+        val baseCooldownSeconds = config.guild.homeTeleportCooldownSeconds
+        val cooldownMultiplier = progressionService.getHomeCooldownMultiplier(ownGuildId)
+        val cooldownSeconds = (baseCooldownSeconds * cooldownMultiplier).toLong()
+        val lastTeleport = lastHomeTeleport[player.uniqueId] ?: return true
+        val elapsedSeconds = (System.currentTimeMillis() - lastTeleport) / 1000
+        if (elapsedSeconds < cooldownSeconds) {
+            player.sendMessage("§c◷ Please wait ${cooldownSeconds - elapsedSeconds}s before teleporting again.")
+            return false
         }
-
-        teleportationService.startTeleport(player, targetLocation) {
-            lastHomeTeleport[playerId] = System.currentTimeMillis()
-            player.sendMessage("§a✅ Teleported to §6${targetGuild.name}§a's ally home.")
-        }
+        return true
     }
 
     @Subcommand("ranks")

--- a/src/main/kotlin/net/lumalyte/lg/interaction/commands/GuildCommand.kt
+++ b/src/main/kotlin/net/lumalyte/lg/interaction/commands/GuildCommand.kt
@@ -516,6 +516,110 @@ class GuildCommand : BaseCommand(), KoinComponent {
         }
     }
 
+    @Subcommand("allyhome")
+    @CommandPermission("lumaguilds.guild.allyhome")
+    @CommandCompletion("@allyguilds")
+    fun onAllyHome(player: Player, guildName: String, @Optional confirm: String?) {
+        if (guildName.lowercase() == "confirm" || confirm?.lowercase() == "confirm") {
+            val pendingLocation = GuildHomeSafety.consumePending(player)
+            if (pendingLocation != null) {
+                teleportationService.startTeleport(player, pendingLocation) {
+                    lastHomeTeleport[player.uniqueId] = System.currentTimeMillis()
+                }
+                return
+            } else {
+                player.sendMessage("§cNo pending unsafe teleport to confirm, or confirmation expired.")
+                return
+            }
+        }
+
+        val playerId = player.uniqueId
+
+        val guilds = guildService.getPlayerGuilds(playerId)
+        if (guilds.isEmpty()) {
+            player.sendMessage("§cYou are not in a guild.")
+            return
+        }
+
+        val guild = guilds.first()
+
+        val targetGuild = net.lumalyte.lg.utils.GuildResolver.resolve(guildName, guildService)
+        if (targetGuild == null) {
+            player.sendMessage("§cNo guild named '$guildName' found.")
+            return
+        }
+
+        if (targetGuild.id == guild.id) {
+            player.sendMessage("§cUse §6/guild home §cfor your own guild's home.")
+            return
+        }
+
+        val relationService: net.lumalyte.lg.application.services.RelationService by inject()
+        val relation = relationService.getRelationType(guild.id, targetGuild.id)
+        if (relation != net.lumalyte.lg.domain.entities.RelationType.ALLY) {
+            player.sendMessage("§c${targetGuild.name} is not an ally of your guild.")
+            return
+        }
+
+        val allyHome = guildService.getAllyHome(targetGuild.id)
+        if (allyHome == null) {
+            player.sendMessage("§c${targetGuild.name} has no ally home set.")
+            return
+        }
+
+        if (!guildService.canUseAllyHome(playerId, guild.id, targetGuild.id)) {
+            player.sendMessage("§c❌ You don't have permission to use ${targetGuild.name}'s ally home.")
+            player.sendMessage("§7Your rank may lack USE_ALLY_HOMES, or that guild has not granted access.")
+            return
+        }
+
+        if (teleportationService.hasActiveTeleport(playerId)) {
+            player.sendMessage("§cYou already have a teleport in progress. Please wait for it to complete.")
+            return
+        }
+
+        val config = configService.loadConfig()
+        val baseCooldownSeconds = config.guild.homeTeleportCooldownSeconds
+        val cooldownMultiplier = progressionService.getHomeCooldownMultiplier(guild.id)
+        val cooldownSeconds = (baseCooldownSeconds * cooldownMultiplier).toLong()
+
+        val lastTeleport = lastHomeTeleport[playerId]
+        if (lastTeleport != null) {
+            val elapsedSeconds = (System.currentTimeMillis() - lastTeleport) / 1000
+            if (elapsedSeconds < cooldownSeconds) {
+                val remainingSeconds = cooldownSeconds - elapsedSeconds
+                player.sendMessage("§c◷ Please wait ${remainingSeconds}s before teleporting again.")
+                return
+            }
+        }
+
+        val world = player.server.getWorld(allyHome.worldId)
+        if (world == null) {
+            player.sendMessage("§cAlly guild home world is not available.")
+            return
+        }
+
+        val targetLocation = Location(
+            world,
+            allyHome.position.x.toDouble() + 0.5,
+            allyHome.position.y.toDouble(),
+            allyHome.position.z.toDouble() + 0.5,
+            player.location.yaw,
+            player.location.pitch
+        )
+
+        if (config.guild.homeTeleportSafetyCheck) {
+            if (!GuildHomeSafety.checkOrAskConfirm(player, targetLocation, "/guild allyhome ${targetGuild.name} confirm")) {
+                return
+            }
+        }
+
+        teleportationService.startTeleport(player, targetLocation) {
+            lastHomeTeleport[playerId] = System.currentTimeMillis()
+            player.sendMessage("§a✅ Teleported to §6${targetGuild.name}§a's ally home.")
+        }
+    }
+
     @Subcommand("ranks")
     @CommandPermission("lumaguilds.guild.ranks")
     fun onRanks(player: Player) {
@@ -1909,6 +2013,7 @@ class GuildCommand : BaseCommand(), KoinComponent {
 
     @Subcommand("help")
     @CommandPermission("lumaguilds.guild.help")
+    @CommandCompletion("create|tag|home|relations|chat|vault")
     fun onHelp(player: Player, @Optional topic: String?) {
         when (topic?.lowercase()) {
             "create", "name" -> {
@@ -1952,21 +2057,60 @@ class GuildCommand : BaseCommand(), KoinComponent {
             else -> {
                 player.sendMessage("§6§l=== Guild Commands ===")
                 player.sendMessage("§7")
-                player.sendMessage("§eBasic Commands:")
-                player.sendMessage("§7 • §f/guild create <name> §7- Create a guild")
-                player.sendMessage("§7 • §f/guild menu §7- Open guild menu")
-                player.sendMessage("§7 • §f/guild info §7- View guild info")
-                player.sendMessage("§7 • §f/guild invite <player> §7- Invite a player")
-                player.sendMessage("§7 • §f/guild leave §7- Leave your guild")
+                player.sendMessage("§eBasic:")
+                player.sendMessage("§7 • §f/g create <name> §7- Create a guild")
+                player.sendMessage("§7 • §f/g menu §7- Open guild menu")
+                player.sendMessage("§7 • §f/g info [guild|player] §7- View guild info")
+                player.sendMessage("§7 • §f/g list §7- List all guilds")
+                player.sendMessage("§7 • §f/g lfg §7- Browse guilds looking for members")
+                player.sendMessage("§7 • §f/g disband §7- Disband your guild")
+                player.sendMessage("§7")
+                player.sendMessage("§eMembership:")
+                player.sendMessage("§7 • §f/g invite <player> §7- Invite a player")
+                player.sendMessage("§7 • §f/g join|accept <guild> §7- Join/accept invite")
+                player.sendMessage("§7 • §f/g decline <guild> §7- Decline an invite")
+                player.sendMessage("§7 • §f/g invites §7- List pending invites")
+                player.sendMessage("§7 • §f/g kick <player> §7- Kick a member")
+                player.sendMessage("§7 • §f/g leave §7- Leave your guild")
+                player.sendMessage("§7 • §f/g transfer <player> §7- Transfer ownership")
+                player.sendMessage("§7 • §f/g history <player> §7- View member history")
+                player.sendMessage("§7 • §f/g ranks §7- List guild ranks")
+                player.sendMessage("§7")
+                player.sendMessage("§eHomes:")
+                player.sendMessage("§7 • §f/g home [name] §7- Teleport to guild home")
+                player.sendMessage("§7 • §f/g homes §7- List guild homes")
+                player.sendMessage("§7 • §f/g sethome [name] §7- Set a guild home")
+                player.sendMessage("§7 • §f/g removehome <name> §7- Remove a guild home")
+                player.sendMessage("§7 • §f/g setallyhome §7- Set the ally home")
+                player.sendMessage("§7 • §f/g removeallyhome §7- Remove the ally home")
+                player.sendMessage("§7 • §f/g allyhome <guild> §7- Teleport to an ally's home")
+                player.sendMessage("§7")
+                player.sendMessage("§eRelations:")
+                player.sendMessage("§7 • §f/g ally <guild> §7- Request alliance")
+                player.sendMessage("§7 • §f/g enemy <guild> §7- Declare war")
+                player.sendMessage("§7 • §f/g truce <guild> [days] §7- Request truce")
+                player.sendMessage("§7 • §f/g neutral <guild> §7- Request peace")
+                player.sendMessage("§7 • §f/g war §7- Open war menu")
                 player.sendMessage("§7")
                 player.sendMessage("§eCustomization:")
-                player.sendMessage("§7 • §f/guild tag §7- Set fancy formatted tag")
-                player.sendMessage("§7 • §f/guild rename <name> §7- Rename guild")
-                player.sendMessage("§7 • §f/guild desc <text> §7- Set description")
+                player.sendMessage("§7 • §f/g tag §7- Set fancy formatted tag")
+                player.sendMessage("§7 • §f/g rename <name> §7- Rename guild")
+                player.sendMessage("§7 • §f/g desc <text> §7- Set description")
+                player.sendMessage("§7 • §f/g emoji [:name:] §7- Set guild emoji")
+                player.sendMessage("§7 • §f/g mode <peaceful|hostile> §7- Switch mode")
+                player.sendMessage("§7")
+                player.sendMessage("§eChat:")
+                player.sendMessage("§7 • §f/g chat §7- Toggle guild chat")
+                player.sendMessage("§7 • §f/g allychat §7- Toggle ally chat")
+                player.sendMessage("§7")
+                player.sendMessage("§eVault & Shop:")
+                player.sendMessage("§7 • §f/g vault §7- Open guild vault")
+                player.sendMessage("§7 • §f/g getvault §7- Get a vault item")
+                player.sendMessage("§7 • §f/g setshop §7- Convert shop to guild shop")
                 player.sendMessage("§7")
                 player.sendMessage("§eFor detailed help:")
-                player.sendMessage("§7 • §f/guild help create §7- Guild name & tag guide")
-                player.sendMessage("§7 • §f/guild help tag §7- Tag formatting examples")
+                player.sendMessage("§7 • §f/g help create §7- Guild name & tag guide")
+                player.sendMessage("§7 • §f/g help tag §7- Tag formatting examples")
             }
         }
     }

--- a/src/main/kotlin/net/lumalyte/lg/interaction/commands/GuildCommand.kt
+++ b/src/main/kotlin/net/lumalyte/lg/interaction/commands/GuildCommand.kt
@@ -609,7 +609,7 @@ class GuildCommand : BaseCommand(), KoinComponent {
         )
 
         if (config.guild.homeTeleportSafetyCheck) {
-            if (!GuildHomeSafety.checkOrAskConfirm(player, targetLocation, "/guild allyhome ${targetGuild.name} confirm")) {
+            if (!GuildHomeSafety.checkOrAskConfirm(player, targetLocation, "/guild allyhome ${targetGuild.id} confirm")) {
                 return
             }
         }

--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -58,6 +58,7 @@ permissions:
       lumaguilds.guild.rename: true
       lumaguilds.guild.sethome: true
       lumaguilds.guild.home: true
+      lumaguilds.guild.allyhome: true
       lumaguilds.guild.ranks: true
       lumaguilds.guild.emoji: true
       lumaguilds.guild.mode: true
@@ -86,6 +87,9 @@ permissions:
     default: true
   lumaguilds.guild.home:
     description: Teleport to guild home
+    default: true
+  lumaguilds.guild.allyhome:
+    description: Teleport to an allied guild's ally home
     default: true
   lumaguilds.guild.ranks:
     description: Manage guild ranks


### PR DESCRIPTION
## Summary

Two related changes bundled on one branch:

### 1. `feat(commands): add /g allyhome` (bd5b5ec)
New slash command for teleporting to an allied guild's ally home, mirroring the existing `/g home` flow (cooldown via `progressionService.getHomeCooldownMultiplier`, `GuildHomeSafety` confirm flow, `teleportationService.startTeleport` countdown, `lastHomeTeleport` map).

Validation chain:
- Player belongs to a guild
- Target guild resolves and is not the player's own guild
- `RelationType.ALLY` is the active relation
- Target has `allyHome` set
- `canUseAllyHome(playerId, sourceGuildId, targetGuildId)` passes (rank `USE_ALLY_HOMES` + inbound whitelist)

Adds:
- `@allyguilds` async tab completion — only lists allies the executing player can actually teleport to (active ally relation, ally-home set, `canUseAllyHome` true), so the completion never offers commands that would just bounce off an error.
- `@CommandCompletion("create|tag|home|relations|chat|vault")` on `/g help` itself.
- Rewritten default `/g help` body grouped by Basic / Membership / Homes / Relations / Customization / Chat / Vault & Shop, enumerating every registered subcommand including the new one.
- `lumaguilds.guild.allyhome` permission node in `plugin.yml` (default true), wired into the `lumaguilds.guild.*` parent.

### 2. `fix(db): run SQLite migrations for VirtualThreadSQLiteStorage` (d31f523)
`initDatabase` only matched `is SQLiteStorage`. With `use_virtual_threads: true` the storage is `VirtualThreadSQLiteStorage` (which implements `Storage<Database>` directly, not `SQLiteStorage`), so it falls through to the `else` branch, logs `⚠ Unknown storage type: VirtualThreadSQLiteStorage`, and **silently skips every migration**.

Plugin then crashes during Koin init at `GuildInvitationRepositorySQLite.preload` because `guild_invitations` was never created:

```
SQLITE_ERROR: no such table: guild_invitations
  at GuildInvitationRepositorySQLite.preload(GuildInvitationRepositorySQLite.kt:32)
```

Affected installs end up with a partial schema — only tables individual repositories lazily create on first use exist (`guilds`, `members`, `ranks`, `bank_*`, `leaderboard_*`, …); core tables owned by `SQLiteMigrations` (`relations`, `parties`, `audits`, `wars`, `vault_*`, `guild_invitations`, and `claims*` when `claims_enabled`) are missing.

Fix: add `is VirtualThreadSQLiteStorage` to the SQLite when-branch.

> Existing broken installs need `lumaguilds.db` deleted (or the schema manually patched) so migrations can bring them up to v20. Triggered against an empty server data dir here — clean fresh start verified.

## Test plan
- [x] `./gradlew shadowJar` clean (only pre-existing deprecation warnings).
- [x] Server start with `use_virtual_threads: true` + fresh db: migrations run (`Current database schema version: v0` → `✓ Database migrations completed (v20)`), plugin enables, `guild_invitations` and other v11+ tables present.
- [ ] In-game: `/g allyhome <ally>` from a guild member with `USE_ALLY_HOMES` rank perm + reciprocal whitelist teleports to the ally's set home.
- [ ] In-game: `/g allyhome <non-ally>` rejects with "is not an ally".
- [ ] In-game: `/g allyhome <ally-without-home>` rejects with "has no ally home set".
- [ ] In-game: tab completion under `/g allyhome ` only lists eligible allies.
- [ ] In-game: `/g help` lists every subcommand grouped by section.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added `/guild allyhome` subcommand to teleport to allied guild homes with async auto-completion.
  * Auto-completion now suggests only allied guilds that have an ally home you may use.
  * New permission for allyhome access.

* **Improvements**
  * Optional confirmation flow, safety-check prompt, concurrency blocking and integrated per-player cooldowns applied.

* **Chores**
  * Database migration handling updated to include virtual-thread storage variants.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/BadgersMC/LumaGuilds/pull/43)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->