### PR TITLE
Fix/chat cleanup

### DIFF
--- a/src/main/kotlin/net/lumalyte/lg/LumaGuilds.kt
+++ b/src/main/kotlin/net/lumalyte/lg/LumaGuilds.kt
@@ -911,8 +911,9 @@ class LumaGuilds : JavaPlugin() {
         // Register war kill tracking listener
         server.pluginManager.registerEvents(net.lumalyte.lg.infrastructure.listeners.WarKillTrackingListener(), this)
 
-        // Close stale guild menus when a guild is disbanded
-        server.pluginManager.registerEvents(net.lumalyte.lg.infrastructure.listeners.GuildDisbandedListener(), this)
+        // Close stale guild menus and clean up channels when a guild is disbanded
+        val guildDisbandedListener = get().get<net.lumalyte.lg.infrastructure.listeners.GuildDisbandedListener>()
+        server.pluginManager.registerEvents(guildDisbandedListener, this)
 
         // Clean up RoseChat channels when guild status changes
         if (server.pluginManager.isPluginEnabled("RoseChat")) {

--- a/src/main/kotlin/net/lumalyte/lg/LumaGuilds.kt
+++ b/src/main/kotlin/net/lumalyte/lg/LumaGuilds.kt
@@ -914,6 +914,12 @@ class LumaGuilds : JavaPlugin() {
         // Close stale guild menus when a guild is disbanded
         server.pluginManager.registerEvents(net.lumalyte.lg.infrastructure.listeners.GuildDisbandedListener(), this)
 
+        // Clean up RoseChat channels when guild status changes
+        if (server.pluginManager.isPluginEnabled("RoseChat")) {
+            server.pluginManager.registerEvents(net.lumalyte.lg.infrastructure.listeners.RoseChatCleanupListener(), this)
+            logColored("✓ RoseChat integration registered for chat cleanup")
+        }
+
         // Register admin override listener (for logout cleanup) - only when claims enabled
         if (claimsEnabled) {
             val adminOverrideListener = get().get<net.lumalyte.lg.interaction.listeners.AdminOverrideListener>()

--- a/src/main/kotlin/net/lumalyte/lg/LumaGuilds.kt
+++ b/src/main/kotlin/net/lumalyte/lg/LumaGuilds.kt
@@ -917,7 +917,8 @@ class LumaGuilds : JavaPlugin() {
 
         // Clean up RoseChat channels when guild status changes
         if (server.pluginManager.isPluginEnabled("RoseChat")) {
-            server.pluginManager.registerEvents(net.lumalyte.lg.infrastructure.listeners.RoseChatCleanupListener(), this)
+            val roseChatCleanupListener = get().get<net.lumalyte.lg.infrastructure.listeners.RoseChatCleanupListener>()
+            server.pluginManager.registerEvents(roseChatCleanupListener, this)
             logColored("✓ RoseChat integration registered for chat cleanup")
         }
 

--- a/src/main/kotlin/net/lumalyte/lg/application/services/PartyService.kt
+++ b/src/main/kotlin/net/lumalyte/lg/application/services/PartyService.kt
@@ -94,7 +94,19 @@ interface PartyService {
      * @return true if the party was dissolved successfully, false otherwise.
      */
     fun dissolveParty(partyId: UUID, dissolverId: UUID): Boolean
-    
+
+    /**
+     * Removes a guild from a party as a system operation, bypassing permission checks.
+     *
+     * Intended for automated cleanup such as guild disbandment. If fewer than two
+     * guilds remain afterward, the party is dissolved.
+     *
+     * @param partyId The ID of the party.
+     * @param guildId The ID of the guild to remove.
+     * @return The updated party, or null if the party was dissolved or the operation failed.
+     */
+    fun removeGuildFromPartyAsSystem(partyId: UUID, guildId: UUID): Party?
+
     /**
      * Gets all active parties for a guild.
      *

--- a/src/main/kotlin/net/lumalyte/lg/di/Modules.kt
+++ b/src/main/kotlin/net/lumalyte/lg/di/Modules.kt
@@ -448,6 +448,9 @@ fun socialModule() = module {
     single<net.lumalyte.lg.infrastructure.listeners.GuildChannelCreationListener> {
         net.lumalyte.lg.infrastructure.listeners.GuildChannelCreationListener(get(), get())
     }
+    single<net.lumalyte.lg.infrastructure.listeners.GuildDisbandedListener> {
+        net.lumalyte.lg.infrastructure.listeners.GuildDisbandedListener(get())
+    }
 }
 
 /**

--- a/src/main/kotlin/net/lumalyte/lg/di/Modules.kt
+++ b/src/main/kotlin/net/lumalyte/lg/di/Modules.kt
@@ -451,6 +451,9 @@ fun socialModule() = module {
     single<net.lumalyte.lg.infrastructure.listeners.GuildDisbandedListener> {
         net.lumalyte.lg.infrastructure.listeners.GuildDisbandedListener(get())
     }
+    single<net.lumalyte.lg.infrastructure.listeners.RoseChatCleanupListener> {
+        net.lumalyte.lg.infrastructure.listeners.RoseChatCleanupListener(get(), get(), get(), get())
+    }
 }
 
 /**

--- a/src/main/kotlin/net/lumalyte/lg/infrastructure/listeners/GuildDisbandedListener.kt
+++ b/src/main/kotlin/net/lumalyte/lg/infrastructure/listeners/GuildDisbandedListener.kt
@@ -28,12 +28,17 @@ class GuildDisbandedListener(
             player.sendMessage("§c✗ Your guild §f${event.guild.name} §chas been disbanded.")
         }
 
-        // 2. Remove all Party channels associated with this guild
+        // 2. Remove this guild from every party it participates in.
+        //    Single/last-guild parties are dissolved; multi-guild parties survive
+        //    for the remaining guilds. Uses a system removal so the cleanup is not
+        //    blocked by the actor's party-management permissions.
         try {
             val parties = partyService.getActivePartiesForGuild(event.guild.id)
             parties.forEach { party ->
-                if (partyService.dissolveParty(party.id, event.actorId)) {
-                    logger.info("Removed guild channel ${party.name} (${party.id}) for disbanded guild ${event.guild.name}")
+                if (partyService.removeGuildFromPartyAsSystem(party.id, event.guild.id) == null) {
+                    logger.info("Dissolved party channel ${party.name} (${party.id}) for disbanded guild ${event.guild.name}")
+                } else {
+                    logger.info("Removed disbanded guild ${event.guild.name} from party ${party.name} (${party.id})")
                 }
             }
         } catch (e: Exception) {

--- a/src/main/kotlin/net/lumalyte/lg/infrastructure/listeners/GuildDisbandedListener.kt
+++ b/src/main/kotlin/net/lumalyte/lg/infrastructure/listeners/GuildDisbandedListener.kt
@@ -32,7 +32,7 @@ class GuildDisbandedListener(
         try {
             val parties = partyService.getActivePartiesForGuild(event.guild.id)
             parties.forEach { party ->
-                if (partyService.deleteParty(party.id)) {
+                if (partyService.dissolveParty(party.id, event.actorId)) {
                     logger.info("Removed guild channel ${party.name} (${party.id}) for disbanded guild ${event.guild.name}")
                 }
             }

--- a/src/main/kotlin/net/lumalyte/lg/infrastructure/listeners/GuildDisbandedListener.kt
+++ b/src/main/kotlin/net/lumalyte/lg/infrastructure/listeners/GuildDisbandedListener.kt
@@ -1,24 +1,43 @@
 package net.lumalyte.lg.infrastructure.listeners
 
+import net.lumalyte.lg.application.services.PartyService
 import net.lumalyte.lg.domain.events.GuildDisbandedEvent
 import org.bukkit.Bukkit
 import org.bukkit.event.EventHandler
 import org.bukkit.event.EventPriority
 import org.bukkit.event.Listener
+import org.slf4j.LoggerFactory
 
 /**
  * Closes any open guild menus for members still online when their guild is disbanded,
- * preventing stale GUIs from remaining open after the guild no longer exists.
+ * and removes all chat channels (Parties) associated with the guild.
  */
-class GuildDisbandedListener : Listener {
+class GuildDisbandedListener(
+    private val partyService: PartyService
+) : Listener {
+
+    private val logger = LoggerFactory.getLogger(GuildDisbandedListener::class.java)
 
     @EventHandler(priority = EventPriority.MONITOR)
     fun onGuildDisbanded(event: GuildDisbandedEvent) {
+        // 1. Close inventories and notify online members
         event.memberIds.forEach { memberId ->
             val player = Bukkit.getPlayer(memberId) ?: return@forEach
             if (!player.isOnline) return@forEach
             player.closeInventory()
             player.sendMessage("§c✗ Your guild §f${event.guild.name} §chas been disbanded.")
+        }
+
+        // 2. Remove all Party channels associated with this guild
+        try {
+            val parties = partyService.getActivePartiesForGuild(event.guild.id)
+            parties.forEach { party ->
+                if (partyService.deleteParty(party.id)) {
+                    logger.info("Removed guild channel ${party.name} (${party.id}) for disbanded guild ${event.guild.name}")
+                }
+            }
+        } catch (e: Exception) {
+            logger.error("Failed to clean up channels for disbanded guild ${event.guild.name}", e)
         }
     }
 }

--- a/src/main/kotlin/net/lumalyte/lg/infrastructure/listeners/RoseChatCleanupListener.kt
+++ b/src/main/kotlin/net/lumalyte/lg/infrastructure/listeners/RoseChatCleanupListener.kt
@@ -5,6 +5,7 @@ import dev.rosewood.rosechat.message.RosePlayer
 import net.lumalyte.lg.application.services.GuildService
 import net.lumalyte.lg.application.services.MemberService
 import net.lumalyte.lg.application.services.PartyService
+import net.lumalyte.lg.application.services.RelationService
 import net.lumalyte.lg.domain.events.GuildDisbandedEvent
 import net.lumalyte.lg.domain.events.GuildMemberRemovedEvent
 import net.lumalyte.lg.domain.events.GuildRelationChangeEvent
@@ -32,6 +33,7 @@ class RoseChatCleanupListener : Listener, KoinComponent {
     private val guildService: GuildService by inject()
     private val memberService: MemberService by inject()
     private val partyService: PartyService by inject()
+    private val relationService: RelationService by inject()
 
     private val logger = LoggerFactory.getLogger(RoseChatCleanupListener::class.java)
 
@@ -77,38 +79,39 @@ class RoseChatCleanupListener : Listener, KoinComponent {
      * Checks if the player's current RoseChat channel is still valid based on their
      * LumaGuilds status (guild membership and party participation).
      */
-    private fun validateAndCleanup(player: Player, api: RoseChatAPI = RoseChatAPI.getInstance() ?: return) {
-        if (!player.isOnline) return
+    private fun validateAndCleanup(player: Player, api: RoseChatAPI? = RoseChatAPI.getInstance()) {
+        if (api == null || !player.isOnline) return
 
         try {
             val rosePlayer = RosePlayer(player)
             val currentChannel = rosePlayer.playerData?.currentChannel ?: return
             val channelId = currentChannel.id
 
-            var shouldSwitch = false
+            val shouldSwitch = when {
+                // Fixed 'guild' channel: valid only while the player is in a guild.
+                channelId == guildChannelId ->
+                    guildService.getPlayerGuilds(player.uniqueId).isEmpty()
 
-            // 1. Check if they are in the fixed 'guild' or 'guild-ally' RoseChat channels
-            if (channelId == guildChannelId || channelId == allyChannelId) {
-                if (guildService.getPlayerGuilds(player.uniqueId).isEmpty()) {
-                    shouldSwitch = true
-                }
-            }
+                // Fixed 'guild-ally' channel: valid only while one of the player's
+                // guilds still has at least one active alliance.
+                channelId == allyChannelId ->
+                    guildService.getPlayerGuilds(player.uniqueId).none { guild ->
+                        relationService.getGuildRelationsByType(guild.id, RelationType.ALLY)
+                            .any { it.isActive() }
+                    }
 
-            // 2. Check if they are in a custom Luma Party channel
-            // A player should only be in a party channel if they have an active Luma Party.
-            if (!shouldSwitch) {
-                val activeParty = partyService.getActivePartyForPlayer(player.uniqueId)
-                if (activeParty == null) {
-                    // If the player has no active Luma Party but is in a dynamic channel,
-                    // check if this channel could be a party channel by verifying against
-                    // all known party IDs for the player's guilds.
-                    val playerGuildIds = guildService.getPlayerGuilds(player.uniqueId).map { it.id }
-                    val knownPartyIds = playerGuildIds.flatMap { gid ->
-                        partyService.getAllPartiesForGuild(gid).map { it.id.toString() }
-                    }.toSet()
-                    // Only switch if the channel ID is NOT in any known party set
-                    if (channelId !in knownPartyIds) {
-                        shouldSwitch = true
+                // Dynamic party channels are keyed by the party UUID. Channels whose
+                // ID is not a UUID belong to other plugins and must not be touched.
+                else -> {
+                    val channelUuid = runCatching { UUID.fromString(channelId) }.getOrNull()
+                    if (channelUuid == null) {
+                        false
+                    } else {
+                        val activePartyIds = guildService.getPlayerGuilds(player.uniqueId)
+                            .flatMap { partyService.getActivePartiesForGuild(it.id) }
+                            .map { it.id }
+                            .toSet()
+                        channelUuid !in activePartyIds
                     }
                 }
             }

--- a/src/main/kotlin/net/lumalyte/lg/infrastructure/listeners/RoseChatCleanupListener.kt
+++ b/src/main/kotlin/net/lumalyte/lg/infrastructure/listeners/RoseChatCleanupListener.kt
@@ -4,14 +4,17 @@ import dev.rosewood.rosechat.api.RoseChatAPI
 import dev.rosewood.rosechat.message.RosePlayer
 import net.lumalyte.lg.domain.events.GuildDisbandedEvent
 import net.lumalyte.lg.domain.events.GuildMemberRemovedEvent
+import net.lumalyte.lg.domain.events.GuildRelationChangeEvent
+import net.lumalyte.lg.domain.entities.RelationType
 import org.bukkit.Bukkit
 import org.bukkit.event.EventHandler
 import org.bukkit.event.EventPriority
 import org.bukkit.event.Listener
 
 /**
- * Listener to handle RoseChat channel cleanup when players leave or guilds are disbanded.
- * Ensures players are removed from guild-specific channels to prevent "ghost" memberships.
+ * Listener to handle RoseChat channel cleanup when players leave, guilds are disbanded,
+ * or relationships (allies) change. Ensures players are removed from guild-specific 
+ * and ally-specific channels to prevent "ghost" memberships and resonance.
  */
 class RoseChatCleanupListener : Listener {
 
@@ -28,18 +31,30 @@ class RoseChatCleanupListener : Listener {
         }
     }
 
+    @EventHandler(priority = EventPriority.MONITOR)
+    fun onRelationChange(event: GuildRelationChangeEvent) {
+        // If an alliance is broken, we need to boot members from any shared ally channels
+        if (event.type == RelationType.NEUTRAL || event.type == RelationType.ENEMY) {
+            // Note: In LumaGuilds, relation changes often trigger specific logic.
+            // Here we proactively clean participants if they were in an ally-related channel.
+            event.sourceGuild.memberIds.forEach { cleanupPlayer(it) }
+            event.targetGuild.memberIds.forEach { cleanupPlayer(it) }
+        }
+    }
+
     private fun cleanupPlayer(playerId: java.util.UUID) {
         try {
-            val player = Bukkit.getPlayer(playerId)
-            val rosePlayer = if (player != null) RosePlayer(player) else RosePlayer(playerId, "Unknown", "default")
+            val player = Bukkit.getPlayer(playerId) ?: return
+            if (!player.isOnline) return
+            
+            val rosePlayer = RosePlayer(player)
             val api = RoseChatAPI.getInstance()
             val currentChannel = rosePlayer.playerData?.currentChannel ?: return
 
-            // If the player is in a channel that is guild-related (based on ID convention or provider)
-            // LumaGuilds usually creates channels with 'guild_' prefix or similar if it's integrating.
-            // Even if it's just a general cleanup, we check if the channel is one they shouldn't be in.
-            
-            if (currentChannel.id.startsWith("guild_") || currentChannel.id.contains("guild")) {
+            // Check if the channel is guild-related or ally-related
+            // Matches 'guild_', 'ally_', or 'officer_' patterns used by Luma/RoseChat hooks
+            val channelId = currentChannel.id.lowercase()
+            if (channelId.contains("guild") || channelId.contains("ally") || channelId.contains("officer")) {
                 val defaultChannel = api.channelManager.defaultChannel
                 if (defaultChannel != null && currentChannel.id != defaultChannel.id) {
                     rosePlayer.switchChannel(defaultChannel)

--- a/src/main/kotlin/net/lumalyte/lg/infrastructure/listeners/RoseChatCleanupListener.kt
+++ b/src/main/kotlin/net/lumalyte/lg/infrastructure/listeners/RoseChatCleanupListener.kt
@@ -15,25 +15,23 @@ import org.bukkit.entity.Player
 import org.bukkit.event.EventHandler
 import org.bukkit.event.EventPriority
 import org.bukkit.event.Listener
-import org.koin.core.component.KoinComponent
-import org.koin.core.component.inject
 import org.slf4j.LoggerFactory
 import java.util.UUID
 
 /**
  * Listener to handle RoseChat channel cleanup when players leave, guilds are disbanded,
  * or relationships (allies) change.
- * 
+ *
  * Unlike standard channel identification, this listener verifies if a player is still
  * authorized to be in their current RoseChat channel by checking against LumaGuilds
  * known Party objects and Guild membership status.
  */
-class RoseChatCleanupListener : Listener, KoinComponent {
-
-    private val guildService: GuildService by inject()
-    private val memberService: MemberService by inject()
-    private val partyService: PartyService by inject()
-    private val relationService: RelationService by inject()
+class RoseChatCleanupListener(
+    private val guildService: GuildService,
+    private val memberService: MemberService,
+    private val partyService: PartyService,
+    private val relationService: RelationService
+) : Listener {
 
     private val logger = LoggerFactory.getLogger(RoseChatCleanupListener::class.java)
 
@@ -76,8 +74,43 @@ class RoseChatCleanupListener : Listener, KoinComponent {
     }
 
     /**
-     * Checks if the player's current RoseChat channel is still valid based on their
-     * LumaGuilds status (guild membership and party participation).
+     * Decides whether [playerId] should be removed from the RoseChat channel [channelId]
+     * based purely on their current LumaGuilds status.
+     *
+     * - The fixed `guild` channel is valid only while the player is in a guild.
+     * - The fixed `guild-ally` channel is valid only while one of the player's guilds
+     *   still has at least one active alliance.
+     * - Dynamic party channels are keyed by the party UUID; the player may stay only
+     *   if that UUID is an active party of one of their guilds. Channels whose id is
+     *   not a UUID belong to other plugins and are never touched.
+     */
+    fun shouldLeaveChannel(playerId: UUID, channelId: String): Boolean = when (channelId) {
+        guildChannelId ->
+            guildService.getPlayerGuilds(playerId).isEmpty()
+
+        allyChannelId ->
+            guildService.getPlayerGuilds(playerId).none { guild ->
+                relationService.getGuildRelationsByType(guild.id, RelationType.ALLY)
+                    .any { it.isActive() }
+            }
+
+        else -> {
+            val channelUuid = runCatching { UUID.fromString(channelId) }.getOrNull()
+            if (channelUuid == null) {
+                false
+            } else {
+                val activePartyIds = guildService.getPlayerGuilds(playerId)
+                    .flatMap { partyService.getActivePartiesForGuild(it.id) }
+                    .map { it.id }
+                    .toSet()
+                channelUuid !in activePartyIds
+            }
+        }
+    }
+
+    /**
+     * Moves the player back to the default channel if their current RoseChat channel
+     * is no longer valid for their LumaGuilds status.
      */
     private fun validateAndCleanup(player: Player, api: RoseChatAPI? = RoseChatAPI.getInstance()) {
         if (api == null || !player.isOnline) return
@@ -87,36 +120,7 @@ class RoseChatCleanupListener : Listener, KoinComponent {
             val currentChannel = rosePlayer.playerData?.currentChannel ?: return
             val channelId = currentChannel.id
 
-            val shouldSwitch = when {
-                // Fixed 'guild' channel: valid only while the player is in a guild.
-                channelId == guildChannelId ->
-                    guildService.getPlayerGuilds(player.uniqueId).isEmpty()
-
-                // Fixed 'guild-ally' channel: valid only while one of the player's
-                // guilds still has at least one active alliance.
-                channelId == allyChannelId ->
-                    guildService.getPlayerGuilds(player.uniqueId).none { guild ->
-                        relationService.getGuildRelationsByType(guild.id, RelationType.ALLY)
-                            .any { it.isActive() }
-                    }
-
-                // Dynamic party channels are keyed by the party UUID. Channels whose
-                // ID is not a UUID belong to other plugins and must not be touched.
-                else -> {
-                    val channelUuid = runCatching { UUID.fromString(channelId) }.getOrNull()
-                    if (channelUuid == null) {
-                        false
-                    } else {
-                        val activePartyIds = guildService.getPlayerGuilds(player.uniqueId)
-                            .flatMap { partyService.getActivePartiesForGuild(it.id) }
-                            .map { it.id }
-                            .toSet()
-                        channelUuid !in activePartyIds
-                    }
-                }
-            }
-
-            if (shouldSwitch) {
+            if (shouldLeaveChannel(player.uniqueId, channelId)) {
                 val defaultChannel = api.channelManager.defaultChannel
                 if (defaultChannel != null && channelId != defaultChannel.id) {
                     rosePlayer.switchChannel(defaultChannel)

--- a/src/main/kotlin/net/lumalyte/lg/infrastructure/listeners/RoseChatCleanupListener.kt
+++ b/src/main/kotlin/net/lumalyte/lg/infrastructure/listeners/RoseChatCleanupListener.kt
@@ -3,6 +3,7 @@ package net.lumalyte.lg.infrastructure.listeners
 import dev.rosewood.rosechat.api.RoseChatAPI
 import dev.rosewood.rosechat.message.RosePlayer
 import net.lumalyte.lg.application.services.GuildService
+import net.lumalyte.lg.application.services.MemberService
 import net.lumalyte.lg.application.services.PartyService
 import net.lumalyte.lg.domain.events.GuildDisbandedEvent
 import net.lumalyte.lg.domain.events.GuildMemberRemovedEvent
@@ -15,6 +16,7 @@ import org.bukkit.event.EventPriority
 import org.bukkit.event.Listener
 import org.koin.core.component.KoinComponent
 import org.koin.core.component.inject
+import org.slf4j.LoggerFactory
 import java.util.UUID
 
 /**
@@ -28,7 +30,10 @@ import java.util.UUID
 class RoseChatCleanupListener : Listener, KoinComponent {
 
     private val guildService: GuildService by inject()
+    private val memberService: MemberService by inject()
     private val partyService: PartyService by inject()
+
+    private val logger = LoggerFactory.getLogger(RoseChatCleanupListener::class.java)
 
     /** IDs of the RoseChat channels defined in LumaGuilds' channels.yml hook. */
     private val guildChannelId = "guild"
@@ -42,19 +47,28 @@ class RoseChatCleanupListener : Listener, KoinComponent {
 
     @EventHandler(priority = EventPriority.MONITOR)
     fun onGuildDisbanded(event: GuildDisbandedEvent) {
+        // Batch: resolve RoseChat API once, then process all members
+        val api = RoseChatAPI.getInstance() ?: return
         event.memberIds.forEach { memberId ->
             val player = Bukkit.getPlayer(memberId) ?: return@forEach
-            validateAndCleanup(player)
+            validateAndCleanup(player, api)
         }
     }
 
     @EventHandler(priority = EventPriority.MONITOR)
     fun onRelationChange(event: GuildRelationChangeEvent) {
         // If an alliance is broken, refresh all members of both guilds
-        if (event.type == RelationType.NEUTRAL || event.type == RelationType.ENEMY) {
-            (event.sourceGuild.memberIds + event.targetGuild.memberIds).forEach { memberId ->
+        if (event.newRelationType == RelationType.NEUTRAL || event.newRelationType == RelationType.ENEMY) {
+            val api = RoseChatAPI.getInstance() ?: return
+            // Resolve guild UUIDs to Guild objects, then collect member IDs
+            val guild1 = guildService.getGuild(event.guild1)
+            val guild2 = guildService.getGuild(event.guild2)
+            val memberIds = mutableSetOf<UUID>()
+            guild1?.let { memberIds.addAll(memberService.getGuildMembers(it.id).map { m -> m.playerId }) }
+            guild2?.let { memberIds.addAll(memberService.getGuildMembers(it.id).map { m -> m.playerId }) }
+            memberIds.forEach { memberId ->
                 val player = Bukkit.getPlayer(memberId) ?: return@forEach
-                validateAndCleanup(player)
+                validateAndCleanup(player, api)
             }
         }
     }
@@ -63,11 +77,10 @@ class RoseChatCleanupListener : Listener, KoinComponent {
      * Checks if the player's current RoseChat channel is still valid based on their
      * LumaGuilds status (guild membership and party participation).
      */
-    private fun validateAndCleanup(player: Player) {
+    private fun validateAndCleanup(player: Player, api: RoseChatAPI = RoseChatAPI.getInstance() ?: return) {
         if (!player.isOnline) return
 
         try {
-            val api = RoseChatAPI.getInstance() ?: return
             val rosePlayer = RosePlayer(player)
             val currentChannel = rosePlayer.playerData?.currentChannel ?: return
             val channelId = currentChannel.id
@@ -81,19 +94,22 @@ class RoseChatCleanupListener : Listener, KoinComponent {
                 }
             }
 
-            // 2. Check if they are in a custom Luma Party channel (Dynamic IDs)
-            // Luma's Party system uses UUIDs as names in some contexts or metadata.
-            // We check the PartyService to see if they are allowed in any party matching this ID.
+            // 2. Check if they are in a custom Luma Party channel
+            // A player should only be in a party channel if they have an active Luma Party.
             if (!shouldSwitch) {
-                val parties = partyService.getAllPartiesForGuild(UUID.randomUUID()) // Stub for "all parties" check if needed
-                // Actually, the most robust check is: can they still join their active party?
                 val activeParty = partyService.getActivePartyForPlayer(player.uniqueId)
-                
-                // If they are in a channel that looks like a party but don't have an active authorized party
-                if (channelId.length > 30 && activeParty == null) {
-                    // Check if the current channel is a known party channel they are NOT in
-                    // Note: Luma parties often map 1:1 to RoseChat dynamic channels if integrated.
-                    shouldSwitch = true
+                if (activeParty == null) {
+                    // If the player has no active Luma Party but is in a dynamic channel,
+                    // check if this channel could be a party channel by verifying against
+                    // all known party IDs for the player's guilds.
+                    val playerGuildIds = guildService.getPlayerGuilds(player.uniqueId).map { it.id }
+                    val knownPartyIds = playerGuildIds.flatMap { gid ->
+                        partyService.getAllPartiesForGuild(gid).map { it.id.toString() }
+                    }.toSet()
+                    // Only switch if the channel ID is NOT in any known party set
+                    if (channelId !in knownPartyIds) {
+                        shouldSwitch = true
+                    }
                 }
             }
 
@@ -107,7 +123,7 @@ class RoseChatCleanupListener : Listener, KoinComponent {
         } catch (e: NoClassDefFoundError) {
             // RoseChat not loaded
         } catch (e: Exception) {
-            // Ignore
+            logger.debug("Error during RoseChat cleanup for player ${player.uniqueId}", e)
         }
     }
 }

--- a/src/main/kotlin/net/lumalyte/lg/infrastructure/listeners/RoseChatCleanupListener.kt
+++ b/src/main/kotlin/net/lumalyte/lg/infrastructure/listeners/RoseChatCleanupListener.kt
@@ -2,68 +2,112 @@ package net.lumalyte.lg.infrastructure.listeners
 
 import dev.rosewood.rosechat.api.RoseChatAPI
 import dev.rosewood.rosechat.message.RosePlayer
+import net.lumalyte.lg.application.services.GuildService
+import net.lumalyte.lg.application.services.PartyService
 import net.lumalyte.lg.domain.events.GuildDisbandedEvent
 import net.lumalyte.lg.domain.events.GuildMemberRemovedEvent
 import net.lumalyte.lg.domain.events.GuildRelationChangeEvent
 import net.lumalyte.lg.domain.entities.RelationType
 import org.bukkit.Bukkit
+import org.bukkit.entity.Player
 import org.bukkit.event.EventHandler
 import org.bukkit.event.EventPriority
 import org.bukkit.event.Listener
+import org.koin.core.component.KoinComponent
+import org.koin.core.component.inject
+import java.util.UUID
 
 /**
  * Listener to handle RoseChat channel cleanup when players leave, guilds are disbanded,
- * or relationships (allies) change. Ensures players are removed from guild-specific 
- * and ally-specific channels to prevent "ghost" memberships and resonance.
+ * or relationships (allies) change.
+ * 
+ * Unlike standard channel identification, this listener verifies if a player is still
+ * authorized to be in their current RoseChat channel by checking against LumaGuilds
+ * known Party objects and Guild membership status.
  */
-class RoseChatCleanupListener : Listener {
+class RoseChatCleanupListener : Listener, KoinComponent {
+
+    private val guildService: GuildService by inject()
+    private val partyService: PartyService by inject()
+
+    /** IDs of the RoseChat channels defined in LumaGuilds' channels.yml hook. */
+    private val guildChannelId = "guild"
+    private val allyChannelId = "guild-ally"
 
     @EventHandler(priority = EventPriority.MONITOR)
     fun onGuildMemberRemoved(event: GuildMemberRemovedEvent) {
         val player = Bukkit.getPlayer(event.playerId) ?: return
-        cleanupPlayer(player.uniqueId)
+        validateAndCleanup(player)
     }
 
     @EventHandler(priority = EventPriority.MONITOR)
     fun onGuildDisbanded(event: GuildDisbandedEvent) {
         event.memberIds.forEach { memberId ->
-            cleanupPlayer(memberId)
+            val player = Bukkit.getPlayer(memberId) ?: return@forEach
+            validateAndCleanup(player)
         }
     }
 
     @EventHandler(priority = EventPriority.MONITOR)
     fun onRelationChange(event: GuildRelationChangeEvent) {
-        // If an alliance is broken, we need to boot members from any shared ally channels
+        // If an alliance is broken, refresh all members of both guilds
         if (event.type == RelationType.NEUTRAL || event.type == RelationType.ENEMY) {
-            // Note: In LumaGuilds, relation changes often trigger specific logic.
-            // Here we proactively clean participants if they were in an ally-related channel.
-            event.sourceGuild.memberIds.forEach { cleanupPlayer(it) }
-            event.targetGuild.memberIds.forEach { cleanupPlayer(it) }
+            (event.sourceGuild.memberIds + event.targetGuild.memberIds).forEach { memberId ->
+                val player = Bukkit.getPlayer(memberId) ?: return@forEach
+                validateAndCleanup(player)
+            }
         }
     }
 
-    private fun cleanupPlayer(playerId: java.util.UUID) {
-        try {
-            val player = Bukkit.getPlayer(playerId) ?: return
-            if (!player.isOnline) return
-            
-            val rosePlayer = RosePlayer(player)
-            val api = RoseChatAPI.getInstance()
-            val currentChannel = rosePlayer.playerData?.currentChannel ?: return
+    /**
+     * Checks if the player's current RoseChat channel is still valid based on their
+     * LumaGuilds status (guild membership and party participation).
+     */
+    private fun validateAndCleanup(player: Player) {
+        if (!player.isOnline) return
 
-            // Check if the channel is guild-related or ally-related
-            // Matches 'guild_', 'ally_', or 'officer_' patterns used by Luma/RoseChat hooks
-            val channelId = currentChannel.id.lowercase()
-            if (channelId.contains("guild") || channelId.contains("ally") || channelId.contains("officer")) {
+        try {
+            val api = RoseChatAPI.getInstance() ?: return
+            val rosePlayer = RosePlayer(player)
+            val currentChannel = rosePlayer.playerData?.currentChannel ?: return
+            val channelId = currentChannel.id
+
+            var shouldSwitch = false
+
+            // 1. Check if they are in the fixed 'guild' or 'guild-ally' RoseChat channels
+            if (channelId == guildChannelId || channelId == allyChannelId) {
+                if (guildService.getPlayerGuilds(player.uniqueId).isEmpty()) {
+                    shouldSwitch = true
+                }
+            }
+
+            // 2. Check if they are in a custom Luma Party channel (Dynamic IDs)
+            // Luma's Party system uses UUIDs as names in some contexts or metadata.
+            // We check the PartyService to see if they are allowed in any party matching this ID.
+            if (!shouldSwitch) {
+                val parties = partyService.getAllPartiesForGuild(UUID.randomUUID()) // Stub for "all parties" check if needed
+                // Actually, the most robust check is: can they still join their active party?
+                val activeParty = partyService.getActivePartyForPlayer(player.uniqueId)
+                
+                // If they are in a channel that looks like a party but don't have an active authorized party
+                if (channelId.length > 30 && activeParty == null) {
+                    // Check if the current channel is a known party channel they are NOT in
+                    // Note: Luma parties often map 1:1 to RoseChat dynamic channels if integrated.
+                    shouldSwitch = true
+                }
+            }
+
+            if (shouldSwitch) {
                 val defaultChannel = api.channelManager.defaultChannel
-                if (defaultChannel != null && currentChannel.id != defaultChannel.id) {
+                if (defaultChannel != null && channelId != defaultChannel.id) {
                     rosePlayer.switchChannel(defaultChannel)
+                    player.sendMessage("§7[§6!§7] §eYou have been moved to Global chat because you are no longer in that channel's guild/party.")
                 }
             }
         } catch (e: NoClassDefFoundError) {
             // RoseChat not loaded
         } catch (e: Exception) {
-            // Log or ignore
+            // Ignore
         }
     }
 }

--- a/src/main/kotlin/net/lumalyte/lg/infrastructure/listeners/RoseChatCleanupListener.kt
+++ b/src/main/kotlin/net/lumalyte/lg/infrastructure/listeners/RoseChatCleanupListener.kt
@@ -1,0 +1,54 @@
+package net.lumalyte.lg.infrastructure.listeners
+
+import dev.rosewood.rosechat.api.RoseChatAPI
+import dev.rosewood.rosechat.message.RosePlayer
+import net.lumalyte.lg.domain.events.GuildDisbandedEvent
+import net.lumalyte.lg.domain.events.GuildMemberRemovedEvent
+import org.bukkit.Bukkit
+import org.bukkit.event.EventHandler
+import org.bukkit.event.EventPriority
+import org.bukkit.event.Listener
+
+/**
+ * Listener to handle RoseChat channel cleanup when players leave or guilds are disbanded.
+ * Ensures players are removed from guild-specific channels to prevent "ghost" memberships.
+ */
+class RoseChatCleanupListener : Listener {
+
+    @EventHandler(priority = EventPriority.MONITOR)
+    fun onGuildMemberRemoved(event: GuildMemberRemovedEvent) {
+        val player = Bukkit.getPlayer(event.playerId) ?: return
+        cleanupPlayer(player.uniqueId)
+    }
+
+    @EventHandler(priority = EventPriority.MONITOR)
+    fun onGuildDisbanded(event: GuildDisbandedEvent) {
+        event.memberIds.forEach { memberId ->
+            cleanupPlayer(memberId)
+        }
+    }
+
+    private fun cleanupPlayer(playerId: java.util.UUID) {
+        try {
+            val player = Bukkit.getPlayer(playerId)
+            val rosePlayer = if (player != null) RosePlayer(player) else RosePlayer(playerId, "Unknown", "default")
+            val api = RoseChatAPI.getInstance()
+            val currentChannel = rosePlayer.playerData?.currentChannel ?: return
+
+            // If the player is in a channel that is guild-related (based on ID convention or provider)
+            // LumaGuilds usually creates channels with 'guild_' prefix or similar if it's integrating.
+            // Even if it's just a general cleanup, we check if the channel is one they shouldn't be in.
+            
+            if (currentChannel.id.startsWith("guild_") || currentChannel.id.contains("guild")) {
+                val defaultChannel = api.channelManager.defaultChannel
+                if (defaultChannel != null && currentChannel.id != defaultChannel.id) {
+                    rosePlayer.switchChannel(defaultChannel)
+                }
+            }
+        } catch (e: NoClassDefFoundError) {
+            // RoseChat not loaded
+        } catch (e: Exception) {
+            // Log or ignore
+        }
+    }
+}

--- a/src/main/kotlin/net/lumalyte/lg/infrastructure/services/PartyServiceBukkit.kt
+++ b/src/main/kotlin/net/lumalyte/lg/infrastructure/services/PartyServiceBukkit.kt
@@ -44,13 +44,15 @@ class PartyServiceBukkit(
                 return null
             }
 
-            // Check if any of the guilds are already in an active party
-            // For private parties, allow multiple parties per guild (one per player/leader)
+            // A guild may only be in one multi-guild party at a time. Its own internal
+            // single-guild channels (Guild_Chat, Officer_Chat, ...) are also Party rows,
+            // so they must be excluded from this check.
             if (!isPrivateParty) {
                 for (guildId in party.guildIds) {
-                    val existingParties = partyRepository.getActivePartiesByGuild(guildId)
-                    if (existingParties.isNotEmpty()) {
-                        logger.warn("Guild $guildId is already in an active party")
+                    val inMultiGuildParty = partyRepository.getActivePartiesByGuild(guildId)
+                        .any { !it.isPrivateParty() }
+                    if (inMultiGuildParty) {
+                        logger.warn("Guild $guildId is already in an active multi-guild party")
                         return null
                     }
                 }

--- a/src/main/kotlin/net/lumalyte/lg/infrastructure/services/PartyServiceBukkit.kt
+++ b/src/main/kotlin/net/lumalyte/lg/infrastructure/services/PartyServiceBukkit.kt
@@ -412,6 +412,43 @@ class PartyServiceBukkit(
         }
     }
     
+    override fun removeGuildFromPartyAsSystem(partyId: UUID, guildId: UUID): Party? {
+        try {
+            val party = partyRepository.getById(partyId)
+            if (party == null || !party.isActive()) {
+                logger.warn("Party $partyId not found or not active")
+                return null
+            }
+
+            if (!party.includesGuild(guildId)) {
+                logger.warn("Guild $guildId is not part of party $partyId")
+                return null
+            }
+
+            val remainingGuilds = party.guildIds - guildId
+
+            return if (remainingGuilds.size < 2) {
+                // Dissolve party if fewer than 2 guilds remain
+                partyRepository.update(party.copy(status = PartyStatus.DISSOLVED))
+                logger.info("Party $partyId dissolved (system): guild $guildId removed, insufficient guilds remaining")
+                null
+            } else {
+                val updatedParty = party.copy(guildIds = remainingGuilds)
+                if (partyRepository.update(updatedParty)) {
+                    logger.info("Guild $guildId removed from party $partyId (system)")
+                    updatedParty
+                } else {
+                    logger.error("Failed to update party $partyId after system guild removal")
+                    null
+                }
+            }
+        } catch (e: Exception) {
+            // In-memory operation - catching runtime exceptions from state validation
+            logger.error("Error removing guild from party (system)", e)
+            return null
+        }
+    }
+
     override fun getActivePartiesForGuild(guildId: UUID): Set<Party> {
         return partyRepository.getActivePartiesByGuild(guildId)
     }

--- a/src/test/kotlin/net/lumalyte/lg/infrastructure/listeners/RoseChatCleanupListenerTest.kt
+++ b/src/test/kotlin/net/lumalyte/lg/infrastructure/listeners/RoseChatCleanupListenerTest.kt
@@ -1,0 +1,139 @@
+package net.lumalyte.lg.infrastructure.listeners
+
+import io.mockk.every
+import io.mockk.mockk
+import net.lumalyte.lg.application.services.GuildService
+import net.lumalyte.lg.application.services.MemberService
+import net.lumalyte.lg.application.services.PartyService
+import net.lumalyte.lg.application.services.RelationService
+import net.lumalyte.lg.domain.entities.Guild
+import net.lumalyte.lg.domain.entities.Party
+import net.lumalyte.lg.domain.entities.PartyStatus
+import net.lumalyte.lg.domain.entities.Relation
+import net.lumalyte.lg.domain.entities.RelationStatus
+import net.lumalyte.lg.domain.entities.RelationType
+import org.junit.jupiter.api.Assertions.*
+import org.junit.jupiter.api.Test
+import java.time.Instant
+import java.util.UUID
+
+/**
+ * Behaviour specification for [RoseChatCleanupListener.shouldLeaveChannel].
+ *
+ * The decision answers: given a player's current LumaGuilds status, may they remain
+ * in the RoseChat channel they are currently in? The listener uses it to move stale
+ * players back to the default channel.
+ */
+class RoseChatCleanupListenerTest {
+
+    private val guildService = mockk<GuildService>()
+    private val memberService = mockk<MemberService>(relaxed = true)
+    private val partyService = mockk<PartyService>()
+    private val relationService = mockk<RelationService>()
+
+    private val listener = RoseChatCleanupListener(guildService, memberService, partyService, relationService)
+
+    private val playerId = UUID.randomUUID()
+
+    private fun guild(id: UUID = UUID.randomUUID()) = Guild(id = id, name = "G", createdAt = Instant.now())
+
+    private fun activeAlly(ownerGuild: UUID) = Relation.create(
+        guildA = ownerGuild, guildB = UUID.randomUUID(),
+        type = RelationType.ALLY, status = RelationStatus.ACTIVE
+    )
+
+    // --- fixed 'guild' channel ------------------------------------------
+
+    @Test
+    fun `player in guild channel stays while they have a guild`() {
+        every { guildService.getPlayerGuilds(playerId) } returns setOf(guild())
+        assertFalse(listener.shouldLeaveChannel(playerId, "guild"))
+    }
+
+    @Test
+    fun `player in guild channel leaves once they have no guild`() {
+        every { guildService.getPlayerGuilds(playerId) } returns emptySet()
+        assertTrue(listener.shouldLeaveChannel(playerId, "guild"))
+    }
+
+    // --- fixed 'guild-ally' channel -------------------------------------
+
+    @Test
+    fun `player in ally channel stays while their guild has an active alliance`() {
+        val g = guild()
+        every { guildService.getPlayerGuilds(playerId) } returns setOf(g)
+        every { relationService.getGuildRelationsByType(g.id, RelationType.ALLY) } returns setOf(activeAlly(g.id))
+        assertFalse(listener.shouldLeaveChannel(playerId, "guild-ally"))
+    }
+
+    @Test
+    fun `player in ally channel leaves when their guild has no alliances`() {
+        // A player who still has a guild but lost every ally must be moved out of ally chat.
+        val g = guild()
+        every { guildService.getPlayerGuilds(playerId) } returns setOf(g)
+        every { relationService.getGuildRelationsByType(g.id, RelationType.ALLY) } returns emptySet()
+        assertTrue(listener.shouldLeaveChannel(playerId, "guild-ally"))
+    }
+
+    @Test
+    fun `player in ally channel leaves when the only ally relation is not active`() {
+        val g = guild()
+        every { guildService.getPlayerGuilds(playerId) } returns setOf(g)
+        every { relationService.getGuildRelationsByType(g.id, RelationType.ALLY) } returns setOf(
+            Relation.create(
+                guildA = g.id, guildB = UUID.randomUUID(),
+                type = RelationType.ALLY, status = RelationStatus.PENDING
+            )
+        )
+        assertTrue(listener.shouldLeaveChannel(playerId, "guild-ally"))
+    }
+
+    @Test
+    fun `player in ally channel stays when any of their guilds has an alliance`() {
+        val g1 = guild(); val g2 = guild()
+        every { guildService.getPlayerGuilds(playerId) } returns setOf(g1, g2)
+        every { relationService.getGuildRelationsByType(g1.id, RelationType.ALLY) } returns emptySet()
+        every { relationService.getGuildRelationsByType(g2.id, RelationType.ALLY) } returns setOf(activeAlly(g2.id))
+        assertFalse(listener.shouldLeaveChannel(playerId, "guild-ally"))
+    }
+
+    // --- dynamic party channels (keyed by party UUID) -------------------
+
+    @Test
+    fun `player in a party channel leaves when that party has been dissolved`() {
+        val g = guild()
+        val dissolvedParty = Party(
+            id = UUID.randomUUID(), name = "P", guildIds = setOf(g.id),
+            leaderId = UUID.randomUUID(), status = PartyStatus.DISSOLVED, createdAt = Instant.now()
+        )
+        every { guildService.getPlayerGuilds(playerId) } returns setOf(g)
+        // A dissolved party still appears in the full party list, but not the active one.
+        every { partyService.getAllPartiesForGuild(g.id) } returns setOf(dissolvedParty)
+        every { partyService.getActivePartiesForGuild(g.id) } returns emptySet()
+        assertTrue(listener.shouldLeaveChannel(playerId, dissolvedParty.id.toString()))
+    }
+
+    @Test
+    fun `player in a party channel stays when it is an active party of their guild`() {
+        val g = guild()
+        val party = Party(
+            id = UUID.randomUUID(), name = "P", guildIds = setOf(g.id),
+            leaderId = UUID.randomUUID(), status = PartyStatus.ACTIVE, createdAt = Instant.now()
+        )
+        every { guildService.getPlayerGuilds(playerId) } returns setOf(g)
+        every { partyService.getActivePartiesForGuild(g.id) } returns setOf(party)
+        assertFalse(listener.shouldLeaveChannel(playerId, party.id.toString()))
+    }
+
+    @Test
+    fun `non-uuid channels from other plugins are never touched`() {
+        // "staff", "global", etc. are not LumaGuilds channels and must be left alone.
+        assertFalse(listener.shouldLeaveChannel(playerId, "staff"))
+    }
+
+    @Test
+    fun `player with no guild leaves a party channel`() {
+        every { guildService.getPlayerGuilds(playerId) } returns emptySet()
+        assertTrue(listener.shouldLeaveChannel(playerId, UUID.randomUUID().toString()))
+    }
+}

--- a/src/test/kotlin/net/lumalyte/lg/infrastructure/services/PartyServiceMultiGuildCreationTest.kt
+++ b/src/test/kotlin/net/lumalyte/lg/infrastructure/services/PartyServiceMultiGuildCreationTest.kt
@@ -1,0 +1,89 @@
+package net.lumalyte.lg.infrastructure.services
+
+import io.mockk.every
+import io.mockk.mockk
+import net.lumalyte.lg.application.persistence.PartyRepository
+import net.lumalyte.lg.application.persistence.PartyRequestRepository
+import net.lumalyte.lg.application.services.GuildService
+import net.lumalyte.lg.application.services.MemberService
+import net.lumalyte.lg.domain.entities.Party
+import net.lumalyte.lg.domain.entities.PartyStatus
+import net.lumalyte.lg.domain.entities.RankPermission
+import org.junit.jupiter.api.Assertions.*
+import org.junit.jupiter.api.Test
+import java.time.Instant
+import java.util.UUID
+
+/**
+ * Behaviour specification for multi-guild party creation in [PartyServiceBukkit.createParty].
+ *
+ * A guild's internal chat channels (Guild_Chat, Officer_Chat, Leader_Chat) are stored as
+ * single-guild [Party] rows. They must not count against the "one multi-guild party per
+ * guild" rule, otherwise no guild with default channels can ever be invited into a party.
+ */
+class PartyServiceMultiGuildCreationTest {
+
+    private val partyRepository = mockk<PartyRepository>(relaxed = true)
+    private val memberService = mockk<MemberService>(relaxed = true)
+    private val service = PartyServiceBukkit(
+        partyRepository = partyRepository,
+        partyRequestRepository = mockk<PartyRequestRepository>(relaxed = true),
+        memberService = memberService,
+        guildService = mockk<GuildService>(relaxed = true)
+    )
+
+    private val guildA = UUID.randomUUID()
+    private val guildB = UUID.randomUUID()
+    private val leaderId = UUID.randomUUID()
+
+    private fun internalChannel(guildId: UUID) = Party(
+        id = UUID.randomUUID(),
+        name = "Guild_Chat",
+        guildIds = setOf(guildId),
+        leaderId = UUID.randomUUID(),
+        status = PartyStatus.ACTIVE,
+        createdAt = Instant.now()
+    )
+
+    private fun multiGuildParty(vararg guildIds: UUID) = Party(
+        id = UUID.randomUUID(),
+        name = "AllianceParty",
+        guildIds = guildIds.toSet(),
+        leaderId = leaderId,
+        status = PartyStatus.ACTIVE,
+        createdAt = Instant.now()
+    )
+
+    private fun grantLeaderPermission() {
+        every { memberService.getPlayerGuilds(leaderId) } returns setOf(guildA)
+        every { memberService.hasPermission(leaderId, guildA, RankPermission.MANAGE_RELATIONS) } returns true
+    }
+
+    @Test
+    fun `a guild's internal channels do not block being invited into a multi-guild party`() {
+        grantLeaderPermission()
+        // Both guilds only have their internal single-guild channels active.
+        every { partyRepository.getActivePartiesByGuild(guildA) } returns setOf(internalChannel(guildA))
+        every { partyRepository.getActivePartiesByGuild(guildB) } returns setOf(internalChannel(guildB))
+        every { partyRepository.add(any()) } returns true
+
+        val result = service.createParty(multiGuildParty(guildA, guildB))
+
+        assertNotNull(result, "internal channel-parties must not count as an existing multi-guild party")
+    }
+
+    @Test
+    fun `a guild already in a real multi-guild party cannot join another`() {
+        grantLeaderPermission()
+        val guildC = UUID.randomUUID()
+        // guildA is already in a genuine multi-guild party.
+        every { partyRepository.getActivePartiesByGuild(guildA) } returns
+            setOf(internalChannel(guildA), multiGuildParty(guildA, guildC))
+        every { partyRepository.getActivePartiesByGuild(guildB) } returns setOf(internalChannel(guildB))
+        every { partyRepository.add(any()) } returns true
+
+        val result = service.createParty(multiGuildParty(guildA, guildB))
+
+        assertNull(result, "a guild may only be in one multi-guild party at a time")
+    }
+}

--- a/src/test/kotlin/net/lumalyte/lg/infrastructure/services/PartyServiceSystemRemovalTest.kt
+++ b/src/test/kotlin/net/lumalyte/lg/infrastructure/services/PartyServiceSystemRemovalTest.kt
@@ -1,0 +1,131 @@
+package net.lumalyte.lg.infrastructure.services
+
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.slot
+import io.mockk.verify
+import net.lumalyte.lg.application.persistence.PartyRepository
+import net.lumalyte.lg.application.persistence.PartyRequestRepository
+import net.lumalyte.lg.application.services.GuildService
+import net.lumalyte.lg.application.services.MemberService
+import net.lumalyte.lg.domain.entities.Party
+import net.lumalyte.lg.domain.entities.PartyStatus
+import net.lumalyte.lg.domain.entities.RankPermission
+import org.junit.jupiter.api.Assertions.*
+import org.junit.jupiter.api.Test
+import java.time.Instant
+import java.util.UUID
+
+/**
+ * Behaviour specification for [PartyServiceBukkit.removeGuildFromPartyAsSystem].
+ *
+ * The system removal exists so automated cleanup (guild disbandment) can detach a
+ * guild from its parties without being blocked by the actor's permissions, and
+ * without destroying parties that other guilds still rely on.
+ */
+class PartyServiceSystemRemovalTest {
+
+    private val partyRepository = mockk<PartyRepository>(relaxed = true)
+    private val memberService = mockk<MemberService>(relaxed = true)
+    private val service = PartyServiceBukkit(
+        partyRepository = partyRepository,
+        partyRequestRepository = mockk<PartyRequestRepository>(relaxed = true),
+        memberService = memberService,
+        guildService = mockk<GuildService>(relaxed = true)
+    )
+
+    private fun party(vararg guildIds: UUID, status: PartyStatus = PartyStatus.ACTIVE) = Party(
+        id = UUID.randomUUID(),
+        name = "TestParty",
+        guildIds = guildIds.toSet(),
+        leaderId = UUID.randomUUID(),
+        status = status,
+        createdAt = Instant.now()
+    )
+
+    @Test
+    fun `removing one guild from a three-guild party keeps the party active for the others`() {
+        val g1 = UUID.randomUUID(); val g2 = UUID.randomUUID(); val g3 = UUID.randomUUID()
+        val p = party(g1, g2, g3)
+        every { partyRepository.getById(p.id) } returns p
+        val saved = slot<Party>()
+        every { partyRepository.update(capture(saved)) } returns true
+
+        val result = service.removeGuildFromPartyAsSystem(p.id, g1)
+
+        assertNotNull(result, "a multi-guild party must survive when one guild leaves")
+        assertEquals(setOf(g2, g3), result!!.guildIds)
+        assertEquals(PartyStatus.ACTIVE, result.status)
+        assertEquals(setOf(g2, g3), saved.captured.guildIds)
+        assertEquals(PartyStatus.ACTIVE, saved.captured.status)
+    }
+
+    @Test
+    fun `removing a guild from a two-guild party dissolves it`() {
+        val g1 = UUID.randomUUID(); val g2 = UUID.randomUUID()
+        val p = party(g1, g2)
+        every { partyRepository.getById(p.id) } returns p
+        val saved = slot<Party>()
+        every { partyRepository.update(capture(saved)) } returns true
+
+        val result = service.removeGuildFromPartyAsSystem(p.id, g1)
+
+        assertNull(result, "a party with fewer than two guilds must be dissolved")
+        assertEquals(PartyStatus.DISSOLVED, saved.captured.status)
+    }
+
+    @Test
+    fun `removing the only guild from a single-guild channel dissolves it`() {
+        val g1 = UUID.randomUUID()
+        val p = party(g1)
+        every { partyRepository.getById(p.id) } returns p
+        val saved = slot<Party>()
+        every { partyRepository.update(capture(saved)) } returns true
+
+        val result = service.removeGuildFromPartyAsSystem(p.id, g1)
+
+        assertNull(result)
+        assertEquals(PartyStatus.DISSOLVED, saved.captured.status)
+    }
+
+    @Test
+    fun `system removal succeeds even when the actor would lack party-management permission`() {
+        val g1 = UUID.randomUUID(); val g2 = UUID.randomUUID()
+        val p = party(g1, g2)
+        val unprivilegedActor = UUID.randomUUID() // not the party leader
+        every { partyRepository.getById(p.id) } returns p
+        every { partyRepository.update(any()) } returns true
+        every { memberService.hasPermission(any(), any(), RankPermission.MANAGE_RELATIONS) } returns false
+
+        // The permissioned path is blocked for an actor without MANAGE_RELATIONS...
+        assertFalse(service.dissolveParty(p.id, unprivilegedActor))
+        // ...but the system path still performs the cleanup.
+        assertNull(service.removeGuildFromPartyAsSystem(p.id, g1))
+        verify { partyRepository.update(match { it.status == PartyStatus.DISSOLVED }) }
+    }
+
+    @Test
+    fun `removing a guild that is not in the party makes no change`() {
+        val g1 = UUID.randomUUID(); val g2 = UUID.randomUUID()
+        val outsider = UUID.randomUUID()
+        val p = party(g1, g2)
+        every { partyRepository.getById(p.id) } returns p
+
+        val result = service.removeGuildFromPartyAsSystem(p.id, outsider)
+
+        assertNull(result)
+        verify(exactly = 0) { partyRepository.update(any()) }
+    }
+
+    @Test
+    fun `removing a guild from an already-dissolved party makes no change`() {
+        val g1 = UUID.randomUUID(); val g2 = UUID.randomUUID()
+        val p = party(g1, g2, status = PartyStatus.DISSOLVED)
+        every { partyRepository.getById(p.id) } returns p
+
+        val result = service.removeGuildFromPartyAsSystem(p.id, g1)
+
+        assertNull(result)
+        verify(exactly = 0) { partyRepository.update(any()) }
+    }
+}


### PR DESCRIPTION
Ally Chat Cleanup: RoseChatCleanupListener now monitors GuildRelationChangeEvent. If an alliance is broken (changed to Neutral or Enemy), all members of both guilds are proactively booted from any ally-related RoseChat channels.
Channel/Party Removal: I updated GuildDisbandedListener to use the PartyService. When a guild is disbanded, it now actively deletes all associated Party objects (Guild Chat, Officer Chat, etc.) from the internal database and memory, preventing "channel stacking."
DI Refactor: I converted GuildDisbandedListener to be managed by Koin (DI) to allow for safe service injection, rather than manual instantiation

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Automatic cleanup of guild-associated party channels when a guild is disbanded.
  * RoseChat integration: players are moved off now-invalid guild/ally/party channels to the default channel and receive a notification.

* **Bug Fixes**
  * Improved handling to avoid orphaned party channels and better logging when cleanup fails.

* **Tests**
  * Added unit tests covering channel-leave logic, multi-guild party creation, and system-driven party removals.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/BadgersMC/LumaGuilds/pull/46?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->