### PR TITLE
feat(guild): bank baltop, ally-home fixes, relation request/cleanup improvements

### DIFF
--- a/src/main/kotlin/net/lumalyte/lg/LumaGuilds.kt
+++ b/src/main/kotlin/net/lumalyte/lg/LumaGuilds.kt
@@ -150,6 +150,9 @@ class LumaGuilds : JavaPlugin() {
         // Initialize experience transaction cleanup scheduler
         initExperienceTransactionCleanupScheduler()
 
+        // Initialize relation maintenance scheduler (truce expiry + stale-request cleanup)
+        initRelationMaintenanceScheduler()
+
         // Start Web API (read-only JSON endpoint for the website)
         try {
             get().get<net.lumalyte.lg.infrastructure.web.WebApiServer>().start()
@@ -700,8 +703,8 @@ class LumaGuilds : JavaPlugin() {
         }
 
         // Ally guilds whose ally-home the executing player can teleport to.
-        // Filters: target must be an active ALLY of player's guild, have ally-home set,
-        // and pass canUseAllyHome (rank perm + inbound whitelist).
+        // Includes the player's OWN guild (gated by canUseOwnAllyHome) plus every active ALLY
+        // that has an ally-home set and passes canUseAllyHome (rank perm + inbound whitelist).
         commandManager.commandCompletions.registerAsyncCompletion("allyguilds") { context ->
             val player = context.player ?: return@registerAsyncCompletion emptyList()
             val guildService = get().get<net.lumalyte.lg.application.services.GuildService>()
@@ -709,17 +712,22 @@ class LumaGuilds : JavaPlugin() {
             val guilds = guildService.getPlayerGuilds(player.uniqueId)
             if (guilds.isEmpty()) return@registerAsyncCompletion emptyList()
             val sourceGuild = guilds.first()
+            val results = mutableListOf<String>()
+            // Own guild's ally-home, when set and the player's rank may use it.
+            if (sourceGuild.allyHome != null &&
+                guildService.canUseOwnAllyHome(player.uniqueId, sourceGuild.id)) {
+                results.add(sourceGuild.name)
+            }
             relationService
                 .getGuildRelationsByType(sourceGuild.id, net.lumalyte.lg.domain.entities.RelationType.ALLY)
-                .mapNotNull { rel ->
+                .mapNotNullTo(results) { rel ->
                     val otherId = rel.getOtherGuild(sourceGuild.id)
-                    val other = guildService.getGuild(otherId) ?: return@mapNotNull null
-                    if (other.allyHome == null) return@mapNotNull null
-                    if (!guildService.canUseAllyHome(player.uniqueId, sourceGuild.id, other.id)) return@mapNotNull null
+                    val other = guildService.getGuild(otherId) ?: return@mapNotNullTo null
+                    if (other.allyHome == null) return@mapNotNullTo null
+                    if (!guildService.canUseAllyHome(player.uniqueId, sourceGuild.id, other.id)) return@mapNotNullTo null
                     other.name
                 }
-                .distinct()
-                .sorted()
+            results.distinct().sorted()
         }
 
         commandManager.commandCompletions.registerAsyncCompletion("guildhomes") { context ->
@@ -972,6 +980,38 @@ class LumaGuilds : JavaPlugin() {
         } catch (e: Exception) {
             // Broad exception handling acceptable - scheduler failure shouldn't prevent plugin load
             logColored("❌ Failed to initialize experience transaction cleanup scheduler: ${e.message}")
+            e.printStackTrace()
+        }
+    }
+
+    /**
+     * Initializes the periodic relation maintenance task.
+     *
+     * Runs on the main thread (the relation service fires Bukkit events on truce expiry, which
+     * must not happen off-thread) every 5 minutes after a 1-minute startup delay. It expires due
+     * truces (reverting them to enemy) and clears stale/orphaned relation rows so they can no
+     * longer block new ally/truce requests.
+     */
+    private fun initRelationMaintenanceScheduler() {
+        try {
+            val relationService = get().get<net.lumalyte.lg.application.services.RelationService>()
+            val intervalTicks = 20L * 60L * 5L // every 5 minutes
+            val initialDelayTicks = 20L * 60L  // first run after 1 minute
+            server.scheduler.runTaskTimer(this, Runnable {
+                try {
+                    val expired = relationService.processExpiredRelations()
+                    val cleaned = relationService.cleanupStaleRelations()
+                    if (expired > 0 || cleaned > 0) {
+                        logger.info("Relation maintenance: expired=$expired, cleaned=$cleaned")
+                    }
+                } catch (e: Exception) {
+                    logger.warning("Relation maintenance run failed: ${e.message}")
+                }
+            }, initialDelayTicks, intervalTicks)
+            logColored("✓ Relation maintenance scheduler started")
+        } catch (e: Exception) {
+            // Broad exception handling acceptable - scheduler failure shouldn't prevent plugin load
+            logColored("❌ Failed to initialize relation maintenance scheduler: ${e.message}")
             e.printStackTrace()
         }
     }

--- a/src/main/kotlin/net/lumalyte/lg/LumaGuilds.kt
+++ b/src/main/kotlin/net/lumalyte/lg/LumaGuilds.kt
@@ -987,27 +987,44 @@ class LumaGuilds : JavaPlugin() {
     /**
      * Initializes the periodic relation maintenance task.
      *
-     * Runs on the main thread (the relation service fires Bukkit events on truce expiry, which
-     * must not happen off-thread) every 5 minutes after a 1-minute startup delay. It expires due
-     * truces (reverting them to enemy) and clears stale/orphaned relation rows so they can no
-     * longer block new ally/truce requests.
+     * Split into two scheduled tasks so we don't park the main thread on DB I/O every 5 minutes:
+     *  - cleanupStaleRelations runs ASYNC. It only does DB reads/writes, never fires Bukkit events.
+     *  - processExpiredRelations runs SYNC. It fires GuildRelationChangeEvent for each expired
+     *    truce, which is not safe to dispatch from an async thread (listeners assume main-thread
+     *    access to Bukkit APIs).
+     *
+     * Both run every 5 minutes after a 1-minute startup delay.
      */
     private fun initRelationMaintenanceScheduler() {
         try {
             val relationService = get().get<net.lumalyte.lg.application.services.RelationService>()
             val intervalTicks = 20L * 60L * 5L // every 5 minutes
             val initialDelayTicks = 20L * 60L  // first run after 1 minute
+
+            // Async pass: pure DB maintenance.
+            server.scheduler.runTaskTimerAsynchronously(this, Runnable {
+                try {
+                    val cleaned = relationService.cleanupStaleRelations()
+                    if (cleaned > 0) {
+                        logger.info("Relation maintenance (async): cleaned=$cleaned")
+                    }
+                } catch (e: Exception) {
+                    logger.warning("Relation cleanup run failed: ${e.message}")
+                }
+            }, initialDelayTicks, intervalTicks)
+
+            // Sync pass: fires Bukkit events on truce expiry, must stay on the main thread.
             server.scheduler.runTaskTimer(this, Runnable {
                 try {
                     val expired = relationService.processExpiredRelations()
-                    val cleaned = relationService.cleanupStaleRelations()
-                    if (expired > 0 || cleaned > 0) {
-                        logger.info("Relation maintenance: expired=$expired, cleaned=$cleaned")
+                    if (expired > 0) {
+                        logger.info("Relation maintenance (sync): expired=$expired")
                     }
                 } catch (e: Exception) {
-                    logger.warning("Relation maintenance run failed: ${e.message}")
+                    logger.warning("Relation expiry run failed: ${e.message}")
                 }
             }, initialDelayTicks, intervalTicks)
+
             logColored("✓ Relation maintenance scheduler started")
         } catch (e: Exception) {
             // Broad exception handling acceptable - scheduler failure shouldn't prevent plugin load

--- a/src/main/kotlin/net/lumalyte/lg/application/persistence/BankRepository.kt
+++ b/src/main/kotlin/net/lumalyte/lg/application/persistence/BankRepository.kt
@@ -35,6 +35,16 @@ interface BankRepository {
     fun getGuildBalance(guildId: UUID): Int
 
     /**
+     * Gets the highest-balance guilds, ranked by bank balance descending.
+     * Backed by the in-memory balance cache, so it performs no database query and scales to
+     * large guild counts. Only guilds that have had at least one transaction are included.
+     *
+     * @param limit The maximum number of guilds to return.
+     * @return A list of (guildId, balance) pairs ordered by balance descending.
+     */
+    fun getTopBalances(limit: Int): List<Pair<UUID, Int>>
+
+    /**
      * Gets the total amount deposited by a player to a guild.
      *
      * @param playerId The ID of the player.

--- a/src/main/kotlin/net/lumalyte/lg/application/services/BankService.kt
+++ b/src/main/kotlin/net/lumalyte/lg/application/services/BankService.kt
@@ -41,6 +41,16 @@ interface BankService {
     fun getBalance(guildId: UUID): Int
 
     /**
+     * Gets the top guilds ranked by bank balance (descending). Results are cached briefly and the
+     * cache is invalidated automatically whenever a balance changes (deposit/withdraw/deduct), so
+     * callers always observe up-to-date rankings without hitting the database per call.
+     *
+     * @param limit The maximum number of guilds to return.
+     * @return A list of (guildId, balance) pairs ordered by balance descending.
+     */
+    fun getTopBalances(limit: Int): List<Pair<UUID, Int>>
+
+    /**
      * Gets the current balance of a player's economy account.
      *
      * @param playerId The ID of the player.

--- a/src/main/kotlin/net/lumalyte/lg/application/services/GuildService.kt
+++ b/src/main/kotlin/net/lumalyte/lg/application/services/GuildService.kt
@@ -353,6 +353,17 @@ interface GuildService {
     fun canUseAllyHome(playerId: UUID, sourceGuildId: UUID, targetGuildId: UUID): Boolean
 
     /**
+     * Checks whether a player may teleport to their OWN guild's ally-home. Returns true when:
+     * - the player is a member of the guild, AND
+     * - the guild has an ally-home set, AND
+     * - (player's rank is the highest-priority Owner rank) OR (rank has USE_ALLY_HOMES permission).
+     *
+     * This is distinct from [canUseAllyHome], which gates teleporting to an *allied* guild's
+     * ally-home and therefore requires an active alliance between two different guilds.
+     */
+    fun canUseOwnAllyHome(playerId: UUID, guildId: UUID): Boolean
+
+    /**
      * Updates the rank whitelist for a named home. Caller must have MANAGE_HOME.
      */
     fun setHomeAllowedRanks(guildId: UUID, homeName: String, allowedRankIds: Set<UUID>, actorId: UUID): Boolean

--- a/src/main/kotlin/net/lumalyte/lg/application/services/RelationService.kt
+++ b/src/main/kotlin/net/lumalyte/lg/application/services/RelationService.kt
@@ -181,6 +181,18 @@ interface RelationService {
      * @return The number of relations that were updated.
      */
     fun processExpiredRelations(): Int
+
+    /**
+     * Cleans up stale and orphaned relation rows. This should be called periodically.
+     * - Removes terminal rows (REJECTED/EXPIRED) left behind by older versions, which would
+     *   otherwise occupy the unique guild-pair slot and block new requests.
+     * - Auto-resolves pending requests that have been outstanding longer than the staleness
+     *   window, restoring the pre-request state (war stands for truce/unenemy; alliance drops
+     *   back to neutral).
+     *
+     * @return The number of relations that were cleaned up.
+     */
+    fun cleanupStaleRelations(): Int
     
     /**
      * Breaks an active alliance unilaterally.

--- a/src/main/kotlin/net/lumalyte/lg/infrastructure/persistence/guilds/BankRepositorySQLite.kt
+++ b/src/main/kotlin/net/lumalyte/lg/infrastructure/persistence/guilds/BankRepositorySQLite.kt
@@ -14,6 +14,7 @@ import org.slf4j.LoggerFactory
 import java.sql.SQLException
 import java.time.Instant
 import java.util.UUID
+import java.util.concurrent.ConcurrentHashMap
 
 class BankRepositorySQLite(private val storage: Storage<Database>) : BankRepository {
 
@@ -21,7 +22,9 @@ class BankRepositorySQLite(private val storage: Storage<Database>) : BankReposit
 
     private val transactions: MutableMap<UUID, BankTransaction> = mutableMapOf()
     private val audits: MutableMap<UUID, BankAudit> = mutableMapOf()
-    private val guildBalances: MutableMap<UUID, Int> = mutableMapOf()
+    // Concurrent: read from async threads (PlaceholderAPI, tab-completion) while the main thread
+    // mutates it during deposits/withdrawals. Also lets getTopBalances iterate without a CME.
+    private val guildBalances: MutableMap<UUID, Int> = ConcurrentHashMap()
 
     init {
         createBankTables()
@@ -411,6 +414,16 @@ class BankRepositorySQLite(private val storage: Storage<Database>) : BankReposit
             logger.error("Failed to delete transaction $transactionId", e)
             throw DatabaseOperationException("Failed to delete transaction", e)
         }
+    }
+
+    override fun getTopBalances(limit: Int): List<Pair<UUID, Int>> {
+        if (limit <= 0) return emptyList()
+        // Snapshot the in-memory cache (authoritative; preloaded and kept current on every
+        // transaction) so ranking needs no database query even for large guild counts.
+        return guildBalances.entries
+            .map { it.key to it.value }
+            .sortedByDescending { it.second }
+            .take(limit)
     }
 
     private fun calculateGuildBalance(guildId: UUID): Int {

--- a/src/main/kotlin/net/lumalyte/lg/infrastructure/persistence/guilds/RelationRepositorySQLite.kt
+++ b/src/main/kotlin/net/lumalyte/lg/infrastructure/persistence/guilds/RelationRepositorySQLite.kt
@@ -14,12 +14,18 @@ import org.slf4j.LoggerFactory
 import java.sql.SQLException
 import java.time.Instant
 import java.util.UUID
+import java.util.concurrent.ConcurrentHashMap
 
 class RelationRepositorySQLite(private val storage: Storage<Database>) : RelationRepository {
 
     private val logger = LoggerFactory.getLogger(RelationRepositorySQLite::class.java)
 
-    private val relations: MutableMap<UUID, Relation> = mutableMapOf()
+    // Thread-safe: tab-completions read this map from async threads while the main thread mutates
+    // it during request/accept/cancel flows. A plain HashMap here caused stale/inconsistent reads
+    // between players.
+    private val relations: MutableMap<UUID, Relation> = ConcurrentHashMap()
+
+    @Volatile
     private var isInitialized = false
 
     init {
@@ -27,6 +33,7 @@ class RelationRepositorySQLite(private val storage: Storage<Database>) : Relatio
         // This prevents issues when the database file doesn't exist yet
     }
 
+    @Synchronized
     private fun ensureInitialized() {
         if (!isInitialized) {
             logger.info("Initializing relation database...")
@@ -153,6 +160,8 @@ class RelationRepositorySQLite(private val storage: Storage<Database>) : Relatio
     }
     
     override fun update(relation: Relation): Boolean {
+        ensureInitialized()
+
         val sql = """
             UPDATE relations
             SET guild_a = ?, guild_b = ?, type = ?, status = ?, expires_at = ?, requesting_guild = ?, updated_at = ?
@@ -183,6 +192,7 @@ class RelationRepositorySQLite(private val storage: Storage<Database>) : Relatio
     }
     
     override fun remove(relationId: UUID): Boolean {
+        ensureInitialized()
         val sql = "DELETE FROM relations WHERE id = ?"
         
         return try {
@@ -200,10 +210,12 @@ class RelationRepositorySQLite(private val storage: Storage<Database>) : Relatio
     }
     
     override fun getById(relationId: UUID): Relation? {
+        ensureInitialized()
         return relations[relationId]
     }
-    
+
     override fun getByGuilds(guildA: UUID, guildB: UUID): Relation? {
+        ensureInitialized()
         // Normalize guild order for consistent lookup
         val (firstGuild, secondGuild) = if (guildA.toString() < guildB.toString()) {
             guildA to guildB
@@ -222,18 +234,21 @@ class RelationRepositorySQLite(private val storage: Storage<Database>) : Relatio
     }
     
     override fun getByGuildAndType(guildId: UUID, type: RelationType): Set<Relation> {
-        return relations.values.filter { 
+        ensureInitialized()
+        return relations.values.filter {
             it.involves(guildId) && it.type == type && it.isActive()
         }.toSet()
     }
-    
+
     override fun getByGuildAndStatus(guildId: UUID, status: RelationStatus): Set<Relation> {
-        return relations.values.filter { 
+        ensureInitialized()
+        return relations.values.filter {
             it.involves(guildId) && it.status == status
         }.toSet()
     }
-    
+
     override fun getExpiredRelations(): Set<Relation> {
+        ensureInitialized()
         val now = Instant.now()
         return relations.values.filter { relation ->
             relation.expiresAt != null && relation.expiresAt.isBefore(now) && 
@@ -242,15 +257,17 @@ class RelationRepositorySQLite(private val storage: Storage<Database>) : Relatio
     }
     
     override fun getByType(type: RelationType): Set<Relation> {
-        return relations.values.filter { 
+        ensureInitialized()
+        return relations.values.filter {
             it.type == type && it.isActive()
         }.toSet()
     }
-    
+
     override fun getByStatus(status: RelationStatus): Set<Relation> {
+        ensureInitialized()
         return relations.values.filter { it.status == status }.toSet()
     }
-    
+
     override fun hasRelationType(guildA: UUID, guildB: UUID, type: RelationType): Boolean {
         val relation = getByGuilds(guildA, guildB)
         return relation?.type == type && relation.isActive()
@@ -272,6 +289,7 @@ class RelationRepositorySQLite(private val storage: Storage<Database>) : Relatio
     }
 
     override fun getAll(): Set<Relation> {
+        ensureInitialized()
         return relations.values.toSet()
     }
 }

--- a/src/main/kotlin/net/lumalyte/lg/infrastructure/placeholders/LumaGuildsExpansion.kt
+++ b/src/main/kotlin/net/lumalyte/lg/infrastructure/placeholders/LumaGuildsExpansion.kt
@@ -137,7 +137,10 @@ class LumaGuildsExpansion : PlaceholderExpansion(), KoinComponent {
             "guild_tag_plain" -> renderTagAsPlain(guild)
             "guild_emoji" -> convertEmojiToNexoPlaceholder(guild.emoji)
             "guild_level" -> guild.level.toString()
-            "guild_balance" -> guild.bankBalance.toString()
+            // Bank table is the source of truth (Guild.bankBalance is a separate virtual-currency
+            // field that is not kept in sync with deposits/withdrawals). Read it live so the
+            // placeholder always reflects the current bank value.
+            "guild_balance" -> safeBalance(guildId).toString()
             "guild_mode" -> guild.mode.toString()
             "has_guild" -> "true"
 

--- a/src/main/kotlin/net/lumalyte/lg/infrastructure/services/BankServiceBukkit.kt
+++ b/src/main/kotlin/net/lumalyte/lg/infrastructure/services/BankServiceBukkit.kt
@@ -227,6 +227,10 @@ class BankServiceBukkit(
 
                 if (!rollbackSuccess) {
                     logger.error("CRITICAL: Transaction ${transaction.id} exists in database but Vault withdrawal failed AND rollback failed - manual cleanup required")
+                    // Ledger row persisted despite payout failure — drop the leaderboard cache so
+                    // /baltop reflects the new (incorrect-but-real) balance until the operator
+                    // resolves it. Stale cached numbers would hide the inconsistency.
+                    invalidateBalanceLeaderboard()
                 } else {
                     logger.info("Successfully rolled back failed deposit transaction ${transaction.id}")
                 }
@@ -405,6 +409,10 @@ class BankServiceBukkit(
                     details = "Failed to deposit money to player account - withdrawal recorded but payout failed, manual payout required"
                 ))
                 logger.warn("MANUAL ACTION REQUIRED: Withdrawal transaction ${transaction.id} recorded but Vault deposit failed - player $playerId needs manual credit of $finalAmount coins")
+                // Withdrawal ledger row was committed, so the real guild balance dropped even
+                // though payout failed. Invalidate the cache or /baltop keeps the pre-withdrawal
+                // number until TTL expires.
+                invalidateBalanceLeaderboard()
                 return null
             }
 

--- a/src/main/kotlin/net/lumalyte/lg/infrastructure/services/BankServiceBukkit.kt
+++ b/src/main/kotlin/net/lumalyte/lg/infrastructure/services/BankServiceBukkit.kt
@@ -34,6 +34,16 @@ class BankServiceBukkit(
     // Vault Economy integration
     private var economy: Economy? = null
 
+    // --- Balance leaderboard cache ---
+    // The underlying repository already keeps balances in memory, so this cache only amortizes the
+    // sort. It is invalidated immediately whenever a balance changes (deposit/withdraw/deduct), and
+    // also carries a short TTL as a safety net against any balance path that bypasses this service.
+    private val balanceLeaderboardLock = Any()
+    @Volatile private var cachedTopBalances: List<Pair<UUID, Int>> = emptyList()
+    @Volatile private var balanceLeaderboardExpiresAtMs: Long = 0L
+    private val balanceLeaderboardTtlMs = 30_000L
+    private val balanceLeaderboardCacheSize = 100
+
     init {
         setupEconomy()
     }
@@ -224,6 +234,7 @@ class BankServiceBukkit(
             }
 
             // SUCCESS: Both database record and Vault withdrawal succeeded
+            invalidateBalanceLeaderboard()
             val newBalance = bankRepository.getGuildBalance(guildId)
             recordAudit(BankAudit(
                 transactionId = transaction.id,
@@ -398,6 +409,7 @@ class BankServiceBukkit(
             }
 
             // SUCCESS: Both database record and Vault deposit succeeded
+            invalidateBalanceLeaderboard()
             val newBalance = bankRepository.getGuildBalance(guildId)
             recordAudit(BankAudit(
                 transactionId = transaction.id,
@@ -431,6 +443,25 @@ class BankServiceBukkit(
 
     override fun getBalance(guildId: UUID): Int {
         return bankRepository.getGuildBalance(guildId)
+    }
+
+    override fun getTopBalances(limit: Int): List<Pair<UUID, Int>> {
+        if (limit <= 0) return emptyList()
+        // Cache the largest requested page so callers asking for a smaller N reuse it.
+        val cacheSize = maxOf(limit, balanceLeaderboardCacheSize)
+        val now = System.currentTimeMillis()
+        synchronized(balanceLeaderboardLock) {
+            if (now >= balanceLeaderboardExpiresAtMs || cachedTopBalances.size < limit) {
+                cachedTopBalances = bankRepository.getTopBalances(cacheSize)
+                balanceLeaderboardExpiresAtMs = now + balanceLeaderboardTtlMs
+            }
+            return cachedTopBalances.take(limit)
+        }
+    }
+
+    /** Invalidates the cached balance leaderboard so the next read reflects the change. */
+    private fun invalidateBalanceLeaderboard() {
+        balanceLeaderboardExpiresAtMs = 0L
     }
 
     override fun getPlayerBalance(playerId: UUID): Int {
@@ -644,7 +675,9 @@ class BankServiceBukkit(
                 description = reason ?: "Guild bank deduction"
             )
 
-            return bankRepository.recordTransaction(transaction)
+            val recorded = bankRepository.recordTransaction(transaction)
+            if (recorded) invalidateBalanceLeaderboard()
+            return recorded
         } catch (e: SQLException) {
             logger.error("Database error processing guild bank deduction for guild $guildId", e)
             return false

--- a/src/main/kotlin/net/lumalyte/lg/infrastructure/services/GuildServiceBukkit.kt
+++ b/src/main/kotlin/net/lumalyte/lg/infrastructure/services/GuildServiceBukkit.kt
@@ -714,6 +714,17 @@ class GuildServiceBukkit(
         return RankPermission.USE_ALLY_HOMES in rank.permissions
     }
 
+    override fun canUseOwnAllyHome(playerId: UUID, guildId: UUID): Boolean {
+        val guild = guildRepository.getById(guildId) ?: return false
+        if (guild.allyHome == null) return false
+        val member = memberRepository.getByPlayerAndGuild(playerId, guildId) ?: return false
+        val rank = rankRepository.getById(member.rankId) ?: return false
+        // Guild owner (highest-priority rank) always has access; otherwise gate on USE_ALLY_HOMES.
+        val ownerRank = rankRepository.getHighestRank(guildId)
+        if (ownerRank != null && rank.id == ownerRank.id) return true
+        return RankPermission.USE_ALLY_HOMES in rank.permissions
+    }
+
     override fun setHomeAllowedRanks(
         guildId: UUID, homeName: String, allowedRankIds: Set<UUID>, actorId: UUID
     ): Boolean {

--- a/src/main/kotlin/net/lumalyte/lg/infrastructure/services/RelationServiceBukkit.kt
+++ b/src/main/kotlin/net/lumalyte/lg/infrastructure/services/RelationServiceBukkit.kt
@@ -59,8 +59,16 @@ class RelationServiceBukkit(
                     logger.warn("A pending request already exists between guilds $requestingGuildId and $targetGuildId")
                     return null
                 }
-                if (existingRelation.isActive() && existingRelation.type == RelationType.ALLY) {
-                    logger.warn("Guilds $requestingGuildId and $targetGuildId are already allied")
+                // Only NEUTRAL or terminal (REJECTED/EXPIRED) rows may be overwritten with a
+                // pending alliance. Reusing an active TRUCE or ENEMY row would silently destroy
+                // the underlying state — on reject/cancel, resolvePendingRequest would either
+                // delete the row (losing the truce) or revert to ENEMY (losing an unrelated war
+                // history). Force the caller to go through the proper transition first.
+                if (existingRelation.isActive() && existingRelation.type != RelationType.NEUTRAL) {
+                    logger.warn(
+                        "Cannot request alliance between guilds $requestingGuildId and $targetGuildId" +
+                            " - active ${existingRelation.type} relation must be ended first",
+                    )
                     return null
                 }
                 // Reuse the stale/inactive row by updating it to a fresh pending alliance request.
@@ -241,15 +249,20 @@ class RelationServiceBukkit(
                 return null
             }
 
-            val expiresAt = Instant.now().plus(duration)
+            // Stamp expiresAt as createdAt + duration even though the truce is only pending —
+            // acceptTruce derives the requested duration from (expiresAt - createdAt) and
+            // re-anchors expiresAt to the moment of acceptance. Without this, a 1-day truce
+            // accepted 20 hours later would only last 4 hours.
+            val now = Instant.now()
+            val requestedExpiresAt = currentRelation.createdAt.plus(duration)
 
             // Update existing relation to pending truce
             val truceRelation = currentRelation.copy(
                 type = RelationType.TRUCE,
                 status = RelationStatus.PENDING,
-                expiresAt = expiresAt,
+                expiresAt = requestedExpiresAt,
                 requestingGuildId = requestingGuildId,
-                updatedAt = Instant.now()
+                updatedAt = now
             )
             
             return if (relationRepository.update(truceRelation)) {
@@ -298,11 +311,18 @@ class RelationServiceBukkit(
                 logger.warn("Guild $acceptingGuildId cannot accept its own truce request")
                 return null
             }
-            
-            // Update relation to active
+
+            // The truce duration is encoded as (expiresAt - createdAt) on the pending row; the
+            // real timer starts now, on acceptance. Without this re-anchor the truce would
+            // already have burned hours/days of life while waiting for the target to respond.
+            val now = Instant.now()
+            val requestedDuration = relation.expiresAt
+                ?.let { Duration.between(relation.createdAt, it) }
+                ?: Duration.ZERO
             val updatedRelation = relation.copy(
                 status = RelationStatus.ACTIVE,
-                updatedAt = Instant.now()
+                expiresAt = now.plus(requestedDuration),
+                updatedAt = now
             )
             
             return if (relationRepository.update(updatedRelation)) {

--- a/src/main/kotlin/net/lumalyte/lg/infrastructure/services/RelationServiceBukkit.kt
+++ b/src/main/kotlin/net/lumalyte/lg/infrastructure/services/RelationServiceBukkit.kt
@@ -22,11 +22,17 @@ class RelationServiceBukkit(
 ) : RelationService {
     
     private val logger = LoggerFactory.getLogger(RelationServiceBukkit::class.java)
-    
+
+    companion object {
+        /** Pending requests outstanding longer than this are auto-resolved by cleanupStaleRelations. */
+        private val PENDING_REQUEST_TTL: Duration = Duration.ofDays(14)
+    }
+
     /** Checks whether [guildId] is the recorded requester of [relation], allowing legacy null rows. */
     private fun isRequester(relation: Relation, guildId: UUID): Boolean =
         relation.requestingGuildId == guildId
-    
+
+
     override fun requestAlliance(requestingGuildId: UUID, targetGuildId: UUID, actorId: UUID): Relation? {
         try {
             // Validate permissions
@@ -41,13 +47,39 @@ class RelationServiceBukkit(
                 return null
             }
             
-            // Check for existing relation
+            // Check for existing relation. The relations table has a UNIQUE(guild_a, guild_b)
+            // constraint, so at most one row exists per pair. A live pending request or an
+            // active alliance must block a new request, but a *terminal* row (REJECTED/EXPIRED)
+            // or a superseded one must be reused in place — otherwise the stale row permanently
+            // blocks all future alliance requests (the "request that no longer exists still
+            // blocks new ones" bug).
             val existingRelation = relationRepository.getByGuilds(requestingGuildId, targetGuildId)
             if (existingRelation != null) {
-                logger.warn("Relation already exists between guilds $requestingGuildId and $targetGuildId")
-                return null
+                if (existingRelation.status == RelationStatus.PENDING) {
+                    logger.warn("A pending request already exists between guilds $requestingGuildId and $targetGuildId")
+                    return null
+                }
+                if (existingRelation.isActive() && existingRelation.type == RelationType.ALLY) {
+                    logger.warn("Guilds $requestingGuildId and $targetGuildId are already allied")
+                    return null
+                }
+                // Reuse the stale/inactive row by updating it to a fresh pending alliance request.
+                val reused = existingRelation.copy(
+                    type = RelationType.ALLY,
+                    status = RelationStatus.PENDING,
+                    expiresAt = null,
+                    requestingGuildId = requestingGuildId,
+                    updatedAt = Instant.now()
+                )
+                return if (relationRepository.update(reused)) {
+                    logger.info("Alliance request created (reused stale row) from guild $requestingGuildId to guild $targetGuildId")
+                    reused
+                } else {
+                    logger.error("Failed to save alliance request (reusing stale row)")
+                    null
+                }
             }
-            
+
             // Create pending alliance request
             val relation = Relation.create(
                 guildA = requestingGuildId,
@@ -56,7 +88,7 @@ class RelationServiceBukkit(
                 status = RelationStatus.PENDING,
                 requestingGuildId = requestingGuildId,
             )
-            
+
             return if (relationRepository.add(relation)) {
                 logger.info("Alliance request created from guild $requestingGuildId to guild $targetGuildId")
                 relation
@@ -194,13 +226,23 @@ class RelationServiceBukkit(
             
             // Check that guilds are currently enemies
             val currentRelation = relationRepository.getByGuilds(requestingGuildId, targetGuildId)
-            if (currentRelation?.type != RelationType.ENEMY || !currentRelation.isActive()) {
+            if (currentRelation == null) {
+                logger.warn("Cannot request truce - no relation exists between guilds $requestingGuildId and $targetGuildId")
+                return null
+            }
+            if (currentRelation.status == RelationStatus.PENDING) {
+                logger.warn("Cannot request truce - a request is already pending between guilds $requestingGuildId and $targetGuildId")
+                return null
+            }
+            // effectiveType treats the underlying war as still in force; a stale TRUCE/EXPIRED row
+            // must not be mistaken for a non-war state.
+            if (effectiveType(currentRelation) != RelationType.ENEMY) {
                 logger.warn("Cannot request truce - guilds are not currently at war")
                 return null
             }
-            
+
             val expiresAt = Instant.now().plus(duration)
-            
+
             // Update existing relation to pending truce
             val truceRelation = currentRelation.copy(
                 type = RelationType.TRUCE,
@@ -291,11 +333,19 @@ class RelationServiceBukkit(
             
             // Check that guilds are currently enemies
             val currentRelation = relationRepository.getByGuilds(requestingGuildId, targetGuildId)
-            if (currentRelation?.type != RelationType.ENEMY || !currentRelation.isActive()) {
+            if (currentRelation == null) {
+                logger.warn("Cannot request unenemy - no relation exists between guilds $requestingGuildId and $targetGuildId")
+                return null
+            }
+            if (currentRelation.status == RelationStatus.PENDING) {
+                logger.warn("Cannot request unenemy - a request is already pending between guilds $requestingGuildId and $targetGuildId")
+                return null
+            }
+            if (effectiveType(currentRelation) != RelationType.ENEMY) {
                 logger.warn("Cannot request unenemy - guilds are not currently at war")
                 return null
             }
-            
+
             // Update existing relation to pending neutral request
             val unEnemyRelation = currentRelation.copy(
                 type = RelationType.NEUTRAL,
@@ -444,27 +494,19 @@ class RelationServiceBukkit(
                 logger.warn("Relation $relationId is not pending")
                 return false
             }
-            
-            // Enforce direction: only the non-requester can reject
-            // Legacy rows with null requestingGuildId can be rejected by either guild
+
+            // Enforce direction: only the non-requester can reject.
+            // Legacy rows with null requestingGuildId can be rejected by either guild.
             if (relation.requestingGuildId != null && isRequester(relation, rejectingGuildId)) {
                 logger.warn("Guild $rejectingGuildId cannot reject its own request")
                 return false
             }
-            
-            // Update relation to rejected
-            val rejectedRelation = relation.copy(
-                status = RelationStatus.REJECTED,
-                updatedAt = Instant.now()
-            )
-            
-            return if (relationRepository.update(rejectedRelation)) {
-                logger.info("Relation request $relationId rejected by guild $rejectingGuildId")
-                true
-            } else {
-                logger.error("Failed to update rejected relation")
-                false
-            }
+
+            // Rejecting a request must restore the pre-request state, NOT just mark it REJECTED:
+            // a rejected truce/unenemy request leaves the guilds still at war (revert to ENEMY),
+            // while a rejected alliance request returns to neutral (row removed). Leaving a
+            // REJECTED row behind both lost the war state and blocked future requests.
+            return resolvePendingRequest(relation, "rejected by guild $rejectingGuildId")
         } catch (e: Exception) {
             // In-memory operation - catching runtime exceptions from state validation
             logger.error("Error rejecting request", e)
@@ -497,22 +539,18 @@ class RelationServiceBukkit(
                 logger.warn("Relation $relationId is not pending")
                 return false
             }
-            
-            // Enforce direction: only the requester can cancel
-            // Legacy rows with null requestingGuildId can be cancelled by either guild
+
+            // Enforce direction: only the requester can cancel.
+            // Legacy rows with null requestingGuildId can be cancelled by either guild.
             if (relation.requestingGuildId != null && !isRequester(relation, cancellingGuildId)) {
                 logger.warn("Guild $cancellingGuildId cannot cancel a request it did not send")
                 return false
             }
-            
-            // Remove the pending relation
-            return if (relationRepository.remove(relationId)) {
-                logger.info("Relation request $relationId cancelled by guild $cancellingGuildId")
-                true
-            } else {
-                logger.error("Failed to remove cancelled relation")
-                false
-            }
+
+            // Cancelling restores the pre-request state (same rules as rejection): a cancelled
+            // truce/unenemy request must keep the guilds at war, not silently end it by deleting
+            // the row.
+            return resolvePendingRequest(relation, "cancelled by guild $cancellingGuildId")
         } catch (e: Exception) {
             // In-memory operation - catching runtime exceptions from state validation
             logger.error("Error cancelling request", e)
@@ -525,11 +563,57 @@ class RelationServiceBukkit(
     }
     
     override fun getRelationType(guildA: UUID, guildB: UUID): RelationType {
-        val relation = relationRepository.getByGuilds(guildA, guildB)
-        return if (relation != null && relation.isActive()) {
-            relation.type
-        } else {
-            RelationType.NEUTRAL
+        val relation = relationRepository.getByGuilds(guildA, guildB) ?: return RelationType.NEUTRAL
+        return effectiveType(relation)
+    }
+
+    /**
+     * Computes the effective relation type for a row, accounting for pending de-escalation
+     * requests. A pending TRUCE or unenemy (NEUTRAL) request is always raised from an active
+     * ENEMY state and does NOT take effect until accepted, so the guilds remain enemies until
+     * then. Inactive/terminal rows (REJECTED/EXPIRED) read as NEUTRAL.
+     */
+    private fun effectiveType(relation: Relation): RelationType = when {
+        relation.isActive() -> relation.type
+        relation.status == RelationStatus.PENDING &&
+            (relation.type == RelationType.TRUCE || relation.type == RelationType.NEUTRAL) ->
+            RelationType.ENEMY
+        else -> RelationType.NEUTRAL
+    }
+
+    /**
+     * Restores the pre-request state when a pending request is rejected, cancelled, or expires.
+     * - Pending TRUCE / unenemy (NEUTRAL): the underlying war stands — revert to active ENEMY.
+     * - Pending ALLY: return to neutral by removing the row.
+     * Returns true on success. [reason] is used only for logging.
+     */
+    private fun resolvePendingRequest(relation: Relation, reason: String): Boolean {
+        return when (relation.type) {
+            RelationType.TRUCE, RelationType.NEUTRAL -> {
+                val reverted = relation.copy(
+                    type = RelationType.ENEMY,
+                    status = RelationStatus.ACTIVE,
+                    expiresAt = null,
+                    requestingGuildId = null,
+                    updatedAt = Instant.now()
+                )
+                if (relationRepository.update(reverted)) {
+                    logger.info("Pending request ${relation.id} $reason - reverted to enemy (war stands)")
+                    true
+                } else {
+                    logger.error("Failed to revert pending request ${relation.id}")
+                    false
+                }
+            }
+            RelationType.ALLY, RelationType.ENEMY -> {
+                if (relationRepository.remove(relation.id)) {
+                    logger.info("Pending request ${relation.id} $reason - removed (back to neutral)")
+                    true
+                } else {
+                    logger.error("Failed to remove pending request ${relation.id}")
+                    false
+                }
+            }
         }
     }
     
@@ -623,6 +707,36 @@ class RelationServiceBukkit(
             return 0
         }
     }
+
+    override fun cleanupStaleRelations(): Int {
+        var cleaned = 0
+        try {
+            // 1) Remove terminal rows (REJECTED/EXPIRED). With the current request flows these are
+            //    no longer produced, but legacy databases may still contain them — and a lingering
+            //    terminal row occupies the UNIQUE(guild_a, guild_b) slot and blocks new requests.
+            val terminal = relationRepository.getByStatus(RelationStatus.REJECTED) +
+                relationRepository.getByStatus(RelationStatus.EXPIRED)
+            for (relation in terminal) {
+                if (relationRepository.remove(relation.id)) {
+                    logger.info("Cleaned up terminal (${relation.status}) relation ${relation.id} between ${relation.guildA} and ${relation.guildB}")
+                    cleaned++
+                }
+            }
+
+            // 2) Auto-resolve pending requests that have been outstanding too long.
+            val cutoff = Instant.now().minus(PENDING_REQUEST_TTL)
+            val stalePending = relationRepository.getByStatus(RelationStatus.PENDING)
+                .filter { it.updatedAt.isBefore(cutoff) }
+            for (relation in stalePending) {
+                if (resolvePendingRequest(relation, "auto-expired after $PENDING_REQUEST_TTL")) {
+                    cleaned++
+                }
+            }
+        } catch (e: Exception) {
+            logger.error("Error cleaning up stale relations", e)
+        }
+        return cleaned
+    }
     
     override fun isValidRelationChange(fromGuildId: UUID, toGuildId: UUID, newType: RelationType): Boolean {
         // Basic validation
@@ -648,9 +762,10 @@ class RelationServiceBukkit(
     }
 
     override fun isGuildInActiveWar(guildId: UUID): Boolean {
-        val enemyRelations = relationRepository.getByGuildAndType(guildId, RelationType.ENEMY)
-        return enemyRelations.any { relation ->
-            relation.isActive() && relation.type == RelationType.ENEMY
+        // A guild is at war when it has an active ENEMY relation, OR a pending de-escalation
+        // (truce/unenemy) request that has not yet been accepted — those leave the war in force.
+        return relationRepository.getByGuild(guildId).any { relation ->
+            effectiveType(relation) == RelationType.ENEMY
         }
     }
 

--- a/src/main/kotlin/net/lumalyte/lg/interaction/commands/GuildCommand.kt
+++ b/src/main/kotlin/net/lumalyte/lg/interaction/commands/GuildCommand.kt
@@ -674,10 +674,13 @@ class GuildCommand : BaseCommand(), KoinComponent {
         }
         player.sendMessage("§6§l✦ Top Guilds by Bank Balance ✦")
         val ownGuildId = guildService.getPlayerGuilds(player.uniqueId).firstOrNull()?.id
-        top.forEachIndexed { index, (guildId, balance) ->
+        // Resolve names first and drop rows whose guild was deleted out from under the cache;
+        // re-numbering after the filter keeps display ranks contiguous (no #1, #3, #4 gaps).
+        val resolved = top.mapNotNull { (guildId, balance) ->
+            guildService.getGuild(guildId)?.let { Triple(guildId, it.name, balance) }
+        }
+        resolved.forEachIndexed { index, (guildId, name, balance) ->
             val rank = index + 1
-            // Resolve the name lazily; skip rows whose guild was deleted out from under the cache.
-            val name = guildService.getGuild(guildId)?.name ?: return@forEachIndexed
             val highlight = if (guildId == ownGuildId) "§e" else "§f"
             player.sendMessage("§7#§f$rank $highlight$name §7- §a$${formatMoney(balance)}")
         }

--- a/src/main/kotlin/net/lumalyte/lg/interaction/commands/GuildCommand.kt
+++ b/src/main/kotlin/net/lumalyte/lg/interaction/commands/GuildCommand.kt
@@ -51,8 +51,13 @@ class GuildCommand : BaseCommand(), KoinComponent {
     private val adminOverrideService: net.lumalyte.lg.application.services.AdminOverrideService by inject()
     private val teleportationService: net.lumalyte.lg.infrastructure.services.TeleportationService by inject()
     private val bannermanListeners: net.lumalyte.lg.infrastructure.bukkit.bannerman.BannermanListeners by inject()
+    private val bankService: net.lumalyte.lg.application.services.BankService by inject()
 
     private val lastHomeTeleport = mutableMapOf<java.util.UUID, Long>()
+
+    private companion object {
+        const val BALTOP_DISPLAY_LIMIT = 10
+    }
 
     private fun notifyGuildMembers(guildId: java.util.UUID, message: String) {
         val members = memberService.getGuildMembers(guildId)
@@ -573,9 +578,10 @@ class GuildCommand : BaseCommand(), KoinComponent {
             player.sendMessage("§cNo guild named '$guildName' found.")
             return null
         }
+        // Own guild's ally-home is a valid target: members with USE_ALLY_HOMES (or the owner)
+        // may teleport to it. The ally-relation check below only applies to other guilds.
         if (targetGuild.id == ownGuild.id) {
-            player.sendMessage("§cUse §6/guild home §cfor your own guild's home.")
-            return null
+            return targetGuild
         }
         val relationService: net.lumalyte.lg.application.services.RelationService by inject()
         if (relationService.getRelationType(ownGuild.id, targetGuild.id)
@@ -596,9 +602,20 @@ class GuildCommand : BaseCommand(), KoinComponent {
             player.sendMessage("§c${targetGuild.name} has no ally home set.")
             return null
         }
-        if (!guildService.canUseAllyHome(player.uniqueId, ownGuild.id, targetGuild.id)) {
-            player.sendMessage("§c❌ You don't have permission to use ${targetGuild.name}'s ally home.")
-            player.sendMessage("§7Your rank may lack USE_ALLY_HOMES, or that guild has not granted access.")
+        val isOwnGuild = targetGuild.id == ownGuild.id
+        val allowed = if (isOwnGuild) {
+            guildService.canUseOwnAllyHome(player.uniqueId, ownGuild.id)
+        } else {
+            guildService.canUseAllyHome(player.uniqueId, ownGuild.id, targetGuild.id)
+        }
+        if (!allowed) {
+            if (isOwnGuild) {
+                player.sendMessage("§c❌ You don't have permission to use your guild's ally home.")
+                player.sendMessage("§7Your rank needs the USE_ALLY_HOMES permission.")
+            } else {
+                player.sendMessage("§c❌ You don't have permission to use ${targetGuild.name}'s ally home.")
+                player.sendMessage("§7Your rank may lack USE_ALLY_HOMES, or that guild has not granted access.")
+            }
             return null
         }
         if (teleportationService.hasActiveTeleport(player.uniqueId)) {
@@ -633,6 +650,41 @@ class GuildCommand : BaseCommand(), KoinComponent {
         }
         return true
     }
+
+    @Subcommand("bal|balance")
+    @CommandPermission("lumaguilds.guild.bal")
+    fun onBalance(player: Player) {
+        val guild = guildService.getPlayerGuilds(player.uniqueId).firstOrNull()
+        if (guild == null) {
+            player.sendMessage("§cYou are not in a guild.")
+            return
+        }
+        // Bank table is the source of truth for guild balance.
+        val balance = bankService.getBalance(guild.id)
+        player.sendMessage("§6§l${guild.name} §7Bank Balance: §a$${formatMoney(balance)}")
+    }
+
+    @Subcommand("baltop|balancetop")
+    @CommandPermission("lumaguilds.guild.baltop")
+    fun onBalanceTop(player: Player) {
+        val top = bankService.getTopBalances(BALTOP_DISPLAY_LIMIT)
+        if (top.isEmpty()) {
+            player.sendMessage("§7No guild balances to display yet.")
+            return
+        }
+        player.sendMessage("§6§l✦ Top Guilds by Bank Balance ✦")
+        val ownGuildId = guildService.getPlayerGuilds(player.uniqueId).firstOrNull()?.id
+        top.forEachIndexed { index, (guildId, balance) ->
+            val rank = index + 1
+            // Resolve the name lazily; skip rows whose guild was deleted out from under the cache.
+            val name = guildService.getGuild(guildId)?.name ?: return@forEachIndexed
+            val highlight = if (guildId == ownGuildId) "§e" else "§f"
+            player.sendMessage("§7#§f$rank $highlight$name §7- §a$${formatMoney(balance)}")
+        }
+    }
+
+    /** Formats an integer money amount with thousands separators (e.g. 1234567 -> 1,234,567). */
+    private fun formatMoney(amount: Int): String = "%,d".format(amount)
 
     @Subcommand("ranks")
     @CommandPermission("lumaguilds.guild.ranks")

--- a/src/main/kotlin/net/lumalyte/lg/utils/GuildDisplayUtils.kt
+++ b/src/main/kotlin/net/lumalyte/lg/utils/GuildDisplayUtils.kt
@@ -20,9 +20,14 @@ object GuildDisplayUtils {
      * @return The formatted display name with emoji prefix if available.
      */
     fun getFormattedGuildName(guild: Guild): String {
+        // A tag that's only formatting (e.g. "<red></red>" or "&l&r") renders to an empty
+        // string after color codes are stripped. Falling through to that empty string would
+        // wipe the guild name in tab lists and chat, so only use the rendered tag when its
+        // visible payload is non-blank.
         val baseName = guild.tag
             ?.takeIf { it.isNotBlank() }
             ?.let { ColorCodeUtils.renderTagForDisplay(it) }
+            ?.takeIf { rendered -> rendered.replace(LEGACY_COLOR_CODE, "").isNotBlank() }
             ?: guild.name
         return if (guild.emoji != null && isValidEmojiFormat(guild.emoji)) {
             "${guild.emoji} $baseName"
@@ -30,6 +35,9 @@ object GuildDisplayUtils {
             baseName
         }
     }
+
+    /** Section-sign legacy color/formatting codes (§0–§9, §a–§f, §k–§o, §r). */
+    private val LEGACY_COLOR_CODE = Regex("(?i)§[0-9a-fk-or]")
     
     /**
      * Gets just the emoji part for a guild, or empty string if not set.

--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -73,6 +73,8 @@ permissions:
       lumaguilds.guild.history: true
       lumaguilds.guild.chat: true
       lumaguilds.guild.bannerman: true
+      lumaguilds.guild.bal: true
+      lumaguilds.guild.baltop: true
 
   lumaguilds.guild.chat:
     description: Toggle guild chat mode (messages go to guild only)
@@ -130,6 +132,12 @@ permissions:
     default: true
   lumaguilds.guild.history:
     description: View player guild membership history
+    default: true
+  lumaguilds.guild.bal:
+    description: View your guild's bank balance
+    default: true
+  lumaguilds.guild.baltop:
+    description: View the guild bank balance leaderboard
     default: true
 
   # Claim Management Permissions

--- a/src/test/kotlin/net/lumalyte/lg/infrastructure/services/GuildServiceAllyHomeAccessTest.kt
+++ b/src/test/kotlin/net/lumalyte/lg/infrastructure/services/GuildServiceAllyHomeAccessTest.kt
@@ -30,11 +30,12 @@ class GuildServiceAllyHomeAccessTest {
         targetAllyHome: GuildHome?,
         targetAllowedGuilds: Set<UUID>,
         memberRankPerms: Set<RankPermission> = emptySet(),
-        activeAlly: Boolean = true
+        activeAlly: Boolean = true,
+        sourceAllyHome: GuildHome? = null
     ): GuildServiceBukkit {
         val ownerRank = Rank(ownerRankId, sourceGuildId, "Owner", 0, RankPermission.values().toSet())
         val memberRank = Rank(memberRankId, sourceGuildId, "Member", 10, memberRankPerms)
-        val sourceGuild = Guild(id = sourceGuildId, name = "S", createdAt = Instant.now())
+        val sourceGuild = Guild(id = sourceGuildId, name = "S", createdAt = Instant.now(), allyHome = sourceAllyHome)
         val targetGuild = Guild(
             id = targetGuildId, name = "T", createdAt = Instant.now(),
             allyHome = targetAllyHome,
@@ -133,5 +134,35 @@ class GuildServiceAllyHomeAccessTest {
             activeAlly = false
         )
         assertFalse(svc.canUseAllyHome(memberPlayerId, sourceGuildId, targetGuildId))
+    }
+
+    // --- canUseOwnAllyHome: a member teleporting to their OWN guild's ally home ---
+
+    @Test
+    fun `own ally home - owner can use without USE_ALLY_HOMES`() {
+        val svc = makeService(targetAllyHome = null, targetAllowedGuilds = emptySet(), sourceAllyHome = ah)
+        assertTrue(svc.canUseOwnAllyHome(ownerPlayerId, sourceGuildId))
+    }
+
+    @Test
+    fun `own ally home - member with USE_ALLY_HOMES can use`() {
+        val svc = makeService(
+            targetAllyHome = null, targetAllowedGuilds = emptySet(),
+            memberRankPerms = setOf(RankPermission.USE_ALLY_HOMES),
+            sourceAllyHome = ah
+        )
+        assertTrue(svc.canUseOwnAllyHome(memberPlayerId, sourceGuildId))
+    }
+
+    @Test
+    fun `own ally home - member without USE_ALLY_HOMES is denied`() {
+        val svc = makeService(targetAllyHome = null, targetAllowedGuilds = emptySet(), sourceAllyHome = ah)
+        assertFalse(svc.canUseOwnAllyHome(memberPlayerId, sourceGuildId))
+    }
+
+    @Test
+    fun `own ally home - denied when no ally home set`() {
+        val svc = makeService(targetAllyHome = null, targetAllowedGuilds = emptySet(), sourceAllyHome = null)
+        assertFalse(svc.canUseOwnAllyHome(ownerPlayerId, sourceGuildId))
     }
 }

--- a/src/test/kotlin/net/lumalyte/lg/infrastructure/services/GuildServiceAllyHomeAccessTest.kt
+++ b/src/test/kotlin/net/lumalyte/lg/infrastructure/services/GuildServiceAllyHomeAccessTest.kt
@@ -165,4 +165,14 @@ class GuildServiceAllyHomeAccessTest {
         val svc = makeService(targetAllyHome = null, targetAllowedGuilds = emptySet(), sourceAllyHome = null)
         assertFalse(svc.canUseOwnAllyHome(ownerPlayerId, sourceGuildId))
     }
+
+    @Test
+    fun `own ally home - denied for non-member`() {
+        // Locks in the access boundary: a player who isn't in the guild at all must be denied
+        // regardless of any other state. memberRepository returns null, so this exercises the
+        // pre-rank early-return that prevents unauthenticated access to the ally home.
+        val svc = makeService(targetAllyHome = null, targetAllowedGuilds = emptySet(), sourceAllyHome = ah)
+        val nonMember = UUID.randomUUID()
+        assertFalse(svc.canUseOwnAllyHome(nonMember, sourceGuildId))
+    }
 }

--- a/src/test/kotlin/net/lumalyte/lg/infrastructure/services/RelationServiceTreatyTest.kt
+++ b/src/test/kotlin/net/lumalyte/lg/infrastructure/services/RelationServiceTreatyTest.kt
@@ -1,0 +1,158 @@
+package net.lumalyte.lg.infrastructure.services
+
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.slot
+import io.mockk.verify
+import net.lumalyte.lg.application.persistence.GuildRepository
+import net.lumalyte.lg.application.persistence.RelationRepository
+import net.lumalyte.lg.application.services.MemberService
+import net.lumalyte.lg.domain.entities.Relation
+import net.lumalyte.lg.domain.entities.RelationStatus
+import net.lumalyte.lg.domain.entities.RelationType
+import net.lumalyte.lg.domain.entities.RankPermission
+import org.junit.jupiter.api.Assertions.*
+import org.junit.jupiter.api.Test
+import java.time.Duration
+import java.time.Instant
+import java.util.UUID
+
+/**
+ * Regression tests for the treaty/relation lifecycle fixes:
+ * - stale terminal rows must not block new alliance requests (they are reused in place)
+ * - rejecting/cancelling a truce or unenemy request must keep the guilds at war
+ * - a pending de-escalation request must read as ENEMY until accepted
+ * - cleanup purges terminal rows and auto-resolves long-pending requests
+ */
+class RelationServiceTreatyTest {
+
+    private val guildA: UUID = UUID.fromString("00000000-0000-0000-0000-000000000001")
+    private val guildB: UUID = UUID.fromString("00000000-0000-0000-0000-000000000002")
+    private val actorId: UUID = UUID.randomUUID()
+
+    private fun service(
+        repo: RelationRepository
+    ): RelationServiceBukkit {
+        val memberService = mockk<MemberService>(relaxed = true)
+        every { memberService.getPlayerGuilds(any()) } returns setOf(guildA, guildB)
+        every { memberService.hasPermission(any(), any(), RankPermission.MANAGE_RELATIONS) } returns true
+        val guildRepository = mockk<GuildRepository>(relaxed = true)
+        return RelationServiceBukkit(repo, memberService, guildRepository)
+    }
+
+    private fun truce(status: RelationStatus, updatedAt: Instant = Instant.now()): Relation =
+        Relation.create(
+            guildA = guildA, guildB = guildB,
+            type = RelationType.TRUCE, status = status,
+            expiresAt = Instant.now().plus(Duration.ofDays(1)),
+            requestingGuildId = guildA
+        ).copy(updatedAt = updatedAt)
+
+    private fun ally(status: RelationStatus): Relation =
+        Relation.create(guildA = guildA, guildB = guildB, type = RelationType.ALLY, status = status)
+
+    private fun enemy(): Relation =
+        Relation.create(guildA = guildA, guildB = guildB, type = RelationType.ENEMY, status = RelationStatus.ACTIVE)
+
+    @Test
+    fun `stale rejected alliance row is reused, not blocked`() {
+        val repo = mockk<RelationRepository>(relaxed = true)
+        every { repo.getByGuilds(any(), any()) } returns ally(RelationStatus.REJECTED)
+        every { repo.update(any()) } returns true
+
+        val result = service(repo).requestAlliance(guildA, guildB, actorId)
+
+        assertNotNull(result)
+        val saved = slot<Relation>()
+        verify { repo.update(capture(saved)) }
+        assertEquals(RelationType.ALLY, saved.captured.type)
+        assertEquals(RelationStatus.PENDING, saved.captured.status)
+    }
+
+    @Test
+    fun `pending alliance request blocks a new alliance request`() {
+        val repo = mockk<RelationRepository>(relaxed = true)
+        every { repo.getByGuilds(any(), any()) } returns ally(RelationStatus.PENDING)
+
+        assertNull(service(repo).requestAlliance(guildA, guildB, actorId))
+        verify(exactly = 0) { repo.update(any()) }
+        verify(exactly = 0) { repo.add(any()) }
+    }
+
+    @Test
+    fun `rejecting a pending truce reverts to active enemy`() {
+        val repo = mockk<RelationRepository>(relaxed = true)
+        val pending = truce(RelationStatus.PENDING)
+        every { repo.getById(pending.id) } returns pending
+        every { repo.update(any()) } returns true
+
+        assertTrue(service(repo).rejectRequest(pending.id, guildB, actorId))
+
+        val saved = slot<Relation>()
+        verify { repo.update(capture(saved)) }
+        assertEquals(RelationType.ENEMY, saved.captured.type)
+        assertEquals(RelationStatus.ACTIVE, saved.captured.status)
+        assertNull(saved.captured.expiresAt)
+    }
+
+    @Test
+    fun `cancelling a pending truce reverts to active enemy, not removed`() {
+        val repo = mockk<RelationRepository>(relaxed = true)
+        val pending = truce(RelationStatus.PENDING)
+        every { repo.getById(pending.id) } returns pending
+        every { repo.update(any()) } returns true
+
+        assertTrue(service(repo).cancelRequest(pending.id, guildA, actorId))
+
+        verify(exactly = 0) { repo.remove(any()) }
+        val saved = slot<Relation>()
+        verify { repo.update(capture(saved)) }
+        assertEquals(RelationType.ENEMY, saved.captured.type)
+    }
+
+    @Test
+    fun `rejecting a pending alliance removes the row`() {
+        val repo = mockk<RelationRepository>(relaxed = true)
+        val pending = ally(RelationStatus.PENDING)
+        every { repo.getById(pending.id) } returns pending
+        every { repo.remove(pending.id) } returns true
+
+        assertTrue(service(repo).rejectRequest(pending.id, guildB, actorId))
+        verify { repo.remove(pending.id) }
+    }
+
+    @Test
+    fun `pending truce reads as enemy until accepted`() {
+        val repo = mockk<RelationRepository>(relaxed = true)
+        every { repo.getByGuilds(any(), any()) } returns truce(RelationStatus.PENDING)
+        assertEquals(RelationType.ENEMY, service(repo).getRelationType(guildA, guildB))
+    }
+
+    @Test
+    fun `rejected row reads as neutral`() {
+        val repo = mockk<RelationRepository>(relaxed = true)
+        every { repo.getByGuilds(any(), any()) } returns ally(RelationStatus.REJECTED)
+        assertEquals(RelationType.NEUTRAL, service(repo).getRelationType(guildA, guildB))
+    }
+
+    @Test
+    fun `cleanup removes terminal rows and resolves long-pending requests`() {
+        val repo = mockk<RelationRepository>(relaxed = true)
+        val rejected = ally(RelationStatus.REJECTED)
+        val stalePending = truce(RelationStatus.PENDING, updatedAt = Instant.now().minus(Duration.ofDays(30)))
+        every { repo.getByStatus(RelationStatus.REJECTED) } returns setOf(rejected)
+        every { repo.getByStatus(RelationStatus.EXPIRED) } returns emptySet()
+        every { repo.getByStatus(RelationStatus.PENDING) } returns setOf(stalePending)
+        every { repo.remove(rejected.id) } returns true
+        every { repo.update(any()) } returns true
+
+        val cleaned = service(repo).cleanupStaleRelations()
+
+        assertEquals(2, cleaned)
+        verify { repo.remove(rejected.id) }
+        // stale pending truce reverted to enemy
+        val saved = slot<Relation>()
+        verify { repo.update(capture(saved)) }
+        assertEquals(RelationType.ENEMY, saved.captured.type)
+    }
+}

--- a/src/test/kotlin/net/lumalyte/lg/infrastructure/services/RelationServiceTreatyTest.kt
+++ b/src/test/kotlin/net/lumalyte/lg/infrastructure/services/RelationServiceTreatyTest.kt
@@ -67,6 +67,10 @@ class RelationServiceTreatyTest {
         verify { repo.update(capture(saved)) }
         assertEquals(RelationType.ALLY, saved.captured.type)
         assertEquals(RelationStatus.PENDING, saved.captured.status)
+        // The reused row must record the requester so direction-based accept/reject/cancel
+        // guards work. Without this assertion the test would pass even if requestingGuildId
+        // were dropped on the reuse path.
+        assertEquals(guildA, saved.captured.requestingGuildId)
     }
 
     @Test


### PR DESCRIPTION
## Summary
Builds on the 2.1.0 guild-name validation work with several guild feature fixes and additions. Branch diverged before main's #50 merge — overlapping files (`RelationServiceBukkit`, `RelationRepositorySQLite`, `GuildDisplayUtils`, `GuildTagValidator`) will need conflict resolution on merge.

## Changes
- **Bank leaderboard**: `BankService.getTopBalances(limit)` with a short-lived cache invalidated on every balance change; new `/guild bal` and `/guild baltop` commands + `lumaguilds.guild.bal` / `.baltop` permissions; baltop placeholders in `LumaGuildsExpansion`.
- **Own ally-home access**: `GuildService.canUseOwnAllyHome()` lets members with `USE_ALLY_HOMES` (or the Owner rank) teleport to their own guild's ally-home, separate from the allied-guild path.
- **Relation hygiene**: `RelationService.cleanupStaleRelations()` purges terminal REJECTED/EXPIRED rows that blocked new requests and auto-resolves pending requests past the staleness window.
- Earlier commits: case-insensitive guild-name collision check + bounded retry, color-code sanitizer fix, relation request direction / allyhome syntax / tag safety + display fixes, config-driven `experience_transactions` cleanup.

## Notes
- Built locally with MS-OpenJDK 21 (`shadowJar`), 2.1.0.
- New tests: `RelationServiceTreatyTest`, updated `GuildServiceAllyHomeAccessTest`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

**New Features**
- Added `/guild bal` command to view your guild's bank balance
- Added `/guild baltop` command to view top guild bank balances
- Guild tags now display in guild names when set
- Enhanced ally-home permissions with distinct access controls for own-guild vs allied-guild homes

**Bug Fixes**
- Guild tag validation now blocks dangerous interactive content
- Stale alliance requests are automatically cleaned up
- Guild bank balance displays now reflect live data

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/BadgersMC/LumaGuilds/pull/51?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->