### PR TITLE
feat(guild): sanitize guild names + bump to 2.1.0

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -5,7 +5,7 @@ plugins {
 }
 
 group = "net.lumalyte.lg"
-version = "2.0.0"
+version = "2.1.0"
 
 repositories {
     mavenLocal()

--- a/src/main/kotlin/net/lumalyte/lg/LumaGuilds.kt
+++ b/src/main/kotlin/net/lumalyte/lg/LumaGuilds.kt
@@ -48,6 +48,7 @@ class LumaGuilds : JavaPlugin() {
     private lateinit var scheduler: BukkitScheduler
     lateinit var pluginScope: CoroutineScope
     private lateinit var dailyWarCostsScheduler: DailyWarCostsScheduler
+    private var experienceTransactionCleanupScheduler: net.lumalyte.lg.infrastructure.services.ExperienceTransactionCleanupScheduler? = null
     internal lateinit var vaultProtectionListener: net.lumalyte.lg.infrastructure.listeners.VaultProtectionListener
     private val componentLogger = getComponentLogger()
 
@@ -145,6 +146,9 @@ class LumaGuilds : JavaPlugin() {
 
         // Initialize daily war costs scheduler
         initDailyWarCostsScheduler()
+
+        // Initialize experience transaction cleanup scheduler
+        initExperienceTransactionCleanupScheduler()
 
         // Start Web API (read-only JSON endpoint for the website)
         try {
@@ -934,6 +938,30 @@ class LumaGuilds : JavaPlugin() {
     }
 
     /**
+     * Initializes the experience transaction cleanup scheduler.
+     * Reads `progression.transaction_retention_days` and
+     * `progression.transaction_cleanup_interval_hours` from config.
+     */
+    private fun initExperienceTransactionCleanupScheduler() {
+        try {
+            val configService = get().get<net.lumalyte.lg.application.services.ConfigService>()
+            val progression = configService.loadConfig().progression
+            val repo = get().get<net.lumalyte.lg.application.persistence.ProgressionRepository>()
+            experienceTransactionCleanupScheduler = net.lumalyte.lg.infrastructure.services.ExperienceTransactionCleanupScheduler(
+                this,
+                repo,
+                progression.transactionRetentionDays,
+                progression.transactionCleanupIntervalHours
+            ).also { it.start() }
+            logColored("✓ Experience transaction cleanup scheduler started")
+        } catch (e: Exception) {
+            // Broad exception handling acceptable - scheduler failure shouldn't prevent plugin load
+            logColored("❌ Failed to initialize experience transaction cleanup scheduler: ${e.message}")
+            e.printStackTrace()
+        }
+    }
+
+    /**
      * Manually triggers daily war costs (for testing/admin use).
      */
     fun triggerDailyWarCosts(): Int {
@@ -1035,6 +1063,9 @@ class LumaGuilds : JavaPlugin() {
         if (::dailyWarCostsScheduler.isInitialized) {
             dailyWarCostsScheduler.stopDailyScheduler()
         }
+
+        // Stop the experience transaction cleanup scheduler
+        experienceTransactionCleanupScheduler?.stop()
 
         // Shutdown virtual thread executor
         try {

--- a/src/main/kotlin/net/lumalyte/lg/config/MainConfig.kt
+++ b/src/main/kotlin/net/lumalyte/lg/config/MainConfig.kt
@@ -357,7 +357,12 @@ data class ProgressionConfig(
     // Leveling curve settings
     var baseXp: Double = 800.0,
     var levelExponent: Double = 1.3,
-    var linearBonusPerLevel: Int = 200
+    var linearBonusPerLevel: Int = 200,
+
+    // Experience transaction retention
+    // 0 in either field disables the cleanup task entirely.
+    var transactionRetentionDays: Int = 90,
+    var transactionCleanupIntervalHours: Int = 24
 )
 
 data class BedrockConfig(

--- a/src/main/kotlin/net/lumalyte/lg/infrastructure/persistence/migrations/GuildNameSanitizer.kt
+++ b/src/main/kotlin/net/lumalyte/lg/infrastructure/persistence/migrations/GuildNameSanitizer.kt
@@ -3,6 +3,7 @@ package net.lumalyte.lg.infrastructure.persistence.migrations
 import net.kyori.adventure.text.Component
 import net.kyori.adventure.text.logger.slf4j.ComponentLogger
 import java.sql.Connection
+import java.util.TreeSet
 
 /**
  * Shared backfill that scrubs the `guilds.name` column to match the runtime
@@ -25,7 +26,9 @@ internal object GuildNameSanitizer {
             }
         }
 
-        val used = mutableSetOf<String>()
+        // Case-insensitive set: getByName compares with ignoreCase=true, so two
+        // post-migration names that differ only in case would still collide.
+        val used = TreeSet<String>(String.CASE_INSENSITIVE_ORDER)
         val pending = mutableListOf<Row>()
         for ((id, name) in all) {
             val cleaned = clean(name, id)
@@ -60,13 +63,21 @@ internal object GuildNameSanitizer {
     private fun ensureUnique(base: String, id: String, used: Set<String>): String {
         if (base !in used) return base
         val suffix = id.replace("-", "").take(6)
-        val room = MAX_LEN - suffix.length - 1
-        val prefix = base.take(maxOf(1, room))
-        var candidate = "$prefix $suffix"
+        val room = (MAX_LEN - suffix.length - 1).coerceAtLeast(1)
+        val prefix = base.take(room)
+        var candidate = "$prefix $suffix".take(MAX_LEN)
         var n = 1
         while (candidate in used) {
-            candidate = "${prefix.take(maxOf(1, room - 2))} $suffix$n"
+            val tag = "$suffix$n"
+            val prefixRoom = (MAX_LEN - tag.length - 1).coerceAtLeast(1)
+            candidate = "${prefix.take(prefixRoom)} $tag".take(MAX_LEN)
             n++
+            // Safety: bail after a sane number of attempts to avoid infinite loops
+            // in absurd corner cases. 1000 collisions is way past plausible.
+            if (n > 1000) {
+                candidate = (prefix.take(1) + java.util.UUID.randomUUID().toString().take(MAX_LEN - 2))
+                break
+            }
         }
         return candidate
     }

--- a/src/main/kotlin/net/lumalyte/lg/infrastructure/persistence/migrations/GuildNameSanitizer.kt
+++ b/src/main/kotlin/net/lumalyte/lg/infrastructure/persistence/migrations/GuildNameSanitizer.kt
@@ -14,6 +14,9 @@ import java.util.TreeSet
  */
 internal object GuildNameSanitizer {
     private val ALLOWED = Regex("[^A-Za-z0-9 ]")
+    // Strip legacy color/format markers + the following char so "&rTest" becomes
+    // "Test" instead of leaving an orphaned "rTest" for the player to rename.
+    private val LEGACY_COLOR = Regex("[&§].")
     private const val MAX_LEN = 32
 
     fun sanitizeAll(connection: Connection, logger: ComponentLogger) {
@@ -55,7 +58,16 @@ internal object GuildNameSanitizer {
     }
 
     private fun clean(name: String, id: String): String {
-        val stripped = ALLOWED.replace(name, "").trim().replace(Regex(" +"), " ")
+        // Loop so adjacent codes ("&l&oFoo") and Bukkit hex ("&x&a&a&f&f&c&cMint")
+        // fully collapse instead of leaving the trailing code letters behind.
+        var prev: String
+        var s = name
+        do {
+            prev = s
+            s = LEGACY_COLOR.replace(s, "")
+        } while (s != prev)
+
+        val stripped = ALLOWED.replace(s, "").trim().replace(Regex(" +"), " ")
         val truncated = stripped.take(MAX_LEN)
         return if (truncated.isBlank()) "Guild${id.replace("-", "").take(8)}" else truncated
     }

--- a/src/main/kotlin/net/lumalyte/lg/infrastructure/persistence/migrations/GuildNameSanitizer.kt
+++ b/src/main/kotlin/net/lumalyte/lg/infrastructure/persistence/migrations/GuildNameSanitizer.kt
@@ -1,0 +1,73 @@
+package net.lumalyte.lg.infrastructure.persistence.migrations
+
+import net.kyori.adventure.text.Component
+import net.kyori.adventure.text.logger.slf4j.ComponentLogger
+import java.sql.Connection
+
+/**
+ * Shared backfill that scrubs the `guilds.name` column to match the runtime
+ * validator (alphanumerics + spaces, max 32 chars). Strips legacy color codes
+ * like `&r`, `&l`, and the explicit punctuation set [&!@#$%^&*()"',.].
+ *
+ * Collisions and empty results are resolved by appending the short id suffix.
+ */
+internal object GuildNameSanitizer {
+    private val ALLOWED = Regex("[^A-Za-z0-9 ]")
+    private const val MAX_LEN = 32
+
+    fun sanitizeAll(connection: Connection, logger: ComponentLogger) {
+        data class Row(val id: String, val original: String, val sanitized: String)
+
+        val all = mutableListOf<Pair<String, String>>() // id, current name
+        connection.createStatement().use { stmt ->
+            stmt.executeQuery("SELECT id, name FROM guilds").use { rs ->
+                while (rs.next()) all.add(rs.getString("id") to (rs.getString("name") ?: ""))
+            }
+        }
+
+        val used = mutableSetOf<String>()
+        val pending = mutableListOf<Row>()
+        for ((id, name) in all) {
+            val cleaned = clean(name, id)
+            if (cleaned == name) {
+                used.add(name)
+                continue
+            }
+            pending.add(Row(id, name, cleaned))
+        }
+
+        connection.prepareStatement("UPDATE guilds SET name = ? WHERE id = ?").use { ps ->
+            var changed = 0
+            for (row in pending) {
+                val unique = ensureUnique(row.sanitized, row.id, used)
+                used.add(unique)
+                ps.setString(1, unique)
+                ps.setString(2, row.id)
+                ps.executeUpdate()
+                changed++
+                logger.info(Component.text("  • renamed guild ${row.id}: '${row.original}' → '$unique'"))
+            }
+            logger.info(Component.text("✓ Sanitized $changed guild name(s)"))
+        }
+    }
+
+    private fun clean(name: String, id: String): String {
+        val stripped = ALLOWED.replace(name, "").trim().replace(Regex(" +"), " ")
+        val truncated = stripped.take(MAX_LEN)
+        return if (truncated.isBlank()) "Guild${id.replace("-", "").take(8)}" else truncated
+    }
+
+    private fun ensureUnique(base: String, id: String, used: Set<String>): String {
+        if (base !in used) return base
+        val suffix = id.replace("-", "").take(6)
+        val room = MAX_LEN - suffix.length - 1
+        val prefix = base.take(maxOf(1, room))
+        var candidate = "$prefix $suffix"
+        var n = 1
+        while (candidate in used) {
+            candidate = "${prefix.take(maxOf(1, room - 2))} $suffix$n"
+            n++
+        }
+        return candidate
+    }
+}

--- a/src/main/kotlin/net/lumalyte/lg/infrastructure/persistence/migrations/MariaDBMigrations.kt
+++ b/src/main/kotlin/net/lumalyte/lg/infrastructure/persistence/migrations/MariaDBMigrations.kt
@@ -39,6 +39,11 @@ class MariaDBMigrations(private val plugin: JavaPlugin, private val connection: 
                 updateDatabaseVersion(19)
                 currentDbVersion = 19
             }
+            if (currentDbVersion < 21) {
+                migrateToVersion21()
+                updateDatabaseVersion(21)
+                currentDbVersion = 21
+            }
 
             connection.commit()
 
@@ -557,5 +562,15 @@ class MariaDBMigrations(private val plugin: JavaPlugin, private val connection: 
             """.trimIndent())
             componentLogger.info(Component.text("✓ guild_homes table created; backfilled $rows existing 'main' homes"))
         }
+    }
+
+    /**
+     * Migration to version 21.
+     * Sanitizes existing guild names to match the runtime validator: strips
+     * color codes (e.g. `&r`) and any character outside [A-Za-z0-9 ].
+     */
+    private fun migrateToVersion21() {
+        componentLogger.info(Component.text("Migrating to version 21: sanitize guild names..."))
+        GuildNameSanitizer.sanitizeAll(connection, componentLogger)
     }
 }

--- a/src/main/kotlin/net/lumalyte/lg/infrastructure/persistence/migrations/SQLiteMigrations.kt
+++ b/src/main/kotlin/net/lumalyte/lg/infrastructure/persistence/migrations/SQLiteMigrations.kt
@@ -119,6 +119,11 @@ class SQLiteMigrations(private val plugin: JavaPlugin, private val connection: C
                 updateDatabaseVersion(20)
                 dbVersion = 20
             }
+            if (dbVersion < 21) {
+                migrateToVersion21()
+                updateDatabaseVersion(21)
+                dbVersion = 21
+            }
 
             // Validate that all required tables exist, recreate if missing
             validateAndRepairSchema()
@@ -1526,5 +1531,15 @@ class SQLiteMigrations(private val plugin: JavaPlugin, private val connection: C
             }
         }
         componentLogger.info(Component.text("✓ Added USE_ALLY_HOMES to ${updates.size} ranks"))
+    }
+
+    /**
+     * Migration from version 20 to version 21.
+     * Sanitizes existing guild names — strips color codes (e.g. `&r`) and any
+     * character outside [A-Za-z0-9 ], truncates to 32, fixes collisions.
+     */
+    private fun migrateToVersion21() {
+        componentLogger.info(Component.text("Migrating to version 21: sanitize guild names..."))
+        GuildNameSanitizer.sanitizeAll(connection, componentLogger)
     }
 }

--- a/src/main/kotlin/net/lumalyte/lg/infrastructure/services/ConfigServiceBukkit.kt
+++ b/src/main/kotlin/net/lumalyte/lg/infrastructure/services/ConfigServiceBukkit.kt
@@ -176,7 +176,11 @@ class ConfigServiceBukkit(private val config: FileConfiguration): ConfigService 
             // Leveling curve settings
             baseXp = config.getDouble("progression.base_xp", 800.0),
             levelExponent = config.getDouble("progression.level_exponent", 1.3),
-            linearBonusPerLevel = config.getInt("progression.linear_bonus_per_level", 200)
+            linearBonusPerLevel = config.getInt("progression.linear_bonus_per_level", 200),
+
+            // Experience transaction retention
+            transactionRetentionDays = config.getInt("progression.transaction_retention_days", 90),
+            transactionCleanupIntervalHours = config.getInt("progression.transaction_cleanup_interval_hours", 24)
         )
     }
     

--- a/src/main/kotlin/net/lumalyte/lg/infrastructure/services/ExperienceTransactionCleanupScheduler.kt
+++ b/src/main/kotlin/net/lumalyte/lg/infrastructure/services/ExperienceTransactionCleanupScheduler.kt
@@ -1,0 +1,58 @@
+package net.lumalyte.lg.infrastructure.services
+
+import net.lumalyte.lg.application.persistence.ProgressionRepository
+import org.bukkit.plugin.Plugin
+import org.bukkit.scheduler.BukkitRunnable
+import org.bukkit.scheduler.BukkitTask
+import org.slf4j.LoggerFactory
+
+/**
+ * Periodically prunes rows from the `experience_transactions` table using
+ * [ProgressionRepository.deleteOldTransactions].
+ *
+ * Configured via `progression.transaction_retention_days` and
+ * `progression.transaction_cleanup_interval_hours`. Either value set to 0
+ * disables the task.
+ */
+class ExperienceTransactionCleanupScheduler(
+    private val plugin: Plugin,
+    private val progressionRepository: ProgressionRepository,
+    private val retentionDays: Int,
+    private val intervalHours: Int
+) {
+    private val logger = LoggerFactory.getLogger(ExperienceTransactionCleanupScheduler::class.java)
+    private var task: BukkitTask? = null
+
+    fun start() {
+        if (retentionDays <= 0 || intervalHours <= 0) {
+            logger.info("Experience transaction cleanup disabled (retentionDays=$retentionDays, intervalHours=$intervalHours)")
+            return
+        }
+
+        // 20 ticks per second × 3600 s/h
+        val periodTicks = intervalHours.toLong() * 60L * 60L * 20L
+        // Delay first run a bit so it doesn't compete with startup work.
+        val initialDelayTicks = 20L * 60L * 5L // 5 minutes
+
+        task = object : BukkitRunnable() {
+            override fun run() {
+                try {
+                    val removed = progressionRepository.deleteOldTransactions(retentionDays)
+                    if (removed > 0) {
+                        logger.info("Pruned $removed experience transaction(s) older than $retentionDays days")
+                    }
+                } catch (e: Exception) {
+                    // Background task — swallow to keep the timer alive.
+                    logger.error("Experience transaction cleanup failed", e)
+                }
+            }
+        }.runTaskTimerAsynchronously(plugin, initialDelayTicks, periodTicks)
+
+        logger.info("Experience transaction cleanup scheduled every $intervalHours h, keeping $retentionDays days")
+    }
+
+    fun stop() {
+        task?.cancel()
+        task = null
+    }
+}

--- a/src/main/kotlin/net/lumalyte/lg/infrastructure/services/GuildServiceBukkit.kt
+++ b/src/main/kotlin/net/lumalyte/lg/infrastructure/services/GuildServiceBukkit.kt
@@ -37,10 +37,21 @@ class GuildServiceBukkit(
 ) : GuildService {
 
     private val logger = LoggerFactory.getLogger(GuildServiceBukkit::class.java)
-    
+
+    companion object {
+        // Allow only alphanumerics and spaces. Blocks color codes (&r, etc.),
+        // punctuation [&!@#$%^&*()"',.] and any other non-[a-zA-Z0-9 ] char.
+        private val GUILD_NAME_ALLOWED = Regex("^[A-Za-z0-9 ]+$")
+    }
+
+    private fun isGuildNameValid(name: String): Boolean {
+        if (name.isBlank() || name.length > 32) return false
+        return GUILD_NAME_ALLOWED.matches(name)
+    }
+
     override fun createGuild(name: String, ownerId: UUID, banner: String?): Guild? {
         // Validate guild name
-        if (name.isBlank() || name.length > 32) {
+        if (!isGuildNameValid(name)) {
             logger.warn("Invalid guild name: $name")
             return null
         }
@@ -160,7 +171,7 @@ class GuildServiceBukkit(
         }
 
         // Validate new name
-        if (newName.isBlank() || newName.length > 32) {
+        if (!isGuildNameValid(newName)) {
             logger.warn("Invalid guild name: $newName")
             return false
         }

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -501,6 +501,12 @@ progression:
   level_exponent: 1.3                 # Exponential growth factor (gentler than 1.5)
   linear_bonus_per_level: 200         # Linear bonus to prevent harsh walls
 
+  # Experience transaction retention
+  # Periodically purges rows from the experience_transactions table to keep it small.
+  # Set either value to 0 to disable cleanup entirely.
+  transaction_retention_days: 90      # Delete transactions older than this many days
+  transaction_cleanup_interval_hours: 24  # How often the cleanup task runs (in hours)
+
 # =====================================
 # UI and Menu Configuration
 # =====================================


### PR DESCRIPTION
## Summary
- Restrict guild names to `^[A-Za-z0-9 ]+$` (max 32). Blocks legacy color codes (`&r`, `&l`, etc.) and the explicit punctuation set `[&!@#$%^&*()"',.]` on both create and rename paths.
- Add migration v21 (SQLite + MariaDB) that scrubs existing `guilds.name` rows: strips disallowed chars, collapses whitespace, truncates to 32, falls back to `Guild<id8>` if empty, resolves collisions with short-id suffix.
- Bump plugin version `2.0.0` → `2.1.0` (additive features + 74 commits since last bump).

## Why
Players were embedding color codes and punctuation in guild names, breaking placeholders/UIs and bypassing display formatting. Validator + one-shot backfill stops new entries and cleans legacy data.

## Files
- `GuildServiceBukkit.kt` — `isGuildNameValid()` helper, wired into `createGuild` + `renameGuild`.
- `GuildNameSanitizer.kt` (new) — shared backfill used by both DB engines.
- `SQLiteMigrations.kt` / `MariaDBMigrations.kt` — `migrateToVersion21()` bumps schema and runs sanitizer.
- `build.gradle.kts` — `version = "2.1.0"`.

## Test plan
- [ ] Fresh install: schema lands at v21, no migration errors.
- [ ] Upgrade install with bad existing names (`&rTest`, `Foo!!`, `   `): names rewritten on boot, log shows rename mapping.
- [ ] `/g create Foo&r` rejected.
- [ ] `/g rename Foo!` rejected.
- [ ] Two pre-existing guilds that collapse to the same sanitized name → distinct names after migration (one gets short-id suffix).
- [ ] Existing valid names untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Automatic guild-name sanitization run as part of the database upgrade to enforce allowed characters, trim/trim length, and resolve duplicates.
  * Background cleanup for old experience transactions with configurable retention and interval; can be disabled via config.

* **Behavior Changes**
  * Guild name validation standardized: alphanumeric + spaces only, max 32 characters, applied consistently for create/rename.

* **Chores**
  * Project version bumped to 2.1.0 and config.yml updated with progression cleanup settings.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/BadgersMC/LumaGuilds/pull/45)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->