### PR TITLE
feat(guild): unify guild bank balance onto one source of truth (vault gold)

### DIFF
--- a/src/main/kotlin/net/lumalyte/lg/application/persistence/GuildVaultRepository.kt
+++ b/src/main/kotlin/net/lumalyte/lg/application/persistence/GuildVaultRepository.kt
@@ -112,4 +112,13 @@ interface GuildVaultRepository {
      * @return The new balance, or -1 if failed or insufficient balance.
      */
     fun subtractGoldBalance(guildId: UUID, amount: Long): Long
+
+    /**
+     * Gets the highest-balance guilds, ranked by vault gold balance descending.
+     * Only guilds that have a gold balance entry are included.
+     *
+     * @param limit The maximum number of guilds to return.
+     * @return A list of (guildId, balance) pairs ordered by balance descending.
+     */
+    fun getTopGoldBalances(limit: Int): List<Pair<UUID, Long>>
 }

--- a/src/main/kotlin/net/lumalyte/lg/application/services/BankService.kt
+++ b/src/main/kotlin/net/lumalyte/lg/application/services/BankService.kt
@@ -89,6 +89,17 @@ interface BankService {
     fun deductFromGuildBank(guildId: UUID, amount: Int, reason: String? = null): Boolean
 
     /**
+     * Credits money into a guild's bank without taking it from any player (system credit).
+     * Used for system-driven income such as war wager payouts/refunds.
+     *
+     * @param guildId The ID of the guild.
+     * @param amount The amount to credit.
+     * @param reason Optional reason for the transaction.
+     * @return true if successful, false otherwise.
+     */
+    fun creditToGuildBank(guildId: UUID, amount: Int, reason: String? = null): Boolean
+
+    /**
      * Checks if a player can withdraw from a guild's bank.
      *
      * @param playerId The ID of the player.

--- a/src/main/kotlin/net/lumalyte/lg/application/services/VaultInventoryManager.kt
+++ b/src/main/kotlin/net/lumalyte/lg/application/services/VaultInventoryManager.kt
@@ -299,6 +299,17 @@ class VaultInventoryManager(
     }
 
     /**
+     * Gets the top guilds ranked by vault gold balance (descending).
+     * Queries the repository directly so it does not force every vault into the cache.
+     *
+     * @param limit The maximum number of guilds to return.
+     * @return A list of (guildId, balance) pairs ordered by balance descending.
+     */
+    fun getTopGoldBalances(limit: Int): List<Pair<UUID, Long>> {
+        return vaultRepository.getTopGoldBalances(limit)
+    }
+
+    /**
      * Sets the gold balance for a vault.
      * Updates the in-memory cache immediately and queues database write.
      *

--- a/src/main/kotlin/net/lumalyte/lg/di/Modules.kt
+++ b/src/main/kotlin/net/lumalyte/lg/di/Modules.kt
@@ -518,7 +518,7 @@ fun economyModule() = module {
     single<BankRepository> { BankRepositorySQLite(get()) }
 
     // Services
-    single<BankService> { BankServiceBukkit(get(), get(), get(), get(), get(), get(), get()) }
+    single<BankService> { BankServiceBukkit(get(), get(), get(), get(), get(), get(), get(), get()) }
     single<net.lumalyte.lg.application.services.PhysicalCurrencyService> {
         net.lumalyte.lg.infrastructure.services.PhysicalCurrencyServiceBukkit(get(), get())
     }

--- a/src/main/kotlin/net/lumalyte/lg/infrastructure/persistence/guilds/GuildVaultRepositorySQLite.kt
+++ b/src/main/kotlin/net/lumalyte/lg/infrastructure/persistence/guilds/GuildVaultRepositorySQLite.kt
@@ -214,6 +214,22 @@ class GuildVaultRepositorySQLite(private val storage: Storage<Database>) : Guild
         }
     }
 
+    override fun getTopGoldBalances(limit: Int): List<Pair<UUID, Long>> {
+        if (limit <= 0) return emptyList()
+        val sql = "SELECT guild_id, balance FROM vault_gold ORDER BY balance DESC LIMIT ?"
+
+        return try {
+            val results = storage.connection.getResults(sql, limit)
+            results.mapNotNull { row ->
+                val id = try { UUID.fromString(row.getString("guild_id")) } catch (e: Exception) { null }
+                id?.let { it to row.getInt("balance").toLong() }
+            }
+        } catch (e: SQLException) {
+            logger.error("Failed to query top gold balances", e)
+            emptyList()
+        }
+    }
+
     /**
      * Serializes an ItemStack to a Base64-encoded string using Paper's native NBT serialization.
      */

--- a/src/main/kotlin/net/lumalyte/lg/infrastructure/persistence/guilds/GuildVaultRepositorySQLite.kt
+++ b/src/main/kotlin/net/lumalyte/lg/infrastructure/persistence/guilds/GuildVaultRepositorySQLite.kt
@@ -222,7 +222,9 @@ class GuildVaultRepositorySQLite(private val storage: Storage<Database>) : Guild
             val results = storage.connection.getResults(sql, limit)
             results.mapNotNull { row ->
                 val id = try { UUID.fromString(row.getString("guild_id")) } catch (e: Exception) { null }
-                id?.let { it to row.getInt("balance").toLong() }
+                // Read as Long directly; SQLite INTEGER holds 8 bytes and balances can exceed
+                // Int.MAX_VALUE on a long-running server. getInt(...).toLong() would narrow first.
+                id?.let { it to row.getLong("balance") }
             }
         } catch (e: SQLException) {
             logger.error("Failed to query top gold balances", e)

--- a/src/main/kotlin/net/lumalyte/lg/infrastructure/persistence/migrations/GuildBalanceConsolidator.kt
+++ b/src/main/kotlin/net/lumalyte/lg/infrastructure/persistence/migrations/GuildBalanceConsolidator.kt
@@ -23,8 +23,16 @@ import java.sql.Connection
  */
 internal object GuildBalanceConsolidator {
 
-    /** Result of a single guild's fold, exposed for logging and testing. */
-    data class Fold(val guildId: String, val oldVault: Int, val ledger: Int, val legacy: Int, val newVault: Int)
+    /**
+     * Result of a single guild's fold, exposed for logging and testing.
+     *
+     * All fields are Long because the migration is one-shot and NOT idempotent: an Int
+     * overflow during aggregation would silently truncate the new balance, zero out the
+     * legacy column, and leave no audit trail to recover the original values. SQLite
+     * INTEGER columns hold 8-byte values, so the JDBC reads, in-memory math, and prepared
+     * statement bindings must all stay in 64-bit space end-to-end.
+     */
+    data class Fold(val guildId: String, val oldVault: Long, val ledger: Long, val legacy: Long, val newVault: Long)
 
     /**
      * Computes and applies the consolidation. Returns the list of guilds whose balance changed.
@@ -37,22 +45,22 @@ internal object GuildBalanceConsolidator {
         val now = System.currentTimeMillis()
 
         // Store A: ledger sum per guild (matches BankRepositorySQLite.calculateGuildBalance formula).
-        val ledger = HashMap<String, Int>()
+        val ledger = HashMap<String, Long>()
         if (tableExists(connection, "bank_transactions")) {
             val sql = "SELECT guild_id, COALESCE(SUM(CASE WHEN type='DEPOSIT' THEN amount ELSE -amount - fee END), 0) AS bal " +
                 "FROM bank_transactions GROUP BY guild_id"
             connection.createStatement().use { st ->
                 st.executeQuery(sql).use { rs ->
-                    while (rs.next()) ledger[rs.getString("guild_id")] = rs.getInt("bal")
+                    while (rs.next()) ledger[rs.getString("guild_id")] = rs.getLong("bal")
                 }
             }
         }
 
         // Store B: existing vault gold balances.
-        val vaultB = HashMap<String, Int>()
+        val vaultB = HashMap<String, Long>()
         connection.createStatement().use { st ->
             st.executeQuery("SELECT guild_id, balance FROM vault_gold").use { rs ->
-                while (rs.next()) vaultB[rs.getString("guild_id")] = rs.getInt("balance")
+                while (rs.next()) vaultB[rs.getString("guild_id")] = rs.getLong("balance")
             }
         }
 
@@ -62,11 +70,11 @@ internal object GuildBalanceConsolidator {
             st.executeQuery("SELECT id, bank_balance FROM guilds").use { rs ->
                 while (rs.next()) {
                     val id = rs.getString("id")
-                    val legacy = rs.getInt("bank_balance")
-                    val a = ledger[id] ?: 0
-                    val oldVault = vaultB[id] ?: 0
-                    val newVault = maxOf(0, oldVault + a + legacy)
-                    if (a != 0 || legacy != 0) folds.add(Fold(id, oldVault, a, legacy, newVault))
+                    val legacy = rs.getLong("bank_balance")
+                    val a = ledger[id] ?: 0L
+                    val oldVault = vaultB[id] ?: 0L
+                    val newVault = maxOf(0L, oldVault + a + legacy)
+                    if (a != 0L || legacy != 0L) folds.add(Fold(id, oldVault, a, legacy, newVault))
                 }
             }
         }
@@ -75,7 +83,7 @@ internal object GuildBalanceConsolidator {
             logger.info(Component.text("  No legacy balances to fold; all guilds already unified."))
         } else {
             logger.info(Component.text("  Folding legacy balances for ${folds.size} guild(s):"))
-            var totalFolded = 0
+            var totalFolded = 0L
             for (f in folds) {
                 totalFolded += f.ledger + f.legacy
                 logger.info(Component.text("    guild ${f.guildId.take(8)}: vault=${f.oldVault} + ledger=${f.ledger} + legacy=${f.legacy} -> ${f.newVault}"))
@@ -87,7 +95,7 @@ internal object GuildBalanceConsolidator {
             connection.prepareStatement(upsert).use { ps ->
                 for (f in folds) {
                     ps.setString(1, f.guildId)
-                    ps.setInt(2, f.newVault)
+                    ps.setLong(2, f.newVault)
                     ps.setLong(3, now)
                     ps.addBatch()
                 }

--- a/src/main/kotlin/net/lumalyte/lg/infrastructure/persistence/migrations/GuildBalanceConsolidator.kt
+++ b/src/main/kotlin/net/lumalyte/lg/infrastructure/persistence/migrations/GuildBalanceConsolidator.kt
@@ -1,0 +1,113 @@
+package net.lumalyte.lg.infrastructure.persistence.migrations
+
+import net.kyori.adventure.text.Component
+import net.kyori.adventure.text.logger.slf4j.ComponentLogger
+import java.sql.Connection
+
+/**
+ * Shared one-time consolidation that unifies the three historical guild-balance stores into a
+ * single source of truth (store B: the `vault_gold.balance` column):
+ *
+ *  - Store A: the `bank_transactions` ledger sum (server-coin bank).
+ *  - Store C: the `guilds.bank_balance` column (legacy virtual currency).
+ *  - Store B: the `vault_gold.balance` column (vault gold counter) — the canonical store.
+ *
+ * For every guild, the ledger sum (A) and legacy column (C) are folded into the vault gold
+ * balance (B), 1:1. The `guilds.bank_balance` column is then zeroed so it can no longer be
+ * mistaken for a live balance. The `bank_transactions` ledger is left intact as audit/history.
+ *
+ * IMPORTANT: this is a one-shot migration and is NOT safe to run twice. The ledger rows are
+ * retained for history, so a second pass would re-sum store A on top of the already-folded
+ * balance and double-count. It must run exactly once, enforced by the schema-version guard in
+ * [SQLiteMigrations] (version 21 -> 22).
+ */
+internal object GuildBalanceConsolidator {
+
+    /** Result of a single guild's fold, exposed for logging and testing. */
+    data class Fold(val guildId: String, val oldVault: Int, val ledger: Int, val legacy: Int, val newVault: Int)
+
+    /**
+     * Computes and applies the consolidation. Returns the list of guilds whose balance changed.
+     */
+    fun consolidate(connection: Connection, logger: ComponentLogger): List<Fold> {
+        if (!tableExists(connection, "guilds") || !tableExists(connection, "vault_gold")) {
+            logger.info(Component.text("  Skipping balance consolidation (required tables not present yet)"))
+            return emptyList()
+        }
+        val now = System.currentTimeMillis()
+
+        // Store A: ledger sum per guild (matches BankRepositorySQLite.calculateGuildBalance formula).
+        val ledger = HashMap<String, Int>()
+        if (tableExists(connection, "bank_transactions")) {
+            val sql = "SELECT guild_id, COALESCE(SUM(CASE WHEN type='DEPOSIT' THEN amount ELSE -amount - fee END), 0) AS bal " +
+                "FROM bank_transactions GROUP BY guild_id"
+            connection.createStatement().use { st ->
+                st.executeQuery(sql).use { rs ->
+                    while (rs.next()) ledger[rs.getString("guild_id")] = rs.getInt("bal")
+                }
+            }
+        }
+
+        // Store B: existing vault gold balances.
+        val vaultB = HashMap<String, Int>()
+        connection.createStatement().use { st ->
+            st.executeQuery("SELECT guild_id, balance FROM vault_gold").use { rs ->
+                while (rs.next()) vaultB[rs.getString("guild_id")] = rs.getInt("balance")
+            }
+        }
+
+        // Store C: legacy guilds.bank_balance, iterated as the authoritative guild set.
+        val folds = ArrayList<Fold>()
+        connection.createStatement().use { st ->
+            st.executeQuery("SELECT id, bank_balance FROM guilds").use { rs ->
+                while (rs.next()) {
+                    val id = rs.getString("id")
+                    val legacy = rs.getInt("bank_balance")
+                    val a = ledger[id] ?: 0
+                    val oldVault = vaultB[id] ?: 0
+                    val newVault = maxOf(0, oldVault + a + legacy)
+                    if (a != 0 || legacy != 0) folds.add(Fold(id, oldVault, a, legacy, newVault))
+                }
+            }
+        }
+
+        if (folds.isEmpty()) {
+            logger.info(Component.text("  No legacy balances to fold; all guilds already unified."))
+        } else {
+            logger.info(Component.text("  Folding legacy balances for ${folds.size} guild(s):"))
+            var totalFolded = 0
+            for (f in folds) {
+                totalFolded += f.ledger + f.legacy
+                logger.info(Component.text("    guild ${f.guildId.take(8)}: vault=${f.oldVault} + ledger=${f.ledger} + legacy=${f.legacy} -> ${f.newVault}"))
+            }
+            logger.info(Component.text("  Total folded into vault gold: $totalFolded across ${folds.size} guild(s)"))
+
+            val upsert = "INSERT INTO vault_gold (guild_id, balance, last_modified) VALUES (?, ?, ?) " +
+                "ON CONFLICT(guild_id) DO UPDATE SET balance = excluded.balance, last_modified = excluded.last_modified"
+            connection.prepareStatement(upsert).use { ps ->
+                for (f in folds) {
+                    ps.setString(1, f.guildId)
+                    ps.setInt(2, f.newVault)
+                    ps.setLong(3, now)
+                    ps.addBatch()
+                }
+                ps.executeBatch()
+            }
+        }
+
+        // Zero the legacy column so it cannot be mistaken for a live balance.
+        connection.createStatement().use { st ->
+            val zeroed = st.executeUpdate("UPDATE guilds SET bank_balance = 0 WHERE bank_balance <> 0")
+            if (zeroed > 0) logger.info(Component.text("  Cleared legacy bank_balance on $zeroed guild(s)"))
+        }
+
+        return folds
+    }
+
+    private fun tableExists(connection: Connection, tableName: String): Boolean {
+        connection.prepareStatement("SELECT name FROM sqlite_master WHERE type='table' AND name=?").use { ps ->
+            ps.setString(1, tableName)
+            ps.executeQuery().use { rs -> return rs.next() }
+        }
+    }
+}

--- a/src/main/kotlin/net/lumalyte/lg/infrastructure/persistence/migrations/SQLiteMigrations.kt
+++ b/src/main/kotlin/net/lumalyte/lg/infrastructure/persistence/migrations/SQLiteMigrations.kt
@@ -129,6 +129,11 @@ class SQLiteMigrations(private val plugin: JavaPlugin, private val connection: C
                 updateDatabaseVersion(22)
                 dbVersion = 22
             }
+            if (dbVersion < 23) {
+                migrateToVersion23()
+                updateDatabaseVersion(23)
+                dbVersion = 23
+            }
 
             // Validate that all required tables exist, recreate if missing
             validateAndRepairSchema()
@@ -1565,5 +1570,26 @@ class SQLiteMigrations(private val plugin: JavaPlugin, private val connection: C
         }
 
         componentLogger.info(Component.text("✓ Migration v22 complete: added bannerman_enabled column"))
+    }
+
+    /**
+     * Migration from version 22 to version 23.
+     *
+     * Unifies the three historical guild-balance stores into a single source of truth:
+     *  - Store A: the bank_transactions ledger sum (server-coin bank)
+     *  - Store C: the guilds.bank_balance column (legacy virtual currency)
+     *  - Store B: the vault_gold.balance column (vault gold counter) — the new canonical store
+     *
+     * For every guild, the ledger sum (A) and legacy column (C) are folded into the vault gold
+     * balance (B), 1:1. The guilds.bank_balance column is then zeroed so it can no longer be
+     * mistaken for a live balance. The bank_transactions ledger is left intact as audit/history.
+     * A per-guild dry-run report is logged before any rows are written.
+     *
+     * One-shot, NOT idempotent — the ledger rows persist, so a second pass would re-sum store A
+     * and double-count. The dbVersion guard above is the enforcement.
+     */
+    private fun migrateToVersion23() {
+        componentLogger.info(Component.text("Migrating to version 23: consolidating guild balances into unified vault gold (store B)..."))
+        GuildBalanceConsolidator.consolidate(connection, componentLogger)
     }
 }

--- a/src/main/kotlin/net/lumalyte/lg/infrastructure/placeholders/LumaGuildsExpansion.kt
+++ b/src/main/kotlin/net/lumalyte/lg/infrastructure/placeholders/LumaGuildsExpansion.kt
@@ -137,9 +137,8 @@ class LumaGuildsExpansion : PlaceholderExpansion(), KoinComponent {
             "guild_tag_plain" -> renderTagAsPlain(guild)
             "guild_emoji" -> convertEmojiToNexoPlaceholder(guild.emoji)
             "guild_level" -> guild.level.toString()
-            // Bank table is the source of truth (Guild.bankBalance is a separate virtual-currency
-            // field that is not kept in sync with deposits/withdrawals). Read it live so the
-            // placeholder always reflects the current bank value.
+            // BankService.getBalance resolves to the unified guild balance (store B: vault gold),
+            // the single source of truth shared by /g bal, /g baltop, /g menu -> Bank and the vault.
             "guild_balance" -> safeBalance(guildId).toString()
             "guild_mode" -> guild.mode.toString()
             "has_guild" -> "true"

--- a/src/main/kotlin/net/lumalyte/lg/infrastructure/services/BankServiceBukkit.kt
+++ b/src/main/kotlin/net/lumalyte/lg/infrastructure/services/BankServiceBukkit.kt
@@ -26,7 +26,8 @@ class BankServiceBukkit(
     private val progressionRepository: ProgressionRepository,
     private val progressionConfigService: ProgressionConfigService,
     private val configService: ConfigService,
-    private val guildRepository: net.lumalyte.lg.application.persistence.GuildRepository
+    private val guildRepository: net.lumalyte.lg.application.persistence.GuildRepository,
+    private val vaultInventoryManager: net.lumalyte.lg.application.services.VaultInventoryManager
 ) : BankService {
 
     private val logger = LoggerFactory.getLogger(BankServiceBukkit::class.java)
@@ -149,7 +150,7 @@ class BankServiceBukkit(
             }
 
             // Check guild bank balance limit (progression-based)
-            val currentBalance = bankRepository.getGuildBalance(guildId)
+            val currentBalance = getBalance(guildId)
             val progression = progressionRepository.getGuildProgression(guildId)
             val progressionConfig = progressionConfigService.getProgressionConfig()
             val levelRewards = progressionConfig.getActiveLevelRewards()
@@ -183,63 +184,52 @@ class BankServiceBukkit(
                 return null
             }
 
-            // Create transaction object BEFORE withdrawing from player
-            // This ensures we have a transaction ID for crash recovery
+            // Build the audit/history transaction record up front so it carries a stable id.
             val transaction = BankTransaction.deposit(guildId, playerId, amount, description)
 
-            // ATOMICITY IMPROVEMENT: Record pending transaction FIRST
-            // This acts as a write-ahead log (WAL) for crash recovery
-            val pendingRecorded = try {
-                bankRepository.recordTransaction(transaction)
-            } catch (e: Exception) {
-                logger.error("Failed to record pending transaction - aborting deposit", e)
-                return null
-            }
-
-            if (!pendingRecorded) {
-                logger.error("Failed to record pending transaction - aborting deposit")
-                return null
-            }
-
-            // Now withdraw money from player's account
+            // Take money from the player's economy account FIRST.
             val withdrawResult = economy.withdrawPlayer(player, amount.toDouble())
             if (!withdrawResult.transactionSuccess()) {
-                logger.error("Failed to withdraw $amount from player $playerId - ROLLING BACK transaction")
-                // ROLLBACK: Delete the pending transaction we just recorded
-                val rollbackSuccess = try {
-                    bankRepository.deleteTransaction(transaction.id)
-                } catch (e: Exception) {
-                    logger.error("CRITICAL: Failed to rollback transaction ${transaction.id}", e)
-                    false
-                }
+                logger.warn("Failed to withdraw $amount from player $playerId - aborting deposit")
+                recordAudit(BankAudit(
+                    transactionId = transaction.id,
+                    guildId = guildId,
+                    actorId = playerId,
+                    action = AuditAction.INSUFFICIENT_FUNDS,
+                    details = "Failed to withdraw money from player account"
+                ))
+                return null
+            }
 
+            // Credit the unified guild balance (store B: vault gold). This is atomic and the
+            // balance is immediately visible to all readers via VaultInventoryManager.
+            val creditedBalance = try {
+                vaultInventoryManager.depositGold(guildId, playerId, amount.toLong())
+            } catch (e: Exception) {
+                // Credit failed AFTER taking the player's money - refund to avoid loss.
+                logger.error("Failed to credit guild balance for guild $guildId - refunding player $playerId", e)
+                economy.depositPlayer(player, amount.toDouble())
                 recordAudit(BankAudit(
                     transactionId = transaction.id,
                     guildId = guildId,
                     actorId = playerId,
                     action = AuditAction.PERMISSION_DENIED,
-                    details = if (rollbackSuccess) {
-                        "Failed to withdraw money from player account - transaction rolled back successfully"
-                    } else {
-                        "Failed to withdraw money from player account - ROLLBACK FAILED! Manual intervention required"
-                    }
+                    details = "Failed to credit guild balance - player refunded"
                 ))
-
-                if (!rollbackSuccess) {
-                    logger.error("CRITICAL: Transaction ${transaction.id} exists in database but Vault withdrawal failed AND rollback failed - manual cleanup required")
-                    // Ledger row persisted despite payout failure — drop the leaderboard cache so
-                    // /baltop reflects the new (incorrect-but-real) balance until the operator
-                    // resolves it. Stale cached numbers would hide the inconsistency.
-                    invalidateBalanceLeaderboard()
-                } else {
-                    logger.info("Successfully rolled back failed deposit transaction ${transaction.id}")
-                }
                 return null
             }
 
-            // SUCCESS: Both database record and Vault withdrawal succeeded
+            // Record the transaction in the ledger as audit/history (best-effort; the balance
+            // no longer depends on it, so a failure here does not corrupt funds).
+            try {
+                bankRepository.recordTransaction(transaction)
+            } catch (e: Exception) {
+                logger.warn("Failed to record deposit transaction history for ${transaction.id} (balance already updated)", e)
+            }
+
+            // SUCCESS: player debited and guild balance credited
             invalidateBalanceLeaderboard()
-            val newBalance = bankRepository.getGuildBalance(guildId)
+            val newBalance = creditedBalance.toInt()
             recordAudit(BankAudit(
                 transactionId = transaction.id,
                 guildId = guildId,
@@ -352,73 +342,61 @@ class BankServiceBukkit(
 
             // Calculate final amount player receives (after fee)
             val finalAmount = amount
+            val totalDebit = amount + fee
 
-            // Create transaction object BEFORE depositing to player
-            // This ensures we have a transaction ID for crash recovery
+            // Build the audit/history transaction record up front so it carries a stable id.
             val transaction = BankTransaction.withdraw(guildId, playerId, amount, fee, description)
 
-            // ATOMICITY IMPROVEMENT: Record pending transaction FIRST
-            // This acts as a write-ahead log (WAL) for crash recovery
-            // For withdrawals, we record as NEGATIVE in the database first
-            val pendingRecorded = try {
-                bankRepository.recordTransaction(transaction)
-            } catch (e: Exception) {
-                logger.error("Failed to record pending withdrawal transaction - aborting withdrawal", e)
-                return null
-            }
-
-            if (!pendingRecorded) {
-                logger.error("Failed to record pending withdrawal transaction - aborting withdrawal")
-                return null
-            }
-
-            // Record fee transaction if applicable
-            if (fee > 0) {
-                val feeTransaction = BankTransaction(
+            // Debit the unified guild balance (store B: vault gold) FIRST, including the fee.
+            // withdrawGold is atomic and returns -1 if funds are insufficient.
+            val debitedBalance = vaultInventoryManager.withdrawGold(guildId, playerId, totalDebit.toLong())
+            if (debitedBalance == -1L) {
+                logger.warn("Insufficient guild balance for withdrawal of $totalDebit from guild $guildId")
+                recordAudit(BankAudit(
+                    transactionId = transaction.id,
                     guildId = guildId,
                     actorId = playerId,
-                    type = TransactionType.FEE,
-                    amount = fee,
-                    description = "Withdrawal fee"
-                )
-                try {
-                    bankRepository.recordTransaction(feeTransaction)
-                } catch (e: Exception) {
-                    logger.error("Failed to record fee transaction", e)
-                    // Continue anyway - fee is less critical than the main transaction
-                }
+                    action = AuditAction.INSUFFICIENT_FUNDS,
+                    details = "Insufficient guild balance for withdrawal of $amount (+$fee fee)"
+                ))
+                return null
             }
 
-            // Now deposit money to player's account (from guild bank withdrawal)
+            // Now pay the player from the guild withdrawal.
             val depositResult = economy.depositPlayer(player, finalAmount.toDouble())
             if (!depositResult.transactionSuccess()) {
-                logger.error("Failed to deposit $finalAmount to player $playerId - INCOMPLETE WITHDRAWAL")
-                // IMPORTANT: For withdrawals, we do NOT delete the transaction like we do for deposits
-                // The guild bank has already been debited (transaction recorded)
-                // If we delete the transaction, the guild gets their money back for free
-                // This is the SAFER failure mode:
-                //   - Guild bank shows money was withdrawn (correct)
-                //   - Player didn't receive money (needs manual credit by admin)
-                //   - Admin can audit logs and manually credit the player
-                // This prevents money duplication exploits
+                logger.error("Failed to deposit $finalAmount to player $playerId - re-crediting guild balance")
+                // Player payout failed AFTER debiting the guild - re-credit to avoid loss.
+                vaultInventoryManager.depositGold(guildId, playerId, totalDebit.toLong())
                 recordAudit(BankAudit(
                     transactionId = transaction.id,
                     guildId = guildId,
                     actorId = playerId,
                     action = AuditAction.PERMISSION_DENIED,
-                    details = "Failed to deposit money to player account - withdrawal recorded but payout failed, manual payout required"
+                    details = "Failed to deposit money to player account - withdrawal reverted"
                 ))
-                logger.warn("MANUAL ACTION REQUIRED: Withdrawal transaction ${transaction.id} recorded but Vault deposit failed - player $playerId needs manual credit of $finalAmount coins")
-                // Withdrawal ledger row was committed, so the real guild balance dropped even
-                // though payout failed. Invalidate the cache or /baltop keeps the pre-withdrawal
-                // number until TTL expires.
-                invalidateBalanceLeaderboard()
                 return null
             }
 
-            // SUCCESS: Both database record and Vault deposit succeeded
+            // Record the ledger history (best-effort; balance no longer depends on it).
+            try {
+                bankRepository.recordTransaction(transaction)
+                if (fee > 0) {
+                    bankRepository.recordTransaction(BankTransaction(
+                        guildId = guildId,
+                        actorId = playerId,
+                        type = TransactionType.FEE,
+                        amount = fee,
+                        description = "Withdrawal fee"
+                    ))
+                }
+            } catch (e: Exception) {
+                logger.warn("Failed to record withdrawal transaction history for ${transaction.id} (balance already updated)", e)
+            }
+
+            // SUCCESS: guild balance debited and player paid
             invalidateBalanceLeaderboard()
-            val newBalance = bankRepository.getGuildBalance(guildId)
+            val newBalance = debitedBalance.toInt()
             recordAudit(BankAudit(
                 transactionId = transaction.id,
                 guildId = guildId,
@@ -450,7 +428,9 @@ class BankServiceBukkit(
     }
 
     override fun getBalance(guildId: UUID): Int {
-        return bankRepository.getGuildBalance(guildId)
+        // Store B (guild vault gold balance) is the single source of truth for guild funds.
+        // The bank_transactions ledger is retained only as an audit/history trail.
+        return vaultInventoryManager.getGoldBalance(guildId).toInt()
     }
 
     override fun getTopBalances(limit: Int): List<Pair<UUID, Int>> {
@@ -460,7 +440,9 @@ class BankServiceBukkit(
         val now = System.currentTimeMillis()
         synchronized(balanceLeaderboardLock) {
             if (now >= balanceLeaderboardExpiresAtMs || cachedTopBalances.size < limit) {
-                cachedTopBalances = bankRepository.getTopBalances(cacheSize)
+                // Ranked by store B (vault gold balance), the unified source of truth.
+                cachedTopBalances = vaultInventoryManager.getTopGoldBalances(cacheSize)
+                    .map { (id, balance) -> id to balance.toInt() }
                 balanceLeaderboardExpiresAtMs = now + balanceLeaderboardTtlMs
             }
             return cachedTopBalances.take(limit)
@@ -667,27 +649,67 @@ class BankServiceBukkit(
 
     override fun deductFromGuildBank(guildId: UUID, amount: Int, reason: String?): Boolean {
         try {
-            // Check if guild has sufficient balance
-            val currentBalance = getBalance(guildId)
-            if (currentBalance < amount) {
+            val systemActor = UUID.randomUUID() // System deductions have no player actor
+
+            // Debit the unified guild balance (store B). Atomic; -1 if insufficient.
+            val debitedBalance = vaultInventoryManager.withdrawGold(guildId, systemActor, amount.toLong())
+            if (debitedBalance == -1L) {
                 logger.warn("Guild $guildId has insufficient funds for deduction of $amount")
                 return false
             }
 
-            // Record the transaction as a deduction (no player involved)
-            val transaction = BankTransaction(
-                guildId = guildId,
-                actorId = UUID.randomUUID(), // Use random UUID for system deductions
-                type = TransactionType.DEDUCTION,
-                amount = amount, // Positive amount (will be negated in balance calculation)
-                description = reason ?: "Guild bank deduction"
-            )
+            // Record the deduction in the ledger as audit/history (best-effort).
+            try {
+                bankRepository.recordTransaction(BankTransaction(
+                    guildId = guildId,
+                    actorId = systemActor,
+                    type = TransactionType.DEDUCTION,
+                    amount = amount,
+                    description = reason ?: "Guild bank deduction"
+                ))
+            } catch (e: Exception) {
+                logger.warn("Failed to record deduction history for guild $guildId (balance already updated)", e)
+            }
 
-            val recorded = bankRepository.recordTransaction(transaction)
-            if (recorded) invalidateBalanceLeaderboard()
-            return recorded
+            invalidateBalanceLeaderboard()
+            return true
         } catch (e: SQLException) {
             logger.error("Database error processing guild bank deduction for guild $guildId", e)
+            return false
+        }
+    }
+
+    override fun creditToGuildBank(guildId: UUID, amount: Int, reason: String?): Boolean {
+        if (amount <= 0) return false
+        try {
+            val systemActor = UUID.randomUUID() // System credits have no player actor
+
+            // Credit the unified guild balance (store B). Atomic and immediately visible.
+            val newBalance = try {
+                vaultInventoryManager.depositGold(guildId, systemActor, amount.toLong())
+            } catch (e: Exception) {
+                logger.error("Failed to credit guild balance for guild $guildId", e)
+                return false
+            }
+
+            // Record in the ledger as audit/history (best-effort).
+            try {
+                bankRepository.recordTransaction(BankTransaction.deposit(guildId, systemActor, amount, reason))
+                recordAudit(BankAudit(
+                    guildId = guildId,
+                    actorId = systemActor,
+                    action = AuditAction.DEPOSIT,
+                    details = reason ?: "Guild bank credit",
+                    newBalance = newBalance.toInt()
+                ))
+            } catch (e: Exception) {
+                logger.warn("Failed to record credit history for guild $guildId (balance already updated)", e)
+            }
+
+            invalidateBalanceLeaderboard()
+            return true
+        } catch (e: SQLException) {
+            logger.error("Database error processing guild bank credit for guild $guildId", e)
             return false
         }
     }

--- a/src/main/kotlin/net/lumalyte/lg/infrastructure/services/BankServiceBukkit.kt
+++ b/src/main/kotlin/net/lumalyte/lg/infrastructure/services/BankServiceBukkit.kt
@@ -649,7 +649,10 @@ class BankServiceBukkit(
 
     override fun deductFromGuildBank(guildId: UUID, amount: Int, reason: String?): Boolean {
         try {
-            val systemActor = UUID.randomUUID() // System deductions have no player actor
+            // Reuse the sentinel UUID(0,0) defined by GuildVaultServiceBukkit so every system-driven
+            // gold movement is correlatable in the audit log (grep "all system ops" stays possible).
+            // A fresh randomUUID() per call would scatter system rows across orphan-looking ids.
+            val systemActor = GuildVaultServiceBukkit.SYSTEM_ACTOR
 
             // Debit the unified guild balance (store B). Atomic; -1 if insufficient.
             val debitedBalance = vaultInventoryManager.withdrawGold(guildId, systemActor, amount.toLong())
@@ -682,7 +685,8 @@ class BankServiceBukkit(
     override fun creditToGuildBank(guildId: UUID, amount: Int, reason: String?): Boolean {
         if (amount <= 0) return false
         try {
-            val systemActor = UUID.randomUUID() // System credits have no player actor
+            // Same shared sentinel as deductFromGuildBank above — see comment there.
+            val systemActor = GuildVaultServiceBukkit.SYSTEM_ACTOR
 
             // Credit the unified guild balance (store B). Atomic and immediately visible.
             val newBalance = try {

--- a/src/main/kotlin/net/lumalyte/lg/infrastructure/services/GuildVaultServiceBukkit.kt
+++ b/src/main/kotlin/net/lumalyte/lg/infrastructure/services/GuildVaultServiceBukkit.kt
@@ -49,8 +49,10 @@ class GuildVaultServiceBukkit(
     // Cache for vault location to guild mapping
     private val vaultLocationCache = mutableMapOf<String, UUID>()
 
-    private companion object {
+    companion object {
         // Sentinel actor id for system-driven (non-player) gold movements in the vault ledger.
+        // Public so peer services (BankServiceBukkit, war/cost services) can reuse the same
+        // identifier — every system-driven row in audit/history is then grouped under one UUID.
         val SYSTEM_ACTOR: UUID = UUID(0L, 0L)
     }
 

--- a/src/main/kotlin/net/lumalyte/lg/infrastructure/services/GuildVaultServiceBukkit.kt
+++ b/src/main/kotlin/net/lumalyte/lg/infrastructure/services/GuildVaultServiceBukkit.kt
@@ -49,6 +49,11 @@ class GuildVaultServiceBukkit(
     // Cache for vault location to guild mapping
     private val vaultLocationCache = mutableMapOf<String, UUID>()
 
+    private companion object {
+        // Sentinel actor id for system-driven (non-player) gold movements in the vault ledger.
+        val SYSTEM_ACTOR: UUID = UUID(0L, 0L)
+    }
+
     // Persistent Data Container keys for marking vault chests
     private val vaultGuildIdKey = NamespacedKey(plugin, "vault_guild_id")
     private val vaultMarkerKey = NamespacedKey(plugin, "vault_marker")
@@ -494,14 +499,14 @@ class GuildVaultServiceBukkit(
     }
 
     private fun depositVirtual(guild: Guild, amount: Double, reason: String): VaultResult<Double> {
-        // Add to guild bank balance
-        val newBalance = guild.bankBalance + amount.toInt()
-        val updatedGuild = guild.copy(bankBalance = newBalance)
-
-        return if (guildRepository.update(updatedGuild)) {
+        // Credit the unified guild balance (store B: vault gold). The legacy Guild.bankBalance
+        // column is no longer the source of truth.
+        return try {
+            val newBalance = vaultInventoryManager.depositGold(guild.id, SYSTEM_ACTOR, amount.toLong())
             logger.info("Guild ${guild.name} deposited $amount virtual currency for: $reason")
             VaultResult.Success(newBalance.toDouble())
-        } else {
+        } catch (e: Exception) {
+            logger.error("Failed to credit guild balance for ${guild.id}", e)
             VaultResult.Failure("Failed to update guild balance in database")
         }
     }
@@ -595,28 +600,23 @@ class GuildVaultServiceBukkit(
     }
 
     private fun withdrawVirtual(guild: Guild, amount: Double, reason: String): VaultResult<WithdrawalInfo> {
-        if (guild.bankBalance < amount.toInt()) {
+        // Debit the unified guild balance (store B: vault gold). Atomic; -1 if insufficient.
+        val newBalance = vaultInventoryManager.withdrawGold(guild.id, SYSTEM_ACTOR, amount.toLong())
+        if (newBalance == -1L) {
+            val current = vaultInventoryManager.getGoldBalance(guild.id)
             return VaultResult.Failure(
-                "Insufficient virtual currency: ${guild.bankBalance} < ${amount.toInt()}"
+                "Insufficient virtual currency: $current < ${amount.toInt()}"
             )
         }
 
-        // Deduct from guild bank balance
-        val newBalance = guild.bankBalance - amount.toInt()
-        val updatedGuild = guild.copy(bankBalance = newBalance)
-
-        return if (guildRepository.update(updatedGuild)) {
-            logger.info("Guild ${guild.name} withdrew $amount virtual currency for: $reason")
-            VaultResult.Success(
-                WithdrawalInfo(
-                    withdrawnAmount = amount,
-                    remainingBalance = newBalance.toDouble(),
-                    mode = BankMode.VIRTUAL
-                )
+        logger.info("Guild ${guild.name} withdrew $amount virtual currency for: $reason")
+        return VaultResult.Success(
+            WithdrawalInfo(
+                withdrawnAmount = amount,
+                remainingBalance = newBalance.toDouble(),
+                mode = BankMode.VIRTUAL
             )
-        } else {
-            VaultResult.Failure("Failed to update guild balance in database")
-        }
+        )
     }
 
     private fun withdrawPhysical(guild: Guild, amount: Double, reason: String): VaultResult<WithdrawalInfo> {

--- a/src/main/kotlin/net/lumalyte/lg/infrastructure/services/WarServiceBukkit.kt
+++ b/src/main/kotlin/net/lumalyte/lg/infrastructure/services/WarServiceBukkit.kt
@@ -1,6 +1,5 @@
 package net.lumalyte.lg.infrastructure.services
 
-import net.lumalyte.lg.application.persistence.BankRepository
 import net.lumalyte.lg.application.persistence.ProgressionRepository
 import net.lumalyte.lg.application.services.ConfigService
 import net.lumalyte.lg.application.services.WarService
@@ -16,7 +15,7 @@ import java.util.concurrent.ConcurrentHashMap
 
 class WarServiceBukkit(
     private val configService: ConfigService,
-    private val bankRepository: BankRepository,
+    private val bankService: net.lumalyte.lg.application.services.BankService,
     private val progressionRepository: ProgressionRepository,
     private val progressionConfigService: ProgressionConfigService
 ) : WarService {
@@ -439,9 +438,9 @@ class WarServiceBukkit(
                 return null
             }
 
-            // Check if both guilds have sufficient funds
-            val declaringBalance = bankRepository.getGuildBalance(war.declaringGuildId)
-            val defendingBalance = bankRepository.getGuildBalance(war.defendingGuildId)
+            // Check if both guilds have sufficient funds (store B: unified guild balance)
+            val declaringBalance = bankService.getBalance(war.declaringGuildId)
+            val defendingBalance = bankService.getBalance(war.defendingGuildId)
 
             if (declaringBalance < declaringGuildWager) {
                 logger.warn("Declaring guild ${war.declaringGuildId} has insufficient funds for wager: $declaringBalance < $declaringGuildWager")
@@ -453,15 +452,11 @@ class WarServiceBukkit(
                 return null
             }
 
+            val wagerDesc = "War wager for war ${warId.toString().substring(0, 8)}"
+
             // Deduct wager from declaring guild
             val declaringDeductSuccess = if (declaringGuildWager > 0) {
-                val withdrawal = BankTransaction.withdraw(
-                    guildId = war.declaringGuildId,
-                    actorId = UUID.randomUUID(), // System actor
-                    amount = declaringGuildWager,
-                    description = "War wager for war ${warId.toString().substring(0, 8)}"
-                )
-                bankRepository.recordTransaction(withdrawal)
+                bankService.deductFromGuildBank(war.declaringGuildId, declaringGuildWager, wagerDesc)
             } else true
 
             if (!declaringDeductSuccess) {
@@ -471,26 +466,18 @@ class WarServiceBukkit(
 
             // Deduct wager from defending guild
             val defendingDeductSuccess = if (defendingGuildWager > 0) {
-                val withdrawal = BankTransaction.withdraw(
-                    guildId = war.defendingGuildId,
-                    actorId = UUID.randomUUID(), // System actor
-                    amount = defendingGuildWager,
-                    description = "War wager for war ${warId.toString().substring(0, 8)}"
-                )
-                bankRepository.recordTransaction(withdrawal)
+                bankService.deductFromGuildBank(war.defendingGuildId, defendingGuildWager, wagerDesc)
             } else true
 
             if (!defendingDeductSuccess) {
                 logger.error("Failed to deduct wager from defending guild ${war.defendingGuildId}")
                 // ROLLBACK: Refund declaring guild
                 if (declaringGuildWager > 0) {
-                    val deposit = BankTransaction.deposit(
-                        guildId = war.declaringGuildId,
-                        actorId = UUID.randomUUID(), // System actor
-                        amount = declaringGuildWager,
-                        description = "Wager rollback - defending guild deduction failed"
+                    val rollbackSuccess = bankService.creditToGuildBank(
+                        war.declaringGuildId,
+                        declaringGuildWager,
+                        "Wager rollback - defending guild deduction failed"
                     )
-                    val rollbackSuccess = bankRepository.recordTransaction(deposit)
                     if (!rollbackSuccess) {
                         logger.error("CRITICAL: Failed to rollback wager for declaring guild ${war.declaringGuildId}! Manual intervention required.")
                     }
@@ -526,21 +513,16 @@ class WarServiceBukkit(
                 return null
             }
 
-            val systemActor = UUID.fromString("00000000-0000-0000-0000-000000000000") // System UUID
-
             if (winnerGuildId != null) {
                 // War ended with winner - pay out total pot to winner
                 val totalPot = wager.totalPot
 
                 if (totalPot > 0) {
-                    val depositTransaction = net.lumalyte.lg.domain.entities.BankTransaction.deposit(
-                        guildId = winnerGuildId,
-                        actorId = systemActor,
-                        amount = totalPot,
-                        description = "War wager winnings from war ${warId.toString().substring(0, 8)}"
+                    val depositSuccess = bankService.creditToGuildBank(
+                        winnerGuildId,
+                        totalPot,
+                        "War wager winnings from war ${warId.toString().substring(0, 8)}"
                     )
-
-                    val depositSuccess = bankRepository.recordTransaction(depositTransaction)
 
                     if (!depositSuccess) {
                         logger.error("CRITICAL: Failed to deposit wager winnings of $totalPot to winner guild $winnerGuildId! Manual intervention required.")
@@ -565,14 +547,11 @@ class WarServiceBukkit(
 
                 // Refund declaring guild
                 if (wager.declaringGuildWager > 0) {
-                    val declaringRefundTransaction = net.lumalyte.lg.domain.entities.BankTransaction.deposit(
-                        guildId = wager.declaringGuildId,
-                        actorId = systemActor,
-                        amount = wager.declaringGuildWager,
-                        description = "War wager refund (draw) from war ${warId.toString().substring(0, 8)}"
-                    )
-
-                    if (!bankRepository.recordTransaction(declaringRefundTransaction)) {
+                    if (!bankService.creditToGuildBank(
+                            wager.declaringGuildId,
+                            wager.declaringGuildWager,
+                            "War wager refund (draw) from war ${warId.toString().substring(0, 8)}"
+                    )) {
                         logger.error("CRITICAL: Failed to refund wager of ${wager.declaringGuildWager} to declaring guild ${wager.declaringGuildId}! Manual intervention required.")
                         refundSuccess = false
                     } else {
@@ -582,14 +561,11 @@ class WarServiceBukkit(
 
                 // Refund defending guild
                 if (wager.defendingGuildWager > 0) {
-                    val defendingRefundTransaction = net.lumalyte.lg.domain.entities.BankTransaction.deposit(
-                        guildId = wager.defendingGuildId,
-                        actorId = systemActor,
-                        amount = wager.defendingGuildWager,
-                        description = "War wager refund (draw) from war ${warId.toString().substring(0, 8)}"
-                    )
-
-                    if (!bankRepository.recordTransaction(defendingRefundTransaction)) {
+                    if (!bankService.creditToGuildBank(
+                            wager.defendingGuildId,
+                            wager.defendingGuildWager,
+                            "War wager refund (draw) from war ${warId.toString().substring(0, 8)}"
+                    )) {
                         logger.error("CRITICAL: Failed to refund wager of ${wager.defendingGuildWager} to defending guild ${wager.defendingGuildId}! Manual intervention required.")
                         refundSuccess = false
                     } else {

--- a/src/main/kotlin/net/lumalyte/lg/interaction/menus/guild/GuildInfoMenu.kt
+++ b/src/main/kotlin/net/lumalyte/lg/interaction/menus/guild/GuildInfoMenu.kt
@@ -35,6 +35,7 @@ class GuildInfoMenu(private val menuNavigator: MenuNavigator, private val player
     private val memberService: MemberService by inject()
     private val rankService: RankService by inject()
     private val relationService: RelationService by inject()
+    private val bankService: net.lumalyte.lg.application.services.BankService by inject()
     private val menuFactory: net.lumalyte.lg.interaction.menus.MenuFactory by inject()
 
     override fun open() {
@@ -213,7 +214,7 @@ class GuildInfoMenu(private val menuNavigator: MenuNavigator, private val player
     private fun addStatisticsSection(pane: StaticPane, x: Int, y: Int) {
         val statsItem = ItemStack.of(Material.BOOK)
             .name("§eStatistics")
-            .lore("§7Bank Balance: §6$${guild.bankBalance}")
+            .lore("§7Bank Balance: §6$${bankService.getBalance(guild.id)}")
             .lore("§7Level: §e${guild.level}")
 
         if (guild.home != null) {

--- a/src/main/kotlin/net/lumalyte/lg/interaction/menus/guild/GuildWarAcceptanceMenu.kt
+++ b/src/main/kotlin/net/lumalyte/lg/interaction/menus/guild/GuildWarAcceptanceMenu.kt
@@ -196,10 +196,11 @@ class GuildWarAcceptanceMenu(
                 }
 
                 // Check if guild has sufficient funds to match wager
-                if (guild.bankBalance < warDeclaration.wagerAmount) {
+                val currentBalance = bankService.getBalance(guild.id)
+                if (currentBalance < warDeclaration.wagerAmount) {
                     player.sendMessage("§c❌ Insufficient guild bank funds to match wager!")
                     player.sendMessage("§7Need: §6${warDeclaration.wagerAmount} gold")
-                    player.sendMessage("§7Have: §6${guild.bankBalance} gold")
+                    player.sendMessage("§7Have: §6$currentBalance gold")
                     player.playSound(player.location, Sound.ENTITY_VILLAGER_NO, 1.0f, 1.0f)
                     return
                 }

--- a/src/main/kotlin/net/lumalyte/lg/interaction/menus/guild/GuildWarDeclarationMenu.kt
+++ b/src/main/kotlin/net/lumalyte/lg/interaction/menus/guild/GuildWarDeclarationMenu.kt
@@ -237,7 +237,7 @@ class GuildWarDeclarationMenu(
     }
 
     private fun addWarWagerSection(pane: StaticPane) {
-        val guildBalance = guild.bankBalance
+        val guildBalance = bankService.getBalance(guild.id)
         val maxWager = guildBalance // No limits - high stakes gambling!
 
         // Main wager display
@@ -328,7 +328,7 @@ class GuildWarDeclarationMenu(
             pane.addItem(wagerAllGuiItem, 7, 2)
 
             // Wager Enemy Bank button (if enemy guild has funds)
-            val enemyBalance = targetGuild?.bankBalance ?: 0
+            val enemyBalance = targetGuild?.let { bankService.getBalance(it.id) } ?: 0
             if (enemyBalance > 0) {
                 val wagerEnemyItem = ItemStack.of(Material.PURPLE_CONCRETE)
                     .name("§5∩ MATCH ENEMY")
@@ -508,10 +508,11 @@ class GuildWarDeclarationMenu(
             // Handle wager escrow if there's a wager
             if (wagerAmount > 0) {
                 // Check if guild has sufficient funds
-                if (guild.bankBalance < wagerAmount) {
+                val currentBalance = bankService.getBalance(guild.id)
+                if (currentBalance < wagerAmount) {
                     player.sendMessage("§c❌ Insufficient guild bank funds for wager!")
                     player.sendMessage("§7Need: §6$wagerAmount coins")
-                    player.sendMessage("§7Have: §6${guild.bankBalance} coins")
+                    player.sendMessage("§7Have: §6$currentBalance coins")
                     player.playSound(player.location, Sound.ENTITY_VILLAGER_NO, 1.0f, 1.0f)
                     return
                 }

--- a/src/test/kotlin/net/lumalyte/lg/infrastructure/persistence/migrations/GuildBalanceConsolidatorTest.kt
+++ b/src/test/kotlin/net/lumalyte/lg/infrastructure/persistence/migrations/GuildBalanceConsolidatorTest.kt
@@ -1,0 +1,140 @@
+package net.lumalyte.lg.infrastructure.persistence.migrations
+
+import net.kyori.adventure.text.logger.slf4j.ComponentLogger
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.Assertions.*
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.io.TempDir
+import java.io.File
+import java.nio.file.Path
+import java.sql.Connection
+import java.sql.DriverManager
+
+/**
+ * Tests for the v22 balance consolidation: folding the bank_transactions ledger (store A) and the
+ * legacy guilds.bank_balance column (store C) into the unified vault_gold balance (store B).
+ */
+class GuildBalanceConsolidatorTest {
+
+    @TempDir
+    lateinit var tempDir: Path
+
+    private lateinit var connection: Connection
+    private val logger = ComponentLogger.logger("test")
+
+    @BeforeEach
+    fun setUp() {
+        val file: File = tempDir.resolve("test.db").toFile()
+        connection = DriverManager.getConnection("jdbc:sqlite:${file.absolutePath}")
+        connection.autoCommit = true
+        connection.createStatement().use { st ->
+            st.execute("CREATE TABLE guilds (id TEXT PRIMARY KEY, name TEXT NOT NULL, bank_balance INTEGER NOT NULL DEFAULT 0)")
+            st.execute("CREATE TABLE vault_gold (guild_id TEXT PRIMARY KEY, balance INTEGER NOT NULL DEFAULT 0, last_modified INTEGER NOT NULL)")
+            st.execute("CREATE TABLE bank_transactions (id TEXT PRIMARY KEY, guild_id TEXT NOT NULL, actor_id TEXT, type TEXT NOT NULL, amount INTEGER NOT NULL, fee INTEGER NOT NULL DEFAULT 0)")
+        }
+    }
+
+    @AfterEach
+    fun tearDown() = connection.close()
+
+    private fun addGuild(id: String, bankBalance: Int) {
+        connection.createStatement().use { it.execute("INSERT INTO guilds (id, name, bank_balance) VALUES ('$id', 'G-$id', $bankBalance)") }
+    }
+
+    private fun addVaultGold(id: String, balance: Int) {
+        connection.createStatement().use { it.execute("INSERT INTO vault_gold (guild_id, balance, last_modified) VALUES ('$id', $balance, 0)") }
+    }
+
+    private fun addTx(id: String, guildId: String, type: String, amount: Int, fee: Int = 0) {
+        connection.createStatement().use { it.execute("INSERT INTO bank_transactions (id, guild_id, actor_id, type, amount, fee) VALUES ('$id', '$guildId', 'a', '$type', $amount, $fee)") }
+    }
+
+    private fun vaultBalance(id: String): Int =
+        connection.createStatement().use { st ->
+            st.executeQuery("SELECT balance FROM vault_gold WHERE guild_id='$id'").use { rs -> if (rs.next()) rs.getInt("balance") else -1 }
+        }
+
+    private fun legacyBalance(id: String): Int =
+        connection.createStatement().use { st ->
+            st.executeQuery("SELECT bank_balance FROM guilds WHERE id='$id'").use { rs -> if (rs.next()) rs.getInt("bank_balance") else -1 }
+        }
+
+    @Test
+    fun `folds ledger and legacy into existing vault balance`() {
+        // Guild has 100 in vault, ledger nets 250 (300 deposit - 50 withdrawal), legacy column 30.
+        addGuild("g1", bankBalance = 30)
+        addVaultGold("g1", 100)
+        addTx("t1", "g1", "DEPOSIT", 300)
+        addTx("t2", "g1", "WITHDRAWAL", 50)
+
+        GuildBalanceConsolidator.consolidate(connection, logger)
+
+        assertEquals(380, vaultBalance("g1")) // 100 + (300-50) + 30
+        assertEquals(0, legacyBalance("g1"))  // legacy column zeroed
+    }
+
+    @Test
+    fun `creates vault row for guild that has no existing vault entry`() {
+        addGuild("g2", bankBalance = 75)
+        addTx("t1", "g2", "DEPOSIT", 200)
+        // no vault_gold row for g2
+
+        GuildBalanceConsolidator.consolidate(connection, logger)
+
+        assertEquals(275, vaultBalance("g2")) // 0 + 200 + 75
+    }
+
+    @Test
+    fun `withdrawal fee is subtracted from folded ledger`() {
+        addGuild("g3", bankBalance = 0)
+        addVaultGold("g3", 0)
+        addTx("t1", "g3", "DEPOSIT", 100)
+        addTx("t2", "g3", "WITHDRAWAL", 20, fee = 5)
+
+        GuildBalanceConsolidator.consolidate(connection, logger)
+
+        assertEquals(75, vaultBalance("g3")) // 100 - 20 - 5
+    }
+
+    @Test
+    fun `negative net is clamped to zero`() {
+        addGuild("g4", bankBalance = 0)
+        addVaultGold("g4", 10)
+        addTx("t1", "g4", "DEDUCTION", 1000)
+
+        GuildBalanceConsolidator.consolidate(connection, logger)
+
+        assertEquals(0, vaultBalance("g4")) // max(0, 10 + (-1000) + 0)
+    }
+
+    @Test
+    fun `guild with no legacy balance and no ledger is left untouched`() {
+        addGuild("g5", bankBalance = 0)
+        addVaultGold("g5", 500)
+
+        GuildBalanceConsolidator.consolidate(connection, logger)
+
+        assertEquals(500, vaultBalance("g5"))
+    }
+
+    @Test
+    fun `returns an accurate per-guild fold report and only for changed guilds`() {
+        addGuild("g6", bankBalance = 40)
+        addVaultGold("g6", 10)
+        addTx("t1", "g6", "DEPOSIT", 100)
+        // g7 has nothing to fold and must be excluded from the report.
+        addGuild("g7", bankBalance = 0)
+        addVaultGold("g7", 500)
+
+        val report = GuildBalanceConsolidator.consolidate(connection, logger)
+
+        assertEquals(1, report.size)
+        val fold = report.single()
+        assertEquals("g6", fold.guildId)
+        assertEquals(10, fold.oldVault)
+        assertEquals(100, fold.ledger)
+        assertEquals(40, fold.legacy)
+        assertEquals(150, fold.newVault)
+    }
+}


### PR DESCRIPTION
> **Note:** this branch stacks on earlier unmerged guild work (name sanitization, baltop leaderboard, relation/allyhome fixes — commits `759c9cf`..`d69c72e`); the unification builds on the `getTopBalances` added there. The headline change is the **final commit** (`3eb2f11`). If those earlier commits are landing via another PR, rebase this onto it.

## Summary

The guild **balance** was split across three independent stores that never synced. This PR collapses them onto a single source of truth: **store B — `vault_gold.balance`** (the gold-nugget counter shown in `/g menu → Bank` and the guild vault).

### Root cause: three divergent stores

| Store | Backing | Drove |
|---|---|---|
| **A** | `bank_transactions` ledger sum (`BankService`/`BankRepository`) | `/g bal`, `/g baltop`, all balance placeholders, Bedrock bank menu |
| **B** | `vault_gold.balance` counter (`VaultInventoryManager`) | Java `/g menu → Bank`, physical vault gold button |
| **C** | `guilds.bank_balance` column (`Guild.bankBalance`) | shop/ARM deposits, war-wager displays, `GuildInfoMenu` |

**Observed symptoms**
- Deposit gold via `/g menu → Bank` (store B) → `/g bal` (store A) unchanged.
- Java vs Bedrock bank menus wrote *different databases*.
- War wager **displayed** store C but **deducted** store A.

## Approach

Make store B the one balance; demote A to audit-only and zero out C.

- **Reroute** `BankService.getBalance / getTopBalances / deposit / withdraw / deductFromGuildBank` to store B. Because ~30 call sites already go through `bankService.*`, this carries `/g bal`, `/g baltop`, every balance placeholder, LFG join fee, daily war costs, banner purchase, the Bedrock bank menu, and the leaderboard web handler **automatically**.
- **Add** `BankService.creditToGuildBank` (system credit, no player) and `GuildVaultRepository.getTopGoldBalances` (+ SQLite impl, ranks `vault_gold`).
- **Collapse store C**: `GuildVaultService.depositVirtual/withdrawVirtual` delegate to store B; direct `guild.bankBalance` readers repointed (`GuildInfoMenu`, `GuildWarDeclarationMenu`, `GuildWarAcceptanceMenu`).
- **Fix `WarServiceBukkit`** (critical): it wrote the ledger directly for wager escrow/payout, which no longer moves funds under the unified model. Escrow → `deductFromGuildBank`; payouts/refunds → `creditToGuildBank`.
- **Demote** the `bank_transactions` ledger to audit/history only; records retained.

## Migration

SQLite **v22** (`GuildBalanceConsolidator`) folds ledger-sum (A) + `guilds.bank_balance` (C) into `vault_gold` (B), 1:1, clamped ≥0. Logs a **per-guild dry-run report** before writing, then zeroes `bank_balance`. The ledger is left intact as history.

⚠️ **One-shot, NOT idempotent** — the ledger rows persist, so a second pass would re-sum store A and double-count. Enforced to run once by the `PRAGMA user_version` 21→22 guard. **Back up the DB before first launch on this build.**

## Tests

- New `GuildBalanceConsolidatorTest` (6): fold math, withdrawal-fee subtraction, negative→0 clamp, new-row creation, no-op guild, dry-run report accuracy.
- Full suite green (`./gradlew test`, JDK 21).

## Risks / caveats

- **Ledger ≠ balance now.** `getBankStats`, member contributions, transaction history still read the ledger (correct — they're history). Java `GuildBankMenu` gold deposits write store B directly and skip the ledger, so the history panel won't list GUI gold deposits (pre-existing behavior, unchanged).
- **Currency model** (per maintainer decision): the guild balance is one integer (gold); coin-based features keep their player-side coin/gold interactions but the *guild's number* is store B, 1:1.
- **MariaDB not migrated** — no MariaDB repositories exist; runtime is SQLite-only, so `MariaDBMigrations` is effectively dead for guild data.
- **PHYSICAL bank-mode item slots** (`PhysicalCurrencyService`) untouched — separate from the B counter; default config `BOTH`→virtual(B) is the active path.

## Not yet verified

End-to-end in-game flow (deposit via `/g menu → Bank`, then confirm `/g bal` + `/g baltop` + placeholder show the same number) — needs a live server. Unit + migration tests pass and wiring is consistent.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Breaking

Guild bank balance now unified from vault_gold.balance; migration consolidates prior ledger sum and guilds.bank_balance (SQLite v22).

## Features

`/g bal`, `/g baltop`, `/g menu` and placeholders now reflect unified vault_gold.balance.

Guild war balance checks and escrow now use unified vault_gold.balance via BankService.

Add BankService.creditToGuildBank(guildId, amount, reason) for system-driven payouts and refunds.

Add VaultInventoryManager/GuildVaultRepository.getTopGoldBalances(limit) for ranked vault balance queries.

Route BankService.getBalance/getTopBalances/deposit/withdraw through vault_gold.balance.

Route GuildVaultService.depositVirtual/withdrawVirtual through vault_gold.balance.

Repoint WarServiceBukkit to use BankService methods for wager escrow and payouts instead of direct ledger writes.

Add SQLite migration v22 (GuildBalanceConsolidator) to fold ledger and legacy guild.bankBalance into vault_gold with zero-clamp.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/BadgersMC/LumaGuilds/pull/52?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->