### PR TITLE
feat: guild bannerman — wear guild banner on back

### DIFF
--- a/src/main/kotlin/net/lumalyte/lg/LumaGuilds.kt
+++ b/src/main/kotlin/net/lumalyte/lg/LumaGuilds.kt
@@ -918,8 +918,9 @@ class LumaGuilds : JavaPlugin() {
         // Register war kill tracking listener
         server.pluginManager.registerEvents(net.lumalyte.lg.infrastructure.listeners.WarKillTrackingListener(), this)
 
-        // Close stale guild menus when a guild is disbanded
-        server.pluginManager.registerEvents(net.lumalyte.lg.infrastructure.listeners.GuildDisbandedListener(), this)
+        // Close stale guild menus and despawn bannerman displays when a guild is disbanded
+        val guildDisbandedListener = get().get<net.lumalyte.lg.infrastructure.listeners.GuildDisbandedListener>()
+        server.pluginManager.registerEvents(guildDisbandedListener, this)
 
         // Register admin override listener (for logout cleanup) - only when claims enabled
         if (claimsEnabled) {

--- a/src/main/kotlin/net/lumalyte/lg/LumaGuilds.kt
+++ b/src/main/kotlin/net/lumalyte/lg/LumaGuilds.kt
@@ -889,6 +889,13 @@ class LumaGuilds : JavaPlugin() {
         server.pluginManager.registerEvents(net.lumalyte.lg.interaction.listeners.GuildVaultCraftingPreventionListener(), this)
         server.pluginManager.registerEvents(GuildVaultFuelPreventionListener(), this)
 
+        // Register bannerman listener and tick task
+        val bannermanRenderer = get().get<net.lumalyte.lg.infrastructure.bukkit.bannerman.BannermanRenderService>()
+        val bannermanListeners = get().get<net.lumalyte.lg.infrastructure.bukkit.bannerman.BannermanListeners>()
+        server.pluginManager.registerEvents(bannermanListeners, this)
+        net.lumalyte.lg.infrastructure.bukkit.bannerman.BannermanTickTask(this, bannermanRenderer).start()
+        bannermanRenderer.sweepOrphans()
+
         // Register progression event listener
         val progressionEventListener = get().get<ProgressionEventListener>()
         server.pluginManager.registerEvents(progressionEventListener, this)
@@ -1057,6 +1064,14 @@ class LumaGuilds : JavaPlugin() {
             // Broad exception handling acceptable - shutdown should be resilient
             logger.severe("Failed to stop vault hologram service: ${e.message}")
             e.printStackTrace()
+        }
+
+        // Despawn all bannerman displays
+        try {
+            val bannermanRenderer = get().get<net.lumalyte.lg.infrastructure.bukkit.bannerman.BannermanRenderService>()
+            bannermanRenderer.despawnAll()
+        } catch (_: Exception) {
+            // Koin already torn down — nothing to clean up
         }
 
         // Stop the daily war costs scheduler

--- a/src/main/kotlin/net/lumalyte/lg/application/services/GuildService.kt
+++ b/src/main/kotlin/net/lumalyte/lg/application/services/GuildService.kt
@@ -296,6 +296,25 @@ interface GuildService {
     fun getJoinFeeSettings(guildId: UUID): Pair<Boolean, Int>?
 
     /**
+     * Enables or disables bannerman rendering (guild banner on player backs) for a guild.
+     * Requires MANAGE_BANNER permission on the actor.
+     *
+     * @param guildId The ID of the guild.
+     * @param enabled true to enable bannerman, false to disable.
+     * @param actorId The ID of the player performing the action.
+     * @return true if successful, false otherwise (guild not found or lacks permission).
+     */
+    fun setBannermanEnabled(guildId: UUID, enabled: Boolean, actorId: UUID): Boolean
+
+    /**
+     * Gets whether bannerman rendering is enabled for a guild.
+     *
+     * @param guildId The ID of the guild.
+     * @return true if enabled; false if disabled or guild not found.
+     */
+    fun getBannermanEnabled(guildId: UUID): Boolean
+
+    /**
      * Enables or disables Lunar Client location tracking (Apollo teams/waypoints) for a guild.
      *
      * @param guildId The ID of the guild.

--- a/src/main/kotlin/net/lumalyte/lg/di/Modules.kt
+++ b/src/main/kotlin/net/lumalyte/lg/di/Modules.kt
@@ -416,6 +416,14 @@ fun guildsModule() = module {
     single<net.lumalyte.lg.infrastructure.services.ARMIntegrationService> {
         net.lumalyte.lg.infrastructure.services.ARMIntegrationService()
     }
+
+    // Bannerman services
+    single<net.lumalyte.lg.infrastructure.bukkit.bannerman.BannermanRenderService> {
+        net.lumalyte.lg.infrastructure.bukkit.bannerman.BannermanRenderService(get<LumaGuilds>())
+    }
+    single<net.lumalyte.lg.infrastructure.bukkit.bannerman.BannermanListeners> {
+        net.lumalyte.lg.infrastructure.bukkit.bannerman.BannermanListeners(get<LumaGuilds>(), get(), get(), get())
+    }
 }
 
 /**

--- a/src/main/kotlin/net/lumalyte/lg/di/Modules.kt
+++ b/src/main/kotlin/net/lumalyte/lg/di/Modules.kt
@@ -424,6 +424,11 @@ fun guildsModule() = module {
     single<net.lumalyte.lg.infrastructure.bukkit.bannerman.BannermanListeners> {
         net.lumalyte.lg.infrastructure.bukkit.bannerman.BannermanListeners(get<LumaGuilds>(), get(), get(), get())
     }
+
+    // Guild event listeners
+    single<net.lumalyte.lg.infrastructure.listeners.GuildDisbandedListener> {
+        net.lumalyte.lg.infrastructure.listeners.GuildDisbandedListener(get())
+    }
 }
 
 /**

--- a/src/main/kotlin/net/lumalyte/lg/domain/entities/Guild.kt
+++ b/src/main/kotlin/net/lumalyte/lg/domain/entities/Guild.kt
@@ -26,6 +26,7 @@ import java.util.UUID
  * @property joinFeeAmount The amount of currency required to join this guild via LFG (0 if no fee).
  * @property trackingEnabled Whether Lunar Client location tracking (Apollo teams/waypoints) is enabled for this guild.
  * @property bankFrozen Whether the guild bank is emergency-frozen (all deposits and withdrawals blocked).
+ * @property bannermanEnabled Whether members of this guild render the guild banner on their backs.
  */
 data class Guild(
     val id: UUID,
@@ -48,6 +49,7 @@ data class Guild(
     val joinFeeAmount: Int = 0,
     val trackingEnabled: Boolean = true,
     val bankFrozen: Boolean = false,
+    val bannermanEnabled: Boolean = false,
     val allyHome: GuildHome? = null,
     val allyHomeAllowedGuilds: Set<UUID> = emptySet()
 ) {

--- a/src/main/kotlin/net/lumalyte/lg/infrastructure/bukkit/bannerman/BannermanListeners.kt
+++ b/src/main/kotlin/net/lumalyte/lg/infrastructure/bukkit/bannerman/BannermanListeners.kt
@@ -61,10 +61,19 @@ class BannermanListeners(
         memberService.getGuildMembers(guildId).forEach { renderer.despawnFor(it.playerId) }
     }
 
-    /** Re-render every online member when the guild banner ItemStack changes. */
+    /**
+     * Re-render every online member when the guild banner ItemStack changes.
+     * If the banner has been cleared (or fails to deserialize) we despawn rather than bail —
+     * leaving stale displays around would mean a removed banner stays visible forever.
+     */
     fun onGuildBannerChanged(guildId: UUID) {
         val guild = guildService.getGuild(guildId) ?: return
-        val banner = guild.banner?.deserializeToItemStack() ?: return
-        memberService.getGuildMembers(guildId).forEach { renderer.updateBanner(it.playerId, banner) }
+        val members = memberService.getGuildMembers(guildId)
+        val banner = guild.banner?.deserializeToItemStack()
+        if (banner == null) {
+            members.forEach { renderer.despawnFor(it.playerId) }
+            return
+        }
+        members.forEach { renderer.updateBanner(it.playerId, banner) }
     }
 }

--- a/src/main/kotlin/net/lumalyte/lg/infrastructure/bukkit/bannerman/BannermanListeners.kt
+++ b/src/main/kotlin/net/lumalyte/lg/infrastructure/bukkit/bannerman/BannermanListeners.kt
@@ -38,7 +38,7 @@ class BannermanListeners(
     @EventHandler
     fun onWorldChange(e: PlayerChangedWorldEvent) {
         renderer.despawnFor(e.player.uniqueId)
-        trySpawn(e.player)
+        plugin.server.scheduler.runTask(plugin, Runnable { trySpawn(e.player) })
     }
 
     private fun trySpawn(player: Player) {

--- a/src/main/kotlin/net/lumalyte/lg/infrastructure/bukkit/bannerman/BannermanListeners.kt
+++ b/src/main/kotlin/net/lumalyte/lg/infrastructure/bukkit/bannerman/BannermanListeners.kt
@@ -1,0 +1,70 @@
+package net.lumalyte.lg.infrastructure.bukkit.bannerman
+
+import net.lumalyte.lg.application.services.GuildService
+import net.lumalyte.lg.application.services.MemberService
+import net.lumalyte.lg.utils.deserializeToItemStack
+import org.bukkit.entity.Player
+import org.bukkit.event.EventHandler
+import org.bukkit.event.Listener
+import org.bukkit.event.entity.PlayerDeathEvent
+import org.bukkit.event.player.PlayerChangedWorldEvent
+import org.bukkit.event.player.PlayerJoinEvent
+import org.bukkit.event.player.PlayerQuitEvent
+import org.bukkit.event.player.PlayerRespawnEvent
+import org.bukkit.plugin.java.JavaPlugin
+import java.util.UUID
+
+class BannermanListeners(
+    private val plugin: JavaPlugin,
+    private val renderer: BannermanRenderService,
+    private val guildService: GuildService,
+    private val memberService: MemberService
+) : Listener {
+
+    @EventHandler
+    fun onJoin(e: PlayerJoinEvent) = trySpawn(e.player)
+
+    @EventHandler
+    fun onQuit(e: PlayerQuitEvent) = renderer.despawnFor(e.player.uniqueId)
+
+    @EventHandler
+    fun onDeath(e: PlayerDeathEvent) = renderer.despawnFor(e.entity.uniqueId)
+
+    @EventHandler
+    fun onRespawn(e: PlayerRespawnEvent) {
+        plugin.server.scheduler.runTask(plugin, Runnable { trySpawn(e.player) })
+    }
+
+    @EventHandler
+    fun onWorldChange(e: PlayerChangedWorldEvent) {
+        renderer.despawnFor(e.player.uniqueId)
+        trySpawn(e.player)
+    }
+
+    private fun trySpawn(player: Player) {
+        val guildId = memberService.getPlayerGuilds(player.uniqueId).firstOrNull() ?: return
+        if (!guildService.getBannermanEnabled(guildId)) return
+        val guild = guildService.getGuild(guildId) ?: return
+        val banner = guild.banner?.deserializeToItemStack() ?: return
+        renderer.spawnFor(player, banner)
+    }
+
+    /** Spawn displays for every online member when a guild flips bannerman ON. */
+    fun onBannermanEnabled(guildId: UUID) {
+        memberService.getGuildMembers(guildId)
+            .mapNotNull { plugin.server.getPlayer(it.playerId) }
+            .forEach { trySpawn(it) }
+    }
+
+    /** Despawn displays for every member when a guild flips bannerman OFF (or is disbanded). */
+    fun onBannermanDisabled(guildId: UUID) {
+        memberService.getGuildMembers(guildId).forEach { renderer.despawnFor(it.playerId) }
+    }
+
+    /** Re-render every online member when the guild banner ItemStack changes. */
+    fun onGuildBannerChanged(guildId: UUID) {
+        val guild = guildService.getGuild(guildId) ?: return
+        val banner = guild.banner?.deserializeToItemStack() ?: return
+        memberService.getGuildMembers(guildId).forEach { renderer.updateBanner(it.playerId, banner) }
+    }
+}

--- a/src/main/kotlin/net/lumalyte/lg/infrastructure/bukkit/bannerman/BannermanRenderService.kt
+++ b/src/main/kotlin/net/lumalyte/lg/infrastructure/bukkit/bannerman/BannermanRenderService.kt
@@ -1,0 +1,91 @@
+package net.lumalyte.lg.infrastructure.bukkit.bannerman
+
+import org.bukkit.Bukkit
+import org.bukkit.NamespacedKey
+import org.bukkit.entity.ItemDisplay
+import org.bukkit.entity.Player
+import org.bukkit.inventory.ItemStack
+import org.bukkit.persistence.PersistentDataType
+import org.bukkit.plugin.java.JavaPlugin
+import org.bukkit.util.Transformation
+import org.joml.Quaternionf
+import org.joml.Vector3f
+import java.util.UUID
+import java.util.concurrent.ConcurrentHashMap
+
+/**
+ * Manages one [ItemDisplay] per online player in a bannerman-enabled guild.
+ * Each display is tagged with a PDC key so we can sweep orphans after a crash.
+ */
+class BannermanRenderService(private val plugin: JavaPlugin) {
+
+    private val tagKey = NamespacedKey(plugin, "bannerman_owner")
+
+    /** player UUID -> spawned display entity UUID */
+    private val displays = ConcurrentHashMap<UUID, UUID>()
+
+    /**
+     * Spawn (or respawn) a banner display attached to the player. The previous display, if any, is removed.
+     */
+    fun spawnFor(player: Player, banner: ItemStack) {
+        despawnFor(player.uniqueId)
+        val location = player.location.clone().add(0.0, 1.0, 0.0)
+        val display = player.world.spawn(location, ItemDisplay::class.java) { d ->
+            d.setItemStack(banner)
+            d.isPersistent = false
+            d.transformation = backTransformation()
+            d.interpolationDuration = 2
+            d.teleportDuration = 2
+            d.persistentDataContainer.set(tagKey, PersistentDataType.STRING, player.uniqueId.toString())
+        }
+        displays[player.uniqueId] = display.uniqueId
+    }
+
+    /** Swap the rendered ItemStack on a player's existing display, if any. */
+    fun updateBanner(playerId: UUID, banner: ItemStack) {
+        val display = currentDisplay(playerId) ?: return
+        display.setItemStack(banner)
+    }
+
+    /** Remove the player's display, if any. */
+    fun despawnFor(playerId: UUID) {
+        val display = currentDisplay(playerId)
+        display?.remove()
+        displays.remove(playerId)
+    }
+
+    fun isTracking(playerId: UUID): Boolean = displays.containsKey(playerId)
+
+    /** Returns the live ItemDisplay entity, or null if not spawned (or the entity has since been removed). */
+    fun currentDisplay(playerId: UUID): ItemDisplay? {
+        val entityId = displays[playerId] ?: return null
+        return Bukkit.getEntity(entityId) as? ItemDisplay
+    }
+
+    /** Removes all tracked displays. Call on plugin disable. */
+    fun despawnAll() {
+        displays.keys.toList().forEach { despawnFor(it) }
+    }
+
+    /**
+     * Sweep every loaded world for ItemDisplay entities tagged as ours. Used at plugin enable
+     * to clean up orphans left behind by a server crash.
+     */
+    fun sweepOrphans() {
+        for (world in Bukkit.getWorlds()) {
+            for (entity in world.entities) {
+                if (entity is ItemDisplay &&
+                    entity.persistentDataContainer.has(tagKey, PersistentDataType.STRING)) {
+                    entity.remove()
+                }
+            }
+        }
+    }
+
+    private fun backTransformation(): Transformation = Transformation(
+        Vector3f(0f, 0f, -0.25f),                       // translate behind torso
+        Quaternionf().rotateY(Math.PI.toFloat()),       // face backwards relative to player
+        Vector3f(1.0f, 1.5f, 1.0f),                     // taller than wide
+        Quaternionf()
+    )
+}

--- a/src/main/kotlin/net/lumalyte/lg/infrastructure/bukkit/bannerman/BannermanTickTask.kt
+++ b/src/main/kotlin/net/lumalyte/lg/infrastructure/bukkit/bannerman/BannermanTickTask.kt
@@ -1,0 +1,46 @@
+package net.lumalyte.lg.infrastructure.bukkit.bannerman
+
+import org.bukkit.Bukkit
+import org.bukkit.Material
+import org.bukkit.entity.Player
+import org.bukkit.plugin.java.JavaPlugin
+import org.bukkit.potion.PotionEffectType
+import org.bukkit.scheduler.BukkitRunnable
+
+/**
+ * Every 2 ticks: keep each tracked player's bannerman display following the player
+ * and toggle visibility based on elytra / invisibility state.
+ */
+class BannermanTickTask(
+    private val plugin: JavaPlugin,
+    private val renderer: BannermanRenderService
+) : BukkitRunnable() {
+
+    fun start() {
+        runTaskTimer(plugin, 0L, 2L)
+    }
+
+    override fun run() {
+        for (player in Bukkit.getOnlinePlayers()) {
+            if (!renderer.isTracking(player.uniqueId)) continue
+            val display = renderer.currentDisplay(player.uniqueId) ?: continue
+
+            val shouldShow = BannermanVisibility.shouldShow(
+                hasElytra = isWearingElytra(player),
+                hasInvisibility = player.hasPotionEffect(PotionEffectType.INVISIBILITY)
+            )
+            display.isVisibleByDefault = shouldShow
+
+            val target = player.location.clone()
+            target.y += 1.0
+            target.yaw = player.location.yaw
+            target.pitch = 0f
+            if (display.world != player.world || display.location.distanceSquared(target) > 0.0001) {
+                display.teleport(target)
+            }
+        }
+    }
+
+    private fun isWearingElytra(player: Player): Boolean =
+        player.inventory.chestplate?.type == Material.ELYTRA
+}

--- a/src/main/kotlin/net/lumalyte/lg/infrastructure/bukkit/bannerman/BannermanVisibility.kt
+++ b/src/main/kotlin/net/lumalyte/lg/infrastructure/bukkit/bannerman/BannermanVisibility.kt
@@ -1,0 +1,16 @@
+package net.lumalyte.lg.infrastructure.bukkit.bannerman
+
+/**
+ * Decides whether a guild bannerman display should be visible on a player's back.
+ *
+ * Pure function: takes only what affects the decision, returns the decision.
+ * Live Bukkit state (elytra slot, potion effects) is queried by the caller and passed in,
+ * keeping this logic trivially unit-testable.
+ */
+object BannermanVisibility {
+    /**
+     * @return true if the banner should be shown to onlookers.
+     */
+    fun shouldShow(hasElytra: Boolean, hasInvisibility: Boolean): Boolean =
+        !hasElytra && !hasInvisibility
+}

--- a/src/main/kotlin/net/lumalyte/lg/infrastructure/listeners/GuildDisbandedListener.kt
+++ b/src/main/kotlin/net/lumalyte/lg/infrastructure/listeners/GuildDisbandedListener.kt
@@ -1,6 +1,7 @@
 package net.lumalyte.lg.infrastructure.listeners
 
 import net.lumalyte.lg.domain.events.GuildDisbandedEvent
+import net.lumalyte.lg.infrastructure.bukkit.bannerman.BannermanListeners
 import org.bukkit.Bukkit
 import org.bukkit.event.EventHandler
 import org.bukkit.event.EventPriority
@@ -9,8 +10,11 @@ import org.bukkit.event.Listener
 /**
  * Closes any open guild menus for members still online when their guild is disbanded,
  * preventing stale GUIs from remaining open after the guild no longer exists.
+ * Also despawns any bannerman displays attached to those members.
  */
-class GuildDisbandedListener : Listener {
+class GuildDisbandedListener(
+    private val bannermanListeners: BannermanListeners
+) : Listener {
 
     @EventHandler(priority = EventPriority.MONITOR)
     fun onGuildDisbanded(event: GuildDisbandedEvent) {
@@ -20,5 +24,7 @@ class GuildDisbandedListener : Listener {
             player.closeInventory()
             player.sendMessage("§c✗ Your guild §f${event.guild.name} §chas been disbanded.")
         }
+        // Despawn bannerman displays for every member (online or offline).
+        bannermanListeners.onBannermanDisabled(event.guild.id)
     }
 }

--- a/src/main/kotlin/net/lumalyte/lg/infrastructure/persistence/guilds/GuildRepositorySQLite.kt
+++ b/src/main/kotlin/net/lumalyte/lg/infrastructure/persistence/guilds/GuildRepositorySQLite.kt
@@ -40,8 +40,7 @@ class GuildRepositorySQLite(private val storage: Storage<Database>) : GuildRepos
     private val hasLfgColumns: Boolean by lazy {
         checkColumnExists("guilds", "is_open") &&
         checkColumnExists("guilds", "join_fee_enabled") &&
-        checkColumnExists("guilds", "join_fee_amount") &&
-        checkColumnExists("guilds", "bannerman_enabled")
+        checkColumnExists("guilds", "join_fee_amount")
     }
 
     private val hasTrackingColumn: Boolean by lazy {
@@ -51,6 +50,32 @@ class GuildRepositorySQLite(private val storage: Storage<Database>) : GuildRepos
     private val hasBankFrozenColumn: Boolean by lazy {
         checkColumnExists("guilds", "bank_frozen")
     }
+
+    /**
+     * Bannerman column lives on its own flag because LFG persistence MUST NOT be gated on it.
+     * A partially-migrated DB (LFG yes, bannerman no) used to fall back to non-LFG INSERT/UPDATE
+     * variants, silently dropping `is_open` / `join_fee_*` writes. The flag is consulted at
+     * every site that mentions `bannerman_enabled` so an absent column is simply skipped.
+     */
+    private val hasBannermanColumn: Boolean by lazy {
+        checkColumnExists("guilds", "bannerman_enabled")
+    }
+
+    /** SQL column-list fragment for bannerman (leading comma) — empty when the column is missing. */
+    private val bannermanColumnSql: String
+        get() = if (hasBannermanColumn) ", bannerman_enabled" else ""
+
+    /** SQL VALUES-list fragment for bannerman — empty when the column is missing. */
+    private val bannermanValueSql: String
+        get() = if (hasBannermanColumn) ", ?" else ""
+
+    /** SQL UPDATE assignment fragment for bannerman (trailing comma) — empty when the column is missing. */
+    private val bannermanSetSql: String
+        get() = if (hasBannermanColumn) "bannerman_enabled = ?, " else ""
+
+    /** Single-element argument array for the bannerman parameter — empty when the column is missing. */
+    private fun bannermanArg(guild: Guild): Array<Any?> =
+        if (hasBannermanColumn) arrayOf(if (guild.bannermanEnabled) 1 else 0) else emptyArray()
 
     init {
         createGuildTable()
@@ -493,18 +518,18 @@ class GuildRepositorySQLite(private val storage: Storage<Database>) : GuildRepos
         // Use cached column existence check
         val sql = if (hasLfgColumns && hasTrackingColumn && hasBankFrozenColumn) {
             """
-            INSERT INTO guilds (id, name, banner, emoji, tag, home_world, home_x, home_y, home_z, level, bank_balance, mode, mode_changed_at, created_at, is_open, join_fee_enabled, join_fee_amount, tracking_enabled, bank_frozen, bannerman_enabled, ally_home_world, ally_home_x, ally_home_y, ally_home_z, ally_home_allowed_guilds)
-            VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+            INSERT INTO guilds (id, name, banner, emoji, tag, home_world, home_x, home_y, home_z, level, bank_balance, mode, mode_changed_at, created_at, is_open, join_fee_enabled, join_fee_amount, tracking_enabled, bank_frozen${bannermanColumnSql}, ally_home_world, ally_home_x, ally_home_y, ally_home_z, ally_home_allowed_guilds)
+            VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?${bannermanValueSql}, ?, ?, ?, ?, ?)
             """.trimIndent()
         } else if (hasLfgColumns && hasTrackingColumn) {
             """
-            INSERT INTO guilds (id, name, banner, emoji, tag, home_world, home_x, home_y, home_z, level, bank_balance, mode, mode_changed_at, created_at, is_open, join_fee_enabled, join_fee_amount, tracking_enabled, bannerman_enabled, ally_home_world, ally_home_x, ally_home_y, ally_home_z, ally_home_allowed_guilds)
-            VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+            INSERT INTO guilds (id, name, banner, emoji, tag, home_world, home_x, home_y, home_z, level, bank_balance, mode, mode_changed_at, created_at, is_open, join_fee_enabled, join_fee_amount, tracking_enabled${bannermanColumnSql}, ally_home_world, ally_home_x, ally_home_y, ally_home_z, ally_home_allowed_guilds)
+            VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?${bannermanValueSql}, ?, ?, ?, ?, ?)
             """.trimIndent()
         } else if (hasLfgColumns) {
             """
-            INSERT INTO guilds (id, name, banner, emoji, tag, home_world, home_x, home_y, home_z, level, bank_balance, mode, mode_changed_at, created_at, is_open, join_fee_enabled, join_fee_amount, bannerman_enabled, ally_home_world, ally_home_x, ally_home_y, ally_home_z, ally_home_allowed_guilds)
-            VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+            INSERT INTO guilds (id, name, banner, emoji, tag, home_world, home_x, home_y, home_z, level, bank_balance, mode, mode_changed_at, created_at, is_open, join_fee_enabled, join_fee_amount${bannermanColumnSql}, ally_home_world, ally_home_x, ally_home_y, ally_home_z, ally_home_allowed_guilds)
+            VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?${bannermanValueSql}, ?, ?, ?, ?, ?)
             """.trimIndent()
         } else if (hasTrackingColumn) {
             """
@@ -543,7 +568,7 @@ class GuildRepositorySQLite(private val storage: Storage<Database>) : GuildRepos
                     guild.joinFeeAmount,
                     if (guild.trackingEnabled) 1 else 0,
                     if (guild.bankFrozen) 1 else 0,
-                    if (guild.bannermanEnabled) 1 else 0,
+                    *bannermanArg(guild),
                     guild.allyHome?.worldId?.toString(),
                     guild.allyHome?.position?.x,
                     guild.allyHome?.position?.y,
@@ -570,7 +595,7 @@ class GuildRepositorySQLite(private val storage: Storage<Database>) : GuildRepos
                     if (guild.joinFeeEnabled) 1 else 0,
                     guild.joinFeeAmount,
                     if (guild.trackingEnabled) 1 else 0,
-                    if (guild.bannermanEnabled) 1 else 0,
+                    *bannermanArg(guild),
                     guild.allyHome?.worldId?.toString(),
                     guild.allyHome?.position?.x,
                     guild.allyHome?.position?.y,
@@ -596,7 +621,7 @@ class GuildRepositorySQLite(private val storage: Storage<Database>) : GuildRepos
                     if (guild.isOpen) 1 else 0,
                     if (guild.joinFeeEnabled) 1 else 0,
                     guild.joinFeeAmount,
-                    if (guild.bannermanEnabled) 1 else 0,
+                    *bannermanArg(guild),
                     guild.allyHome?.worldId?.toString(),
                     guild.allyHome?.position?.x,
                     guild.allyHome?.position?.y,
@@ -667,7 +692,7 @@ class GuildRepositorySQLite(private val storage: Storage<Database>) : GuildRepos
             UPDATE guilds SET name = ?, banner = ?, emoji = ?, tag = ?, home_world = ?, home_x = ?, home_y = ?, home_z = ?,
             level = ?, bank_balance = ?, mode = ?, mode_changed_at = ?,
             vault_status = ?, vault_chest_world = ?, vault_chest_x = ?, vault_chest_y = ?, vault_chest_z = ?, is_open = ?,
-            join_fee_enabled = ?, join_fee_amount = ?, tracking_enabled = ?, bank_frozen = ?, bannerman_enabled = ?,
+            join_fee_enabled = ?, join_fee_amount = ?, tracking_enabled = ?, bank_frozen = ?, ${bannermanSetSql}
             ally_home_world = ?, ally_home_x = ?, ally_home_y = ?, ally_home_z = ?, ally_home_allowed_guilds = ?
             WHERE id = ?
             """.trimIndent()
@@ -676,7 +701,7 @@ class GuildRepositorySQLite(private val storage: Storage<Database>) : GuildRepos
             UPDATE guilds SET name = ?, banner = ?, emoji = ?, tag = ?, home_world = ?, home_x = ?, home_y = ?, home_z = ?,
             level = ?, bank_balance = ?, mode = ?, mode_changed_at = ?,
             vault_status = ?, vault_chest_world = ?, vault_chest_x = ?, vault_chest_y = ?, vault_chest_z = ?, is_open = ?,
-            join_fee_enabled = ?, join_fee_amount = ?, tracking_enabled = ?, bannerman_enabled = ?,
+            join_fee_enabled = ?, join_fee_amount = ?, tracking_enabled = ?, ${bannermanSetSql}
             ally_home_world = ?, ally_home_x = ?, ally_home_y = ?, ally_home_z = ?, ally_home_allowed_guilds = ?
             WHERE id = ?
             """.trimIndent()
@@ -685,7 +710,7 @@ class GuildRepositorySQLite(private val storage: Storage<Database>) : GuildRepos
             UPDATE guilds SET name = ?, banner = ?, emoji = ?, tag = ?, home_world = ?, home_x = ?, home_y = ?, home_z = ?,
             level = ?, bank_balance = ?, mode = ?, mode_changed_at = ?,
             vault_status = ?, vault_chest_world = ?, vault_chest_x = ?, vault_chest_y = ?, vault_chest_z = ?, is_open = ?,
-            join_fee_enabled = ?, join_fee_amount = ?, bannerman_enabled = ?,
+            join_fee_enabled = ?, join_fee_amount = ?, ${bannermanSetSql}
             ally_home_world = ?, ally_home_x = ?, ally_home_y = ?, ally_home_z = ?, ally_home_allowed_guilds = ?
             WHERE id = ?
             """.trimIndent()
@@ -740,7 +765,7 @@ class GuildRepositorySQLite(private val storage: Storage<Database>) : GuildRepos
                     guild.joinFeeAmount,
                     if (guild.trackingEnabled) 1 else 0,
                     if (guild.bankFrozen) 1 else 0,
-                    if (guild.bannermanEnabled) 1 else 0,
+                    *bannermanArg(guild),
                     guild.allyHome?.worldId?.toString(),
                     guild.allyHome?.position?.x,
                     guild.allyHome?.position?.y,
@@ -771,7 +796,7 @@ class GuildRepositorySQLite(private val storage: Storage<Database>) : GuildRepos
                     if (guild.joinFeeEnabled) 1 else 0,
                     guild.joinFeeAmount,
                     if (guild.trackingEnabled) 1 else 0,
-                    if (guild.bannermanEnabled) 1 else 0,
+                    *bannermanArg(guild),
                     guild.allyHome?.worldId?.toString(),
                     guild.allyHome?.position?.x,
                     guild.allyHome?.position?.y,
@@ -801,7 +826,7 @@ class GuildRepositorySQLite(private val storage: Storage<Database>) : GuildRepos
                     if (guild.isOpen) 1 else 0,
                     if (guild.joinFeeEnabled) 1 else 0,
                     guild.joinFeeAmount,
-                    if (guild.bannermanEnabled) 1 else 0,
+                    *bannermanArg(guild),
                     guild.allyHome?.worldId?.toString(),
                     guild.allyHome?.position?.x,
                     guild.allyHome?.position?.y,

--- a/src/main/kotlin/net/lumalyte/lg/infrastructure/persistence/guilds/GuildRepositorySQLite.kt
+++ b/src/main/kotlin/net/lumalyte/lg/infrastructure/persistence/guilds/GuildRepositorySQLite.kt
@@ -40,7 +40,8 @@ class GuildRepositorySQLite(private val storage: Storage<Database>) : GuildRepos
     private val hasLfgColumns: Boolean by lazy {
         checkColumnExists("guilds", "is_open") &&
         checkColumnExists("guilds", "join_fee_enabled") &&
-        checkColumnExists("guilds", "join_fee_amount")
+        checkColumnExists("guilds", "join_fee_amount") &&
+        checkColumnExists("guilds", "bannerman_enabled")
     }
 
     private val hasTrackingColumn: Boolean by lazy {
@@ -378,6 +379,12 @@ class GuildRepositorySQLite(private val storage: Storage<Database>) : GuildRepos
             0
         }
 
+        val bannermanEnabled = try {
+            rs.get<Int?>("bannerman_enabled")?.let { it == 1 } ?: false
+        } catch (e: Exception) {
+            false
+        }
+
         // Parse tracking_enabled (default to true for existing guilds)
         val trackingEnabled = try {
             rs.get<Int?>("tracking_enabled")?.let { it == 1 } ?: true
@@ -453,6 +460,7 @@ class GuildRepositorySQLite(private val storage: Storage<Database>) : GuildRepos
             joinFeeAmount = joinFeeAmount,
             trackingEnabled = trackingEnabled,
             bankFrozen = bankFrozen,
+            bannermanEnabled = bannermanEnabled,
             allyHome = allyHome,
             allyHomeAllowedGuilds = allyHomeAllowedGuilds
         )
@@ -485,17 +493,17 @@ class GuildRepositorySQLite(private val storage: Storage<Database>) : GuildRepos
         // Use cached column existence check
         val sql = if (hasLfgColumns && hasTrackingColumn && hasBankFrozenColumn) {
             """
-            INSERT INTO guilds (id, name, banner, emoji, tag, home_world, home_x, home_y, home_z, level, bank_balance, mode, mode_changed_at, created_at, is_open, join_fee_enabled, join_fee_amount, tracking_enabled, bank_frozen, ally_home_world, ally_home_x, ally_home_y, ally_home_z, ally_home_allowed_guilds)
-            VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+            INSERT INTO guilds (id, name, banner, emoji, tag, home_world, home_x, home_y, home_z, level, bank_balance, mode, mode_changed_at, created_at, is_open, join_fee_enabled, join_fee_amount, tracking_enabled, bank_frozen, bannerman_enabled, ally_home_world, ally_home_x, ally_home_y, ally_home_z, ally_home_allowed_guilds)
+            VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
             """.trimIndent()
         } else if (hasLfgColumns && hasTrackingColumn) {
             """
-            INSERT INTO guilds (id, name, banner, emoji, tag, home_world, home_x, home_y, home_z, level, bank_balance, mode, mode_changed_at, created_at, is_open, join_fee_enabled, join_fee_amount, tracking_enabled, ally_home_world, ally_home_x, ally_home_y, ally_home_z, ally_home_allowed_guilds)
-            VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+            INSERT INTO guilds (id, name, banner, emoji, tag, home_world, home_x, home_y, home_z, level, bank_balance, mode, mode_changed_at, created_at, is_open, join_fee_enabled, join_fee_amount, tracking_enabled, bannerman_enabled, ally_home_world, ally_home_x, ally_home_y, ally_home_z, ally_home_allowed_guilds)
+            VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
             """.trimIndent()
         } else if (hasLfgColumns) {
             """
-            INSERT INTO guilds (id, name, banner, emoji, tag, home_world, home_x, home_y, home_z, level, bank_balance, mode, mode_changed_at, created_at, is_open, join_fee_enabled, join_fee_amount, ally_home_world, ally_home_x, ally_home_y, ally_home_z, ally_home_allowed_guilds)
+            INSERT INTO guilds (id, name, banner, emoji, tag, home_world, home_x, home_y, home_z, level, bank_balance, mode, mode_changed_at, created_at, is_open, join_fee_enabled, join_fee_amount, bannerman_enabled, ally_home_world, ally_home_x, ally_home_y, ally_home_z, ally_home_allowed_guilds)
             VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
             """.trimIndent()
         } else if (hasTrackingColumn) {
@@ -535,6 +543,7 @@ class GuildRepositorySQLite(private val storage: Storage<Database>) : GuildRepos
                     guild.joinFeeAmount,
                     if (guild.trackingEnabled) 1 else 0,
                     if (guild.bankFrozen) 1 else 0,
+                    if (guild.bannermanEnabled) 1 else 0,
                     guild.allyHome?.worldId?.toString(),
                     guild.allyHome?.position?.x,
                     guild.allyHome?.position?.y,
@@ -561,6 +570,7 @@ class GuildRepositorySQLite(private val storage: Storage<Database>) : GuildRepos
                     if (guild.joinFeeEnabled) 1 else 0,
                     guild.joinFeeAmount,
                     if (guild.trackingEnabled) 1 else 0,
+                    if (guild.bannermanEnabled) 1 else 0,
                     guild.allyHome?.worldId?.toString(),
                     guild.allyHome?.position?.x,
                     guild.allyHome?.position?.y,
@@ -586,6 +596,7 @@ class GuildRepositorySQLite(private val storage: Storage<Database>) : GuildRepos
                     if (guild.isOpen) 1 else 0,
                     if (guild.joinFeeEnabled) 1 else 0,
                     guild.joinFeeAmount,
+                    if (guild.bannermanEnabled) 1 else 0,
                     guild.allyHome?.worldId?.toString(),
                     guild.allyHome?.position?.x,
                     guild.allyHome?.position?.y,
@@ -656,7 +667,7 @@ class GuildRepositorySQLite(private val storage: Storage<Database>) : GuildRepos
             UPDATE guilds SET name = ?, banner = ?, emoji = ?, tag = ?, home_world = ?, home_x = ?, home_y = ?, home_z = ?,
             level = ?, bank_balance = ?, mode = ?, mode_changed_at = ?,
             vault_status = ?, vault_chest_world = ?, vault_chest_x = ?, vault_chest_y = ?, vault_chest_z = ?, is_open = ?,
-            join_fee_enabled = ?, join_fee_amount = ?, tracking_enabled = ?, bank_frozen = ?,
+            join_fee_enabled = ?, join_fee_amount = ?, tracking_enabled = ?, bank_frozen = ?, bannerman_enabled = ?,
             ally_home_world = ?, ally_home_x = ?, ally_home_y = ?, ally_home_z = ?, ally_home_allowed_guilds = ?
             WHERE id = ?
             """.trimIndent()
@@ -665,7 +676,7 @@ class GuildRepositorySQLite(private val storage: Storage<Database>) : GuildRepos
             UPDATE guilds SET name = ?, banner = ?, emoji = ?, tag = ?, home_world = ?, home_x = ?, home_y = ?, home_z = ?,
             level = ?, bank_balance = ?, mode = ?, mode_changed_at = ?,
             vault_status = ?, vault_chest_world = ?, vault_chest_x = ?, vault_chest_y = ?, vault_chest_z = ?, is_open = ?,
-            join_fee_enabled = ?, join_fee_amount = ?, tracking_enabled = ?,
+            join_fee_enabled = ?, join_fee_amount = ?, tracking_enabled = ?, bannerman_enabled = ?,
             ally_home_world = ?, ally_home_x = ?, ally_home_y = ?, ally_home_z = ?, ally_home_allowed_guilds = ?
             WHERE id = ?
             """.trimIndent()
@@ -674,7 +685,7 @@ class GuildRepositorySQLite(private val storage: Storage<Database>) : GuildRepos
             UPDATE guilds SET name = ?, banner = ?, emoji = ?, tag = ?, home_world = ?, home_x = ?, home_y = ?, home_z = ?,
             level = ?, bank_balance = ?, mode = ?, mode_changed_at = ?,
             vault_status = ?, vault_chest_world = ?, vault_chest_x = ?, vault_chest_y = ?, vault_chest_z = ?, is_open = ?,
-            join_fee_enabled = ?, join_fee_amount = ?,
+            join_fee_enabled = ?, join_fee_amount = ?, bannerman_enabled = ?,
             ally_home_world = ?, ally_home_x = ?, ally_home_y = ?, ally_home_z = ?, ally_home_allowed_guilds = ?
             WHERE id = ?
             """.trimIndent()
@@ -729,6 +740,7 @@ class GuildRepositorySQLite(private val storage: Storage<Database>) : GuildRepos
                     guild.joinFeeAmount,
                     if (guild.trackingEnabled) 1 else 0,
                     if (guild.bankFrozen) 1 else 0,
+                    if (guild.bannermanEnabled) 1 else 0,
                     guild.allyHome?.worldId?.toString(),
                     guild.allyHome?.position?.x,
                     guild.allyHome?.position?.y,
@@ -759,6 +771,7 @@ class GuildRepositorySQLite(private val storage: Storage<Database>) : GuildRepos
                     if (guild.joinFeeEnabled) 1 else 0,
                     guild.joinFeeAmount,
                     if (guild.trackingEnabled) 1 else 0,
+                    if (guild.bannermanEnabled) 1 else 0,
                     guild.allyHome?.worldId?.toString(),
                     guild.allyHome?.position?.x,
                     guild.allyHome?.position?.y,
@@ -788,6 +801,7 @@ class GuildRepositorySQLite(private val storage: Storage<Database>) : GuildRepos
                     if (guild.isOpen) 1 else 0,
                     if (guild.joinFeeEnabled) 1 else 0,
                     guild.joinFeeAmount,
+                    if (guild.bannermanEnabled) 1 else 0,
                     guild.allyHome?.worldId?.toString(),
                     guild.allyHome?.position?.x,
                     guild.allyHome?.position?.y,

--- a/src/main/kotlin/net/lumalyte/lg/infrastructure/persistence/migrations/MariaDBMigrations.kt
+++ b/src/main/kotlin/net/lumalyte/lg/infrastructure/persistence/migrations/MariaDBMigrations.kt
@@ -44,6 +44,11 @@ class MariaDBMigrations(private val plugin: JavaPlugin, private val connection: 
                 updateDatabaseVersion(21)
                 currentDbVersion = 21
             }
+            if (currentDbVersion < 22) {
+                migrateToVersion22()
+                updateDatabaseVersion(22)
+                currentDbVersion = 22
+            }
 
             connection.commit()
 
@@ -572,5 +577,21 @@ class MariaDBMigrations(private val plugin: JavaPlugin, private val connection: 
     private fun migrateToVersion21() {
         componentLogger.info(Component.text("Migrating to version 21: sanitize guild names..."))
         GuildNameSanitizer.sanitizeAll(connection, componentLogger)
+    }
+
+    /**
+     * Migration to version 22.
+     * Adds the `bannerman_enabled` column to the `guilds` table to support the
+     * Guild Bannerman feature.
+     */
+    private fun migrateToVersion22() {
+        componentLogger.info(Component.text("Migrating to version 22: Adding bannerman_enabled column to guilds table..."))
+
+        connection.createStatement().use { stmt ->
+            stmt.execute("""
+                ALTER TABLE guilds ADD COLUMN IF NOT EXISTS bannerman_enabled TINYINT(1) NOT NULL DEFAULT 0
+            """.trimIndent())
+            componentLogger.info(Component.text("✓ Added bannerman_enabled column to guilds table (migration v22)"))
+        }
     }
 }

--- a/src/main/kotlin/net/lumalyte/lg/infrastructure/persistence/migrations/SQLiteMigrations.kt
+++ b/src/main/kotlin/net/lumalyte/lg/infrastructure/persistence/migrations/SQLiteMigrations.kt
@@ -124,6 +124,11 @@ class SQLiteMigrations(private val plugin: JavaPlugin, private val connection: C
                 updateDatabaseVersion(21)
                 dbVersion = 21
             }
+            if (dbVersion < 22) {
+                migrateToVersion22()
+                updateDatabaseVersion(22)
+                dbVersion = 22
+            }
 
             // Validate that all required tables exist, recreate if missing
             validateAndRepairSchema()
@@ -1541,5 +1546,24 @@ class SQLiteMigrations(private val plugin: JavaPlugin, private val connection: C
     private fun migrateToVersion21() {
         componentLogger.info(Component.text("Migrating to version 21: sanitize guild names..."))
         GuildNameSanitizer.sanitizeAll(connection, componentLogger)
+    }
+
+    /**
+     * Migration from version 21 to version 22.
+     * Adds bannerman_enabled column to guilds table for bannerman feature.
+     */
+    private fun migrateToVersion22() {
+        val sqlCommands = mutableListOf<String>()
+
+        // Add bannerman_enabled column to guilds table (if not exists)
+        if (!columnExists("guilds", "bannerman_enabled")) {
+            sqlCommands.add("ALTER TABLE guilds ADD COLUMN bannerman_enabled INTEGER DEFAULT 0;")
+        }
+
+        if (sqlCommands.isNotEmpty()) {
+            executeMigrationCommands(sqlCommands)
+        }
+
+        componentLogger.info(Component.text("✓ Migration v22 complete: added bannerman_enabled column"))
     }
 }

--- a/src/main/kotlin/net/lumalyte/lg/infrastructure/services/GuildServiceBukkit.kt
+++ b/src/main/kotlin/net/lumalyte/lg/infrastructure/services/GuildServiceBukkit.kt
@@ -208,13 +208,15 @@ class GuildServiceBukkit(
             logger.info("Guild $guildId banner set to '$bannerText' by $actorId")
             Bukkit.getPluginManager().callEvent(GuildBannerSetEvent(guildId, actorId))
 
-            // Notify bannerman renderer to re-render the new banner
+            // Notify bannerman renderer to re-render the new banner. Failures are non-fatal
+            // (Koin may be torn down during shutdown), but we log so operators can diagnose
+            // missing-refresh complaints instead of chasing ghost bug reports.
             try {
                 val bannermanListeners = org.koin.java.KoinJavaComponent.getKoin()
                     .get<net.lumalyte.lg.infrastructure.bukkit.bannerman.BannermanListeners>()
                 bannermanListeners.onGuildBannerChanged(guildId)
-            } catch (_: Exception) {
-                // Koin/bannerman not initialized — fine, the feature just won't refresh
+            } catch (e: Exception) {
+                logger.debug("Bannerman refresh skipped for guild $guildId: ${e.message}")
             }
         }
         return result

--- a/src/main/kotlin/net/lumalyte/lg/infrastructure/services/GuildServiceBukkit.kt
+++ b/src/main/kotlin/net/lumalyte/lg/infrastructure/services/GuildServiceBukkit.kt
@@ -639,6 +639,26 @@ class GuildServiceBukkit(
         return Pair(guild.joinFeeEnabled, guild.joinFeeAmount)
     }
 
+    override fun setBannermanEnabled(guildId: UUID, enabled: Boolean, actorId: UUID): Boolean {
+        val guild = guildRepository.getById(guildId) ?: return false
+
+        if (!hasPermission(actorId, guildId, RankPermission.MANAGE_BANNER)) {
+            logger.warn("Player $actorId attempted to toggle bannerman on guild $guildId without permission")
+            return false
+        }
+
+        val updated = guild.copy(bannermanEnabled = enabled)
+        val result = guildRepository.update(updated)
+        if (result) {
+            logger.info("Guild $guildId bannerman ${if (enabled) "enabled" else "disabled"} by $actorId")
+        }
+        return result
+    }
+
+    override fun getBannermanEnabled(guildId: UUID): Boolean {
+        return guildRepository.getById(guildId)?.bannermanEnabled ?: false
+    }
+
     override fun setTrackingEnabled(guildId: UUID, enabled: Boolean, actorId: UUID): Boolean {
         val guild = guildRepository.getById(guildId) ?: return false
 

--- a/src/main/kotlin/net/lumalyte/lg/infrastructure/services/GuildServiceBukkit.kt
+++ b/src/main/kotlin/net/lumalyte/lg/infrastructure/services/GuildServiceBukkit.kt
@@ -207,6 +207,15 @@ class GuildServiceBukkit(
             val bannerText = if (banner != null) "${banner.type.name} with patterns" else "cleared (default white banner)"
             logger.info("Guild $guildId banner set to '$bannerText' by $actorId")
             Bukkit.getPluginManager().callEvent(GuildBannerSetEvent(guildId, actorId))
+
+            // Notify bannerman renderer to re-render the new banner
+            try {
+                val bannermanListeners = org.koin.java.KoinJavaComponent.getKoin()
+                    .get<net.lumalyte.lg.infrastructure.bukkit.bannerman.BannermanListeners>()
+                bannermanListeners.onGuildBannerChanged(guildId)
+            } catch (_: Exception) {
+                // Koin/bannerman not initialized — fine, the feature just won't refresh
+            }
         }
         return result
     }

--- a/src/main/kotlin/net/lumalyte/lg/interaction/commands/GuildCommand.kt
+++ b/src/main/kotlin/net/lumalyte/lg/interaction/commands/GuildCommand.kt
@@ -50,6 +50,7 @@ class GuildCommand : BaseCommand(), KoinComponent {
     private val guildChatListener: net.lumalyte.lg.interaction.listeners.GuildChatListener by inject()
     private val adminOverrideService: net.lumalyte.lg.application.services.AdminOverrideService by inject()
     private val teleportationService: net.lumalyte.lg.infrastructure.services.TeleportationService by inject()
+    private val bannermanListeners: net.lumalyte.lg.infrastructure.bukkit.bannerman.BannermanListeners by inject()
 
     private val lastHomeTeleport = mutableMapOf<java.util.UUID, Long>()
 
@@ -1606,6 +1607,41 @@ class GuildCommand : BaseCommand(), KoinComponent {
             player.sendMessage("§7This will be displayed next to guild member names.")
         } else {
             player.sendMessage("§c❌ Failed to set guild tag. The tag may already be taken.")
+        }
+    }
+
+    @Subcommand("bannerman")
+    @CommandPermission("lumaguilds.guild.bannerman")
+    fun onBannerman(player: Player) {
+        val playerId = player.uniqueId
+
+        val guilds = guildService.getPlayerGuilds(playerId)
+        if (guilds.isEmpty()) {
+            player.sendMessage("§cYou are not in a guild.")
+            return
+        }
+        val guild = guilds.first()
+
+        if (!memberService.hasPermission(playerId, guild.id, RankPermission.MANAGE_BANNER)) {
+            player.sendMessage("§cYou don't have permission to toggle the bannerman.")
+            player.sendMessage("§7You need the MANAGE_BANNER permission.")
+            return
+        }
+
+        val current = guildService.getBannermanEnabled(guild.id)
+        val newState = !current
+        val success = guildService.setBannermanEnabled(guild.id, newState, playerId)
+        if (!success) {
+            player.sendMessage("§c❌ Failed to toggle bannerman.")
+            return
+        }
+
+        if (newState) {
+            bannermanListeners.onBannermanEnabled(guild.id)
+            player.sendMessage("§a✅ Bannerman enabled — guild members will wear the banner on their backs.")
+        } else {
+            bannermanListeners.onBannermanDisabled(guild.id)
+            player.sendMessage("§7Bannerman disabled.")
         }
     }
 

--- a/src/main/kotlin/net/lumalyte/lg/interaction/commands/GuildCommand.kt
+++ b/src/main/kotlin/net/lumalyte/lg/interaction/commands/GuildCommand.kt
@@ -1636,11 +1636,24 @@ class GuildCommand : BaseCommand(), KoinComponent {
             return
         }
 
+        // Persisted state is committed at this point — render-callback failures must not propagate
+        // and crash the command flow, otherwise the player sees an error for a toggle that did save.
+        try {
+            if (newState) {
+                bannermanListeners.onBannermanEnabled(guild.id)
+            } else {
+                bannermanListeners.onBannermanDisabled(guild.id)
+            }
+        } catch (e: Exception) {
+            org.bukkit.Bukkit.getLogger().warning(
+                "Bannerman render callback failed for guild ${guild.id} (newState=$newState): ${e.message}"
+            )
+            player.sendMessage("§eBannerman state was saved, but live refresh failed. Try relogging.")
+            return
+        }
         if (newState) {
-            bannermanListeners.onBannermanEnabled(guild.id)
             player.sendMessage("§a✅ Bannerman enabled — guild members will wear the banner on their backs.")
         } else {
-            bannermanListeners.onBannermanDisabled(guild.id)
             player.sendMessage("§7Bannerman disabled.")
         }
     }

--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -72,9 +72,13 @@ permissions:
       lumaguilds.guild.info: true
       lumaguilds.guild.history: true
       lumaguilds.guild.chat: true
+      lumaguilds.guild.bannerman: true
 
   lumaguilds.guild.chat:
     description: Toggle guild chat mode (messages go to guild only)
+    default: true
+  lumaguilds.guild.bannerman:
+    description: Toggle guild bannerman rendering (banner on members' backs)
     default: true
   lumaguilds.guild.create:
     description: Create new guilds

--- a/src/test/kotlin/net/lumalyte/lg/infrastructure/bukkit/bannerman/BannermanVisibilityTest.kt
+++ b/src/test/kotlin/net/lumalyte/lg/infrastructure/bukkit/bannerman/BannermanVisibilityTest.kt
@@ -1,0 +1,28 @@
+package net.lumalyte.lg.infrastructure.bukkit.bannerman
+
+import org.junit.jupiter.api.Assertions.assertFalse
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+
+class BannermanVisibilityTest {
+
+    @Test
+    fun `visible when player has no hide condition`() {
+        assertTrue(BannermanVisibility.shouldShow(hasElytra = false, hasInvisibility = false))
+    }
+
+    @Test
+    fun `hidden when elytra equipped`() {
+        assertFalse(BannermanVisibility.shouldShow(hasElytra = true, hasInvisibility = false))
+    }
+
+    @Test
+    fun `hidden when invisibility active`() {
+        assertFalse(BannermanVisibility.shouldShow(hasElytra = false, hasInvisibility = true))
+    }
+
+    @Test
+    fun `hidden when both conditions present`() {
+        assertFalse(BannermanVisibility.shouldShow(hasElytra = true, hasInvisibility = true))
+    }
+}

--- a/src/test/kotlin/net/lumalyte/lg/infrastructure/persistence/guilds/GuildRepositoryBannermanTest.kt
+++ b/src/test/kotlin/net/lumalyte/lg/infrastructure/persistence/guilds/GuildRepositoryBannermanTest.kt
@@ -12,6 +12,9 @@ import java.nio.file.Path
 import java.sql.Connection
 import java.sql.DriverManager
 import java.time.Instant
+import java.time.LocalDateTime
+import java.time.ZoneOffset
+import java.time.format.DateTimeFormatter
 import java.util.UUID
 
 /**
@@ -114,11 +117,11 @@ class GuildRepositoryBannermanTest {
     }
 
     @Test
-    fun `existing guilds without bannerman column should default to false`() {
-        // Given: A guild row without explicit bannerman value (simulating migration)
+    fun `guilds inserted without explicit bannerman_enabled get column default of false`() {
+        // The table has bannerman_enabled with DEFAULT 0; this test asserts the default actually
+        // applies when the column is omitted from INSERT (i.e. existing rows from before the v22
+        // migration backfill correctly).
         val guildId = UUID.randomUUID()
-
-        // Insert guild using SQL that mimics pre-migration data (defaults apply)
         connection.createStatement().use { stmt ->
             stmt.execute("""
                 INSERT INTO guilds (id, name, level, bank_balance, mode, created_at)
@@ -126,12 +129,71 @@ class GuildRepositoryBannermanTest {
             """.trimIndent())
         }
 
-        // When: Load guild from database
         val guild = loadGuild(guildId)
 
-        // Then: bannermanEnabled should have default value (false)
         assertNotNull(guild)
         assertFalse(guild!!.bannermanEnabled, "bannermanEnabled should default to false")
+    }
+
+    @Test
+    fun `loader treats missing bannerman_enabled column as false`() {
+        // Reproduces a partially-migrated DB (LFG cols present, bannerman col not yet added).
+        // The real GuildRepositorySQLite mapper wraps the column read in try/catch and falls back
+        // to false; this test verifies the same defensive behavior on a schema that genuinely
+        // lacks the column.
+        connection.createStatement().use { stmt -> stmt.execute("DROP TABLE guilds") }
+        createGuildsTableWithoutBannermanColumn()
+
+        val guildId = UUID.randomUUID()
+        connection.createStatement().use { stmt ->
+            stmt.execute("""
+                INSERT INTO guilds (id, name, level, bank_balance, mode, created_at)
+                VALUES ('$guildId', 'Pre-v22 Guild', 1, 0, 'hostile', datetime('now'))
+            """.trimIndent())
+        }
+
+        val guild = loadGuildDefensive(guildId)
+
+        assertNotNull(guild)
+        assertFalse(guild!!.bannermanEnabled)
+    }
+
+    private fun createGuildsTableWithoutBannermanColumn() {
+        connection.createStatement().use { stmt ->
+            stmt.execute("""
+                CREATE TABLE guilds (
+                    id TEXT PRIMARY KEY,
+                    name TEXT NOT NULL,
+                    level INTEGER NOT NULL DEFAULT 1,
+                    bank_balance INTEGER NOT NULL DEFAULT 0,
+                    mode TEXT NOT NULL DEFAULT 'hostile',
+                    created_at TEXT NOT NULL
+                )
+            """.trimIndent())
+        }
+    }
+
+    /** Mirrors the real repo's defensive-read of bannerman_enabled when the column may not exist. */
+    private fun loadGuildDefensive(guildId: UUID): Guild? {
+        connection.createStatement().use { stmt ->
+            stmt.executeQuery("SELECT * FROM guilds WHERE id = '$guildId'").use { rs ->
+                if (!rs.next()) return null
+                val bannermanEnabled = try {
+                    rs.getInt("bannerman_enabled") == 1
+                } catch (_: java.sql.SQLException) {
+                    false
+                }
+                return Guild(
+                    id = guildId,
+                    name = rs.getString("name"),
+                    level = rs.getInt("level"),
+                    bankBalance = rs.getInt("bank_balance"),
+                    mode = GuildMode.valueOf(rs.getString("mode").uppercase()),
+                    createdAt = parseSqlDateTime(rs.getString("created_at")),
+                    bannermanEnabled = bannermanEnabled
+                )
+            }
+        }
     }
 
     @Test
@@ -202,7 +264,8 @@ class GuildRepositoryBannermanTest {
             stmt.setInt(3, guild.level)
             stmt.setInt(4, guild.bankBalance)
             stmt.setString(5, guild.mode.name.lowercase())
-            stmt.setString(6, guild.createdAt.toString())
+            // Production writes "yyyy-MM-dd HH:mm:ss" via toSqlDateTime() — fixture must match.
+            stmt.setString(6, SQL_DATETIME.withZone(ZoneOffset.UTC).format(guild.createdAt))
             stmt.setInt(7, if (guild.bannermanEnabled) 1 else 0)
             stmt.executeUpdate()
         }
@@ -235,12 +298,10 @@ class GuildRepositoryBannermanTest {
                 val level = rs.getInt("level")
                 val bankBalance = rs.getInt("bank_balance")
                 val mode = GuildMode.valueOf(rs.getString("mode").uppercase())
-                val createdAtStr = rs.getString("created_at")
-                val createdAt = try {
-                    Instant.parse(createdAtStr)
-                } catch (e: Exception) {
-                    Instant.now()
-                }
+                // Production stores datetimes as "yyyy-MM-dd HH:mm:ss" (MariaDB-compatible),
+                // NOT ISO-8601. Parsing must match the real format — Instant.parse would
+                // crash here and the silent-catch fallback used to mask that.
+                val createdAt = parseSqlDateTime(rs.getString("created_at"))
                 val bannermanEnabled = rs.getInt("bannerman_enabled") == 1
 
                 return Guild(
@@ -254,5 +315,16 @@ class GuildRepositoryBannermanTest {
                 )
             }
         }
+    }
+
+    /**
+     * Parses the same datetime format the real GuildRepositorySQLite writes
+     * ("yyyy-MM-dd HH:mm:ss" in UTC, MariaDB-compatible). Fails fast on malformed input.
+     */
+    private fun parseSqlDateTime(s: String): Instant =
+        LocalDateTime.parse(s, SQL_DATETIME).toInstant(ZoneOffset.UTC)
+
+    companion object {
+        private val SQL_DATETIME: DateTimeFormatter = DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss")
     }
 }

--- a/src/test/kotlin/net/lumalyte/lg/infrastructure/persistence/guilds/GuildRepositoryBannermanTest.kt
+++ b/src/test/kotlin/net/lumalyte/lg/infrastructure/persistence/guilds/GuildRepositoryBannermanTest.kt
@@ -1,0 +1,258 @@
+package net.lumalyte.lg.infrastructure.persistence.guilds
+
+import net.lumalyte.lg.domain.entities.Guild
+import net.lumalyte.lg.domain.entities.GuildMode
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.Assertions.*
+import org.junit.jupiter.api.io.TempDir
+import java.io.File
+import java.nio.file.Path
+import java.sql.Connection
+import java.sql.DriverManager
+import java.time.Instant
+import java.util.UUID
+
+/**
+ * Tests for GuildRepository bannerman_enabled persistence functionality.
+ * These tests verify that bannerman_enabled is properly saved to and loaded from the database.
+ */
+class GuildRepositoryBannermanTest {
+
+    @TempDir
+    lateinit var tempDir: Path
+
+    private lateinit var sqliteFile: File
+    private lateinit var connection: Connection
+
+    @BeforeEach
+    fun setUp() {
+        // Create temporary SQLite database
+        sqliteFile = tempDir.resolve("test.db").toFile()
+        connection = DriverManager.getConnection("jdbc:sqlite:${sqliteFile.absolutePath}")
+        connection.autoCommit = true
+
+        // Create guilds table with all columns including bannerman
+        createGuildsTable()
+    }
+
+    @AfterEach
+    fun tearDown() {
+        connection.close()
+    }
+
+    @Test
+    fun `new guild should have bannermanEnabled false after round-trip`() {
+        // Given: A new guild with default bannermanEnabled
+        val guildId = UUID.randomUUID()
+        val guild = Guild(
+            id = guildId,
+            name = "New Guild",
+            createdAt = Instant.now()
+        )
+
+        // When: Save guild to database and reload
+        insertGuild(guild)
+        val loaded = loadGuild(guildId)
+
+        // Then: bannermanEnabled should be false
+        assertNotNull(loaded)
+        assertFalse(loaded!!.bannermanEnabled, "bannermanEnabled should default to false")
+    }
+
+    @Test
+    fun `updating guild with bannermanEnabled true should persist correctly`() {
+        // Given: An existing guild with bannermanEnabled false
+        val guildId = UUID.randomUUID()
+        insertGuildDirectly(guildId, "Test Guild", bannermanEnabled = 0)
+
+        // When: Update guild to enable bannerman
+        updateGuildBannerman(guildId, bannermanEnabled = true)
+
+        // Then: Load and verify bannermanEnabled is true
+        val loaded = loadGuild(guildId)
+        assertNotNull(loaded)
+        assertTrue(loaded!!.bannermanEnabled, "bannermanEnabled should be true after update")
+    }
+
+    @Test
+    fun `saving Guild with bannermanEnabled true should persist correctly`() {
+        // Given: A guild with bannerman enabled
+        val guildId = UUID.randomUUID()
+        val guild = Guild(
+            id = guildId,
+            name = "Bannerman Guild",
+            createdAt = Instant.now(),
+            bannermanEnabled = true
+        )
+
+        // When: Save guild to database
+        insertGuild(guild)
+
+        // Then: bannerman_enabled field should be persisted correctly
+        connection.createStatement().use { stmt ->
+            stmt.executeQuery("SELECT bannerman_enabled FROM guilds WHERE id = '$guildId'").use { rs ->
+                assertTrue(rs.next(), "Guild should exist in database")
+                assertEquals(1, rs.getInt("bannerman_enabled"), "bannerman_enabled should be 1 (true)")
+            }
+        }
+    }
+
+    @Test
+    fun `loading Guild with bannermanEnabled false should return correct value`() {
+        // Given: A guild with bannerman disabled in database
+        val guildId = UUID.randomUUID()
+        insertGuildDirectly(guildId, "Disabled Guild", bannermanEnabled = 0)
+
+        // When: Load guild from database
+        val guild = loadGuild(guildId)
+
+        // Then: bannermanEnabled should be false
+        assertNotNull(guild)
+        assertFalse(guild!!.bannermanEnabled, "bannermanEnabled should be false")
+    }
+
+    @Test
+    fun `existing guilds without bannerman column should default to false`() {
+        // Given: A guild row without explicit bannerman value (simulating migration)
+        val guildId = UUID.randomUUID()
+
+        // Insert guild using SQL that mimics pre-migration data (defaults apply)
+        connection.createStatement().use { stmt ->
+            stmt.execute("""
+                INSERT INTO guilds (id, name, level, bank_balance, mode, created_at)
+                VALUES ('$guildId', 'Legacy Guild', 1, 0, 'hostile', datetime('now'))
+            """.trimIndent())
+        }
+
+        // When: Load guild from database
+        val guild = loadGuild(guildId)
+
+        // Then: bannermanEnabled should have default value (false)
+        assertNotNull(guild)
+        assertFalse(guild!!.bannermanEnabled, "bannermanEnabled should default to false")
+    }
+
+    @Test
+    fun `toggling bannermanEnabled back to false should persist correctly`() {
+        // Given: A guild with bannerman enabled
+        val guildId = UUID.randomUUID()
+        insertGuildDirectly(guildId, "Toggle Guild", bannermanEnabled = 1)
+
+        // When: Update to disable bannerman
+        updateGuildBannerman(guildId, bannermanEnabled = false)
+
+        // Then: Load and verify bannermanEnabled is false
+        val loaded = loadGuild(guildId)
+        assertNotNull(loaded)
+        assertFalse(loaded!!.bannermanEnabled, "bannermanEnabled should be false after toggle")
+    }
+
+    // Helper methods
+
+    private fun createGuildsTable() {
+        connection.createStatement().use { stmt ->
+            stmt.execute("""
+                CREATE TABLE guilds (
+                    id TEXT PRIMARY KEY,
+                    name TEXT NOT NULL,
+                    banner TEXT,
+                    emoji TEXT,
+                    tag TEXT,
+                    home_world TEXT,
+                    home_x INTEGER,
+                    home_y INTEGER,
+                    home_z INTEGER,
+                    level INTEGER NOT NULL DEFAULT 1,
+                    bank_balance INTEGER NOT NULL DEFAULT 0,
+                    mode TEXT NOT NULL DEFAULT 'hostile',
+                    mode_changed_at TEXT,
+                    created_at TEXT NOT NULL,
+                    vault_status TEXT DEFAULT 'NEVER_PLACED',
+                    vault_chest_world TEXT,
+                    vault_chest_x INTEGER,
+                    vault_chest_y INTEGER,
+                    vault_chest_z INTEGER,
+                    is_open INTEGER DEFAULT 0,
+                    join_fee_enabled INTEGER DEFAULT 0,
+                    join_fee_amount INTEGER DEFAULT 0,
+                    tracking_enabled INTEGER DEFAULT 1,
+                    bank_frozen INTEGER DEFAULT 0,
+                    bannerman_enabled INTEGER DEFAULT 0,
+                    ally_home_world TEXT,
+                    ally_home_x INTEGER,
+                    ally_home_y INTEGER,
+                    ally_home_z INTEGER,
+                    ally_home_allowed_guilds TEXT
+                )
+            """.trimIndent())
+        }
+    }
+
+    private fun insertGuild(guild: Guild) {
+        val sql = """
+            INSERT INTO guilds (id, name, level, bank_balance, mode, created_at, bannerman_enabled)
+            VALUES (?, ?, ?, ?, ?, ?, ?)
+        """.trimIndent()
+
+        connection.prepareStatement(sql).use { stmt ->
+            stmt.setString(1, guild.id.toString())
+            stmt.setString(2, guild.name)
+            stmt.setInt(3, guild.level)
+            stmt.setInt(4, guild.bankBalance)
+            stmt.setString(5, guild.mode.name.lowercase())
+            stmt.setString(6, guild.createdAt.toString())
+            stmt.setInt(7, if (guild.bannermanEnabled) 1 else 0)
+            stmt.executeUpdate()
+        }
+    }
+
+    private fun insertGuildDirectly(guildId: UUID, name: String, bannermanEnabled: Int) {
+        connection.createStatement().use { stmt ->
+            stmt.execute("""
+                INSERT INTO guilds (id, name, level, bank_balance, mode, created_at, bannerman_enabled)
+                VALUES ('$guildId', '$name', 1, 0, 'hostile', datetime('now'), $bannermanEnabled)
+            """.trimIndent())
+        }
+    }
+
+    private fun updateGuildBannerman(guildId: UUID, bannermanEnabled: Boolean) {
+        connection.createStatement().use { stmt ->
+            stmt.execute("""
+                UPDATE guilds SET bannerman_enabled = ${if (bannermanEnabled) 1 else 0}
+                WHERE id = '$guildId'
+            """.trimIndent())
+        }
+    }
+
+    private fun loadGuild(guildId: UUID): Guild? {
+        connection.createStatement().use { stmt ->
+            stmt.executeQuery("SELECT * FROM guilds WHERE id = '$guildId'").use { rs ->
+                if (!rs.next()) return null
+
+                val name = rs.getString("name")
+                val level = rs.getInt("level")
+                val bankBalance = rs.getInt("bank_balance")
+                val mode = GuildMode.valueOf(rs.getString("mode").uppercase())
+                val createdAtStr = rs.getString("created_at")
+                val createdAt = try {
+                    Instant.parse(createdAtStr)
+                } catch (e: Exception) {
+                    Instant.now()
+                }
+                val bannermanEnabled = rs.getInt("bannerman_enabled") == 1
+
+                return Guild(
+                    id = guildId,
+                    name = name,
+                    level = level,
+                    bankBalance = bankBalance,
+                    mode = mode,
+                    createdAt = createdAt,
+                    bannermanEnabled = bannermanEnabled
+                )
+            }
+        }
+    }
+}

--- a/src/test/kotlin/net/lumalyte/lg/infrastructure/persistence/migrations/BannermanMigrationTest.kt
+++ b/src/test/kotlin/net/lumalyte/lg/infrastructure/persistence/migrations/BannermanMigrationTest.kt
@@ -1,0 +1,213 @@
+package net.lumalyte.lg.infrastructure.persistence.migrations
+
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.Assertions.*
+import org.junit.jupiter.api.io.TempDir
+import java.io.File
+import java.nio.file.Path
+import java.sql.Connection
+import java.sql.DriverManager
+
+/**
+ * Tests for database migration v22 which adds bannerman_enabled column to guilds table.
+ */
+class BannermanMigrationTest {
+
+    @TempDir
+    lateinit var tempDir: Path
+
+    private lateinit var sqliteFile: File
+    private lateinit var connection: Connection
+
+    @BeforeEach
+    fun setUp() {
+        // Create temporary SQLite database
+        sqliteFile = tempDir.resolve("test.db").toFile()
+        connection = DriverManager.getConnection("jdbc:sqlite:${sqliteFile.absolutePath}")
+        connection.autoCommit = true
+    }
+
+    @AfterEach
+    fun tearDown() {
+        connection.close()
+    }
+
+    @Test
+    fun `v22 adds bannerman_enabled column to guilds table`() {
+        // Given: Create guilds table without bannerman_enabled (v21 state)
+        createGuildsTableV21()
+
+        // When: Run migration to v22
+        migrateToV22()
+
+        // Then: bannerman_enabled column should exist
+        assertTrue(columnExists("guilds", "bannerman_enabled"),
+            "bannerman_enabled column should exist after migration")
+    }
+
+    @Test
+    fun `bannerman_enabled defaults to 0 (false)`() {
+        // Given: Create guilds table and run migration
+        createGuildsTableV21()
+        migrateToV22()
+
+        // When: Insert a new guild without specifying bannerman_enabled
+        connection.createStatement().use { stmt ->
+            stmt.execute("""
+                INSERT INTO guilds (id, name, created_at, level, bank_balance, mode)
+                VALUES ('g1', 'G', datetime('now'), 1, 0, 'Hostile')
+            """.trimIndent())
+        }
+
+        // Then: bannerman_enabled should default to 0
+        connection.createStatement().use { stmt ->
+            stmt.executeQuery("SELECT bannerman_enabled FROM guilds WHERE id='g1'").use { rs ->
+                assertTrue(rs.next())
+                assertEquals(0, rs.getInt("bannerman_enabled"),
+                    "bannerman_enabled should default to 0 (false)")
+            }
+        }
+    }
+
+    @Test
+    fun `migration preserves existing guild rows`() {
+        // Given: Create guilds table with existing data
+        createGuildsTableV21()
+
+        connection.createStatement().use { stmt ->
+            stmt.execute("""
+                INSERT INTO guilds (id, name, created_at, level, bank_balance, mode)
+                VALUES ('keep', 'KeepMe', datetime('now'), 3, 50, 'Peaceful')
+            """.trimIndent())
+        }
+
+        // When: Run migration to v22
+        migrateToV22()
+
+        // Then: Existing data should be preserved
+        connection.createStatement().use { stmt ->
+            stmt.executeQuery("SELECT name, level, bannerman_enabled FROM guilds WHERE id='keep'").use { rs ->
+                assertTrue(rs.next())
+                assertEquals("KeepMe", rs.getString("name"))
+                assertEquals(3, rs.getInt("level"))
+                assertEquals(0, rs.getInt("bannerman_enabled"))
+            }
+        }
+    }
+
+    @Test
+    fun `migration is idempotent`() {
+        // Given: Create guilds table
+        createGuildsTableV21()
+
+        // When: Run migration twice
+        migrateToV22()
+        migrateToV22() // Second run should not fail
+
+        // Then: Column should still exist
+        assertTrue(columnExists("guilds", "bannerman_enabled"))
+    }
+
+    @Test
+    fun `bannerman_enabled should accept integer values 0 and 1`() {
+        // Given: Migrated database
+        createGuildsTableV21()
+        migrateToV22()
+
+        // When: Insert guilds with bannerman_enabled = 0 and 1
+        connection.createStatement().use { stmt ->
+            stmt.execute("""
+                INSERT INTO guilds (id, name, created_at, level, bank_balance, mode, bannerman_enabled)
+                VALUES ('guild-disabled', 'Disabled', datetime('now'), 1, 0, 'Hostile', 0)
+            """.trimIndent())
+
+            stmt.execute("""
+                INSERT INTO guilds (id, name, created_at, level, bank_balance, mode, bannerman_enabled)
+                VALUES ('guild-enabled', 'Enabled', datetime('now'), 1, 0, 'Hostile', 1)
+            """.trimIndent())
+        }
+
+        // Then: Both values should be stored correctly
+        connection.createStatement().use { stmt ->
+            stmt.executeQuery("SELECT bannerman_enabled FROM guilds WHERE id = 'guild-disabled'").use { rs ->
+                assertTrue(rs.next())
+                assertEquals(0, rs.getInt("bannerman_enabled"))
+            }
+
+            stmt.executeQuery("SELECT bannerman_enabled FROM guilds WHERE id = 'guild-enabled'").use { rs ->
+                assertTrue(rs.next())
+                assertEquals(1, rs.getInt("bannerman_enabled"))
+            }
+        }
+    }
+
+    // Helper methods
+
+    private fun createGuildsTableV21() {
+        // Create guilds table as it exists in v21 (with all columns up to v21, but without bannerman_enabled)
+        connection.createStatement().use { stmt ->
+            stmt.execute("""
+                CREATE TABLE guilds (
+                    id TEXT PRIMARY KEY,
+                    name TEXT NOT NULL,
+                    banner TEXT,
+                    emoji TEXT,
+                    tag TEXT,
+                    home_world TEXT,
+                    home_x INTEGER,
+                    home_y INTEGER,
+                    home_z INTEGER,
+                    level INTEGER NOT NULL DEFAULT 1,
+                    bank_balance INTEGER NOT NULL DEFAULT 0,
+                    mode TEXT NOT NULL DEFAULT 'Hostile',
+                    mode_changed_at TEXT,
+                    created_at TEXT NOT NULL,
+                    vault_status TEXT DEFAULT 'NEVER_PLACED',
+                    vault_chest_world TEXT,
+                    vault_chest_x INTEGER,
+                    vault_chest_y INTEGER,
+                    vault_chest_z INTEGER,
+                    is_open INTEGER DEFAULT 0,
+                    join_fee_enabled INTEGER DEFAULT 0,
+                    join_fee_amount INTEGER DEFAULT 0,
+                    ally_home_allowed_guilds TEXT
+                )
+            """.trimIndent())
+        }
+    }
+
+    private fun migrateToV22() {
+        // Replicate the migration logic from SQLiteMigrations.migrateToVersion22()
+        val sqlCommands = mutableListOf<String>()
+
+        // Add bannerman_enabled column (if not exists)
+        if (!columnExists("guilds", "bannerman_enabled")) {
+            sqlCommands.add("ALTER TABLE guilds ADD COLUMN bannerman_enabled INTEGER DEFAULT 0;")
+        }
+
+        sqlCommands.forEach { sql ->
+            connection.createStatement().use { stmt ->
+                stmt.execute(sql)
+            }
+        }
+    }
+
+    private fun columnExists(tableName: String, columnName: String): Boolean {
+        return try {
+            connection.createStatement().use { stmt ->
+                stmt.executeQuery("PRAGMA table_info($tableName)").use { rs ->
+                    while (rs.next()) {
+                        if (rs.getString("name") == columnName) {
+                            return true
+                        }
+                    }
+                    false
+                }
+            }
+        } catch (e: Exception) {
+            false
+        }
+    }
+}

--- a/src/test/kotlin/net/lumalyte/lg/infrastructure/persistence/migrations/BannermanMigrationTest.kt
+++ b/src/test/kotlin/net/lumalyte/lg/infrastructure/persistence/migrations/BannermanMigrationTest.kt
@@ -194,20 +194,21 @@ class BannermanMigrationTest {
         }
     }
 
+    /**
+     * Fails fast on metadata query errors so genuine DB problems don't masquerade as a missing
+     * column. Test-helper only — production code in GuildRepositorySQLite has its own variant
+     * that logs and returns false because runtime persistence should be resilient.
+     */
     private fun columnExists(tableName: String, columnName: String): Boolean {
-        return try {
-            connection.createStatement().use { stmt ->
-                stmt.executeQuery("PRAGMA table_info($tableName)").use { rs ->
-                    while (rs.next()) {
-                        if (rs.getString("name") == columnName) {
-                            return true
-                        }
+        connection.createStatement().use { stmt ->
+            stmt.executeQuery("PRAGMA table_info($tableName)").use { rs ->
+                while (rs.next()) {
+                    if (rs.getString("name") == columnName) {
+                        return true
                     }
-                    false
                 }
+                return false
             }
-        } catch (e: Exception) {
-            false
         }
     }
 }

--- a/src/test/kotlin/net/lumalyte/lg/infrastructure/services/GuildServiceBannermanTest.kt
+++ b/src/test/kotlin/net/lumalyte/lg/infrastructure/services/GuildServiceBannermanTest.kt
@@ -1,0 +1,215 @@
+package net.lumalyte.lg.infrastructure.services
+
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.verify
+import net.lumalyte.lg.application.persistence.GuildRepository
+import net.lumalyte.lg.application.persistence.MemberRepository
+import net.lumalyte.lg.application.persistence.MembershipHistoryRepository
+import net.lumalyte.lg.application.persistence.RankRepository
+import net.lumalyte.lg.application.persistence.RelationRepository
+import net.lumalyte.lg.application.services.MemberService
+import net.lumalyte.lg.application.services.RankService
+import net.lumalyte.lg.application.services.GuildVaultService
+import net.lumalyte.lg.domain.entities.Guild
+import net.lumalyte.lg.domain.entities.Member
+import net.lumalyte.lg.domain.entities.Rank
+import net.lumalyte.lg.domain.entities.RankPermission
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import java.time.Instant
+import java.util.UUID
+import kotlin.test.assertTrue
+import kotlin.test.assertFalse
+import kotlin.test.assertNotNull
+import kotlin.test.assertNull
+
+/**
+ * Tests for GuildService bannerman management methods.
+ */
+class GuildServiceBannermanTest {
+
+    private lateinit var guildRepository: GuildRepository
+    private lateinit var rankRepository: RankRepository
+    private lateinit var memberRepository: MemberRepository
+    private lateinit var rankService: RankService
+    private lateinit var memberService: MemberService
+    private lateinit var nexoEmojiService: NexoEmojiService
+    private lateinit var vaultService: GuildVaultService
+    private lateinit var hologramService: VaultHologramService
+    private lateinit var relationRepository: RelationRepository
+    private lateinit var historyRepository: MembershipHistoryRepository
+
+    private lateinit var guildService: GuildServiceBukkit
+
+    private lateinit var testGuild: Guild
+    private lateinit var testGuildId: UUID
+    private lateinit var ownerId: UUID
+    private lateinit var memberId: UUID
+    private lateinit var ownerRank: Rank
+    private lateinit var memberRank: Rank
+
+    @BeforeEach
+    fun setUp() {
+        // Initialize mocks
+        guildRepository = mockk(relaxed = true)
+        rankRepository = mockk(relaxed = true)
+        memberRepository = mockk(relaxed = true)
+        rankService = mockk(relaxed = true)
+        memberService = mockk(relaxed = true)
+        nexoEmojiService = mockk(relaxed = true)
+        vaultService = mockk(relaxed = true)
+        hologramService = mockk(relaxed = true)
+        relationRepository = mockk(relaxed = true)
+        historyRepository = mockk(relaxed = true)
+
+        // Create service
+        guildService = GuildServiceBukkit(
+            guildRepository = guildRepository,
+            rankRepository = rankRepository,
+            memberRepository = memberRepository,
+            rankService = rankService,
+            memberService = memberService,
+            nexoEmojiService = nexoEmojiService,
+            vaultService = vaultService,
+            hologramService = hologramService,
+            relationRepository = relationRepository,
+            historyRepository = historyRepository
+        )
+
+        // Set up test data
+        testGuildId = UUID.randomUUID()
+        ownerId = UUID.randomUUID()
+        memberId = UUID.randomUUID()
+
+        testGuild = Guild(
+            id = testGuildId,
+            name = "Test Guild",
+            createdAt = Instant.now(),
+            bannermanEnabled = false
+        )
+
+        // Owner rank with MANAGE_BANNER permission
+        ownerRank = Rank(
+            id = UUID.randomUUID(),
+            guildId = testGuildId,
+            name = "Owner",
+            priority = 100,
+            permissions = setOf(RankPermission.MANAGE_BANNER)
+        )
+
+        // Member rank without MANAGE_BANNER permission
+        memberRank = Rank(
+            id = UUID.randomUUID(),
+            guildId = testGuildId,
+            name = "Member",
+            priority = 0,
+            permissions = emptySet()
+        )
+    }
+
+    // ===== setBannermanEnabled Tests =====
+
+    @Test
+    fun `setBannermanEnabled should enable bannerman when actor has MANAGE_BANNER permission`() {
+        // Given: Owner with MANAGE_BANNER permission
+        val ownerMember = Member(ownerId, testGuildId, ownerRank.id, Instant.now())
+        every { guildRepository.getById(testGuildId) } returns testGuild
+        every { memberRepository.getByPlayerAndGuild(ownerId, testGuildId) } returns ownerMember
+        every { rankRepository.getById(ownerRank.id) } returns ownerRank
+        every { guildRepository.update(any()) } returns true
+
+        // When: Enable bannerman
+        val result = guildService.setBannermanEnabled(testGuildId, true, ownerId)
+
+        // Then: Should succeed
+        assertTrue(result, "setBannermanEnabled should return true")
+        verify { guildRepository.update(match { it.bannermanEnabled }) }
+    }
+
+    @Test
+    fun `setBannermanEnabled should disable bannerman when actor has MANAGE_BANNER permission`() {
+        // Given: Guild with bannerman enabled
+        val guildWithBannerman = testGuild.copy(bannermanEnabled = true)
+        val ownerMember = Member(ownerId, testGuildId, ownerRank.id, Instant.now())
+        every { guildRepository.getById(testGuildId) } returns guildWithBannerman
+        every { memberRepository.getByPlayerAndGuild(ownerId, testGuildId) } returns ownerMember
+        every { rankRepository.getById(ownerRank.id) } returns ownerRank
+        every { guildRepository.update(any()) } returns true
+
+        // When: Disable bannerman
+        val result = guildService.setBannermanEnabled(testGuildId, false, ownerId)
+
+        // Then: Should succeed
+        assertTrue(result, "setBannermanEnabled should return true")
+        verify { guildRepository.update(match { !it.bannermanEnabled }) }
+    }
+
+    @Test
+    fun `setBannermanEnabled should fail when actor lacks MANAGE_BANNER permission`() {
+        // Given: Member without MANAGE_BANNER permission
+        val memberMember = Member(memberId, testGuildId, memberRank.id, Instant.now())
+        every { guildRepository.getById(testGuildId) } returns testGuild
+        every { memberRepository.getByPlayerAndGuild(memberId, testGuildId) } returns memberMember
+        every { rankRepository.getById(memberRank.id) } returns memberRank
+
+        // When: Try to enable bannerman
+        val result = guildService.setBannermanEnabled(testGuildId, true, memberId)
+
+        // Then: Should fail
+        assertFalse(result, "setBannermanEnabled should return false without permission")
+        verify(exactly = 0) { guildRepository.update(any()) }
+    }
+
+    @Test
+    fun `setBannermanEnabled should fail when guild does not exist`() {
+        // Given: Non-existent guild
+        every { guildRepository.getById(testGuildId) } returns null
+
+        // When: Try to enable bannerman
+        val result = guildService.setBannermanEnabled(testGuildId, true, ownerId)
+
+        // Then: Should fail
+        assertFalse(result, "setBannermanEnabled should return false for non-existent guild")
+        verify(exactly = 0) { guildRepository.update(any()) }
+    }
+
+    // ===== getBannermanEnabled Tests =====
+
+    @Test
+    fun `getBannermanEnabled should return true when enabled`() {
+        // Given: Guild with bannerman enabled
+        val guildWithBannerman = testGuild.copy(bannermanEnabled = true)
+        every { guildRepository.getById(testGuildId) } returns guildWithBannerman
+
+        // When: Get bannerman enabled status
+        val result = guildService.getBannermanEnabled(testGuildId)
+
+        // Then: Should return true
+        assertTrue(result, "getBannermanEnabled should return true")
+    }
+
+    @Test
+    fun `getBannermanEnabled should return false when disabled`() {
+        // Given: Guild with bannerman disabled
+        every { guildRepository.getById(testGuildId) } returns testGuild
+
+        // When: Get bannerman enabled status
+        val result = guildService.getBannermanEnabled(testGuildId)
+
+        // Then: Should return false
+        assertFalse(result, "getBannermanEnabled should return false")
+    }
+
+    @Test
+    fun `getBannermanEnabled should return false for non-existent guild`() {
+        // Given: Non-existent guild
+        every { guildRepository.getById(testGuildId) } returns null
+
+        // When: Get bannerman enabled status
+        val result = guildService.getBannermanEnabled(testGuildId)
+
+        // Then: Should return false
+        assertFalse(result, "getBannermanEnabled should return false for non-existent guild")
+    }
+}


### PR DESCRIPTION
## Summary

Adds a server-side "bannerman" feature: every online member of a guild renders the guild's banner on their upper back (pillager-style), gated on `RankPermission.MANAGE_BANNER` and toggled via `/g bannerman`.

- Renders via Paper `ItemDisplay` parented to the player — no resource pack required
- Hidden while the player has elytra equipped or `INVISIBILITY` active
- Live-updates when the guild banner is edited; cleaned up on disband
- PDC-tagged displays + startup sweep recover orphans from crashes
- SQLite v22 + MariaDB v22 migrations add `bannerman_enabled` column

13 commits, 19 files, +1133 LoC. Architecture follows existing SPEAR layering (domain ← application ← infrastructure).

## Test plan

- [ ] Officer (`MANAGE_BANNER`) runs `/g bannerman` → confirmation message, banner appears on back of all online members
- [ ] Non-officer runs `/g bannerman` → no-permission message, no state change
- [ ] Walk / sprint / jump / swim — banner follows smoothly
- [ ] Equip elytra → banner hides; unequip → banner returns
- [ ] Drink invisibility potion → banner hides; effect ends → banner returns
- [ ] Edit guild banner via menu → back banner updates without flicker
- [ ] `/kill` → banner despawns; respawn → banner returns
- [ ] Switch worlds via portal → banner follows
- [ ] Disband guild → all members' banners despawn immediately
- [ ] Crash the server → restart → no orphan `item_display` entities (verify with `/data get entity @e[type=item_display,limit=1]`)
- [ ] Toggle off → banners despawn for all online members

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

**New Features**
- Guild banners now display on guild members' backs during gameplay
- Guild leaders can toggle bannerman rendering per guild using the new `/guild bannerman` command
- Requires `MANAGE_BANNER` permission to enable or disable
- Banners automatically hide when guild members use elytra or have active invisibility effects applied
- Bannerman settings persist across server restarts

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/BadgersMC/LumaGuilds/pull/48?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->