### PR TITLE
fix(bank): reliability follow-ups from CodeRabbit review

### DIFF
--- a/src/main/kotlin/net/lumalyte/lg/application/services/BankService.kt
+++ b/src/main/kotlin/net/lumalyte/lg/application/services/BankService.kt
@@ -42,8 +42,8 @@ interface BankService {
 
     /**
      * Gets the top guilds ranked by bank balance (descending). Results are cached briefly and the
-     * cache is invalidated automatically whenever a balance changes (deposit/withdraw/deduct), so
-     * callers always observe up-to-date rankings without hitting the database per call.
+     * cache is invalidated automatically whenever a balance changes (deposit/withdraw/deduct/credit),
+     * so callers always observe up-to-date rankings without hitting the database per call.
      *
      * @param limit The maximum number of guilds to return.
      * @return A list of (guildId, balance) pairs ordered by balance descending.

--- a/src/main/kotlin/net/lumalyte/lg/application/services/VaultInventoryManager.kt
+++ b/src/main/kotlin/net/lumalyte/lg/application/services/VaultInventoryManager.kt
@@ -300,13 +300,34 @@ class VaultInventoryManager(
 
     /**
      * Gets the top guilds ranked by vault gold balance (descending).
-     * Queries the repository directly so it does not force every vault into the cache.
+     *
+     * Reads the DB ranking and overlays the in-memory cache. Gold mutations apply to
+     * [vaultCache] synchronously and only flush to SQLite on a timer, so a direct
+     * repository read returns stale numbers immediately after a deposit/withdraw. Any
+     * guild present in the cache is authoritative; cached values override the DB row.
+     *
+     * Over-fetches by [vaultCache] size so a freshly-deposited cached balance can rank
+     * past entries that would have been clipped at the DB limit.
      *
      * @param limit The maximum number of guilds to return.
      * @return A list of (guildId, balance) pairs ordered by balance descending.
      */
     fun getTopGoldBalances(limit: Int): List<Pair<UUID, Long>> {
-        return vaultRepository.getTopGoldBalances(limit)
+        if (limit <= 0) return emptyList()
+        val overlay = HashMap<UUID, Long>()
+        // Start from the persisted ranking, over-fetching so a cache entry can displace DB rows.
+        for ((id, bal) in vaultRepository.getTopGoldBalances(limit + vaultCache.size)) {
+            overlay[id] = bal
+        }
+        // Cache is authoritative for loaded vaults — its value reflects in-flight deposits
+        // and withdrawals that the buffered DB writer hasn't flushed yet.
+        for ((id, vault) in vaultCache) {
+            overlay[id] = vault.getGold()
+        }
+        return overlay.entries
+            .map { it.key to it.value }
+            .sortedByDescending { it.second }
+            .take(limit)
     }
 
     /**

--- a/src/main/kotlin/net/lumalyte/lg/infrastructure/persistence/migrations/GuildBalanceConsolidator.kt
+++ b/src/main/kotlin/net/lumalyte/lg/infrastructure/persistence/migrations/GuildBalanceConsolidator.kt
@@ -38,9 +38,22 @@ internal object GuildBalanceConsolidator {
      * Computes and applies the consolidation. Returns the list of guilds whose balance changed.
      */
     fun consolidate(connection: Connection, logger: ComponentLogger): List<Fold> {
-        if (!tableExists(connection, "guilds") || !tableExists(connection, "vault_gold")) {
-            logger.info(Component.text("  Skipping balance consolidation (required tables not present yet)"))
+        val hasGuilds = tableExists(connection, "guilds")
+        val hasVaultGold = tableExists(connection, "vault_gold")
+        // Fresh install: no guilds table means no legacy data to fold. Bumping the user_version
+        // is safe — there's nothing to lose.
+        if (!hasGuilds) {
+            logger.info(Component.text("  Skipping balance consolidation (no guilds table — fresh install)"))
             return emptyList()
+        }
+        // Partial schema: guilds exist but vault_gold does not. This is the dangerous case the
+        // outer migration loop must NOT silently mark v23 as applied for, otherwise
+        // validateAndRepairSchema() will create vault_gold empty afterwards and the legacy money
+        // in bank_transactions / guilds.bank_balance is permanently stranded. Throw so the
+        // version bump never runs.
+        check(hasVaultGold) {
+            "Cannot consolidate guild balances: 'vault_gold' table is missing while 'guilds' exists. " +
+                "Repair the schema (or restore from backup) before retrying the v23 migration."
         }
         val now = System.currentTimeMillis()
 

--- a/src/main/kotlin/net/lumalyte/lg/infrastructure/services/BankServiceBukkit.kt
+++ b/src/main/kotlin/net/lumalyte/lg/infrastructure/services/BankServiceBukkit.kt
@@ -418,6 +418,10 @@ class BankServiceBukkit(
                         details = "Failed to deposit money to player account - withdrawal reverted"
                     ))
                 }
+                // The cached top either no longer reflects reality (re-credit failed, guild
+                // stays debited) or briefly bounced (debited then restored). Invalidate either
+                // way so /baltop refreshes on the next read instead of waiting out the TTL.
+                invalidateBalanceLeaderboard()
                 return null
             }
 

--- a/src/main/kotlin/net/lumalyte/lg/infrastructure/services/BankServiceBukkit.kt
+++ b/src/main/kotlin/net/lumalyte/lg/infrastructure/services/BankServiceBukkit.kt
@@ -206,16 +206,37 @@ class BankServiceBukkit(
             val creditedBalance = try {
                 vaultInventoryManager.depositGold(guildId, playerId, amount.toLong())
             } catch (e: Exception) {
-                // Credit failed AFTER taking the player's money - refund to avoid loss.
-                logger.error("Failed to credit guild balance for guild $guildId - refunding player $playerId", e)
-                economy.depositPlayer(player, amount.toDouble())
-                recordAudit(BankAudit(
-                    transactionId = transaction.id,
-                    guildId = guildId,
-                    actorId = playerId,
-                    action = AuditAction.PERMISSION_DENIED,
-                    details = "Failed to credit guild balance - player refunded"
-                ))
+                // Credit failed AFTER taking the player's money — the refund is a second external
+                // write that can ALSO fail. Treat it as critical and audit both outcomes so the
+                // operator can see whether the player was made whole.
+                logger.error("Failed to credit guild balance for guild $guildId - attempting to refund player $playerId", e)
+                val refundResult = try {
+                    economy.depositPlayer(player, amount.toDouble())
+                } catch (re: Exception) {
+                    logger.error("CRITICAL: refund call threw for player $playerId transaction ${transaction.id}", re)
+                    null
+                }
+                if (refundResult == null || !refundResult.transactionSuccess()) {
+                    logger.error(
+                        "CRITICAL: Player $playerId lost $amount (transaction ${transaction.id}) - " +
+                            "guild $guildId credit failed AND refund failed. Manual reimbursement required."
+                    )
+                    recordAudit(BankAudit(
+                        transactionId = transaction.id,
+                        guildId = guildId,
+                        actorId = playerId,
+                        action = AuditAction.PERMISSION_DENIED,
+                        details = "Failed to credit guild balance AND refund failed - MANUAL REIMBURSEMENT REQUIRED"
+                    ))
+                } else {
+                    recordAudit(BankAudit(
+                        transactionId = transaction.id,
+                        guildId = guildId,
+                        actorId = playerId,
+                        action = AuditAction.PERMISSION_DENIED,
+                        details = "Failed to credit guild balance - player refunded"
+                    ))
+                }
                 return null
             }
 
@@ -366,15 +387,37 @@ class BankServiceBukkit(
             val depositResult = economy.depositPlayer(player, finalAmount.toDouble())
             if (!depositResult.transactionSuccess()) {
                 logger.error("Failed to deposit $finalAmount to player $playerId - re-crediting guild balance")
-                // Player payout failed AFTER debiting the guild - re-credit to avoid loss.
-                vaultInventoryManager.depositGold(guildId, playerId, totalDebit.toLong())
-                recordAudit(BankAudit(
-                    transactionId = transaction.id,
-                    guildId = guildId,
-                    actorId = playerId,
-                    action = AuditAction.PERMISSION_DENIED,
-                    details = "Failed to deposit money to player account - withdrawal reverted"
-                ))
+                // Player payout failed AFTER debiting the guild — the re-credit is itself an
+                // external write that can throw or be rejected. If it doesn't succeed the guild
+                // is stranded and the player got nothing; audit it as CRITICAL so the operator
+                // can intervene instead of finding a missing balance days later.
+                val reCreditOk = try {
+                    vaultInventoryManager.depositGold(guildId, playerId, totalDebit.toLong()) >= 0
+                } catch (re: Exception) {
+                    logger.error("CRITICAL: re-credit threw for guild $guildId transaction ${transaction.id}", re)
+                    false
+                }
+                if (!reCreditOk) {
+                    logger.error(
+                        "CRITICAL: Guild $guildId stranded $totalDebit (transaction ${transaction.id}) - " +
+                            "payout to $playerId failed AND re-credit failed. Manual reimbursement required."
+                    )
+                    recordAudit(BankAudit(
+                        transactionId = transaction.id,
+                        guildId = guildId,
+                        actorId = playerId,
+                        action = AuditAction.PERMISSION_DENIED,
+                        details = "Withdrawal payout failed AND re-credit failed - MANUAL REIMBURSEMENT REQUIRED"
+                    ))
+                } else {
+                    recordAudit(BankAudit(
+                        transactionId = transaction.id,
+                        guildId = guildId,
+                        actorId = playerId,
+                        action = AuditAction.PERMISSION_DENIED,
+                        details = "Failed to deposit money to player account - withdrawal reverted"
+                    ))
+                }
                 return null
             }
 


### PR DESCRIPTION
Five follow-ups to #52/#53 that CodeRabbit flagged on #53's stacked diff. None were in #53's scope, so they ship here.

## Critical

- **deposit refund check** — player refund after a failed guild credit was fire-and-forget; if the refund failed the player lost the money silently. Now: check result, wrap in try/catch, audit both outcomes, log CRITICAL on failure.
- **withdraw rollback check** — re-credit after a failed player payout was assumed to succeed. Symmetric fix.

## Major

- **VaultInventoryManager.getTopGoldBalances** — bypassed the in-memory cache; /baltop showed stale numbers right after a deposit. Now overlays cached balances on the DB ranking.
- **GuildBalanceConsolidator** — bail on missing tables was indiscriminate. Fresh install (no guilds table) stays a silent skip; partial schema (guilds present, vault_gold missing) now throws so the outer loop won't mark v23 applied and silently strand legacy money.

## Minor

- **BankService.getTopBalances** KDoc — added "credit" to the invalidation list so it matches behavior.

## Declined

- CodeRabbit suggested `requireNotNull(requestingGuildId)` on PENDING relations at the entity boundary. Would break loading of legacy PENDING rows that predate the requesting_guild column — the null-row path is an explicit backwards-compat design. Service layer already enforces non-null on every new write.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

Fixes

- `/baltop`: Overlay cached gold balances on database ranking to reflect recent deposits immediately in top balances listing
- `deposit`: Wrap player refund in try/catch with CRITICAL logging when guild credit fails, preventing silent fund loss
- `withdraw`: Wrap guild re-credit in try/catch with CRITICAL logging when player payout fails, preventing silent reversions
- GuildBalanceConsolidator: Throw on missing vault_gold table when guilds table exists, preventing legacy balance stranding on schema mismatch
- BankService.getTopBalances: Document that credit operation invalidates ranking cache alongside deposit and withdraw

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/BadgersMC/LumaGuilds/pull/55?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->