### PR TITLE
fix(bannerman): mount display as passenger to remove movement desync

### DIFF
--- a/src/main/kotlin/net/lumalyte/lg/infrastructure/bukkit/bannerman/BannermanRenderService.kt
+++ b/src/main/kotlin/net/lumalyte/lg/infrastructure/bukkit/bannerman/BannermanRenderService.kt
@@ -40,7 +40,10 @@ internal class BannermanRenderService(private val plugin: JavaPlugin) {
             d.transformation = backTransformation()
             d.persistentDataContainer.set(tagKey, PersistentDataType.STRING, player.uniqueId.toString())
         }
-        player.addPassenger(display)
+        if (!player.addPassenger(display)) {
+            display.remove()
+            return
+        }
         player.hideEntity(plugin, display)
         displays[player.uniqueId] = display.uniqueId
     }

--- a/src/main/kotlin/net/lumalyte/lg/infrastructure/bukkit/bannerman/BannermanRenderService.kt
+++ b/src/main/kotlin/net/lumalyte/lg/infrastructure/bukkit/bannerman/BannermanRenderService.kt
@@ -25,21 +25,23 @@ internal class BannermanRenderService(private val plugin: JavaPlugin) {
 
     /**
      * Spawn (or respawn) a banner display attached to the player. The previous display, if any, is removed.
+     * The display rides the player as a passenger so the client renders it rigidly attached —
+     * no per-tick teleports, no position/yaw desync. The owner is hidden from the entity so it
+     * never clips into their first-person FOV; teammates and enemies still see it.
      */
     fun spawnFor(player: Player, banner: ItemStack) {
         despawnFor(player.uniqueId)
-        val location = player.location.clone().add(0.0, 1.0, 0.0)
         val display = player.world.spawn(
-            location,
+            player.location,
             ItemDisplay::class.java,
         ) { d ->
             d.setItemStack(banner)
             d.isPersistent = false
             d.transformation = backTransformation()
-            d.interpolationDuration = 2
-            d.teleportDuration = 2
             d.persistentDataContainer.set(tagKey, PersistentDataType.STRING, player.uniqueId.toString())
         }
+        player.addPassenger(display)
+        player.hideEntity(plugin, display)
         displays[player.uniqueId] = display.uniqueId
     }
 
@@ -86,7 +88,9 @@ internal class BannermanRenderService(private val plugin: JavaPlugin) {
 
     @Suppress("MagicNumber")
     private fun backTransformation(): Transformation = Transformation(
-        Vector3f(0f, 0f, -0.25f), // translate behind torso
+        // Origin sits at the player's passenger mount (~head height). Drop down to the upper
+        // back and offset behind the torso.
+        Vector3f(0f, -0.7f, -0.25f),
         Quaternionf().rotateY(Math.PI.toFloat()), // face backwards relative to player
         Vector3f(1.0f, 1.5f, 1.0f), // taller than wide
         Quaternionf(),

--- a/src/main/kotlin/net/lumalyte/lg/infrastructure/bukkit/bannerman/BannermanTickTask.kt
+++ b/src/main/kotlin/net/lumalyte/lg/infrastructure/bukkit/bannerman/BannermanTickTask.kt
@@ -8,10 +8,10 @@ import org.bukkit.potion.PotionEffectType
 import org.bukkit.scheduler.BukkitRunnable
 
 /**
- * Every 5 ticks: keep each tracked player's bannerman display following the player
- * and toggle visibility based on elytra / invisibility state. 5 ticks (~0.25s) is fast
- * enough to look attached without flooding the scheduler with sub-block teleports while
- * players are walking.
+ * Position and rotation are handled by passenger-mounting the display on the player
+ * (see [BannermanRenderService.spawnFor]) — the vanilla client keeps them rigidly
+ * attached, so no per-tick teleport is needed. This task only flips visibility based
+ * on elytra / invisibility state, which doesn't need sub-second responsiveness.
  */
 internal class BannermanTickTask(
     private val plugin: JavaPlugin,
@@ -19,9 +19,7 @@ internal class BannermanTickTask(
 ) : BukkitRunnable() {
 
     companion object {
-        private const val TICK_PERIOD = 5L
-        // ~0.5 block squared: don't re-teleport for sub-block jitter while walking.
-        private const val REPOSITION_THRESHOLD_SQ = 0.25
+        private const val TICK_PERIOD = 20L
     }
 
     fun start() {
@@ -38,19 +36,10 @@ internal class BannermanTickTask(
         if (!renderer.isTracking(player.uniqueId)) return
         val display = renderer.currentDisplay(player.uniqueId) ?: return
 
-        val shouldShow = BannermanVisibility.shouldShow(
+        display.isVisibleByDefault = BannermanVisibility.shouldShow(
             hasElytra = isWearingElytra(player),
             hasInvisibility = player.hasPotionEffect(PotionEffectType.INVISIBILITY)
         )
-        display.isVisibleByDefault = shouldShow
-
-        val target = player.location.clone()
-        target.y += 1.0
-        target.yaw = player.location.yaw
-        target.pitch = 0f
-        if (display.world != player.world || display.location.distanceSquared(target) > REPOSITION_THRESHOLD_SQ) {
-            display.teleport(target)
-        }
     }
 
     private fun isWearingElytra(player: Player): Boolean =


### PR DESCRIPTION
## Summary

Bannerman display had three visible problems in-game:

- **Movement desync** — the tick task polled at 5t (~250ms) and only teleported on >0.5-block moves, so the banner perpetually lagged behind the player.
- **No yaw rotation** — the reposition gate was distance-only, so turning in place never updated the banner's facing.
- **First-person FOV clipping** — the owner saw their own banner, which entered the camera when looking around.

Fix: spawn the `ItemDisplay`, then `player.addPassenger(display)`. The vanilla client renders passengers rigidly mounted to the player, so position and yaw are perfectly in sync with zero server→client teleport packets. `player.hideEntity(plugin, display)` keeps the owner from rendering their own banner; teammates and enemies still see it normally. The tick task is gutted down to a 1Hz visibility toggle for elytra / invisibility.

Net server cost: drops from N teleport packets per 5 ticks to zero in steady state.

## Test plan

- [ ] Walk, sprint, sneak — banner stays glued to back, no lag
- [ ] Turn in place — banner rotates with body
- [ ] F1 view — owner sees no banner in own camera
- [ ] F5 / external view — owner and others see banner on owner's back
- [ ] Equip elytra — banner hides; unequip — reappears
- [ ] Drink invisibility potion — banner hides; effect ends — reappears
- [ ] Die and respawn — banner re-mounts cleanly
- [ ] Change worlds — banner re-mounts in new world
- [ ] Toggle guild bannerman OFF then ON — all online members update
- [ ] Tune `Vector3f(0f, -0.7f, -0.25f)` translation if the banner sits too high/low on the back
- [ ] Mount a horse/boat — observe behavior; may need a `VehicleEnterEvent` follow-up if the display rides along badly

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Fixes

- Mount bannerman display as player passenger to synchronize position and yaw without server teleport packets
- Hide bannerman display from owner's first-person view to prevent FOV clipping
- Reduce bannerman tick task to 1 Hz visibility updates, eliminating per-tick repositioning

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/BadgersMC/LumaGuilds/pull/56?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->