### PR TITLE
fix(guild-home): floor coordinates so homes land on the set block

### DIFF
--- a/src/main/kotlin/net/lumalyte/lg/infrastructure/adapters/bukkit/BukkitLocationAdapter.kt
+++ b/src/main/kotlin/net/lumalyte/lg/infrastructure/adapters/bukkit/BukkitLocationAdapter.kt
@@ -7,11 +7,15 @@ import org.bukkit.Location
 import org.bukkit.World
 
 fun Location.toPosition2D(): Position2D {
-    return Position2D(this.x.toInt(), this.z.toInt())
+    // blockX/blockZ floor the coordinate; plain toInt() truncates toward zero,
+    // which picks the wrong block for negative coordinates.
+    return Position2D(this.blockX, this.blockZ)
 }
 
 fun Location.toPosition3D(): Position3D {
-    return Position3D(this.x.toInt(), this.y.toInt(), this.z.toInt())
+    // blockX/Y/Z floor the coordinate; plain toInt() truncates toward zero,
+    // which picks the wrong block for negative coordinates.
+    return Position3D(this.blockX, this.blockY, this.blockZ)
 }
 
 fun Position.toLocation(world: World): Location {

--- a/src/main/kotlin/net/lumalyte/lg/interaction/commands/GuildCommand.kt
+++ b/src/main/kotlin/net/lumalyte/lg/interaction/commands/GuildCommand.kt
@@ -488,9 +488,7 @@ class GuildCommand : BaseCommand(), KoinComponent {
 
         val home = GuildHome(
             worldId = location.world.uid,
-            position = net.lumalyte.lg.domain.values.Position3D(
-                location.x.toInt(), location.y.toInt(), location.z.toInt()
-            )
+            position = location.toPosition3D()
         )
 
         val success = guildService.setAllyHome(guild.id, home, playerId)

--- a/src/main/kotlin/net/lumalyte/lg/interaction/menus/bedrock/BedrockGuildHomeMenu.kt
+++ b/src/main/kotlin/net/lumalyte/lg/interaction/menus/bedrock/BedrockGuildHomeMenu.kt
@@ -3,7 +3,7 @@ package net.lumalyte.lg.interaction.menus.bedrock
 import net.lumalyte.lg.application.services.GuildService
 import net.lumalyte.lg.domain.entities.Guild
 import net.lumalyte.lg.domain.entities.GuildHome
-import net.lumalyte.lg.domain.values.Position3D
+import net.lumalyte.lg.infrastructure.adapters.bukkit.toPosition3D
 import net.lumalyte.lg.interaction.menus.MenuNavigator
 import org.bukkit.Bukkit
 import org.bukkit.Location
@@ -182,11 +182,7 @@ class BedrockGuildHomeMenu(
 
         val home = GuildHome(
             worldId = currentLocation.world.uid,
-            position = Position3D(
-                currentLocation.x.toInt(),
-                currentLocation.y.toInt(),
-                currentLocation.z.toInt()
-            )
+            position = currentLocation.toPosition3D()
         )
 
         val success = guildService.setHome(guild.id, homeName, home, player.uniqueId)

--- a/src/test/kotlin/net/lumalyte/lg/infrastructure/adapters/bukkit/BukkitLocationAdapterTest.kt
+++ b/src/test/kotlin/net/lumalyte/lg/infrastructure/adapters/bukkit/BukkitLocationAdapterTest.kt
@@ -1,0 +1,61 @@
+package net.lumalyte.lg.infrastructure.adapters.bukkit
+
+import org.bukkit.Location
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.mockbukkit.mockbukkit.MockBukkit
+import org.mockbukkit.mockbukkit.ServerMock
+import org.mockbukkit.mockbukkit.world.WorldMock
+
+class BukkitLocationAdapterTest {
+
+    private lateinit var server: ServerMock
+    private lateinit var world: WorldMock
+
+    @BeforeEach
+    fun setUp() {
+        server = MockBukkit.mock()
+        world = server.addSimpleWorld("test")
+    }
+
+    @AfterEach
+    fun tearDown() {
+        MockBukkit.unmock()
+    }
+
+    @Test
+    fun `toPosition3D floors positive coordinates`() {
+        val pos = Location(world, 100.7, 64.0, 200.3).toPosition3D()
+        assertEquals(100, pos.x)
+        assertEquals(64, pos.y)
+        assertEquals(200, pos.z)
+    }
+
+    @Test
+    fun `toPosition3D floors negative coordinates instead of truncating`() {
+        // toInt() would give (-100, -201) here; the block actually occupied is (-101, -202).
+        val pos = Location(world, -100.5, 64.0, -201.5).toPosition3D()
+        assertEquals(-101, pos.x)
+        assertEquals(-202, pos.z)
+    }
+
+    @Test
+    fun `toPosition3D round-trips a negative-coordinate block through toLocation`() {
+        // Player stands on a block centered at (-100.5, -200.5): set-home then teleport
+        // must land back inside the same block, not one block away.
+        val standing = Location(world, -100.5, 70.0, -200.5)
+        val restored = standing.toPosition3D().toLocation(world)
+        assertEquals(-100.5, restored.x)
+        assertEquals(-200.5, restored.z)
+        assertEquals(70.0, restored.y)
+    }
+
+    @Test
+    fun `toPosition2D floors negative coordinates instead of truncating`() {
+        val pos = Location(world, -1.5, 0.0, -1.5).toPosition2D()
+        assertEquals(-2, pos.x)
+        assertEquals(-2, pos.z)
+    }
+}


### PR DESCRIPTION
## Summary
- Guild homes set at negative X/Z coordinates teleported the player a full block off the intended block, causing them to fall (reproduced standing on a single block in the sky).
- Root cause: `Location.toPosition3D` / `toPosition2D` used `Double.toInt()`, which truncates toward zero instead of flooring. At negative coordinates the stored block was one too high; the `+0.5` block-centering applied on teleport then landed the player a whole block away.
- Fix: use Bukkit `blockX/blockY/blockZ` (floor semantics) for the conversion. Routed the two inline `.toInt()` copies — `onSetAllyHome` and the Bedrock set-home menu — through `toPosition3D()` so all capture paths share the corrected logic.
- Restore paths (`+0.5` centering) were already correct and left unchanged.

## Notes
- Existing homes already stored at negative coords keep their bad value — truncation lost the original fraction, so there is no reliable migration. Affected guilds must re-run `/guild sethome`.
- `toPosition3D` also feeds claim/edit-tool code, so claims at negative coords had the same latent off-by-one; this corrects that path too.

## Test plan
- [x] New `BukkitLocationAdapterTest` covers positive-coord floor, negative-coord floor, negative-coord round-trip through `toLocation`, and `toPosition2D` negatives — all pass.
- [ ] In-game: set a guild home standing on a single block at negative X/Z, teleport back, confirm the player lands on the block without falling.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated block position calculation in location coordinate conversions
  * Corrected guild home position handling in ally home creation and menu display

* **Tests**
  * Added test suite for location adapter coordinate conversion with edge case validation

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/BadgersMC/LumaGuilds/pull/47?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->