### PR TITLE
fix(bannerman): show owner banner in F5 and rotate with head yaw

### DIFF
--- a/src/main/kotlin/net/lumalyte/lg/infrastructure/bukkit/bannerman/BannermanRenderService.kt
+++ b/src/main/kotlin/net/lumalyte/lg/infrastructure/bukkit/bannerman/BannermanRenderService.kt
@@ -26,8 +26,9 @@ internal class BannermanRenderService(private val plugin: JavaPlugin) {
     /**
      * Spawn (or respawn) a banner display attached to the player. The previous display, if any, is removed.
      * The display rides the player as a passenger so the client renders it rigidly attached —
-     * no per-tick teleports, no position/yaw desync. The owner is hidden from the entity so it
-     * never clips into their first-person FOV; teammates and enemies still see it.
+     * no per-tick teleports, no position/yaw desync. The display is positioned low and behind
+     * the head mount so the owner's first-person camera doesn't see it, while F5 / external
+     * viewers see it on the upper back.
      */
     fun spawnFor(player: Player, banner: ItemStack) {
         despawnFor(player.uniqueId)
@@ -44,7 +45,6 @@ internal class BannermanRenderService(private val plugin: JavaPlugin) {
             display.remove()
             return
         }
-        player.hideEntity(plugin, display)
         displays[player.uniqueId] = display.uniqueId
     }
 

--- a/src/main/kotlin/net/lumalyte/lg/infrastructure/bukkit/bannerman/BannermanTickTask.kt
+++ b/src/main/kotlin/net/lumalyte/lg/infrastructure/bukkit/bannerman/BannermanTickTask.kt
@@ -8,10 +8,16 @@ import org.bukkit.potion.PotionEffectType
 import org.bukkit.scheduler.BukkitRunnable
 
 /**
- * Position and rotation are handled by passenger-mounting the display on the player
- * (see [BannermanRenderService.spawnFor]) — the vanilla client keeps them rigidly
- * attached, so no per-tick teleport is needed. This task only flips visibility based
- * on elytra / invisibility state, which doesn't need sub-second responsiveness.
+ * Position is handled by passenger-mounting the display on the player (see
+ * [BannermanRenderService.spawnFor]) — the vanilla client keeps it rigidly attached.
+ *
+ * Per-tick work for tracked players:
+ *   - Force body yaw to match head yaw. Vanilla lets a standing player swivel their head
+ *     up to ~50° before the body catches up, which leaves a passenger banner facing the
+ *     old direction. Locking body yaw to head yaw makes the banner track shoulder rotation
+ *     in real time.
+ *   - Visibility toggle for elytra / invisibility (only re-applied if it changed, since
+ *     isVisibleByDefault triggers tracker resends).
  */
 internal class BannermanTickTask(
     private val plugin: JavaPlugin,
@@ -19,7 +25,7 @@ internal class BannermanTickTask(
 ) : BukkitRunnable() {
 
     companion object {
-        private const val TICK_PERIOD = 20L
+        private const val TICK_PERIOD = 1L
     }
 
     fun start() {
@@ -36,10 +42,15 @@ internal class BannermanTickTask(
         if (!renderer.isTracking(player.uniqueId)) return
         val display = renderer.currentDisplay(player.uniqueId) ?: return
 
-        display.isVisibleByDefault = BannermanVisibility.shouldShow(
+        player.setBodyYaw(player.location.yaw)
+
+        val shouldShow = BannermanVisibility.shouldShow(
             hasElytra = isWearingElytra(player),
             hasInvisibility = player.hasPotionEffect(PotionEffectType.INVISIBILITY)
         )
+        if (display.isVisibleByDefault != shouldShow) {
+            display.isVisibleByDefault = shouldShow
+        }
     }
 
     private fun isWearingElytra(player: Player): Boolean =


### PR DESCRIPTION
## Summary

Follow-up to #56. Two remaining banner issues from in-game testing:

1. **Owner couldn't see own banner in F5.** The previous PR called `player.hideEntity(plugin, display)` to keep it out of F1, but that hid it from all owner views including third-person. The banner now sits low and behind the head mount (y=-0.7, z=-0.25 in the transform) so F1 doesn't see it naturally — no need to hide-entity. Owner sees own banner in F5, teammates / enemies see it as before.

2. **Banner didn't rotate when player only turned their head.** Passenger-mounted entities follow body yaw. Vanilla lets a standing player swivel their head ~50° before the body catches up, so the banner stayed facing the old direction during head-only rotation. Fix: lock body yaw to head yaw each tick for bannerman-tracked players via `LivingEntity.setBodyYaw`. Shoulders now track the look direction in real time, and the banner follows.

Tick task bumped back to every-tick (was 20t) so yaw sync is smooth; visibility flag only writes when state changes to avoid tracker resends.

## Test plan

- [ ] F1 — own banner not visible in camera
- [ ] F5 — own banner visible on back
- [ ] Stand still, mouse-look left/right — banner rotates with view in real time
- [ ] Walk + turn — smooth, no swivel lag
- [ ] Equip elytra — banner hides within 1 tick; unequip — reappears
- [ ] Invisibility potion — banner hides; effect ends — reappears
- [ ] Other players still see banners correctly

## Known trade-off

Body-yaw lock removes the natural idle head-swivel for bannerman-enabled players (body always faces look direction). Opt-in cost of the feature.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Fixes
- Bannerman: show owner's own banner in third-person (F5) by removing hideEntity hiding
- Bannerman: synchronize banner rotation with head yaw in real time instead of lagging behind body rotation
- Bannerman: rate-limit visibility state updates to prevent unnecessary tracker resends

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/BadgersMC/LumaGuilds/pull/57?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->