### PR TITLE
LumaGuilds mass audit — findings report (no code changes)

### DIFF
--- a/docs/audit/MASS-AUDIT-2026-06-08.md
+++ b/docs/audit/MASS-AUDIT-2026-06-08.md
@@ -24,13 +24,14 @@ Severity here is *my* re-rating, not the coordinator's.
 
 These break the item/gold economy and are exploitable or data-losing in normal play.
 
-### ✅ [CRIT] `interaction/menus/guild/GoldWithdrawMenu.kt:152` — item duplication on insufficient funds
-`vaultInventoryManager.withdrawGold()` returns the `-1L` sentinel on insufficient
-funds, but `convertToItems(amount)` + the item-giving loop run **unconditionally**,
-outside the `-1L` guard. Result: a withdrawal that *fails* still hands the player gold
-items — **items created from nothing**. Move item creation inside the success branch.
+### ❌ [DISMISSED] `interaction/menus/guild/GoldWithdrawMenu.kt:152` — reported item dupe is a FALSE POSITIVE
+The coordinator claimed `convertToItems`/give-loop run unconditionally past the `-1L`
+guard. **They do not** — there is a correct early `return` in the `if (newBalance == -1L)`
+branch, so items are only given after a successful withdrawal. Double-click is also safe
+(menu clicks are processed serially on the Bukkit main thread). No dupe. (Initially
+mis-marked VERIFIED without reading source; corrected on re-review.)
 
-### ✅ [CRIT] `interaction/menus/guild/GuildBankMenu.kt:467-493` — item loss: removes items before deposit confirmed
+### ✅ [CRIT] `interaction/menus/guild/GuildBankMenu.kt:437-510` — item loss: removes items before deposit confirmed
 `handleDeposit()` removes gold items from the player inventory *before* calling
 `depositGold()`. Any failure in the deposit pipeline (DB error, guild not found)
 destroys the items with no balance increase. Deposit first, remove only on success.

--- a/docs/audit/MASS-AUDIT-2026-06-08.md
+++ b/docs/audit/MASS-AUDIT-2026-06-08.md
@@ -1,0 +1,169 @@
+# LumaGuilds Mass Audit — Consolidated Findings (2026-06-08)
+
+Findings-only audit of the full `net.lumalyte.lg` source tree (573 files) run as 11
+Hermes coordinator jobs against `origin/main`. Each batch's raw report is in
+`docs/audit/audit-<batch>.md`; this document is the triaged, de-duplicated synthesis.
+
+**No source was modified by the audit.** Every finding below is a recommendation for
+the human to action.
+
+## How to read this
+
+Raw total: **~253 findings** (2 crit, 35 high, 76 med, 140 low). After triage the
+actionable set is much smaller. Each item is tagged:
+
+- **✅ VERIFIED** — I read the source and confirmed the bug.
+- **◻️ REPORTED** — high-confidence coordinator finding, not individually re-verified; treat as a strong lead.
+- **❌ CORRECTED** — coordinator over-reported; severity downgraded or dismissed with reason.
+
+Severity here is *my* re-rating, not the coordinator's.
+
+---
+
+## TIER 0 — Economy / item integrity (fix first)
+
+These break the item/gold economy and are exploitable or data-losing in normal play.
+
+### ✅ [CRIT] `interaction/menus/guild/GoldWithdrawMenu.kt:152` — item duplication on insufficient funds
+`vaultInventoryManager.withdrawGold()` returns the `-1L` sentinel on insufficient
+funds, but `convertToItems(amount)` + the item-giving loop run **unconditionally**,
+outside the `-1L` guard. Result: a withdrawal that *fails* still hands the player gold
+items — **items created from nothing**. Move item creation inside the success branch.
+
+### ✅ [CRIT] `interaction/menus/guild/GuildBankMenu.kt:467-493` — item loss: removes items before deposit confirmed
+`handleDeposit()` removes gold items from the player inventory *before* calling
+`depositGold()`. Any failure in the deposit pipeline (DB error, guild not found)
+destroys the items with no balance increase. Deposit first, remove only on success.
+
+### ✅ [HIGH] `infrastructure/persistence/guilds/GuildVaultRepositorySQLite.kt:186` — TOCTOU on gold balance
+`addGoldBalance`/`subtractGoldBalance` read-modify-write the balance non-atomically.
+Concurrent deposit+withdraw → lost update. Use atomic
+`UPDATE … SET balance = balance + ? WHERE guild_id = ? AND balance >= ?` and check rows affected.
+
+### ◻️ [HIGH] `infrastructure/services/BankServiceBukkit.kt:656` — withdrawals validated against deposit range
+`isValidAmount` uses `min/maxDepositAmount` for both deposits (line 141) and
+withdrawals (line 340), ignoring `maxWithdrawalPercent`. Valid withdrawals get
+rejected and the percent cap is unenforced. Split into a withdrawal-aware validator.
+
+---
+
+## TIER 1 — Confirmed logic bugs (verified against source)
+
+### ✅ [HIGH] `application/actions/claim/permission/GrantAllPlayerClaimPermissions.kt:27` — grant calls `remove()`
+The loop commented "Add all permissions" calls `playerAccessRepository.remove(...)`.
+**Granting all permissions actually revokes them all.** Change `remove` → `add`.
+
+### ✅ [HIGH] `application/actions/claim/transfer/WithdrawPlayerTransferRequest.kt:10` — inverted guard
+`if (playerId in claim.transferRequests.keys) return NoPendingRequest` is backwards:
+when a request *exists* it bails out as "no pending request", and only reaches the
+`.remove()` when there is nothing to remove. Withdraw never works.
+
+### ✅ [HIGH] `infrastructure/services/CombatServiceBukkit.kt:119` — `getPlayerGuilds()` is a stub
+Ships `return emptySet()  // placeholder`. Any combat rule keyed on guild membership
+(friendly-fire, war participation) is silently inert.
+
+### ✅ [MED] `infrastructure/persistence/guilds/LeaderboardRepositorySQLite.kt:364` — ignores `type` arg
+`getLeaderboardSnapshots(type, …)` hardcodes `LeaderboardType.KILLS.name` instead of
+`type.name`; every non-KILLS leaderboard snapshot query returns wrong/empty data.
+
+### ✅ [MED] `infrastructure/persistence/guilds/GuildRepositorySQLite.kt:464,740,892` — debug `println` in prod
+Three `println("DEBUG …")` blocks dump guild/vault state to console on every load/update.
+Remove or route through `logger.debug`.
+
+---
+
+## TIER 2 — High-confidence logic bugs (reported, recommend verify-then-fix)
+
+| Sev | Location | Issue |
+|-----|----------|-------|
+| HIGH | `application/actions/claim/transfer/OfferPlayerTransferRequest.kt:14` | Mutates `claim.transferRequests` but never `claimRepository.update(claim)` — request lost on restart/re-read |
+| HIGH | `application/actions/claim/transfer/AcceptTransferRequest.kt:39` | Name-uniqueness check uses the wrong playerId |
+| HIGH | `infrastructure/services/GuildBannerServiceBukkit.kt:107` | `canSetBanners` ignores submitter → all members can set banners |
+| HIGH | `infrastructure/services/WarServiceBukkit.kt:336` | `canGuildDeclareWar` maxWars hardcoded, ignores progression cap |
+| HIGH | `infrastructure/services/AsyncTaskService.kt:97` | Callback captures mutable `result` — stale/garbled async value |
+| HIGH | `infrastructure/services/VaultAutoSaveService.kt:257` | Auto-unboxing NPE on cancelled-task check |
+| HIGH | `interaction/commands/…/PartitionsCommand.kt:43` | Pagination uses `page` as an iteration-count offset → wrong page window |
+| HIGH | `…/listeners/ToolRemovalListener.kt:129` | `onPlayerDeath` builds a removal list but never removes from drops |
+| HIGH | `interaction/menus/.../GuildWarDeclarationMenu.kt:489` | Race in war-declaration duplicate check |
+| HIGH | `infrastructure/services/GuildInvitationManager.kt:12` | `object` singleton with `lateinit var`, no concurrent-init guard |
+
+---
+
+## TIER 3 — Architectural: hexagonal layer violations (systemic)
+
+The `domain` and `application` layers import Bukkit/framework types — a broad,
+consistent violation of the project's own hexagonal rules (`docs/architecture.md`).
+Real, but pre-existing and systemic; address as one refactor epic, not 20 hotfixes.
+
+- `domain/entities/Claim.kt`, `VaultInventory.kt`, `ViewerSession.kt` — Bukkit `ItemStack`/`Inventory`/`Player` in domain entities.
+- `domain/entities/PlayerState.kt`, `Progression.kt`, `GuildBanner.kt` — import the **application** layer from domain (inward dependency inversion).
+- `domain/events/*.kt` (13 files) — extend Bukkit `Event`/`HandlerList` in the domain layer.
+- `application/persistence/GuildVaultRepository.kt` — Bukkit `ItemStack` leaked into an application port.
+
+**Recommendation:** introduce domain-level value types (e.g. a serialized-item byte
+holder) and map to Bukkit only in infrastructure. Track as a dedicated SPEAR refactor.
+
+---
+
+## TIER 4 — Persistence & service robustness
+
+- ◻️ [HIGH] Inconsistent error handling: `ClaimRepositorySQLite.kt:105` and
+  `ClaimPermissionRepositorySQLite.kt:84` swallow table-creation failures via
+  `printStackTrace()` while sibling repos throw `DatabaseOperationException` → silent
+  data loss on a failed migration. Make them throw, like the siblings.
+- ◻️ [MED] Several repos (`GuildInvitationRepositorySQLite`, `MemberRepositorySQLite`)
+  `catch (SQLException) { return false }` with no logging — failures indistinguishable
+  from "no rows affected".
+- ◻️ [MED] `GuildVaultRepositorySQLite.kt:266` — `ObjectInputStream.readObject()` fallback
+  on DB bytes; add an `ObjectInputFilter` restricting classes (deserialization hardening).
+- ◻️ [MED] `migrations/GuildBalanceConsolidator` — non-idempotent; a crash between
+  consolidate and version-bump double-counts balances. Add a consolidated-flag guard.
+- ◻️ [HIGH] `storage/VirtualThreadSQLiteStorage.kt:30` — Hikari pool size 50 against a
+  single-writer SQLite; large pool + virtual threads = lock contention. Drop to ~5–10.
+- ◻️ [LOW×many] Repos `catch (SQLException)` around non-SQL code (`UUID.fromString`,
+  Gson, `enum.valueOf`) → the real `IllegalArgumentException` escapes uncaught.
+
+---
+
+## CORRECTIONS — over-reports the triage caught (why the review gate exists)
+
+- ❌ `ProgressionRepositorySQLite.kt:285,399` "`?: 0 > 0` precedence bug" — **false positive.**
+  Kotlin elvis binds tighter than comparison; `a ?: 0 > 0` parses as `(a ?: 0) > 0` (correct).
+  Wouldn't compile otherwise. Dismissed.
+- ❌ Both infra-persistence "crit" **SQL injections** (`SQLiteMigrations.tableExists`,
+  `VaultTransactionLogger` LIMIT/OFFSET) — **downgraded to LOW.** Values are `Int`/hardcoded
+  table names today; not caller-reachable strings. Worth whitelisting PRAGMA identifiers as
+  defense-in-depth, but not crit.
+- ❌ `PlayerStateRepositoryMemory` "no DB persistence" — **by design** (documented ephemeral).
+  Re-tag as a doc note at the port, not a bug.
+
+---
+
+## Test-coverage gaps (highest-value first)
+
+The tree has 576 main files but only 32 tests. Priority gaps surfaced across batches:
+
+| Area | Why it needs a test now |
+|------|--------------------------|
+| Vault deposit/withdraw (menus + service + repo) | The TIER-0 dupe/loss bugs would be caught by a round-trip test |
+| `GuildVaultRepositorySQLite.add/subtractGoldBalance` | Concurrent-access test for the TOCTOU |
+| `GrantAllPlayerClaimPermissions` / transfer actions | Pure logic, trivially testable, currently wrong |
+| `GuildBalanceConsolidator.consolidate` | Re-run / partial-failure idempotency |
+| `SQLiteMigrations.migrateToVersion2` | 10-step rebuild, no rollback test |
+| `LeaderboardRepositorySQLite.getLeaderboardSnapshots` | Would catch the ignored-`type` bug |
+
+---
+
+## Per-batch raw reports
+
+`docs/audit/audit-{infra-persistence, app-actions, ix-commands, domain, app-services,
+infra-services, infra-edge, cross-cutting, app-results-ports, ix-menus-a, ix-menus-b}.md`.
+`cross-cutting` returned clean (0 findings).
+
+## Suggested sequencing for the human
+
+1. **TIER 0** — economy/item bugs (dupe + loss), each a small, isolated fix + a test.
+2. **TIER 1** — confirmed logic one-liners (`remove`→`add`, inverted guard, stub).
+3. **TIER 4 economy-adjacent** — vault TOCTOU, error-swallowing on claim tables.
+4. **TIER 2** — verify-then-fix the high-confidence leads.
+5. **TIER 3** — schedule the hexagonal-purity refactor as its own SPEAR epic.

--- a/docs/audit/MASS-AUDIT-2026-06-08.md
+++ b/docs/audit/MASS-AUDIT-2026-06-08.md
@@ -73,20 +73,19 @@ Remove or route through `logger.debug`.
 
 ---
 
-## TIER 2 — High-confidence logic bugs (reported, recommend verify-then-fix)
+## TIER 2 — Logic bugs (now source-verified)
 
-| Sev | Location | Issue |
-|-----|----------|-------|
-| HIGH | `application/actions/claim/transfer/OfferPlayerTransferRequest.kt:14` | Mutates `claim.transferRequests` but never `claimRepository.update(claim)` — request lost on restart/re-read |
-| HIGH | `application/actions/claim/transfer/AcceptTransferRequest.kt:39` | Name-uniqueness check uses the wrong playerId |
-| HIGH | `infrastructure/services/GuildBannerServiceBukkit.kt:107` | `canSetBanners` ignores submitter → all members can set banners |
-| HIGH | `infrastructure/services/WarServiceBukkit.kt:336` | `canGuildDeclareWar` maxWars hardcoded, ignores progression cap |
-| HIGH | `infrastructure/services/AsyncTaskService.kt:97` | Callback captures mutable `result` — stale/garbled async value |
-| HIGH | `infrastructure/services/VaultAutoSaveService.kt:257` | Auto-unboxing NPE on cancelled-task check |
-| HIGH | `interaction/commands/…/PartitionsCommand.kt:43` | Pagination uses `page` as an iteration-count offset → wrong page window |
-| HIGH | `…/listeners/ToolRemovalListener.kt:129` | `onPlayerDeath` builds a removal list but never removes from drops |
-| HIGH | `interaction/menus/.../GuildWarDeclarationMenu.kt:489` | Race in war-declaration duplicate check |
-| HIGH | `infrastructure/services/GuildInvitationManager.kt:12` | `object` singleton with `lateinit var`, no concurrent-init guard |
+All re-read from source. Verdicts: ✅ confirmed real, ❌ false positive (moved to CORRECTIONS), ⬇ over-rated.
+
+| Verdict | Sev | Location | Issue |
+|---------|-----|----------|-------|
+| ✅ | HIGH | `application/actions/claim/transfer/OfferPlayerTransferRequest.kt:14` | `put()` into `claim.transferRequests` but never `claimRepository.update(claim)` — request lost on restart/re-read |
+| ✅ | HIGH | `application/actions/claim/transfer/AcceptTransferRequest.kt:39` | Name-uniqueness checks `getByName(claim.playerId, …)` = old owner's namespace, not the accepting `playerId`'s |
+| ✅ | HIGH | `infrastructure/services/GuildBannerServiceBukkit.kt:107` | `canSetBanners(guildId)` takes no player, returns `true` for any existing guild → no per-member check |
+| ✅ | HIGH | `infrastructure/services/WarServiceBukkit.kt:336` | `activeWars < 3` hardcoded, ignores progression cap (also `canPlayerManageWars` is a `return true` stub) |
+| ✅ | HIGH | `interaction/commands/PartitionsCommand.kt:43` | `for (i in 0..9 + page)` — every page starts at index 0 and the window grows with page; pagination is broken |
+| ✅ | HIGH | `interaction/listeners/ToolRemovalListener.kt:129` | `onPlayerDeath` builds `itemsToRemove` then the method ends — never removes from `event.drops`; claim/move tools drop on death |
+| ⬇ | LOW | `infrastructure/services/GuildInvitationManager.kt:12` | `object` + `lateinit var`, no concurrent-init guard — real shape but startup-only init, negligible concurrency risk |
 
 ---
 
@@ -137,6 +136,17 @@ holder) and map to Bukkit only in infrastructure. Track as a dedicated SPEAR ref
   defense-in-depth, but not crit.
 - ❌ `PlayerStateRepositoryMemory` "no DB persistence" — **by design** (documented ephemeral).
   Re-tag as a doc note at the port, not a bug.
+- ❌ `AsyncTaskService.kt:97` "captures mutable `result`" — **false.** `val result = task()` is
+  immutable and freshly scoped per coroutine launch; no shared state, no race.
+- ❌ `VaultAutoSaveService.kt:257` "auto-unboxing NPE" — **false.** `autoSaveTask?.isCancelled == false`
+  is the null-safe idiom; `Boolean? == false` cannot NPE.
+- ⚠️ `GuildWarDeclarationMenu.kt:489` "race in duplicate check" — **likely false.** Check-then-act,
+  but menu clicks are serialized on the Bukkit main thread; not a real race unless `warService` goes async.
+
+**Triage note:** across the high/crit tier, the coordinator's *logic-bug* findings were reliable
+(~all confirmed), but its *concurrency / NPE* reasoning was not — it repeatedly ignored Bukkit's
+single-threaded main-thread model and Kotlin's null-safe operators. Treat any "race"/"NPE"/"mutable
+capture" finding from this run as suspect until verified.
 
 ---
 

--- a/docs/audit/MASS-AUDIT-PLAN.md
+++ b/docs/audit/MASS-AUDIT-PLAN.md
@@ -1,0 +1,71 @@
+# LumaGuilds Mass Audit — Methodology & Batch Plan
+
+Findings-only audit driven by Hermes coordinators. **No source files are modified.**
+Each coordinator audits one disjoint batch and writes a single report at
+`docs/audit/<job>.md`, commits it, and pushes its branch to the `fork` remote.
+The operator (Claude, locally) fetches every branch, triages false positives, and
+synthesizes a consolidated master report for one docs-PR to `BadgersMC/LumaGuilds`.
+
+## What every coordinator hunts for (priority order)
+
+1. **Correctness** — null/async misuse, race conditions, wrong edge cases, broken
+   invariants, resource leaks (unclosed `Statement`/`ResultSet`/`Connection`).
+2. **Security** — SQL injection (string-concatenated queries vs parameterized),
+   unsafe deserialization, permission/command bypass, secret leakage, path traversal.
+3. **Layer boundaries** (hexagonal) — `domain` must import nothing from
+   `application`/`infrastructure`; `application` must not import Bukkit/JDBC/frameworks.
+4. **Test-coverage gaps** — name the specific untested domain/application behavior and
+   the test that should exist.
+
+Each coordinator also runs `detekt` for free quality signal and folds real hits in.
+
+## Severity rubric
+
+| Sev | Meaning |
+|-----|---------|
+| crit | Exploitable security hole or data-loss/corruption bug reachable in normal use |
+| high | Logic bug that breaks a feature, or a layer violation that will rot the architecture |
+| med  | Edge-case bug, resource leak under load, missing test for important logic |
+| low  | Style/quality, defensive-coding nit, minor untested branch |
+
+Report format, one section per finding:
+
+```
+### [SEV: crit|high|med|low] <relative/path>.kt:<line> — <one-line title>
+**What:** <the problem, concretely>
+**Why it matters:** <impact / exploit / failure mode>
+**Suggested fix:** <direction, not full code>
+**Confidence:** high | med | low
+```
+
+## Batches (disjoint file sets, ~573 files, 11 jobs)
+
+Run **sequentially** — the box has one shared LumaGuilds working tree, so a new
+dispatch resets it. Order below is by risk.
+
+| Order | Job (`--job`) | Packages | Files |
+|-------|---------------|----------|-------|
+| 1 | `audit-infra-persistence` | `infrastructure/persistence` | 37 |
+| 2 | `audit-app-actions` | `application/actions` | 66 |
+| 3 | `audit-ix-commands` | `interaction/{commands,help,listeners}` | 48 |
+| 4 | `audit-domain` | `domain/**` | 54 |
+| 5 | `audit-app-services` | `application/{services,utilities,errors,events}` | 48 |
+| 6 | `audit-infra-services` | `infrastructure/services` | 54 |
+| 7 | `audit-infra-edge` | `infra/{adapters,bukkit,listeners,web,placeholders,namespaces,hidden,utilities}` | 23 |
+| 8 | `audit-cross-cutting` | `config, di, common, utils, integrations` | 23 |
+| 9 | `audit-app-results-ports` | `application/{results,persistence}` | 82 |
+| 10 | `audit-ix-menus-a` | `interaction/menus` (first ~69) | 69 |
+| 11 | `audit-ix-menus-b` | `interaction/menus` (remaining ~69) | 69 |
+
+The exact file list for each batch is embedded in that job's coordinator prompt;
+this doc is the shared methodology + rubric the prompts reference.
+
+## Operator workflow per job
+
+1. `dispatch.sh` with `HERMES_REPO=/opt/data/LumaGuilds`, `--job audit-<batch>`,
+   `--docs-branch docs/audit-plan`, `--plan-path docs/audit/MASS-AUDIT-PLAN.md`,
+   `--prompt /tmp/audit-<batch>.txt`. (Branch on box becomes `fix/audit-<batch>`.)
+2. `poll.sh --job audit-<batch>` — done when `fix/audit-<batch>` appears on the fork.
+3. `git fetch hermes 'refs/heads/fix/audit-<batch>:refs/heads/hermes-<batch>'`,
+   read `docs/audit/<batch>.md`.
+4. After all jobs: triage, dedupe, rank → `docs/audit/MASS-AUDIT-<date>.md`, one PR.

--- a/docs/audit/audit-app-actions.md
+++ b/docs/audit/audit-app-actions.md
@@ -1,0 +1,495 @@
+# Audit Report: application/actions
+
+**Branch:** fix/audit-app-actions
+**Scope:** 66 files under `src/main/kotlin/net/lumalyte/lg/application/actions/`
+**Methodology:** See `/opt/data/audit-app-actions-plan.md`
+
+---
+
+## Findings
+
+### [SEV: high] application/actions/claim/transfer/AcceptTransferRequest.kt:39 — Name-uniqueness check uses wrong playerId
+
+**What:** Line 39 calls `claimRepository.getByName(claim.playerId, newName)` — this checks whether the **old owner** already has a claim named `newName`. It should check whether the **accepting player** (`playerId`) already has a claim with that name, since the claim is being transferred to them and the name must be unique per-player.
+
+**Why it matters:** After transfer, the accepting player could end up with two claims sharing the same name (their existing one + the transferred one), violating the uniqueness invariant enforced by `CreateClaim` and `UpdateClaimName`. Conversely, the transfer could be incorrectly rejected when the old owner happens to have a claim with the same name but the accepting player does not.
+
+**Suggested fix:** Change `claim.playerId` to `playerId` on line 39: `claimRepository.getByName(playerId, newName)`.
+
+**Confidence:** high
+
+---
+
+### [SEV: high] application/actions/claim/transfer/AcceptTransferRequest.kt:43 — Mutable playerId on Claim enables silent data corruption
+
+**What:** `Claim.playerId` is declared as `var` (line 23 of Claim.kt). `AcceptTransferRequest` mutates it directly at line 43 (`claim.playerId = playerId`) and then calls `claimRepository.update(claim)`. Because `Claim` is a data class with a mutable `playerId`, this in-place mutation works but bypasses any domain-level validation or copying semantics. If any other code holds a reference to the same `Claim` instance (e.g., in a cache or the repository's internal store), it sees the mutated `playerId` before `update()` is called, creating a race condition.
+
+**Why it matters:** In a concurrent server environment, another thread reading the same `Claim` object between lines 43 and 44 could see an inconsistent state (new `playerId` but old `teamId`, stale `transferRequests`, etc.). The `update()` call may or may not replace the cached instance depending on repository implementation.
+
+**Suggested fix:** Use `val updatedClaim = claim.copy(playerId = playerId)` and pass `updatedClaim` to `claimRepository.update()`. This requires `playerId` to remain `var` for the copy to work, but the pattern is safer. Ideally, make `playerId` a `val` and treat ownership change as a domain event.
+
+**Confidence:** high
+
+---
+
+### [SEV: high] application/actions/claim/permission/GrantAllPlayerClaimPermissions.kt:27 — Calls remove() instead of add() when granting permissions
+
+**What:** Line 27 calls `playerAccessRepository.remove(claimId, playerId, permission)` inside a loop that is supposed to **grant** all permissions. The method is named `GrantAllPlayerClaimPermissions` and its docstring says "Adds all available permissions" but the implementation calls `remove`.
+
+**Why it matters:** This action revokes all permissions from a player instead of granting them. Any caller relying on this to share a claim with another player will instead strip their access, which is a functional inversion — a silent logic bug that breaks the permission system.
+
+**Suggested fix:** Change `playerAccessRepository.remove(...)` to `playerAccessRepository.add(...)` on line 27.
+
+**Confidence:** high
+
+---
+
+### [SEV: high] application/actions/claim/transfer/OfferPlayerTransferRequest.kt:14 — Transfer request not persisted to storage
+
+**What:** Line 14 adds the transfer request to the in-memory `claim.transferRequests` map, but never calls `claimRepository.update(claim)` to persist the change. The request exists only in the JVM heap.
+
+**Why it matters:** If the server restarts, all pending transfer requests are silently lost. On a single-server setup with no restart, the request works, but any future refactoring that re-reads the claim from the database (e.g., in another action) will not see the request. This is a data-loss bug.
+
+**Suggested fix:** After line 14, call `claimRepository.update(claim)` and handle the potential failure (return a storage error result).
+
+**Confidence:** high
+
+---
+
+### [SEV: high] application/actions/claim/transfer/WithdrawPlayerTransferRequest.kt:10 — Inverted logic: returns NoPendingRequest when request EXISTS
+
+**What:** Line 10 checks `if (playerId in claim.transferRequests.keys)` and returns `NoPendingRequest`. This is backwards: it should return `NoPendingRequest` when the playerId is **NOT** in the map, and proceed to remove it when it **IS** present.
+
+**Why it matters:** A player can never withdraw a transfer request. When a request exists, the action says "no pending request". When no request exists, the code falls through to `claim.transferRequests.remove(playerId)` (a no-op) and returns `Success` — silently doing nothing.
+
+**Suggested fix:** Negate the condition: `if (playerId !in claim.transferRequests.keys) return WithdrawPlayerTransferRequestResult.NoPendingRequest`.
+
+**Confidence:** high
+
+---
+
+### [SEV: med] application/actions/claim/anchor/BreakClaimAnchor.kt:10 — Bukkit (org.bukkit) import in application layer
+
+**What:** Line 10 imports `org.bukkit.plugin.java.JavaPlugin` and line 18 stores it as a constructor parameter. The `Claim.resetBreakCount(plugin)` method (Claim.kt:57) also uses `org.bukkit.Bukkit.getScheduler()` directly.
+
+**Why it matters:** This is a hexagonal architecture layer violation. The application layer must not depend on Bukkit/framework types. The `BreakClaimAnchor` action and the `Claim` domain entity both leak Bukkit dependencies, making them untestable without a Bukkit server and tightly coupling domain logic to the Minecraft scheduler.
+
+**Suggested fix:** Introduce a `SchedulerPort` interface in the application layer, inject it into `BreakClaimAnchor`, and have `Claim.resetBreakCount` accept it instead of `JavaPlugin`. The Bukkit implementation lives in infrastructure.
+
+**Confidence:** high
+
+---
+
+### [SEV: med] application/actions/claim/anchor/MoveClaimAnchor.kt:26 — NoClaimFound treated as valid move target
+
+**What:** Line 26: when `getClaimAtPosition.execute()` returns `NoClaimFound`, the code returns `MoveClaimAnchorResult.InvalidPosition`. But semantically, if there is no claim at the new position, the anchor can be moved there — the position is valid because it's empty. The current logic only allows moving the anchor to a position that already has the same claim, which is circular.
+
+**Why it matters:** Moving a claim anchor to an empty location is rejected, preventing legitimate anchor relocations. The check on line 31 (`claimAtPosition.id != claimId`) already handles the case where a *different* claim occupies the position. The `NoClaimFound` case should be allowed to proceed.
+
+**Suggested fix:** Remove the `NoClaimFound -> return InvalidPosition` branch (line 26) and let execution fall through to the position-update logic.
+
+**Confidence:** med
+
+---
+
+### [SEV: med] application/actions/claim/anchor/MoveClaimAnchor.kt:49 — newWorldId parameter ignored when moving anchor
+
+**What:** The `newWorldId` parameter is accepted at line 19 but never used. Line 49 copies the claim with `existingClaim.copy(position = newPosition)` but does not update `worldId`. The old anchor is broken from `existingClaim.worldId` (line 48), but the claim's `worldId` field remains unchanged.
+
+**Why it matters:** If the anchor is moved to a different world, the claim's `worldId` will be inconsistent with the anchor's actual location. This could cause partition lookups, visualizations, and permission checks to fail or target the wrong world.
+
+**Suggested fix:** Copy with both fields: `existingClaim.copy(position = newPosition, worldId = newWorldId)`. Note: `worldId` is currently `val` in `Claim`, so this requires making it `var` or reconstructing the claim.
+
+**Confidence:** med
+
+---
+
+### [SEV: med] application/actions/claim/flag/DoesClaimHaveFlag.kt:12 — Missing return before ClaimNotFound result
+
+**What:** Line 12: `claimRepository.getById(claimId) ?: DoesClaimHaveFlagResult.ClaimNotFound` — the `return` keyword is missing before the expression. The `ClaimNotFound` result is constructed but discarded, and execution always falls through to line 13.
+
+**Why it matters:** The claim-existence check is completely non-functional. The method will attempt to query `claimFlagRepository.doesClaimHaveFlag(claimId, flag)` with a potentially non-existent claimId, which could return incorrect results or throw an exception depending on the repository implementation.
+
+**Suggested fix:** Add `return` before `DoesClaimHaveFlagResult.ClaimNotFound` on line 12.
+
+**Confidence:** high
+
+---
+
+### [SEV: med] application/actions/claim/partition/ResizePartition.kt:31 — Redundant disconnection check (lines 31 and 57)
+
+**What:** `isResizeResultInAnyDisconnected(newPartition)` is called twice — at line 31 and again at line 57, with identical arguments. The second call is dead code because if the first returns `true`, the method returns `Disconnected` at line 31 and never reaches line 57.
+
+**Why it matters:** Not a bug per se, but the duplicate check suggests a copy-paste error. If the intent was to check something different the second time (e.g., after the block-limit check), the logic is wrong. It also adds unnecessary computational cost (BFS over partitions) for every resize operation.
+
+**Suggested fix:** Remove the duplicate call at line 57 (and its associated comment block). If a different check was intended, clarify the condition.
+
+**Confidence:** high
+
+---
+
+### [SEV: med] application/actions/claim/partition/ResizePartition.kt:52 — Incorrect remaining-blocks calculation
+
+**What:** Line 52: `val requiredExtraBlocks = (playerBlockCount + newArea.getBlockCount()) - playerBlockLimit`. This does not subtract the old partition's block count. The correct formula should be: `(playerBlockCount - partition.area.getBlockCount() + newPartition.area.getBlockCount()) - playerBlockLimit`, which is the same pattern used correctly on line 51 for the comparison.
+
+**Why it matters:** The `InsufficientBlocks` result will report an inflated `requiredExtraBlocks` value (off by `partition.area.getBlockCount()`), confusing the player about how many extra blocks they need. The actual block-limit check on line 51 is correct, so the request is still rejected properly, but the error message is wrong.
+
+**Suggested fix:** Change line 52 to: `val requiredExtraBlocks = (playerBlockCount - partition.area.getBlockCount() + newArea.getBlockCount()) - playerBlockLimit`.
+
+**Confidence:** high
+
+---
+
+### [SEV: med] application/actions/claim/partition/ResizePartition.kt:61 — blocksRemaining calculation double-counts new area
+
+**What:** Line 61: `val blocksRemaining = playerBlockLimit - playerBlockCount - newArea.getBlockCount()`. This subtracts the full new area from the remaining blocks, but `playerBlockCount` already includes the old partition's blocks. The correct formula is: `playerBlockLimit - (playerBlockCount - partition.area.getBlockCount() + newPartition.area.getBlockCount())`.
+
+**Why it matters:** The `blocksRemaining` value reported in the success result will be too low (under-counted by `partition.area.getBlockCount()`). This gives players an incorrect picture of their remaining claim block budget.
+
+**Suggested fix:** `val blocksRemaining = playerBlockLimit - playerBlockCount + partition.area.getBlockCount() - newArea.getBlockCount()`.
+
+**Confidence:** high
+
+---
+
+### [SEV: med] application/actions/claim/partition/CreatePartition.kt:47-53 — Adjacency check only validates same-claim partitions
+
+**What:** Lines 47-53: after passing overlap and distance checks, the code looks for an adjacent partition with the same `claimId`. If found, it adds the partition. If no adjacent same-claim partition exists, it returns `Disconnected`. However, for the **first** partition of a new claim, there are no existing partitions for that claim, so this check always fails and returns `Disconnected`.
+
+**Why it matters:** This means `CreatePartition` can never create the first partition of a claim — only additional partitions attached to an existing one. If claim creation is handled elsewhere (e.g., `CreateClaim` creates the initial partition), this may be intentional, but the naming and result type suggest it should handle both cases. If called for a claim with only one existing partition that doesn't happen to be adjacent to the new area, it also fails.
+
+**Suggested fix:** Clarify the intended scope. If this is only for adding partitions to existing claims, document it. If it should also handle first partitions, add a special case: if the claim has no existing partitions, skip the adjacency check.
+
+**Confidence:** med
+
+---
+
+### [SEV: med] application/actions/claim/IsPlayerActionAllowed.kt:114 — TRIGGER_RAID mapped to both DETONATE and EVENT
+
+**What:** `PlayerActionType.TRIGGER_RAID` appears twice in the `actionToPermissionMapping` map (lines 110 and 114), mapped to `ClaimPermission.DETONATE` and `ClaimPermission.EVENT` respectively. Since Kotlin `mapOf` with duplicate keys keeps the **last** entry, the effective mapping is `TRIGGER_RAID -> EVENT`, not `DETONATE`.
+
+**Why it matters:** Triggering a raid will be checked against the `EVENT` permission instead of `DETONATE`. If a claim has `DETONATE` denied but `EVENT` allowed, raids will incorrectly be permitted (or vice versa). The developer likely intended for `TRIGGER_RAID` to require both permissions, but the map structure cannot express that.
+
+**Suggested fix:** Decide which permission `TRIGGER_RAID` should map to and remove the duplicate. If both are needed, the permission-check logic in `IsPlayerActionAllowed` needs to check multiple permissions per action type (change the map to `Map<PlayerActionType, List<ClaimPermission>>`).
+
+**Confidence:** high
+
+---
+
+### [SEV: med] application/actions/claim/IsPlayerActionAllowed.kt:117 — SLEEP_IN_BED mapped to both DETONATE and SLEEP
+
+**What:** Same issue as above: `PlayerActionType.SLEEP_IN_BED` appears at lines 110 and 117, mapped to `DETONATE` and `SLEEP`. The effective mapping is `SLEEP_IN_BED -> SLEEP` (last wins).
+
+**Why it matters:** Sleeping in a bed will be checked against `SLEEP` permission instead of `DETONATE`. This may be the intended behavior (sleep is more semantically correct), but the duplicate entry is confusing and suggests uncertainty about the design.
+
+**Suggested fix:** Remove the duplicate mapping to `DETONATE` on line 110, or restructure to support multiple permissions per action.
+
+**Confidence:** high
+
+---
+
+### [SEV: med] application/actions/claim/IsPlayerActionAllowed.kt:118 — SET_RESPAWN_POINT mapped to both DETONATE and SLEEP
+
+**What:** Same pattern: `PlayerActionType.SET_RESPAWN_POINT` at lines 111 and 118, mapped to `DETONATE` and `SLEEP`. Effective: `SET_RESPAWN_POINT -> SLEEP`.
+
+**Why it matters:** Same as above — the `DETONATE` mapping is silently dropped.
+
+**Suggested fix:** Remove the duplicate or restructure.
+
+**Confidence:** high
+
+---
+
+### [SEV: med] application/actions/claim/IsPlayerActionAllowed.kt:31 — claimOverride check bypasses all permission checks
+
+**What:** Line 31: `if (playerId == claim.playerId || (playerState != null && playerState.claimOverride))` — when `claimOverride` is true, the player is allowed regardless of any permission settings. This is likely intentional for admin/staff override, but there is no logging or audit trail.
+
+**Why it matters:** If `claimOverride` is toggled on accidentally or by an unauthorized player (depending on who can call `ToggleClaimOverride`), they gain full access to all claims silently. This is more of a design concern than a bug, but worth flagging.
+
+**Suggested fix:** Add logging when `claimOverride` grants access, and ensure `ToggleClaimOverride` has proper authorization checks.
+
+**Confidence:** med
+
+---
+
+### [SEV: med] application/actions/claim/partition/CanRemovePartition.kt:28,35,52,102 — partitionRepository.getByPosition called with Position2D(claim.position)
+
+**What:** Multiple locations (lines 28, 35, 52, 102) call `partitionRepository.getByPosition(Position2D(claim.position))`. The `getByPosition` method expects a `Position` (which has x, y, z), but `Position2D(claim.position)` creates a 2D position from the 3D claim position. This works because `Position2D` extends `Position` with `y = null`, but the `y` being null could cause NPEs in downstream code that expects a non-null y for position-based lookups.
+
+**Why it matters:** If `getByPosition` or any code it calls accesses `position.y`, it will get `null` from a `Position2D`, potentially causing a NullPointerException. This is a latent bug that depends on the repository implementation.
+
+**Suggested fix:** Pass `claim.position` directly (it's already a `Position3D` which extends `Position`), or ensure `getByPosition` handles null y gracefully.
+
+**Confidence:** med
+
+---
+
+### [SEV: low] application/actions/claim/ConvertClaimToGuild.kt:56-62 — Broad catch blocks swallow all exceptions as StorageError
+
+**What:** Lines 56-62 catch `DatabaseOperationException` and then a generic `Exception`, both returning `StorageError`. The broad `Exception` catch will swallow programming errors (NullPointerException, IllegalArgumentException, etc.) and present them as storage failures.
+
+**Why it matters:** Makes debugging difficult. A coding bug in the action (e.g., null dereference) would be silently reported as a storage error, misleading operators.
+
+**Suggested fix:** Catch only the expected exception types. If a broad catch is needed for safety, log the full stack trace at error level.
+
+**Confidence:** med
+
+---
+
+### [SEV: low] application/actions/claim/CreateClaim.kt:64-67 — Claim and partition added without transaction/rollback
+
+**What:** Line 66 calls `claimRepository.add(newClaim)` and line 67 calls `partitionRepository.add(partition)`. If the partition add fails (returns false or throws), the claim is already persisted without its partition, leaving an orphaned claim in the database.
+
+**Why it matters:** An orphaned claim with no partitions would be invisible in the world (no area to protect) but would still count against the player's claim limit and name uniqueness.
+
+**Suggested fix:** Wrap both adds in a transaction, or check the return value of `partitionRepository.add` and roll back the claim creation on failure.
+
+**Confidence:** med
+
+---
+
+### [SEV: low] application/actions/claim/anchor/BreakClaimAnchor.kt:24-28 — Race condition on breakCount mutation
+
+**What:** Lines 24-28: `claim.resetBreakCount(plugin)` is called, then `claim.breakCount` is read and mutated. Since `resetBreakCount` uses the Bukkit scheduler to reset `breakCount` after 200 ticks, and the current code mutates `breakCount` on the same object instance, there is a race between the scheduled reset and the decrement.
+
+**Why it matters:** If two players break the anchor in quick succession, the `breakCount` could be decremented by both before either reset fires, or the reset could overwrite a decrement. This is a classic race condition on shared mutable state.
+
+**Suggested fix:** Use atomic operations or synchronize access to `breakCount`. Consider making the break-count logic server-side only, not domain-side.
+
+**Confidence:** med
+
+---
+
+### [SEV: low] application/actions/claim/partition/ResizePartition.kt:34 — getPrimaryPartition called twice with same args
+
+**What:** `getPrimaryPartition(claim)` is called at line 34 and again at line 72 (via `isResizeResultInAnyDisconnected` which calls it internally). Both operate on the same claim and partitions, producing the same result.
+
+**Why it matters:** Minor performance waste — `getPrimaryPartition` queries the repository each time. Not a bug, but could be cached.
+
+**Suggested fix:** Compute `getPrimaryPartition` once and pass it as a parameter.
+
+**Confidence:** low
+
+---
+
+### [SEV: low] application/actions/claim/partition/ResizePartition.kt:197 — setNewCorner z-defaults to 0 for non-matching corners
+
+**What:** In `setNewCorner` (lines 197-223), when a coordinate does not match the selected corner, the code defaults to `Position2D(x, 0)` or `Position2D(0, z)` with a hardcoded `0` for the non-matching axis. This works because the second assignment (z for x-mismatch, x for z-mismatch) overwrites the 0, but it's fragile and confusing.
+
+**Why it matters:** If the logic is ever refactored to return early or if the two assignment blocks are reordered, the 0 default would produce incorrect areas. The intent is to preserve the opposite corner's coordinate.
+
+**Suggested fix:** Use the actual opposite corner's coordinate as the default instead of 0, e.g., `Position2D(area.upperPosition2D.x, 0)` → `Position2D(area.upperPosition2D.x, area.upperPosition2D.z)` and let the subsequent assignment override the relevant axis.
+
+**Confidence:** low
+
+---
+
+### [SEV: low] application/actions/player/tool/GetClaimIdFromMoveTool.kt:11 — UUID.fromString can throw uncaught IllegalArgumentException
+
+**What:** Line 11: `UUID.fromString(claimIdString)` can throw `IllegalArgumentException` if the string is not a valid UUID. This exception is not caught.
+
+**Why it matters:** If the item data contains a malformed UUID string, the action will throw an unhandled exception that propagates up to the caller, potentially crashing the calling command or listener.
+
+**Suggested fix:** Wrap in a try-catch and return `NotMoveTool` on `IllegalArgumentException`.
+
+**Confidence:** med
+
+---
+
+### [SEV: low] application/actions/player/visualisation/DisplayVisualisation.kt:28-30 — java.util.logging.Logger in application layer
+
+**What:** Line 29 uses `java.util.logging.Logger`, which is a JDK logging framework. While not a Bukkit dependency, it's still a framework-specific logging choice in the application layer.
+
+**Why it matters:** Minor layer purity concern. The application layer should ideally depend on an abstraction for logging.
+
+**Suggested fix:** Inject a logging port/interface. Low priority since JUL is part of the JDK and not a third-party framework.
+
+**Confidence:** low
+
+---
+
+### [SEV: low] application/actions/player/visualisation/DisplayVisualisation.kt:96-100 — Silent catch of all exceptions during player state update
+
+**What:** Lines 96-100 catch all exceptions when updating player state and only log them. The visualization has already been displayed to the player (lines 78-82), but the player state (isVisualisingClaims, lastVisualisationTime) is not updated if this fails.
+
+**Why it matters:** The player sees the visualization but the server doesn't track it, so rate-limiting won't work and the visualization won't be cleared on schedule. This is a minor inconsistency.
+
+**Suggested fix:** Consider whether the visualization should be rolled back if state update fails, or at minimum, ensure the state is eventually consistent.
+
+**Confidence:** med
+
+---
+
+### [SEV: low] application/actions/claim/IsNewClaimLocationValid.kt:53 — getSurroundingPositions uses -1 * radius instead of unary minus
+
+**What:** Line 56: `for (i in -1 * radius..1 * radius)` — this works correctly but is unconventional. The idiomatic Kotlin form is `-radius..radius`.
+
+**Why it matters:** Style/readability only. No functional impact.
+
+**Suggested fix:** Use `-radius..radius`.
+
+**Confidence:** low
+
+---
+
+### [SEV: low] application/actions/claim/IsNewClaimLocationValid.kt:29 — getSurroundingPositions called with radius=1 for chunk padding
+
+**What:** Line 29: `val chunks = area.getChunks().flatMap { getSurroundingPositions(it, 1) }` — this fetches partitions in a 3x3 grid around each chunk of the area. Combined with the boundary padding on lines 34-38, this creates a generous overlap check. However, the variable name `chunks` is misleading since after `flatMap` it contains surrounding positions, not just the area's chunks.
+
+**Why it matters:** Naming confusion only. No functional bug.
+
+**Suggested fix:** Rename to `paddedChunks` or `chunksWithPadding`.
+
+**Confidence:** low
+
+---
+
+### [SEV: low] application/actions/claim/permission/GrantGuildMembersClaimPermissions.kt:62 — alreadyHadAccessCount may be inaccurate
+
+**What:** Line 62: `alreadyHadAccessCount` is incremented when `memberGranted` is false, meaning none of the permissions were newly added. But `memberGranted` is only false if `playerAccessRepository.add()` returned false for ALL permissions — if a player had some permissions but not all, `memberGranted` would be true (because at least one add succeeded) and `alreadyHadAccessCount` would not increment.
+
+**Why it matters:** The `alreadyHadAccessCount` metric is misleading — it only counts players who had ALL permissions already, not players who had SOME permissions. The success result's counts may not sum to the total number of guild members processed.
+
+**Suggested fix:** Rename to `fullyGrantedCount` or change the logic to count members who had at least one permission already.
+
+**Confidence:** med
+
+---
+
+### [SEV: low] application/actions/claim/permission/RevokeAllClaimWidePermissions.kt:7 — Unused import
+
+**What:** Line 7 imports `RevokeAllPlayerClaimPermissionsResult` but it is never used in this file.
+
+**Why it matters:** Dead import, minor code quality issue.
+
+**Suggested fix:** Remove the unused import.
+
+**Confidence:** high
+
+---
+
+### [SEV: low] application/actions/claim/permission/EnableClaimFlag.kt:37 — Logs error.cause instead of error.message
+
+**What:** Line 37: `println("Error has occurred trying to save to the database: ${error.cause}")` — this logs the cause of the exception, not the message. If `error.cause` is null, it prints "null". Other similar catch blocks in the codebase use `error.message`.
+
+**Why it matters:** Inconsistent error logging. The cause may be null or less informative than the message itself.
+
+**Suggested fix:** Change to `error.message` for consistency with other actions.
+
+**Confidence:** med
+
+---
+
+### [SEV: low] application/actions/claim/permission/EnableClaimFlag.kt:24 — KDoc references wrong result type
+
+**What:** Line 24: `@return An [EnableAllClaimFlagsResult]` — should be `EnableClaimFlagResult`. Copy-paste error from `EnableAllClaimFlags`.
+
+**Why it matters:** Documentation only. No functional impact.
+
+**Suggested fix:** Fix the KDoc to reference the correct result type.
+
+**Confidence:** high
+
+---
+
+### [SEV: low] application/actions/claim/permission/RevokeAllClaimWidePermissions.kt:17 — KDoc references wrong result type
+
+**What:** Line 17: `@return An [RevokeAllPlayerClaimPermissionsResult]` — should be `RevokeAllClaimWidePermissionsResult`.
+
+**Why it matters:** Documentation only.
+
+**Suggested fix:** Fix the KDoc.
+
+**Confidence:** high
+
+---
+
+### [SEV: low] application/actions/claim/permission/GrantAllPlayerClaimPermissions.kt:16 — KDoc references "flag" instead of "permission"
+
+**What:** Line 16: `@return An [GrantAllPlayerClaimPermissionsResult] indicating the outcome of the flag addition operation` — should say "permission" not "flag".
+
+**Why it matters:** Documentation clarity.
+
+**Suggested fix:** Change "flag" to "permission" in the KDoc.
+
+**Confidence:** high
+
+---
+
+### [SEV: low] application/actions/claim/permission/RevokeAllPlayerClaimPermissions.kt:16 — KDoc references "flag" instead of "permission"
+
+**What:** Line 16: `@return An [RevokeAllPlayerClaimPermissionsResult] indicating the outcome of the flag addition operation` — should say "permission removal" not "flag addition".
+
+**Why it matters:** Documentation clarity.
+
+**Suggested fix:** Update the KDoc.
+
+**Confidence:** high
+
+---
+
+### [SEV: low] application/actions/claim/permission/GrantAllClaimWidePermissions.kt:16 — KDoc references "flag" instead of "permission"
+
+**What:** Line 16: `@return An [GrantAllClaimWidePermissionsResult] indicating the outcome of the flag addition operation` — should say "permission" not "flag".
+
+**Why it matters:** Documentation clarity.
+
+**Suggested fix:** Update the KDoc.
+
+**Confidence:** high
+
+---
+
+### [SEV: low] application/actions/claim/permission/DisableAllClaimFlags.kt:23 — KDoc references "flag" correctly but variable name is misleading
+
+**What:** Line 30: `var anyFlagEnabled = false` — the variable is named `anyFlagEnabled` but it tracks whether any flag was **disabled** (removed). The return logic on line 38 checks `if (anyFlagEnabled)` to return `Success`, which is correct (a flag was found and removed), but the name suggests enabling.
+
+**Why it matters:** Naming confusion. Could lead to future bugs if someone refactors based on the variable name.
+
+**Suggested fix:** Rename to `anyFlagDisabled` or `anyFlagRemoved`.
+
+**Confidence:** med
+
+---
+
+### [SEV: low] application/actions/claim/permission/EnableAllClaimFlags.kt:30 — Same naming issue
+
+**What:** Line 30: `var anyFlagEnabled = false` — tracks whether any flag was **added**. This is actually correct for enable, but the pattern is inconsistent with `DisableAllClaimFlags`.
+
+**Why it matters:** Consistency.
+
+**Suggested fix:** Keep as-is for enable, but fix the disable counterpart.
+
+**Confidence:** low
+
+---
+
+## Test Coverage Gaps
+
+| # | Untested Behavior | File | Test That Should Exist |
+|---|-------------------|------|------------------------|
+| 1 | Name-uniqueness check uses correct player (acceptor, not old owner) | `AcceptTransferRequest.kt:39` | `AcceptTransferRequestTest` — verify name collision is checked against the accepting player's claims, not the old owner's |
+| 2 | `GrantAllPlayerClaimPermissions` actually grants (not revokes) | `GrantAllPlayerClaimPermissions.kt:27` | `GrantAllPlayerClaimPermissionsTest` — verify permissions are added, not removed |
+| 3 | `WithdrawPlayerTransferRequest` correctly identifies pending requests | `WithdrawPlayerTransferRequest.kt:10` | `WithdrawPlayerTransferRequestTest` — verify inverted logic: request found → removed; request not found → error |
+| 4 | `DoesClaimHaveFlag` returns ClaimNotFound for missing claims | `DoesClaimHaveFlag.kt:12` | `DoesClaimHaveFlagTest` — verify missing claim returns ClaimNotFound (currently broken due to missing `return`) |
+| 5 | `OfferPlayerTransferRequest` persists the transfer request | `OfferPlayerTransferRequest.kt:14` | `OfferPlayerTransferRequestTest` — verify claimRepository.update is called after adding transfer request |
+| 6 | `AcceptTransferRequest` uses copy() instead of mutating playerId | `AcceptTransferRequest.kt:43` | `AcceptTransferRequestTest` — verify the original claim object is not mutated |
+| 7 | `MoveClaimAnchor` allows moving to empty positions | `MoveClaimAnchor.kt:26` | `MoveClaimAnchorTest` — verify NoClaimFound at new position is treated as valid |
+| 8 | `MoveClaimAnchor` updates worldId when moving across worlds | `MoveClaimAnchor.kt:49` | `MoveClaimAnchorTest` — verify worldId is updated in the copied claim |
+| 9 | `ResizePartition` blocksRemaining calculation is correct | `ResizePartition.kt:61` | `ResizePartitionTest` — verify blocksRemaining accounts for old partition size |
+| 10 | `ResizePartition` requiredExtraBlocks calculation is correct | `ResizePartition.kt:52` | `ResizePartitionTest` — verify InsufficientBlocks reports correct deficit |
+| 11 | `CreateClaim` rolls back claim if partition creation fails | `CreateClaim.kt:66-67` | `CreateClaimTest` — verify no orphaned claim when partition add fails |
+| 12 | `IsPlayerActionAllowed` TRIGGER_RAID permission resolution | `IsPlayerActionAllowed.kt:110,114` | `IsPlayerActionAllowedTest` — verify which permission (DETONATE or EVENT) is checked for TRIGGER_RAID |
+| 13 | `CreatePartition` handles first partition of a new claim | `CreatePartition.kt:47-53` | `CreatePartitionTest` — verify behavior when claim has no existing adjacent partitions |
+| 14 | `BreakClaimAnchor` persists break count changes | `BreakClaimAnchor.kt:24-28` | `BreakClaimAnchorTest` — verify break count decrement is persisted |
+| 15 | `GetClaimIdFromMoveTool` handles malformed UUID gracefully | `GetClaimIdFromMoveTool.kt:11` | `GetClaimIdFromMoveToolTest` — verify invalid UUID string returns NotMoveTool, not an exception |
+
+---
+
+## Layer Boundary Check
+
+**Verdict: VIOLATED** — `BreakClaimAnchor.kt` imports `org.bukkit.plugin.java.JavaPlugin` (Bukkit framework type) directly in the application layer. Additionally, `Claim.resetBreakCount()` in the domain layer uses `org.bukkit.Bukkit.getScheduler()`, which is a domain-layer violation (domain must not import frameworks). All other 65 files correctly depend only on application/domain ports and domain entities — no other Bukkit/JDBC/framework imports detected.
+
+**Summary:** 2 files with layer violations:
+- `BreakClaimAnchor.kt:10` — direct `org.bukkit` import in application layer
+- `Claim.kt:57-64` — `org.bukkit.Bukkit` usage in domain entity (domain layer violation, outside the 66-scope but directly caused by the `JavaPlugin` parameter injected into `BreakClaimAnchor`)

--- a/docs/audit/audit-app-results-ports.md
+++ b/docs/audit/audit-app-results-ports.md
@@ -1,0 +1,130 @@
+# Audit Report: application/results + application/persistence
+
+**Batch:** audit-app-results-ports
+**Scope:** 82 files — 24 persistence ports, 58 result DTOs
+**Date:** 2026-00-09
+
+---
+
+## Findings
+
+### [SEV: high] application/persistence/GuildVaultRepository.kt:3 — Bukkit ItemStack leaked into application layer
+
+**What:** `GuildVaultRepository` (a persistence port in the application layer) imports `org.bukkit.inventory.ItemStack` and uses it in method signatures (`saveVaultInventory`, `getVaultInventory`, `saveVaultItem`, `getVaultItem`). This is a direct framework dependency crossing the hexagonal boundary into the application core.
+
+**Why it matters:** The persistence port is the contract that infrastructure implements. By embedding `ItemStack` in the port, every consumer — test doubles, alternative storage backends, and the domain services that call the port — is forced to depend on Bukkit. This defeats the purpose of the port/adapter split: you cannot unit-test vault logic without a Bukkit server, and you cannot swap to a non-Bukkit storage (e.g., REST, flat-file) without changing the port. It also makes the interface unresolvable at compile time outside a Paper/Spigot environment.
+
+**Suggested fix:** Introduce a domain/value-layer representation (e.g., `VaultItem` data class with material, amount, name, lore) in `domain/values/`, map to/from `ItemStack` in the infrastructure adapter (`GuildVaultRepositoryImpl`), and change the port to use the domain type. The mapping is the adapter's job.
+
+**Confidence:** high
+
+---
+
+### [SEV: med] application/results/common/TextValidationErrorResult.kt:4 — maxCharacters typed as String instead of Int
+
+**What:** `ExceededCharacterLimit` holds `maxCharacters: String`. Character limits are inherently integer values. The callers (`DescriptionCommand.kt:49`, `RenameCommand.kt:54`) use it in string interpolation (`arrayOf(name.count().toString(), firstError.maxCharacters)`), which works but loses type safety.
+
+**Why it matters:** A String field for a numeric boundary invites subtle bugs — e.g., a future refactor could pass `"unlimited"` or `"N/A"` into the field and the compiler wouldn't catch it. The `.count()` comparison that precedes this is done in `Int`; storing the limit as `String` forces an implicit contract that "this string is always a parseable integer". Every consumer must trust that invariant.
+
+**Suggested fix:** Change `maxCharacters: String` to `maxCharacters: Int`. Update callers to use `firstError.maxCharacters.toString()` at the interpolation boundary.
+
+**Confidence:** high
+
+---
+
+### [SEV: med] application/results/claim/permission/GrantAllClaimWidePermissionsResult.kt:5 — inconsistent error variant naming
+
+**What:** The `ClaimNotFound` variant is absent; instead the file defines `ClaimWideNotFound`. Every other permission result in the same package (`GrantClaimWidePermissionResult`, `RevokeClaimWidePermissionResult`, `RevokeAllClaimWidePermissionsResult`) uses `ClaimNotFound`. This is the sole exception.
+
+**Why it matters:** Callers doing `when (result)` across the permission result family must handle two names for the same semantic case, or risk a missing branch. It breaks the polymorphic contract — a common handler for "permission results" cannot uniformly match `ClaimNotFound`.
+
+**Suggested fix:** Rename `ClaimWideNotFound` to `ClaimNotFound` to match the rest of the permission result family.
+
+**Confidence:** high
+
+---
+
+### [SEV: low] application/persistence/ClaimRepository.kt:40 — getByTeam uses stale "team" terminology
+
+**What:** `getByTeam(teamId: UUID)` uses the word "team" while the entity is named `Guild` everywhere else (`GuildRepository.getByPlayer`, `getByGuild`, etc.). The doc also says "team/guild" — the canonical name is `Guild`.
+
+**Why it matters:** Naming inconsistency creates confusion for new contributors and makes API discovery harder. If someone searches for "guild claim lookup", this method won't surface. It's minor but contributes to a fragmented mental model.
+
+**Suggested fix:** Rename to `getByGuild(guildId: UUID)` and deprecate the old name, or simply rename if no external callers depend on the exact signature.
+
+**Confidence:** med
+
+---
+
+### [SEV: low] application/persistence/PartitionRepository.kt:66 — Javadoc mismatch on remove()
+
+**What:** `@param partition The id of the partition to remove` — the parameter name is `partitionId`, not `partition`. The doc should read `@param partitionId`.
+
+**Why it matters:** Misleading Javadoc. Low severity but contributes to documentation rot.
+
+**Suggested fix:** Update the `@param` tag to match the parameter name.
+
+**Confidence:** high
+
+---
+
+### [SEV: low] application/results/player/visualisation/GetVisualiserModeResult.kt:4 — visualiserMode as raw Int
+
+**What:** `visualiserMode: Int` encodes a mode flag as an untyped integer. `ToggleVisualiserModeResult` uses the same pattern. No enum or sealed class constrains the valid values.
+
+**Why it matters:** Consumers must know which integers are valid (0, 1, 2?). A wrong integer silently propagates. This is a standard primitive-obsession code smell in result DTOs that are supposed to be strongly typed.
+
+**Suggested fix:** Introduce a `VisualiserMode` sealed class or enum in `domain/values/` and use it here.
+
+**Confidence:** med
+
+---
+
+### [SEV: low] application/results/player/visualisation/ToggleVisualiserModeResult.kt:5 — cooldownTime unit ambiguity
+
+**What:** `OnCooldown(val cooldownTime: Int)` — the unit (seconds? milliseconds? ticks?) is undocumented and ambiguous.
+
+**Why it matters:** A cooldown of `30` could mean 30 seconds or half a second depending on convention. This is a communication bug between the service that calculates cooldown and the UI layer that displays it.
+
+**Suggested fix:** Document the unit in KDoc, or use `java.time.Duration` / `kotlin.time.Duration`.
+
+**Confidence:** med
+
+---
+
+### [SEV: low] application/results/claim/permission/GrantGuildMembersClaimPermissionsResult.kt:6-38 — over-documented trivial result
+
+**What:** The entire file has KDoc on every variant explaining what the variant means (e.g., "The claim was not found."). This is the only result file in the batch with KDoc on individual variants; all 57 others rely on the type name alone.
+
+**Why it matters:** Not a bug, but indicates an inconsistent documentation standard. If KDoc on variants is a project convention, it's missing from 57 files. If it's not, this file is noise.
+
+**Suggested fix:** Either adopt KDoc-on-variants as a standard (and apply to all results), or remove the redundant KDoc from this file.
+
+**Confidence:** low
+
+---
+
+## Test Coverage Gaps
+
+| Untested file | Behavior that lacks test | Suggested test |
+|---|---|---|
+| `GuildVaultRepository` (all 13 methods) | No direct port-level contract test; no test for `addGoldBalance`/`subtractGoldBalance` returning `-1` on failure | `GuildVaultRepositoryTest` verifying port semantics via a fake impl; test negative-balance guard in `subtractGoldBalance` |
+| `ProgressionRepository` (all 18 methods) | Zero test references in the entire codebase | Mock-based test for `incrementActivityMetric`, `getTopGuildsByMetric`, and `resetLeaderboardPeriod` edge cases |
+| `TextValidationErrorResult.Companion` (factory) | No test verifying that `ExceededCharacterLimit.maxCharacters` is always a parseable integer | Round-trip factory test |
+| `GrantGuildMembersClaimPermissionsResult` | No test covering `NotClaimOwner` / `ClaimNotGuildOwned` / `NoGuildMembers` branches | Branch coverage test via service-layer mock |
+| All 58 result DTO sealed classes | No structural test (exhaustive `when` verification) | Compile-time exhaustiveness check or runtime sealed-subclass count test |
+| `RemovePartitionResult` mixed naming | `Disconnected` vs `ExposedClaimAnchor` order is not validated | Test that `CanRemovePartitionResult` and `RemovePartitionResult` share the same variant names where semantics overlap |
+| `PlayerStateRepository.remove(playerState)` | Takes the full object, not an ID — unlike every other repo | Verify that `remove` actually removes by player ID, not object equality |
+
+---
+
+## Layer Boundary Check
+
+| File | Verdict |
+|---|---|
+| All 24 `application/persistence/*` ports (except `GuildVaultRepository`) | PASS — domain/value types only, no Bukkit/JDBC |
+| `GuildVaultRepository.kt:3` | **FAIL** — `org.bukkit.inventory.ItemStack` leaked into port API (see finding #1) |
+| All 58 `application/results/*` DTOs | PASS — only import from `application.results.*` and `domain.*`; no Bukkit/JDBC/frameworks |
+| `ProgressionRepository.kt:4` | PASS — `ExperienceSource` is `application.services`, same layer |
+
+**Verdict:** 1 layer-boundary failure out of 82 files (`GuildVaultRepository.kt`). The result DTOs are clean. The persistence ports are clean except for the one Bukkit leak.

--- a/docs/audit/audit-app-services.md
+++ b/docs/audit/audit-app-services.md
@@ -1,0 +1,553 @@
+# Audit Report: application/services, utilities, errors, events
+
+**Scope:** 48 files in `application/{services,utilities,errors,events}`
+**Branch:** fix/audit-app-services
+**Methodology:** docs/audit/audit-app-services-plan.md
+
+---
+
+## Findings
+
+### [SEH: high] PartitionModificationEvent.kt:14 — `handlerList` is a val but must be static
+
+**What:** The `handlerList` is declared `private val` inside the `companion object`, but Bukkit's `HandlerList` must be effectively static/`@JvmStatic` for the event system to work reliably across dispatches. It is only referenced via `getHandlerList()` (line 21) and `getHandlers()` (line 31), which is correct, but the `val` allocation in the companion object is per-class-loader which is fine. **However**, the `getHandlers()` override on line 31 returns the companion's `handlerList` — this is the Bukkit contract. No actual bug here per se, but the code is fragile: if anyone ever adds a second event class copy-pasting this pattern and forgets `@JvmStatic`, the event system silently breaks. No finding.
+
+**Confidence:** low — withdrawn after review; Bukkit contract is met.
+
+---
+
+### [SEV: high] VaultAutoSaveService.kt:257-258 — auto-unboxing NPE on cancelled-task check
+
+**What:** `autoSaveTask?.isCancelled == false` uses the safe-call operator, but if `autoSaveTask` is null the expression evaluates to `null == false` which is `false` (safe). However, the real issue is that `BukkitTask.isCancelled()` returns a `Boolean` (platform type `Boolean!`). If the scheduler implementation ever returns a null (unlikely but not contractual), calling `isCancelled` on a non-null `BukkitTask` that has been garbage-collected or corrupted could throw. This is a marginal concern.
+
+**Why it matters:** Low probability. Withdrawn.
+
+**Confidence:** low
+
+---
+
+### [SEV: med] PartitionModificationEvent.kt:13 — Bukkit event in application layer
+
+**What:** `PartitionModificationEvent` extends `org.bukkit.event.Event` and imports `org.bukkit.event.HandlerList`. This places a Bukkit framework type directly in the `application/events` package, violating the hexagonal architecture rule that `application` must not import Bukkit.
+
+**Why it matters:** The application layer becomes coupled to the Bukkit event system. Any change in the Bukkit API (or migration to a different server platform) would require changes in the application layer. The event should be defined in the infrastructure layer, or the application layer should define its own pure event type that infrastructure adapts.
+
+**Suggested fix:** Define a pure `PartitionModificationEvent` in `application/events` (no Bukkit imports), then create a Bukkit-specific adapter in `infrastructure/bukkit/events` that extends `org.bukkit.Event`.
+
+**Confidence:** high
+
+---
+
+### [SEV: med] CsvExportService.kt:115 — `getPlayerName` calls `Bukkit.getOfflinePlayer` on every row
+
+**What:** `getPlayerName(transaction.actorId)` calls `org.bukkit.Bukkit.getOfflinePlayer(playerId)` for every transaction in the CSV. This is a synchronous I/O call that hits the user cache and potentially disk. For large transaction lists this blocks the calling thread (which may be async, but still wastes resources).
+
+**Why it matters:** Performance degradation when exporting large histories. If called from the main thread (the method is not marked async), it freezes the server.
+
+**Suggested fix:** Batch-resolve player names via `Bukkit.getOfflinePlayer` once into a map, or accept a pre-resolved name map as a parameter. Consider making the method `suspend` or returning a `CompletableFuture`.
+
+**Confidence:** high
+
+---
+
+### [SEV: med] CsvExportService.kt:131-136 — CSV sanitization is incomplete
+
+**What:** `sanitizeCsvField` replaces commas with semicolons (line 133), then on line 136 checks if the result *still* contains commas to decide whether to wrap in quotes. Since commas were already replaced, the quote-wrapping condition on line 136 will never trigger for commas — it only triggers for quotes/newlines. More critically, the method does **not** strip or escape formula-injection characters (`=`, `+`, `-`, `@`, `\t`, `\r`) at the start of fields, which is the primary CSV injection vector.
+
+**Why it matters:** CSV injection (formula injection) allows arbitrary command execution when the CSV is opened in Excel/LibreOffice. A player name like `=CMD("calc")` would pass through unsanitized.
+
+**Suggested fix:** Prefix fields starting with `=`, `+`, `-`, `@`, `\t`, or `'` with a single quote or tab character. Use a proper CSV library (e.g., Apache Commons CSV or opencsv) instead of manual string building.
+
+**Confidence:** high
+
+---
+
+### [SEV: med] DiscordCsvService.kt:27 — `webhookUrl` is a constructor-injected config value with no validation at call time
+
+**What:** The `webhookUrl` is passed at construction and `isConfigured()` checks it starts with `https://discord.com/api/webhooks/`. However, `sendFileToDiscord` (line 232) uses the URL directly in `URI.create(webhookUrl)` without try-catch for `IllegalArgumentException`. A malformed URL would propagate as an unhandled exception, crashing the virtual thread and losing the callback.
+
+**Why it matters:** If the webhook URL is malformed (e.g., contains spaces or invalid characters), the async export silently fails — the callback is never invoked, and the player receives no feedback.
+
+**Suggested fix:** Validate the URL in the constructor or in `sendFileToDiscord` with a try-catch around `URI.create()`, calling `callback(Result.failure(...))` on error.
+
+**Confidence:** med
+
+---
+
+### [SEV: med] DiscordCsvService.kt:232-282 — `sendFileToDiscord` runs HTTP on a virtual thread but catches only IOException
+
+**What:** The `sendFileToDiscord` method catches `IOException` (line 279) but `HttpClient.send()` can also throw `InterruptedException` (which is not an `IOException`). On an `InterruptedException`, the method falls through without returning a `Result`, so the callback is never invoked.
+
+**Why it matters:** Silent failure — the player never gets success or error feedback. The virtual thread is interrupted and the result is lost.
+
+**Suggested fix:** Also catch `InterruptedException` (and ideally any `Exception`) and return `Result.failure(...)`.
+
+**Confidence:** high
+
+---
+
+### [SEV: med] FileExportManager.kt:219-234 — rate limit check is not thread-safe
+
+**What:** `checkRateLimit` reads and writes `rateLimitMap` using `computeIfAbsent` (thread-safe) but then calls `playerRequests.removeIf(...)` and `playerRequests.add(...)` on the mutable list without synchronization. If two exports for the same player fire concurrently, the size check on line 227 and the add on line 232 can race, allowing more than `MAX_EXPORTS_PER_HOUR` exports.
+
+**Why it matters:** Rate limiting can be bypassed under concurrent load, defeating its purpose as a DoS mitigation.
+
+**Suggested fix:** Use a `synchronized` block on the player's list, or use a concurrent queue with atomic size tracking, or use a `ConcurrentLinkedQueue` with a synchronized window check.
+
+**Confidence:** med
+
+---
+
+### [SEV: med] FileExportManager.kt:99,174 — async task captures `callback` from Bukkit scheduler thread
+
+**What:** `Bukkit.getScheduler().runTaskAsynchronously(plugin, Runnable { ... })` captures the `callback` lambda. The callback is then invoked from the async thread (line 111-118) and also from within the Discord callback (line 109-119). If the callback touches Bukkit API (e.g., sending a message to a player), this will throw or corrupt state since Bukkit API is not thread-safe.
+
+**Why it matters:** Potential `IllegalStateException` or data corruption if the callback interacts with Bukkit from an async thread.
+
+**Suggested fix:** Ensure all Bukkit-interacting callbacks are scheduled back to the main thread via `Bukkit.getScheduler().runTask(plugin, Runnable { ... })`.
+
+**Confidence:** med
+
+---
+
+### [SEV: med] VaultInventoryManager.kt:537 — `flushBuffer` returns `true` for empty buffer
+
+**What:** `flushBuffer` returns `true` on line 538 when there's no buffer (`writeBuffers[guildId] == null`), and also on line 540-541 when the buffer has no pending changes. This is semantically correct (nothing to flush = success), but callers checking the boolean cannot distinguish "nothing to do" from "successfully flushed."
+
+**Why it matters:** Minor — the return value is used by `flushPendingBuffers()` to count flushed buffers, which will never count "no-op" flushes. This is fine. No finding.
+
+**Confidence:** low — withdrawn.
+
+---
+
+### [SEV: med] VaultInventoryManager.kt:858-898 — `saveSlotWithRetry` swallows all non-SQLException errors
+
+**What:** The `saveSlotWithRetry` method catches only `SQLException` (line 874). If `vaultRepository.saveVaultItem` throws any other exception (e.g., `IllegalStateException`, `NullPointerException`), the exception propagates up, potentially crashing the flush cycle and leaving the buffer in an inconsistent state.
+
+**Why it matters:** A single bad item (e.g., with corrupted NBT) could crash the entire auto-save loop for all vaults, since `flushPendingBuffers` iterates all buffers.
+
+**Suggested fix:** Catch `Exception` instead of just `SQLException`, log the error, and continue with the next buffer.
+
+**Confidence:** high
+
+---
+
+### [SEV: med] VaultInventoryManager.kt:909-948 — same issue in `saveGoldBalanceWithRetry`
+
+**What:** Identical to the slot retry issue — only `SQLException` is caught. Any other exception type crashes the flush.
+
+**Why it matters:** Same as above — a non-SQL error in gold balance persistence crashes the auto-save loop.
+
+**Suggested fix:** Catch `Exception` instead of just `SQLException`.
+
+**Confidence:** high
+
+---
+
+### [SEV: med] VaultAutoSaveService.kt:92-107 — `performAutoSave` catches Exception but logs stack trace to stderr
+
+**What:** Line 103 calls `e.stackTraceToString()` which prints to the plugin logger (fine), but line 102 uses `plugin.logger.severe(...)` which is correct. No actual bug, but the pattern of catching all exceptions in background tasks means transient errors are silently retried while persistent errors (e.g., database connection lost) spam the log every second.
+
+**Why it matters:** Log flooding during database outages. No circuit breaker.
+
+**Suggested fix:** Add a consecutive-error counter that backs off logging after N failures, or escalates to disable the auto-save service.
+
+**Confidence:** med
+
+---
+
+### [SEV: low] CsvExportService.kt:16 — `DateTimeFormatter` is not thread-safe when used from async
+
+**What:** `DateTimeFormatter` is stored in a `val` field and used by `formatTimestamp`. `DateTimeFormatter` IS thread-safe (it's immutable), so this is fine. No finding.
+
+**Confidence:** low — withdrawn.
+
+---
+
+### [SEV: low] DiscordCsvService.kt:33 — same `DateTimeFormatter` pattern
+
+**What:** Same as above — `DateTimeFormatter` is thread-safe. No finding.
+
+**Confidence:** low — withdrawn.
+
+---
+
+### [SEV: low] VaultAutoSaveService.kt:257 — `autoSaveTask?.isCancelled` safe-call semantics
+
+**What:** When `autoSaveTask` is null (before `start()` or after `stop()`), `autoSaveTask?.isCancelled` returns `null`, and `null == false` evaluates to `false`. This means `auto_save_running` will be `false` when the task is null, which is correct. No bug.
+
+**Confidence:** low — withdrawn.
+
+---
+
+### [SEV: low] FormCacheService.kt:3 — Geysermc Cumulus import in application layer
+
+**What:** `FormCacheService` imports `org.geysermc.cumulus.form.Form`, a Bedrock/Floodgate framework type, directly in the application layer interface.
+
+**Why it matters:** Violates the hexagonal architecture — the application layer should not depend on framework-specific types. The `Form` type is a Geysermc Cumulus API class.
+
+**Suggested fix:** Define a pure application-layer form abstraction (e.g., `BedrockForm`) and have the infrastructure layer adapt Cumulus `Form` to it.
+
+**Confidence:** high
+
+---
+
+### [SEV: low] FormValidationService.kt:3 — `BaseBedrockMenu` import in application layer
+
+**What:** `FormValidationService` imports `net.lumalyte.lg.interaction.menus.bedrock.BaseBedrockMenu` — a UI-layer type — in the application service interface. However, looking at the actual usage, `BaseBedrockMenu` is not referenced in the file; the import is unused.
+
+**Why it matters:** Unused import is a code quality issue, not a runtime bug. But if it were used, it would couple the application service to the interaction layer.
+
+**Suggested fix:** Remove the unused import.
+
+**Confidence:** high
+
+---
+
+### [SEV: low] FormValidationService.kt:4 — Bukkit Player import in application layer
+
+**What:** `FormValidationService` imports `org.bukkit.entity.Player` and uses it in `showValidationErrors` (line 36). The application layer should not depend on Bukkit types.
+
+**Why it matters:** Couples the validation service to Bukkit. The player identity should be passed as a `UUID` instead.
+
+**Suggested fix:** Change `showValidationErrors` to accept `UUID playerId` instead of `Player`, and let the caller resolve the player.
+
+**Confidence:** high
+
+---
+
+### [SEV: low] BedrockLocalizationService.kt:3 — Bukkit Player import in application layer
+
+**What:** `BedrockLocalizationService` imports `org.bukkit.entity.Player` and uses it in two method signatures.
+
+**Why it matters:** Same as above — application layer should use `UUID` instead of `Player`.
+
+**Suggested fix:** Replace `Player` parameters with `UUID` and let callers resolve.
+
+**Confidence:** high
+
+---
+
+### [SEV: low] PlatformDetectionService.kt:3 — Bukkit Player import in application layer
+
+**What:** `PlatformDetectionService` imports `org.bukkit.entity.Player`.
+
+**Why it matters:** Same pattern — application layer should use `UUID`.
+
+**Suggested fix:** Replace `Player` with `UUID` and let infrastructure resolve.
+
+**Confidence:** high
+
+---
+
+### [SEV: low] MapRendererService.kt:4-5 — Bukkit Player and ItemStack imports in application layer
+
+**What:** `MapRendererService` imports `org.bukkit.entity.Player` and `org.bukkit.inventory.ItemStack`.
+
+**Why it matters:** `ItemStack` is a Bukkit type. The application layer should define its own item representation or use a domain value.
+
+**Suggested fix:** Replace `ItemStack` with a domain-level `MapItem` or `ItemRepresentation` value type.
+
+**Confidence:** high
+
+---
+
+### [SEV: low] GuildVaultService.kt:5-7 — Bukkit Location, Player, ItemStack imports in application layer
+
+**What:** `GuildVaultService` imports three Bukkit types: `Location`, `Player`, `ItemStack`.
+
+**Why it matters:** All three are framework types. The application layer should use domain values (`GuildHome`, `UUID`, domain item types).
+
+**Suggested fix:** Replace with domain equivalents.
+
+**Confidence:** high
+
+---
+
+### [SEV: low] PhysicalCurrencyService.kt:4 — Bukkit ItemStack import in application layer
+
+**What:** `PhysicalCurrencyService` imports `org.bukkit.inventory.ItemStack`.
+
+**Why it matters:** Same pattern.
+
+**Suggested fix:** Use a domain item representation.
+
+**Confidence:** high
+
+---
+
+### [SEV: low] VaultBackupService.kt:4 — Bukkit ItemStack import in application layer
+
+**What:** `VaultBackupService` imports `org.bukkit.inventory.ItemStack`.
+
+**Why it matters:** Same pattern.
+
+**Suggested fix:** Use a domain item representation.
+
+**Confidence:** high
+
+---
+
+### [SEV: low] LunarClientService.kt:3-4 — Apollo/Bukkit imports in application layer
+
+**What:** `LunarClientService` imports `com.lunarclient.apollo.player.ApolloPlayer` and `org.bukkit.entity.Player`.
+
+**Why it matters:** Apollo is a third-party framework. The application layer should define its own `LunarClientStatus` or similar abstraction.
+
+**Suggested fix:** Define a domain-level interface and adapt Apollo in infrastructure.
+
+**Confidence:** high
+
+---
+
+### [SEV: low] GuildService.kt:51 — Bukkit ItemStack import in application layer
+
+**What:** `GuildService.setBanner` accepts `org.bukkit.inventory.ItemStack?` as a parameter.
+
+**Why it matters:** The application service interface should not expose Bukkit types. The banner should be described by a domain value (material name, patterns, etc.).
+
+**Suggested fix:** Replace `ItemStack?` with a `BannerDesignData` or material name string.
+
+**Confidence:** high
+
+---
+
+### [SEV: low] PartitionModificationEvent.kt:4-5 — Bukkit event imports in application layer
+
+**What:** Already covered in the med finding above. This is the same issue.
+
+**Confidence:** high
+
+---
+
+### [SEV: low] VaultInventoryManager.kt:12-17 — multiple Bukkit and JDBC imports in application layer
+
+**What:** `VaultInventoryManager` imports `org.bukkit.Bukkit`, `org.bukkit.entity.Player`, `org.bukkit.inventory.Inventory`, `org.bukkit.inventory.ItemStack`, `org.slf4j.LoggerFactory`, and `java.sql.SQLException`.
+
+**Why it matters:** This is the most severe layer violation in the audit. `VaultInventoryManager` is a concrete class (not an interface) in the `application/services` package that directly uses Bukkit API (`Bukkit.createInventory`, `Bukkit.getScheduler`) and JDBC (`java.sql.SQLException`). This tightly couples the application service to both the Bukkit framework and the SQL infrastructure.
+
+**Suggested fix:** Extract an interface `VaultInventoryManager` into the application layer with pure domain types. Move the current implementation to `infrastructure/persistence` or `infrastructure/bukkit`. The interface should not expose `Inventory`, `Player`, `ItemStack`, or `SQLException`.
+
+**Confidence:** high
+
+---
+
+### [SEV: low] VaultAutoSaveService.kt:3-5 — Bukkit imports in application layer
+
+**What:** `VaultAutoSaveService` imports `org.bukkit.Bukkit`, `org.bukkit.plugin.java.JavaPlugin`, and `org.bukkit.scheduler.BukkitTask`.
+
+**Why it matters:** Same pattern — concrete class in application layer directly uses Bukkit scheduler and plugin API.
+
+**Suggested fix:** Move to infrastructure layer or extract an interface.
+
+**Confidence:** high
+
+---
+
+### [SEV: low] DiscordCsvService.kt:6-7 — Bukkit imports in application layer
+
+**What:** `DiscordCsvService` imports `org.bukkit.Bukkit` and `org.bukkit.entity.Player`.
+
+**Why it matters:** Same pattern.
+
+**Suggested fix:** Replace `Player` with `UUID` and resolve the name via a port interface.
+
+**Confidence:** high
+
+---
+
+### [SEV: low] FileExportManager.kt:3-5 — Bukkit imports in application layer
+
+**What:** `FileExportManager` imports `org.bukkit.Bukkit`, `org.bukkit.entity.Player`, and `org.bukkit.plugin.Plugin`.
+
+**Why it matters:** Same pattern.
+
+**Suggested fix:** Extract interface, move implementation to infrastructure.
+
+**Confidence:** high
+
+---
+
+### [SEV: low] CsvExportService.kt:115 — Bukkit import via fully-qualified name
+
+**What:** `CsvExportService` uses `org.bukkit.Bukkit.getOfflinePlayer(playerId)` via fully-qualified name (no import, but still a direct Bukkit dependency).
+
+**Why it matters:** Same layer violation, just without an explicit import statement.
+
+**Suggested fix:** Inject a `PlayerNameResolver` port interface.
+
+**Confidence:** high
+
+---
+
+### [SEV: low] GoldBalanceButton.kt:7-11 — Bukkit imports in application utilities
+
+**What:** `GoldBalanceButton` imports `org.bukkit.Material`, `org.bukkit.NamespacedKey`, `org.bukkit.inventory.ItemStack`, `org.bukkit.persistence.PersistentDataType`, and `org.bukkit.plugin.java.JavaPlugin`.
+
+**Why it matters:** Utility class in application layer directly uses Bukkit Material, PDC, and plugin API.
+
+**Suggested fix:** Extract the Bukkit-specific item creation to an infrastructure adapter.
+
+**Confidence:** high
+
+---
+
+### [SEV: low] ValuableItemChecker.kt:4-6 — Bukkit imports in application utilities
+
+**What:** `ValuableItemChecker` imports `org.bukkit.Material`, `org.bukkit.inventory.ItemStack`, and `org.bukkit.persistence.PersistentDataType`.
+
+**Why it matters:** Same pattern.
+
+**Suggested fix:** Use a domain item representation.
+
+**Confidence:** high
+
+---
+
+### [SEV: low] FileExportManager.kt:32-34 — rate limit constants are not configurable
+
+**What:** `MAX_EXPORTS_PER_HOUR = 5` and `RATE_LIMIT_WINDOW_MS` are hardcoded constants.
+
+**Why it matters:** Cannot be tuned without recompilation. Should be in config.
+
+**Suggested fix:** Inject these values from configuration.
+
+**Confidence:** low
+
+---
+
+### [SEV: low] FileExportManager.kt:41-42 — temp file expiry is hardcoded
+
+**What:** `FILE_EXPIRY_MS = 15 minutes` and `MAX_FILE_SIZE_BYTES = 5MB` are hardcoded.
+
+**Why it matters:** Same as above — should be configurable.
+
+**Suggested fix:** Inject from config.
+
+**Confidence:** low
+
+---
+
+### [SEV: low] DiscordCsvService.kt:254 — hardcoded avatar URL
+
+**What:** The Discord embed includes a hardcoded `avatar_url` pointing to `https://i.imgur.com/placeholder.png`.
+
+**Why it matters:** Broken image in Discord embeds. Cosmetic.
+
+**Suggested fix:** Make configurable or remove.
+
+**Confidence:** low
+
+---
+
+### [SEV: low] GuildBannerService.kt:78 — banner limit is hardcoded to 6
+
+**What:** `BannerDesignData.isValid()` checks `patterns.size <= 6` with a comment "Minecraft banner limit." This is correct for vanilla Minecraft but is a game-mechanic constant in the application layer.
+
+**Why it matters:** Minor — the constant is correct and unlikely to change. No real issue.
+
+**Confidence:** low — withdrawn.
+
+---
+
+### [SEV: low] GuildService.kt:61 — emoji parameter accepts raw Nexo placeholder string
+
+**What:** `setEmoji(guildId, emoji, actorId)` accepts a raw string like `":catsmileysmile:"` with no validation.
+
+**Why it matters:** If an invalid placeholder is stored, it may display incorrectly or cause issues with the Nexo parser. No validation that it's a valid Nexo placeholder format.
+
+**Suggested fix:** Validate the emoji string format (e.g., matches `^:[a-z0-9_]+:$`).
+
+**Confidence:** med
+
+---
+
+### [SEV: low] GuildService.kt:79 — tag accepts raw MiniMessage string
+
+**What:** `setTag(guildId, tag, actorId)` accepts a raw MiniMessage-formatted string with no validation or sanitization.
+
+**Why it matters:** Malformed MiniMessage could cause parsing errors or visual glitches. A tag like `<red><unclosed` could break chat rendering.
+
+**Suggested fix:** Validate MiniMessage syntax before storing, or strip formatting and store plain text.
+
+**Confidence:** med
+
+---
+
+### [SEV: low] ConfigService.kt:3 — imports `net.lumalyte.lg.config.MainConfig`
+
+**What:** `ConfigService` imports `net.lumalyte.lg.config.MainConfig`. The `config` package is outside the hexagonal architecture — it's a cross-cutting concern. This is a minor layer concern.
+
+**Why it matters:** The config package likely contains Bukkit-specific config loading. The application service should depend on a config port interface, not a concrete config class.
+
+**Suggested fix:** Inject config values or a config port interface.
+
+**Confidence:** med
+
+---
+
+## Test Coverage Gaps
+
+| File | Untested Behavior | Suggested Test |
+|------|-------------------|----------------|
+| `CsvExportService` | CSV injection sanitization | Test with formula-injection payloads (`=CMD(...)`, `+cmd|...`) |
+| `CsvExportService` | `generateTransactionHistoryCsv` with empty list | Test empty transaction list produces header-only CSV |
+| `CsvExportService` | `generateGuildSummaryCsv` with zero balance | Test edge case of new guild with no activity |
+| `DiscordCsvService` | `sendFileToDiscord` with malformed webhook URL | Test `URI.create` failure path |
+| `DiscordCsvService` | `sendFileToDiscord` with `InterruptedException` | Test interrupt handling during HTTP send |
+| `DiscordCsvService` | `isConfigured` with blank/invalid URL | Test boundary conditions |
+| `FileExportManager` | Rate limit enforcement under concurrency | Test concurrent exports from same player |
+| `FileExportManager` | `cancelExport` for non-existent export | Test canceling already-completed export |
+| `FileExportManager` | `cleanupOldFiles` with no temp files | Test empty directory cleanup |
+| `FileExportManager` | File size limit enforcement | Test export rejection when CSV exceeds max |
+| `VaultInventoryManager` | `flushBuffer` with database failure | Test retry logic and dirty marking |
+| `VaultInventoryManager` | `saveSlotWithRetry` with non-SQLException | Test behavior on unexpected exception types |
+| `VaultInventoryManager` | `depositGold` / `withdrawGold` concurrency | Test concurrent deposits/withdrawals for race conditions |
+| `VaultInventoryManager` | `broadcastSlotUpdate` with disconnected viewer | Test viewer disconnect during broadcast |
+| `VaultInventoryManager` | `cleanupIdleSessions` threshold boundary | Test session exactly at idle threshold |
+| `VaultInventoryManager` | `evictSharedInventory` with active viewers | Test eviction blocked when viewers present |
+| `VaultAutoSaveService` | Crash detection on startup | Test with/without running marker file |
+| `VaultAutoSaveService` | `performAutoSave` with persistent DB failure | Test error logging and retry behavior |
+| `VaultAutoSaveService` | `archiveOldTransactions` with no old transactions | Test no-op archival |
+| `GoldBalanceButton` | `isGoldButton` with null item | Test null input |
+| `GoldBalanceButton` | `convertToItems` with zero balance | Test empty result |
+| `GoldBalanceButton` | `convertToItems` with exact block multiples | Test compression into RAW_GOLD_BLOCK |
+| `GoldBalanceButton` | `calculateGoldValue` with AIR material | Test AIR handling |
+| `ValuableItemChecker` | `isValuableItem` with custom model data | Test CMD matching |
+| `ValuableItemChecker` | `isValuableItem` with enchantments enabled/disabled | Test enchantment check toggle |
+| `FormValidationService` | `GUILD_NAME` regex validation | Test boundary names (1 char, 24 chars, invalid chars) |
+| `FormValidationService` | `PLAYER_NAME` regex vs actual Minecraft rules | Test names with special characters |
+| All 38 interface files | No unit tests exist for any application service interface | Integration tests needed for all service implementations |
+
+---
+
+## Layer Boundary Check
+
+**Verdict: FAIL — widespread Bukkit/framework coupling in application layer.**
+
+The following files violate the hexagonal architecture rule ("application must not import Bukkit/JDBC/frameworks"):
+
+| File | Violation |
+|------|-----------|
+| `PartitionModificationEvent.kt` | `org.bukkit.event.Event`, `org.bukkit.event.HandlerList` |
+| `BedrockLocalizationService.kt` | `org.bukkit.entity.Player` |
+| `FormCacheService.kt` | `org.geysermc.cumulus.form.Form` |
+| `FormValidationService.kt` | `org.bukkit.entity.Player` |
+| `GuildService.kt` | `org.bukkit.inventory.ItemStack` |
+| `GuildVaultService.kt` | `org.bukkit.Location`, `org.bukkit.entity.Player`, `org.bukkit.inventory.ItemStack` |
+| `MapRendererService.kt` | `org.bukkit.entity.Player`, `org.bukkit.inventory.ItemStack` |
+| `PhysicalCurrencyService.kt` | `org.bukkit.inventory.ItemStack` |
+| `PlatformDetectionService.kt` | `org.bukkit.entity.Player` |
+| `VaultBackupService.kt` | `org.bukkit.inventory.ItemStack` |
+| `apollo/LunarClientService.kt` | `com.lunarclient.apollo.player.ApolloPlayer`, `org.bukkit.entity.Player` |
+| `VaultInventoryManager.kt` | `org.bukkit.Bukkit`, `org.bukkit.entity.Player`, `org.bukkit.inventory.Inventory`, `org.bukkit.inventory.ItemStack`, `java.sql.SQLException` |
+| `VaultAutoSaveService.kt` | `org.bukkit.Bukkit`, `org.bukkit.plugin.java.JavaPlugin`, `org.bukkit.scheduler.BukkitTask` |
+| `DiscordCsvService.kt` | `org.bukkit.Bukkit`, `org.bukkit.entity.Player` |
+| `FileExportManager.kt` | `org.bukkit.Bukkit`, `org.bukkit.entity.Player`, `org.bukkit.plugin.Plugin` |
+| `CsvExportService.kt` | `org.bukkit.Bukkit` (via FQN, no import) |
+| `GoldBalanceButton.kt` | `org.bukkit.Material`, `org.bukkit.NamespacedKey`, `org.bukkit.inventory.ItemStack`, `org.bukkit.persistence.PersistentDataType`, `org.bukkit.plugin.java.JavaPlugin` |
+| `ValuableItemChecker.kt` | `org.bukkit.Material`, `org.bukkit.inventory.ItemStack`, `org.bukkit.persistence.PersistentDataType` |
+
+**18 of 48 files** (37.5%) violate the layer boundary. The most severe violations are in the concrete classes (`VaultInventoryManager`, `VaultAutoSaveService`, `FileExportManager`, `DiscordCsvService`, `CsvExportService`) which directly instantiate Bukkit objects. The interface files mostly violate by accepting `Player` or `ItemStack` parameters instead of domain types.
+
+**Recommended remediation:** Define domain-level value types (`PlayerId`, `ItemRepresentation`, `BedrockForm`) in the `domain/values` package and use them in all application service interfaces. Move concrete implementations that require Bukkit to the infrastructure layer.

--- a/docs/audit/audit-cross-cutting.md
+++ b/docs/audit/audit-cross-cutting.md
@@ -1,0 +1,210 @@
+# Cross-Cutting Audit Report
+
+**Scope:** `config`, `di`, `common`, `utils`, `integrations` — 23 files
+**Branch:** `fix/audit-cross-cutting`
+
+---
+
+## Findings
+
+### [SEH: high] ItemStackExtensions.kt:133 — getBooleanMeta return type is String? but setter writes BOOLEAN
+
+**What:** `getBooleanMeta()` declares return type `String?` and reads with `PersistentDataType.STRING`, while `setBooleanMeta()` writes with `PersistentDataType.BOOLEAN`. The getter will always return `null` (or a stale STRING value) for data written by the setter, because the PDC key types are different.
+
+**Why it matters:** Any code that sets a boolean meta and later reads it back will get `null` instead of the stored value. This is a silent correctness bug — no crash, just broken state. If any caller relies on `getBooleanMeta` to check a flag set by `setBooleanMeta`, the check always fails.
+
+**Suggested fix:** Change `getBooleanMeta` to use `PersistentDataType.BOOLEAN` and return `Boolean?`, or rename the getter to `getStringMeta` if a string read is truly intended. Ensure getter and setter use the same `PersistentDataType`.
+
+**Confidence:** high
+
+---
+
+### [SEH: high] GuildHomeSafety.kt:64 — Duplicate LAVA check after already catching it in DAMAGING set
+
+**What:** Line 61 checks `DAMAGING.contains(feet.type)` which already includes `Material.LAVA`. Line 64 then checks `feet.type == Material.LAVA` redundantly. The line 64 check is dead code — it can never be reached because LAVA at feet is already caught by the DAMAGING check on line 61.
+
+**Why it matters:** Not a runtime bug per se, but it reveals incomplete reasoning: the author likely intended the LAVA check to cover a different case (e.g., the block *below* being lava while feet are in a non-damaging block). As written, line 64 is unreachable and the specific "Lava at feet" reason message is dead code.
+
+**Suggested fix:** Remove line 64, or if the intent was to check the block two below (standing on a transparent block above lava), add that check explicitly with a separate head-room safety check.
+
+**Confidence:** high
+
+---
+
+### [SEH: med] GuildHomeSafety.kt:48 — evaluateSafety does not check the head block (eye level)
+
+**What:** `evaluateSafety` checks `feet` and `below` but never checks the block at eye level (~1.62m above feet). A player teleporting into a location where the head block is lava, fire, cactus, or magma block would take damage despite the safety check passing.
+
+**Why it matters:** The safety check is used by `checkOrAskConfirm` before teleporting players to guild homes. A player could teleport into a ceiling of lava/fire and take damage or die, defeating the purpose of the safety system.
+
+**Suggested fix:** Add a `headLoc = base.clone().add(0.0, 1.0, 0.0)` check and test it against DAMAGING materials.
+
+**Confidence:** high
+
+---
+
+### [SEH: med] ColorCodeUtils.kt:23 — convertLegacyToMiniMessage heuristic misidentifies plain text with angle brackets as MiniMessage
+
+**What:** The check `input.contains(Regex("<[^>]+>"))` returns `true` for any string containing `<anything>`, including plain text like `"a < b > c"` or `"use <item>"`. Such input would be returned unconverted instead of being processed through the legacy serializer.
+
+**Why it matters:** If a guild tag or user input contains angle brackets that are NOT MiniMessage tags, the function silently skips conversion. This is a minor correctness issue since the fallback path would also handle it, but the heuristic is fragile and could cause confusion with edge-case inputs.
+
+**Suggested fix:** Use a more specific regex that matches known MiniMessage tag patterns (e.g., `<[a-z][a-z0-9_-]*>` or `</[a-z]>`), or attempt MiniMessage parsing first and fall back to legacy.
+
+**Confidence:** med
+
+---
+
+### [SEH: med] ColorCodeUtils.kt:56 — renderTagForDisplay drops legacy & codes when MiniMessage tags are also present
+
+**What:** The condition `tag.contains('&') && !tag.contains(Regex("<[^>]+>"))` means that if a tag has BOTH `&` codes AND MiniMessage tags, it falls to the else branch which tries MiniMessage parsing. The `&c` prefix would be treated as literal text by MiniMessage, producing garbled output. The catch block then silently returns the original tag.
+
+**Why it matters:** Mixed-format tags (possible from manual edits or data migration) silently produce unformatted output with no warning. This is a minor display issue.
+
+**Suggested fix:** Strip legacy `&` codes before MiniMessage parsing, or normalize the input to one format first.
+
+**Confidence:** med
+
+---
+
+### [SEH: med] ConfigValidator.kt:20 — validateAndCorrect is never called; entire validator is dead code
+
+**What:** `ConfigValidator.validateAndCorrect()` and `logConfigSummary()` are public functions with zero callers in the entire codebase. The `config/MainConfig.kt` data class is loaded via `ConfigServiceBukkit` which returns the raw config without validation.
+
+**Why it matters:** The validator contains useful safety bounds (e.g., `menuSize` rounding, `maxWithdrawalPercent` clamping, material name validation) that are never applied. Invalid config values from `config.yml` are used as-is, potentially causing runtime errors or unexpected behavior.
+
+**Suggested fix:** Either wire `validateAndCorrect` into the config loading path (e.g., in `ConfigServiceBukkit.loadConfig()`), or remove the dead code to avoid confusion.
+
+**Confidence:** high
+
+---
+
+### [SEH: med] ConfigValidator.kt:152 — brewingXp is missing from validateProgressionConfig
+
+**What:** `validateProgressionConfig` validates `craftingXp`, `smeltingXp`, `fishingXp`, and `enchantingXp` but does NOT validate `brewingXp` (line 347 of MainConfig.kt). A negative `brewingXp` value from config would be used as-is.
+
+**Why it matters:** Inconsistent validation — all other XP source values are coerced to non-negative except `brewingXp`. A misconfigured negative value would subtract XP for brewing activities.
+
+**Suggested fix:** Add `brewingXp = config.brewingXp.coerceAtLeast(0)` to the validation chain.
+
+**Confidence:** high
+
+---
+
+### [SEH: med] ItemStackExtensions.kt:136 — PDC namespace "bellclaims" is a leftover from a different plugin
+
+**What:** All four PDC extension functions (`getBooleanMeta`, `setBooleanMeta`, `getStringMeta`, `setStringMeta`) hardcode `NamespacedKey("bellclaims", key)` — "bellclaims" is a different Minecraft plugin entirely. This means LumaGuilds PDC data shares a namespace with BellClaims, risking key collisions if both plugins are installed.
+
+**Why it matters:** If a server runs both LumaGuilds and BellClaims, PDC data could collide — one plugin reading/writing the other's data. This is a namespace pollution issue that could cause subtle data corruption.
+
+**Suggested fix:** Change the namespace to `"lumaguilds"` (using the plugin instance for proper namespacing, as `PluginKeys` does for `NamespacedKey`).
+
+**Confidence:** high
+
+---
+
+### [SEH: med] CombatUtil.kt:16 — Unchecked cast to ICombatLogX without instanceof check
+
+**What:** `getAPI()` casts the plugin instance directly: `plugin as ICombatLogX?`. While the null-safe cast (`as?`) prevents ClassCastException, there is no `instanceof` check. If another plugin named "CombatLogX" is present but doesn't implement `ICombatLogX`, this returns null silently.
+
+**Why it matters:** Low risk in practice since the CombatLogX plugin is well-known, but the pattern is fragile. A misbehaving or renamed plugin could cause silent failures.
+
+**Suggested fix:** Add an `instanceof ICombatLogX` check before casting, or catch the cast more explicitly.
+
+**Confidence:** low
+
+---
+
+### [SEH: low] LumaGuildsHook.kt:83 — getTeamMembers calls getAllGuilds() on every invocation
+
+**What:** `getTeamMembers` calls `guildService.getAllGuilds()` (which likely hits the database or iterates all cached guilds) every time AxKoth queries team members. This is called frequently during KOTH events.
+
+**Why it matters:** Performance issue under load — each call iterates all guilds to find one by name. If the guild list is large, this adds unnecessary overhead on a hot path.
+
+**Suggested fix:** Use a direct lookup by name (e.g., `guildService.getGuildByName(teamName)`) instead of iterating all guilds.
+
+**Confidence:** med
+
+---
+
+### [SEH: low] LumaGuildsHook.kt:121 — getTeamByName also calls getAllGuilds()
+
+**What:** Same issue as `getTeamMembers` — `guildService.getAllGuilds()` is called for a simple name lookup.
+
+**Why it matters:** Unnecessary full scan for a single guild lookup.
+
+**Suggested fix:** Use `guildService.getGuildByName(teamName)` directly.
+
+**Confidence:** med
+
+---
+
+### [SEH: low] GuildDisplayUtils.kt:116 — isValidEmojiFormat only checks colon-wrapped format
+
+**What:** `isValidEmojiFormat` validates that emoji starts with `:` and ends with `:` and has length > 2. This is a very loose check — it would accept `":x:"` or `":   :"` as valid emoji. Meanwhile, the actual emoji resolution (elsewhere) may expect specific formats.
+
+**Why it matters:** Loose validation could let malformed emoji strings through, causing display issues downstream. Not a security risk, just a data quality nit.
+
+**Suggested fix:** Add a regex check for valid emoji name characters between the colons.
+
+**Confidence:** low
+
+---
+
+### [SEH: low] Modules.kt:247 — Unchecked cast in coreModule storage binding
+
+**What:** `@Suppress("UNCHECKED_CAST") single<Storage<Database>> { storage as Storage<Database> }` performs an unchecked cast. If the `storage` parameter is not actually `Storage<Database>`, this will fail at runtime with a ClassCastException when the binding is resolved.
+
+**Why it matters:** The cast is safe as long as all callers pass the correct type, but there is no compile-time guarantee. A wrong storage type would cause a runtime crash during DI initialization.
+
+**Suggested fix:** Consider making `coreModule` generic or passing `Storage<Database>` directly to avoid the cast.
+
+**Confidence:** low
+
+---
+
+### [SEH: low] EmojiUtils.kt / PermissionDisplay.kt — Empty stub files
+
+**What:** Both files are 0 bytes. They are listed in the audit scope but contain no code.
+
+**Why it matters:** Dead files clutter the codebase and may confuse future developers. If they are placeholders, they should be noted or removed.
+
+**Suggested fix:** Remove the files or add a comment explaining why they exist.
+
+**Confidence:** high
+
+---
+
+## Test Coverage Gaps
+
+| File | Untested Behavior | Suggested Test |
+|------|-------------------|----------------|
+| `GuildTagValidator.kt` | Regex matching for disallowed tags (click/hover/insertion) with various casings and edge cases | Unit test: verify `rejectionReason` rejects `<click:...>`, `<hover:...>`, `<insertion>` and allows `<red>`, `<bold>`, `<gradient>` |
+| `GuildHomeSafety.kt` | `evaluateSafety` with various block configurations (lava ceiling, cactus wall, safe location) | Unit test (mocked): verify safety result for feet/below/head block combinations |
+| `ColorCodeUtils.kt` | `convertLegacyToMiniMessage` with mixed-format input, plain text with angle brackets | Unit test: verify conversion of `&cRed`, `<red>Red</red>`, and `"a < b"` inputs |
+| `ColorCodeUtils.kt` | `stripAllFormatting` with nested MiniMessage tags, mixed legacy+MM | Unit test: verify plain text extraction from complex formatted strings |
+| `ConfigValidator.kt` | All validation bounds (negative values, out-of-range menu sizes, invalid materials) | Unit test: verify each validation function coerces out-of-range values correctly |
+| `GuildResolver.kt` | `normalize` with color codes, mixed case, special characters | Unit test: verify normalization strips formatting and produces consistent keys |
+| `GuildResolver.kt` | `resolveGuildByName` ambiguity handling (multiple guilds with same normalized name) | Unit test: verify null is returned for ambiguous matches |
+| `ItemStackExtensions.kt` | `serializeToString` / `deserializeToItemStack` round-trip with complex items (banners, enchanted) | Integration test: verify serialization round-trip preserves NBT data |
+| `ItemStackExtensions.kt` | `getBooleanMeta` / `setBooleanMeta` round-trip | Unit test: verify getter returns what setter wrote (currently broken) |
+| `GuildDisplayUtils.kt` | `getFormattedGuildName` with null tag, blank tag, formatting-only tag | Unit test: verify fallback to guild name when tag is blank after stripping |
+| `CombatUtil.kt` | `isInCombat` when CombatLogX is not installed | Unit test (mocked): verify graceful handling when plugin is null |
+
+---
+
+## Layer Boundary Check
+
+**Verdict: PASS with minor notes.**
+
+- `config/` (MainConfig.kt, ProgressionConfig.kt): Contain only data classes and pure functions. No imports from `application/` or `infrastructure/` except `ProgressionConfig.kt` which imports `PerkType` from `application/services/` and `Material` from Bukkit. The `Material` import in `MilestoneItemRewardConfig` is a domain-value concern and acceptable. The `PerkType` import is an application-layer type used as a config value — this is a minor layer blur but not a hard violation.
+
+- `di/` (Modules.kt): Correctly imports from both `application/` and `infrastructure/` — this is the expected composition root. No domain imports.
+
+- `common/` (PluginKeys.kt): Only imports from `org.bukkit` — acceptable for a key registry.
+
+- `utils/` (all files): Import from `org.bukkit` and `domain/` — utilities are infrastructure-adjacent and this is expected. `ConfigValidator.kt` imports from `config/` and `org.bukkit.Material` — acceptable.
+
+- `integrations/` (LumaGuildsHook.kt): Imports from `application/services/` (ports) and `org.koin` — correct for an integration adapter.
+
+**No hard layer boundary violations detected.** The hexagonal architecture is respected: domain types are used as imports by config/utils, but domain code does not import upward.

--- a/docs/audit/audit-domain.md
+++ b/docs/audit/audit-domain.md
@@ -1,0 +1,233 @@
+# Domain Layer Audit — findings report
+
+## Summary
+
+Audited 54 files in `domain/{entities,events,exceptions,values}`.
+Found 10 findings: 3 high, 4 medium, 3 low.
+Layer boundary violations are the dominant issue.
+
+---
+
+### [SEV: high] domain/entities/Claim.kt:57 — Bukkit API leaked into domain layer
+
+**What:** `Claim.resetBreakCount()` accepts `org.bukkit.plugin.Plugin` and calls `org.bukkit.Bukkit.getScheduler()`. The class also imports `kotlin.concurrent.thread` (unused) and `org.bukkit.*` types. Domain entities must not depend on any Bukkit/server framework types.
+
+**Why it matters:** This is a hard hexagonal-architecture violation. The domain layer cannot be unit-tested without a Bukkit server mock, and the entity is tightly coupled to the server runtime. Any change to the Bukkit scheduler API will break domain code.
+
+**Suggested fix:** Extract the scheduler concern into a domain port (e.g., `TaskScheduler` interface in `domain/ports`), inject it into the application service that calls `resetBreakCount`, and keep `Claim` as a pure data class with no scheduler dependency. The `resetBreakCount` method should either move to an application service or accept an abstraction.
+
+**Confidence:** high
+
+---
+
+### [SEV: high] domain/entities/VaultInventory.kt:3 — Bukkit ItemStack in domain entity
+
+**What:** `VaultInventory` imports `org.bukkit.inventory.ItemStack` throughout — the class stores `ConcurrentHashMap<Int, ItemStack?>`, and `WriteBuffer` (same package) also uses `ItemStack`. These are domain-layer files depending on Bukkit.
+
+**Why it matters:** `ItemStack` is a server-implementation type. The domain layer cannot be reasoned about, serialized, or tested independently of the Bukkit runtime. Every caller must convert to/from Bukkit types at the boundary anyway, so the domain loses type safety.
+
+**Suggested fix:** Replace `ItemStack` with a domain value type (e.g., `VaultItem` holding material, amount, nbt-hash). Add mapping extension functions at the infrastructure boundary.
+
+**Confidence:** high
+
+---
+
+### [SEV: high] domain/entities/ViewerSession.kt:3 — Bukkit Inventory/Player leaked into domain entity
+
+**What:** `ViewerSession` imports `org.bukkit.entity.Player` and `org.bukkit.inventory.Inventory`, storing a raw `Inventory` reference as a property.
+
+**Why it matters:** Same hexagonal boundary violation. The domain entity now holds a live Bukkit inventory handle, tying lifecycle management to the server. If the player disconnects, the `Inventory` reference may become stale, causing undefined behavior.
+
+**Suggested fix:** Store a domain representation of the inventory view (e.g., a value class with the inventory title, size, and item slots mapped to domain types). Translate at the infrastructure boundary.
+
+**Confidence:** high
+
+---
+
+### [SEV: high] domain/entities/PlayerState.kt:3 — application layer import in domain entity
+
+**What:** `PlayerState` imports `net.lumalyte.lg.application.services.scheduling.Task`. Domain must not import anything from `application/` or `infrastructure/`.
+
+**Why it matters:** This creates a bidirectional dependency: domain → application. In hexagonal architecture, dependency must point inward only. This makes it impossible to compile or test the domain independently.
+
+**Suggested fix:** Define a `ScheduledTask` interface (or `Cancellable`) in the domain layer, and have the application service implement it. `PlayerState` should depend only on the domain-defined interface.
+
+**Confidence:** high
+
+---
+
+### [SEV: high] domain/entities/Progression.kt:3 — application layer imports in domain entity
+
+**What:** `GuildProgression` imports `net.lumalyte.lg.application.services.ExperienceSource` and `net.lumalyte.lg.application.services.PerkType`. Both are application-layer enums leaked into domain.
+
+**Why it matters:** `PerkType` and `ExperienceSource` define application-level concepts (what perk types exist, what gives XP). These should either be domain enums or defined in a shared kernel — but not imported from the application layer into domain.
+
+**Suggested fix:** Move `PerkType` and `ExperienceSource` to `domain/values/` as domain enums. If application-specific behavior wraps them, the application can define its own richer types that delegate to the domain enums.
+
+**Confidence:** high
+
+---
+
+### [SEV: high] domain/entities/GuildBanner.kt:3 — application layer import in domain entity
+
+**What:** `GuildBanner` imports `net.lumalyte.lg.application.services.BannerDesignData` and uses it as the type for `designData`.
+
+**Why it matters:** The domain entity depends on an application-service type. `BannerDesignData` may itself contain framework dependencies or business logic that doesn't belong in a domain value.
+
+**Suggested fix:** Replace with a domain type (e.g., `BannerDesign` value class) that holds only the raw design data (colors, patterns). The application service can adapt its `BannerDesignData` to/from this domain type.
+
+**Confidence:** high
+
+---
+
+### [SEV: high] domain/events/*.kt (13 files) — Bukkit Event/HandlerList in domain events
+
+**What:** All 13 event files in `domain/events/` extend `org.bukkit.event.Event` and import `org.bukkit.event.HandlerList`. Examples: `GuildCreatedEvent`, `GuildDisbandedEvent`, `GuildMemberJoinEvent`, `GuildBankDepositEvent`, `GuildBannerSetEvent`, `GuildHomeSetEvent`, `GuildLeaderboardRankChangeEvent`, `GuildLevelUpEvent`, `GuildMemberRemovedEvent`, `GuildOwnershipTransferEvent`, `GuildRelationChangeEvent`, `GuildTrackingChangedEvent`, `GuildVaultPlacedEvent`, `GuildWarDeclaredEvent`, `GuildWarEndEvent`, `GuildWarKillEvent`.
+
+**Why it matters:** Domain events are the backbone of inter-aggregate communication. By extending `org.bukkit.event.Event`, the domain is permanently coupled to the Bukkit event bus. These events cannot be dispatched via a different mechanism (in-process bus, Kafka, etc.) without pulling in the entire server. Unit tests require Bukkit mocks for every event assertion.
+
+**Suggested fix:** Replace `org.bukkit.event.Event` inheritance with plain Kotlin classes (data classes or sealed classes). Define a domain event interface (`DomainEvent`) with timestamp/metadata. At the infrastructure layer, adopt a Bukkit-specific adapter that wraps domain events into Bukkit events for plugin dispatching.
+
+**Confidence:** high
+
+---
+
+### [SEV: med] domain/entities/War.kt:57 — isExpired always returns false for started wars
+
+**What:** `War.isExpired` delegates to `remainingDuration?.isNegative`, but `remainingDuration` returns `Duration.ZERO` (not a negative duration) when `now >= endTime`. Therefore `isExpired` is always `false` for wars past their end time.
+
+**Why it matters:** The `WarServiceBukkit` calls `war.isExpired` to detect wars that should auto-terminate. Since this never returns `true`, wars never expire by time. They must be ended manually or by other logic. This is a silent logic bug — no crash, but the expiration feature is dead code.
+
+**Suggested fix:** In `remainingDuration`, return the raw `Duration.between(now, endTime)` without the `else Duration.ZERO` branch, or change `isExpired` to check `remainingDuration?.isNegative == true || remainingDuration == Duration.ZERO`.
+
+**Confidence:** high
+
+---
+
+### [SEV: med] domain/entities/BankTransaction.kt:22 — integer overflow in overflow guard
+
+**What:** The check `require(amount + fee <= Int.MAX_VALUE)` on line 22 can itself overflow. If `amount = Int.MAX_VALUE - 1` and `fee = 2`, then `amount + fee` overflows to a negative number, which is `<= Int.MAX_VALUE`, so the check passes. Later, `totalAmount` getter (`amount + fee`) also overflows silently.
+
+**Why it matters:** A crafted large `amount` + `fee` combination could produce a negative `totalAmount`, breaking downstream accounting logic (bank balance could increase on withdrawal, decrease on deposit).
+
+**Suggested fix:** Use `require(amount <= Int.MAX_VALUE - fee) { "..." }` which cannot overflow since `fee >= 0`.
+
+**Confidence:** high
+
+---
+
+### [SEV: med] domain/entities/Guild.kt:63 — emoji validation allows single-character names
+
+**What:** The emoji format check `emojiValue.length > 2` only validates that the string starts and ends with `:` and is longer than 2 characters. A string like `":x:"` passes validation but is unlikely a valid Nexo placeholder. More importantly, `": :"` also passes, and there's no check against disallowed characters or format consistency.
+
+**Why it matters:** Invalid emoji strings propagate to display layers, where they may render raw placeholder text to players or cause Nexo lookup failures. The validation gives a false sense of safety.
+
+**Suggested fix:** Add a regex check like `:^[a-zA-Z0-9_]+$:` for the inner name, or at minimum require the inner content (between colons) to be non-blank and alphanumeric.
+
+**Confidence:** med
+
+---
+
+### [SEV: med] domain/entities/WriteBuffer.kt:24 — pendingDeletions is not thread-safe
+
+**What:** `WriteBuffer.pendingDeletions` is a `MutableSet<Int>` (`mutableSetOf()`), which is not thread-safe, while `pendingSlots` uses `ConcurrentHashMap`. Concurrent calls to `bufferSlotChange()` can race on `pendingDeletions`, corrupting the set.
+
+**Why it matters:** `WriteBuffer` is designed for concurrent access (it's in a vault system where multiple players may modify slots simultaneously). A corrupted `pendingDeletions` set could cause slots to not be cleared in the DB, or to be double-removed, leading to data inconsistency.
+
+**Suggested fix:** Change `pendingDeletions` to `ConcurrentHashMap.newKeySet()` or wrap access with synchronization.
+
+**Confidence:** med
+
+---
+
+### [SEV: low] domain/entities/Claim.kt:6 — unused import kotlin.concurrent.thread
+
+**What:** `import kotlin.concurrent.thread` is unused in `Claim.kt`. The comment on line 53 confirms the Bukkit scheduler is used instead of thread-based approaches.
+
+**Why it matters:** Unused imports add noise and may confuse readers about the concurrency model. Static analysis tools flag them.
+
+**Suggested fix:** Remove the import.
+
+**Confidence:** high
+
+---
+
+### [SEV: low] domain/entities/Partition.kt:8 — wildcard import java.util.*
+
+**What:** `import kotlin.collections.ArrayList` appears on line 8 and `import java.util.*` on line 7, but `ArrayList` is already available from `java.util.*`. The explicit `kotlin.collections.ArrayList` import is unused (the code uses `java.util.ArrayList`).
+
+**Why it matters:** Minor style issue — the kotlin.collections import shadows the java.util one but is never used, and the wildcard import makes it unclear which `ArrayList` is actually used.
+
+**Suggested fix:** Remove the `kotlin.collections.ArrayList` import; keep `java.util.*` or prefer explicit imports.
+
+**Confidence:** med
+
+---
+
+### [SEV: low] domain/events/GuildLeaderboardRankChangeEvent.kt:30 — handlerList is public val
+
+**What:** `GuildLeaderboardRankChangeEvent` declares `val handlerList = HandlerList()` (public) while all other events use `private val handlers = HandlerList()`. This exposes the handler list as mutable public state.
+
+**Why it matters:** External code could replace or clear the handler list, silently breaking event dispatch for this event only. The inconsistency also suggests a copy-paste oversight.
+
+**Suggested fix:** Change to `private val handlerList = HandlerList()` to match the pattern used by all sibling events.
+
+**Confidence:** med
+
+---
+
+## Test Coverage Gaps
+
+| Untested behavior | File | Test that should exist |
+|---|---|---|
+| Guild name boundary (empty, 1 char, 32 chars, 33 chars) | `Guild.kt:57` | `GuildTest` |
+| Guild emoji format validation (valid/invalid formats) | `Guild.kt:63` | `GuildTest` |
+| Guild tag MiniMessage safety / length | `Guild.kt` | `GuildTest` |
+| Guild description length validation at boundary (100 chars) | `Guild.kt:71` | `GuildTest` |
+| GuildHomes defaultHome, withHome, withoutHome, hasHomes | `GuildHomes` in `Guild.kt` | `GuildHomeTest` or new `GuildHomesTest` |
+| Rank permission set validation (empty, full, single) | `Rank.kt` | `RankTest` |
+| Member self-kill prevention | `Kill.kt:22` | `KillTest` |
+| Kill isInterGuildKill / isIntraGuildKill edge cases | `Kill.kt:28-35` | `KillTest` |
+| BankTransaction overflow guard at Int boundary | `BankTransaction.kt:22` | `BankTransactionTest` |
+| BankTransaction companion factory methods | `BankTransaction.kt:32-51` | `BankTransactionTest` |
+| MemberContribution contributionStatus transitions | `BankTransaction.kt:77-82` | `MemberContributionTest` |
+| Party isActive with expiry, canPlayerJoin role restrictions | `Party.kt` | `PartyTest` |
+| PartyRequest isValid/isExpired state machine | `PartyRequest.kt` | `PartyRequestTest` |
+| Relation guild ordering invariant, involves, getOther, isActive | `Relation.kt` | `RelationTest` |
+| PeaceAgreement isValid/remainingTime | `PeaceAgreement.kt` | `PeaceAgreementTest` |
+| War isActive/isExpired/remainingDuration | `War.kt` | `WarTest` |
+| WarWager isDraw/getRefundAmount/getWinningsAmount | `WarWager.kt` | `WarWagerTest` |
+| GuildProgression canLevelUp/levelProgress/calculateExperienceForLevel | `Progression.kt` | `GuildProgressionTest` |
+| WriteBuffer thread-safety of pendingDeletions | `WriteBuffer.kt` | `WriteBufferTest` |
+| VaultInventory subtractGold CAS loop correctness | `VaultInventory.kt` | `VaultInventoryTest` |
+| Area isAreaAdjacent with various spatial relationships | `Area.kt` | `AreaTest` |
+| Area isAreaOverlap edge cases (touching, containing) | `Area.kt` | `AreaTest` |
+| Partition Builder incomplete build throws | `Partition.kt:113-118` | `PartitionTest` |
+| Partition Resizer getExtraBlockCount | `Partition.kt:135-140` | `PartitionTest` |
+| Position/Position2D/Position3D getChunk correctness at boundaries | `Position.kt`, `Position2D.kt`, `Position3D.kt` | `PositionTest` |
+| AuditRecord blank action rejection | `AuditRecord.kt:25` | `AuditRecordTest` |
+| Leaderboard getTopEntries/getEntry/getRank | `Leaderboard.kt` | `LeaderboardTest` |
+
+---
+
+## Layer Boundary Check
+
+**FAIL — 7 files with domain → application imports, 16 files with domain → Bukkit imports.**
+
+Violations found:
+
+| File | External import |
+|---|---|
+| `domain/entities/Claim.kt` | `org.bukkit.plugin.Plugin`, `org.bukkit.Bukkit`, `kotlin.concurrent.thread` |
+| `domain/entities/VaultInventory.kt` | `org.bukkit.inventory.ItemStack` |
+| `domain/entities/WriteBuffer.kt` | `org.bukkit.inventory.ItemStack` |
+| `domain/entities/ViewerSession.kt` | `org.bukkit.entity.Player`, `org.bukkit.inventory.Inventory` |
+| `domain/entities/PlayerState.kt` | `net.lumalyte.lg.application.services.scheduling.Task` |
+| `domain/entities/Progression.kt` | `net.lumalyte.lg.application.services.ExperienceSource`, `PerkType` |
+| `domain/entities/GuildBanner.kt` | `net.lumalyte.lg.application.services.BannerDesignData` |
+| `domain/events/*.kt` (13 files) | `org.bukkit.event.Event`, `org.bukkit.event.HandlerList` |
+
+The domain layer has **no imports from `infrastructure/`** — that direction is clean.
+However, 7 entity/event files import from Bukkit (framework) and 2 import from `application/`,
+violating the hexagonal architecture rule that domain must depend on nothing outward.
+All 13 Bukkit event classes should be pure domain objects with Bukkit adapters at the infrastructure boundary.

--- a/docs/audit/audit-infra-edge.md
+++ b/docs/audit/audit-infra-edge.md
@@ -1,0 +1,256 @@
+# Audit Report: audit-infra-edge
+
+**Branch:** `fix/audit-infra-edge`
+**Scope:** 23 files in `infrastructure/{adapters,bukkit,listeners,web,placeholders,namespaces,hidden,utilities}`
+**Generated:** 2026-06-09
+
+---
+
+## Findings
+
+### [SEV: med] infrastructure/web/WebApiServer.kt:89 — Timing side-channel in bearer-token comparison
+
+**What:** `constantTimeEquals` returns `false` immediately when `a.length != b.length`, then uses a non-constant-time loop (`result or ...`) that short-circuits on the first differing character via the `or` accumulator. An attacker can determine token length and perform character-by-character timing attacks.
+
+**Why it matters:** The bearer token is the sole authentication for the web API. A timing side-channel lets an attacker reconstruct the token one character at a time by measuring response latency, especially on a local network where the API binds to `127.0.0.1`.
+
+**Suggested fix:** Use `java.security.MessageDigest.isEqual(a.toByteArray(), b.toByteArray())` or a proper HMAC-based comparison. Always compare all bytes regardless of length mismatch (pad the shorter input to the longer length before comparing).
+
+**Confidence:** high
+
+---
+
+### [SEV: med] infrastructure/web/WebApiServer.kt:104 — `parseQuery` crashes on query strings with `=` in value
+
+**What:** `parseQuery` splits on `=` and takes `pair.substring(idx + 1)` as the value. If a query parameter value itself contains `=` (e.g. `?type=level=1`), only the portion before the second `=` is kept, silently truncating the value. More critically, if a query parameter has no `=` sign (e.g. `?debug`), the pair is silently dropped via `mapNotNull`, which is acceptable but undocumented behavior.
+
+**Why it matters:** While current callers only use simple `type`, `period`, and `limit` parameters, the handler is a public API endpoint. Future consumers may pass values with `=`, causing silent data corruption that is hard to debug.
+
+**Suggested fix:** Use `pair.indexOf('=')` to split into key/value at the *first* `=`, and take everything after it as the value. Alternatively, use a proper URL query parser from the JDK or a library.
+
+**Confidence:** high
+
+---
+
+### [SEV: med] infrastructure/listeners/ProgressionEventListener.kt:79 — `playerGuildCache` is not safely published across threads
+
+**What:** `playerGuildCache` is a `ConcurrentHashMap` but the values are `Collections.unmodifiableSet` snapshots. The `addPlayerGuild` and `removePlayerGuild` methods use `compute`/`computeIfPresent` which are atomic for individual keys, but the cache is read from the hot path of Bukkit event handlers (main thread) and mutated from async coroutine contexts (virtual threads via `AsyncTaskService`). The `rebuildMembershipCache` method clears and repopulates the entire map, which is not atomic with respect to concurrent reads.
+
+**Why it matters:** A race between `rebuildMembershipCache` (called from `refreshCaches`, which can be triggered by `/lumaguilds reload`) and concurrent event processing could cause a player to be missed for XP awards, or worse, a stale guild reference could be used after the player has left.
+
+**Suggested fix:** Use a `ReadWriteLock` or copy-on-write pattern for the cache. Alternatively, make `rebuildMembershipCache` replace the map reference atomically (`@Volatile var`) and let the old references drain naturally.
+
+**Confidence:** med
+
+---
+
+### [SEV: med] infrastructure/listeners/ProgressionEventListener.kt:439 — `onPlayerQuit` drains counters but doesn't flush to DB
+
+**What:** `onPlayerQuit` drains `playerXpCounters` into `pendingGuildXp` via `enqueueGuildExperience`, but does not call `flushPendingGuildXp()`. The pending XP sits in memory until the next 5-second flush cycle. If the server stops shortly after a player quits (e.g., during a restart), that XP is lost.
+
+**Why it matters:** XP earned just before a player disconnects can be silently lost during graceful shutdowns if `shutdown()` is not called, or if the flush cycle hasn't run yet. This is a data-loss edge case.
+
+**Suggested fix:** Call `flushPendingGuildXp()` at the end of `onPlayerQuit`, or ensure `shutdown()` is always called on plugin disable (verify the lifecycle).
+
+**Confidence:** med
+
+---
+
+### [SEV: low] infrastructure/listeners/ProgressionEventListener.kt:431 — `lunarMultiplier` uses `GlobalContext.get()` on every mob kill
+
+**What:** `lunarMultiplier` calls `org.koin.core.context.GlobalContext.get()` on every invocation (mob kill, block break, etc.) to look up `LunarClientService`. This is a map lookup on every event, and `GlobalContext.get()` is not a cheap operation.
+
+**Why it matters:** Mob-kill events can fire at very high rates (mob farms). The repeated `GlobalContext.get()` adds unnecessary overhead on the hot path.
+
+**Suggested fix:** Inject `LunarClientService` (or a nullable wrapper) at construction time, or cache the lookup result in a `@Volatile` field that is refreshed on reload.
+
+**Confidence:** high
+
+---
+
+### [SEV: low] infrastructure/listeners/VaultProtectionListener.kt:293 — Permission check uses `rank.permissions.contains()` instead of `MemberService.hasPermission()`
+
+**What:** `VaultProtectionListener` fetches the player's `Rank` object and checks `rank.permissions.contains(RankPermission.BREAK_VAULT)` directly. The codebase convention (per memory) is to use `MemberService.hasPermission(playerId, guildId, RankPermission.XXX)` because guilds can create custom ranks with custom permission sets.
+
+**Why it matters:** If a guild creates a custom rank that inherits or overrides permissions in a way not captured by the `Rank.permissions` set, this check could bypass the intended permission model. The direct check is not wrong per se, but it's inconsistent with the established pattern and could miss edge cases handled by `hasPermission()`.
+
+**Suggested fix:** Replace with `memberService.hasPermission(player.uniqueId, guild.id, RankPermission.BREAK_VAULT)` for consistency with the rest of the codebase.
+
+**Confidence:** med
+
+---
+
+### [SEV: low] infrastructure/listeners/VaultProtectionListener.kt:529 — `locationToKey` uses `location.world?.uid` which can NPE on unloaded worlds
+
+**What:** `locationToKey` calls `location.world?.uid` which returns `null` if the world is unloaded. The resulting string `"null:x:y:z"` would collide for different unloaded worlds, and the warning system would incorrectly match across worlds.
+
+**Why it matters:** If a player places a vault chest and the world unloads (or the location's world reference becomes null), the break-warning system would produce incorrect location keys, potentially allowing a player to bypass the two-break warning.
+
+**Suggested fix:** Add a null check for `location.world` and return a sentinel value or throw. Use `location.world?.uid ?: "unloaded"` to avoid collisions.
+
+**Confidence:** med
+
+---
+
+### [SEV: low] infrastructure/bukkit/bannerman/BannermanListeners.kt:65 — `deserializeToItemStack()` uses Java `ObjectInputStream` on untrusted data
+
+**What:** `guild.banner?.deserializeToItemStack()` calls into `String.deserializeToItemStack()` which uses Java's `ObjectInputStream.readObject()` to deserialize a `Map<String, Any>`. The banner data is stored in the guild entity and could be set by players via the banner customization menu.
+
+**Why it matters:** Java deserialization of untrusted data is a well-known attack vector (arbitrary code execution via crafted serialized objects). While the data flows from the database (set by the plugin itself), if any bug or SQL injection allows a player to write arbitrary banner data, this becomes a remote code execution vector.
+
+**Suggested fix:** Replace Java serialization with a safe format (e.g., Base64-encoded NBT or JSON). At minimum, validate the deserialized map structure before use.
+
+**Confidence:** med
+
+---
+
+### [SEV: low] infrastructure/bukkit/bannerman/BannermanRenderService.kt:43 — `addPassenger` failure silently drops the display
+
+**What:** If `player.addPassenger(display)` returns `false`, the display entity is removed but the method returns without logging or retrying. The `displays` map is not updated (line 48 is skipped), so `isTracking` returns `false` but the player has no visible banner.
+
+**Why it matters:** In edge cases (e.g., player is in a vehicle, or the entity limit is reached), the banner silently disappears with no log message, making it hard to debug player reports of missing banners.
+
+**Suggested fix:** Add a warning log when `addPassenger` fails. Consider retrying on the next tick.
+
+**Confidence:** high
+
+---
+
+### [SEV: low] infrastructure/namespaces/ItemKeys.kt:13 — Wrong namespace ID `"bell_claims"` instead of `"lumaguilds"`
+
+**What:** `PLUGIN_NAMESPACE_ID` is set to `"bell_claims"`, which is the namespace of a different plugin. This means LumaGuilds' custom item keys (`claim_tool`, `move_tool`) collide with BellClaims' PDC namespace.
+
+**Why it matters:** If both plugins are installed on the same server, items could be misidentified — a BellClaims claim tool would be recognized as a LumaGuilds claim tool and vice versa. This is a correctness bug that could cause item interaction issues.
+
+**Suggested fix:** Change `PLUGIN_NAMESPACE_ID` to `"lumaguilds"`. Note: this is a breaking change for existing items in the world, so a migration strategy may be needed.
+
+**Confidence:** high
+
+---
+
+### [SEV: low] infrastructure/hidden/SystemValidator.kt:47 — Easter egg logs red-text ASCII art on every startup (10% chance)
+
+**What:** `displaySecretMemeText()` logs a large ASCII art banner in red text with `[LumaGuilds]` prefix and "Qwimble is watching" message. This fires with 10% probability on every plugin enable (startup and reload).
+
+**Why it matters:** While not a security vulnerability, this is unprofessional behavior that pollutes server logs with meme content. Server operators may be confused or concerned by the red-text messages. The `SECRET_TRIGGER` constant (`"qwimble_watches"`) is unused dead code.
+
+**Suggested fix:** Remove the easter egg or gate it behind a config flag. Remove the unused `SECRET_TRIGGER` constant and `maintenanceRoutine()` method.
+
+**Confidence:** high
+
+---
+
+### [SEV: low] infrastructure/adapters/bukkit/BukkitLocationAdapter.kt:19 — `Position.toLocation` passes nullable `y` to non-nullable `Location` constructor
+
+**What:** `Position.toLocation` calls `this.y?.toDouble() ?: 0.0` for the Y coordinate. When `y` is `null` (as in `Position2D`), it defaults to `0.0`, which places the location at Y=0 (bedrock level) instead of the player's actual Y position.
+
+**Why it matters:** Any code that converts a `Position2D` to a `Location` will get a location at Y=0, which could cause entities to spawn underground or at the wrong height. The `Position` class declares `y` as `Int?`, but `Location` requires a non-null double.
+
+**Suggested fix:** Require the caller to provide a Y coordinate, or document that `Position2D.toLocation` will always use Y=0. Consider adding a `y` parameter to the function.
+
+**Confidence:** high
+
+---
+
+### [SEV: low] infrastructure/placeholders/LumaGuildsExpansion.kt:443 — `getTop` cache stampede on expiry
+
+**What:** When the 30-second TTL expires, all concurrent PAPI placeholder requests will miss the cache and call `computeTop()` simultaneously, each scanning all guilds from the database.
+
+**Why it matters:** Under high PAPI load (many players, scoreboard updates), this causes a thundering-herd problem where multiple threads recompute the same expensive leaderboard query at the same time.
+
+**Suggested fix:** Use a `computeIfAbsent`-style pattern where only the first thread recomputes and others wait, or use a scheduled refresh that updates the cache before it expires.
+
+**Confidence:** med
+
+---
+
+### [SEV: low] infrastructure/placeholders/LumaGuildsExpansion.kt:446 — `computeTop("level")` calls `getAllGuilds()` and then `getGuildProgression` per guild (N+1 query)
+
+**What:** For the level leaderboard, `getAllGuilds()` fetches all guilds, then for each guild, `progressionRepository.getGuildProgression(g.id)` makes a separate database query. With 1000 guilds, this is 1001 queries every 30 seconds.
+
+**Why it matters:** This is a classic N+1 query problem that can cause significant database load on servers with many guilds.
+
+**Suggested fix:** Add a bulk method to `ProgressionRepository` that returns progression for all guilds in a single query, or join the guild and progression tables.
+
+**Confidence:** high
+
+---
+
+### [SEV: low] infrastructure/listeners/GuildChannelCreationListener.kt:39 — Hardcoded rank name matching breaks with custom ranks
+
+**What:** The listener finds the "Leader" rank by matching `rank.name.equals("Leader", ignoreCase = true) || rank.name.equals("Owner", ignoreCase = true)`. Guilds can create custom rank names, so the leader rank might be called "Guild Master", "Chief", etc.
+
+**Why it matters:** If a guild renames their leader rank, the `Leader_Chat` channel will never be created, and the `Officer_Chat` regex may or may not match depending on the new name. This breaks the default channel creation feature.
+
+**Suggested fix:** Use a flag or property on the `Rank` entity to identify the leader rank (e.g., `rank.isLeader` or `rank.priority`), rather than matching by name.
+
+**Confidence:** high
+
+---
+
+### [SEV: low] infrastructure/listeners/GuildChannelCreationListener.kt:46 — Officer regex matches too broadly
+
+**What:** The officer rank regex `(?i)(officer|admin|moderator|co-?leader|leader|owner)` matches "leader" and "owner", which are already handled by the `leaderRank` variable. This means the leader rank is included in both `officerRanks` and `leaderRank`, so the leader gets both `Officer_Chat` and `Leader_Chat` restrictions.
+
+**Why it matters:** The leader rank is included in the `Officer_Chat` restricted roles, which is redundant but not harmful. However, if a guild has no explicit "officer" rank but does have a "leader" rank, the `Officer_Chat` channel will be created with only the leader rank, which may not be the intended behavior.
+
+**Suggested fix:** Exclude "leader" and "owner" from the officer regex, or document that the leader rank is intentionally included in officer channels.
+
+**Confidence:** med
+
+---
+
+### [SEV: low] infrastructure/utilities/LocalizationProviderProperties.kt:98 — `println` instead of logger for localization load messages
+
+**What:** `loadLayeredProperties` uses `println()` for logging language file load success/failure instead of the plugin logger.
+
+**Why it matters:** `println` writes to stdout, which may not be captured by server log management systems. It also bypasses the plugin's logging configuration and SLF4J logger.
+
+**Suggested fix:** Inject a logger and use it instead of `println`.
+
+**Confidence:** high
+
+---
+
+## Test Coverage Gaps
+
+| # | File | Untested Behavior | Suggested Test |
+|---|------|-------------------|----------------|
+| 1 | `BannermanVisibility.kt` | Pure function `shouldShow` with all 4 combinations of elytra/invisibility | Unit test parameterized over `(hasElytra, hasInvisibility, expected)` |
+| 2 | `BannermanRenderService.kt` | `sweepOrphans` correctly removes only tagged `ItemDisplay` entities | Integration test: spawn tagged/untagged displays, call sweep, verify only tagged removed |
+| 3 | `BannermanListeners.kt` | `onGuildBannerChanged` despawns when banner is null, spawns when player is offline | Unit test with mock renderer verifying despawn/spawn calls |
+| 4 | `ProgressionEventListener.kt` | XP batching: counter drains correctly when cooldown elapses | Unit test: award XP, advance time past cooldown, verify flush |
+| 5 | `ProgressionEventListener.kt` | `onPlayerQuit` drains buffered XP into pending queue | Unit test: award XP, call onPlayerQuit, verify pendingGuildXp contains the amount |
+| 6 | `ProgressionEventListener.kt` | Same-guild kill does not award XP | Unit test: killer and victim in same guild, verify no XP awarded |
+| 7 | `GuildLeaderboardHandler.kt` | `parseLimit` clamps to `[1, leaderboardLimitMax]` | Unit test: pass 0, -1, null, max+1, verify clamping |
+| 8 | `GuildLeaderboardHandler.kt` | `effectivePeriodFor` returns ALL_TIME for non-ACTIVITY categories | Unit test: pass WEEKLY for LEVEL category, verify ALL_TIME returned |
+| 9 | `WebApiServer.kt` | `isAuthorized` rejects missing/invalid Authorization header | Unit test: no header, wrong prefix, wrong token, correct token |
+| 10 | `WebApiServer.kt` | `parseQuery` handles URL-encoded values, empty values, missing `=` | Unit test: `?a=b=c`, `?a=&b`, `?flag` |
+| 11 | `RoseChatCleanupListener.kt` | `shouldLeaveChannel` returns correct boolean for each channel type | Unit test: player in/out of guild, with/without allies, UUID/non-UUID channel IDs |
+| 12 | `GuildChannelCreationListener.kt` | Channel creation when no leader rank exists | Unit test: guild with custom rank names, verify graceful handling |
+| 13 | `VaultProtectionListener.kt` | Break warning system: first break warns, second break within timeout allows | Integration test: two break attempts, verify first cancelled, second allowed |
+| 14 | `VaultProtectionListener.kt` | Piston backfire: piston breaks and drops when pushing vault chest | Integration test: piston extends toward vault, verify piston destroyed |
+| 15 | `LumaGuildsExpansion.kt` | Top-N placeholder returns empty string for invalid rank/category | Unit test: rank=0, rank>25, invalid category, verify empty string |
+| 16 | `WarKillTrackingListener.kt` | Kill only counted once even if multiple wars exist between guilds | Unit test: two active wars, verify only first match records the kill |
+
+---
+
+## Layer Boundary Check
+
+**PASS** — No domain-layer imports from application/infrastructure detected. All 23 files correctly reside in `infrastructure` and import only from `application` (ports/services), `domain` (entities/values/events), and Bukkit/framework packages. The `BukkitLocationAdapter` correctly converts between Bukkit `Location` and domain `Position*` types. The `deserializeToItemStack` extension function in `utils/` operates on `String` → `ItemStack?` and is called from infrastructure, which is acceptable for an adapter concern.
+
+**Minor note:** `BukkitItemStackAdapter.kt` imports from `org.bukkit.inventory.ItemStack` and `org.bukkit.persistence.PersistentDataType` — this is expected for an adapter in the infrastructure layer. No layer violation.
+
+---
+
+## Summary
+
+| Severity | Count |
+|----------|-------|
+| crit | 0 |
+| high | 0 |
+| med | 4 |
+| low | 12 |
+| **Total** | **16** |
+
+No critical or high-severity findings. The most impactful issues are the timing side-channel in bearer-token comparison (med), the query-string parsing bug (med), the thread-safety concern in `playerGuildCache` (med), and the XP loss on player quit (med). The remaining 12 findings are low-severity: code quality, minor correctness, and defensive-coding nits.

--- a/docs/audit/audit-infra-persistence.md
+++ b/docs/audit/audit-infra-persistence.md
@@ -1,0 +1,189 @@
+# Audit: infrastructure/persistence
+
+**Branch:** fix/audit-infra-persistence
+**Scope:** 37 files under src/main/kotlin/net/lumalyte/lg/infrastructure/persistence/
+**Date:** 2026-06-09
+**Method:** Manual line-by-line review + targeted grep for SQL-string patterns
+
+---
+
+## Summary
+
+| Severity | Count |
+|----------|-------|
+| crit     | 2     |
+| high     | 6     |
+| med      | 10    |
+| low      | 6     |
+
+---
+
+## Findings
+
+### [SEV: crit] migrations/SQLiteMigrations.kt:427 — SQL injection in tableExists()
+**What:** `tableExists()` at line 427 builds a query by string interpolation:
+```kotlin
+stmt.executeQuery("SELECT name FROM sqlite_master WHERE type='table' AND name='$tableName'")
+```
+`tableName` is an internal string, but one call site passes it from loop variables over known table names. More critically, the same pattern appears in `columnExists()` at line 442 where `tableName` and `columnName` are interpolated directly into a `PRAGMA table_info($tableName)` query. While the current call sites use hardcoded names, the helper is public (private to the class) and the pattern is an injection vector if ever refactored to accept user input.
+**Why it matters:** If any caller ever passes a table/column name derived from user input (e.g., a guild name used as a dynamic table suffix), it would be exploitable SQL injection. The `PRAGMA table_info($tableName)` pattern is particularly dangerous because PRAGMA does not support parameterized queries in SQLite.
+**Suggested fix:** Validate `tableName` and `columnName` against a strict `[A-Za-z0-9_]` whitelist before interpolation. This makes the helpers safe regardless of future callers.
+**Confidence:** med
+
+### [SEV: crit] guilds/VaultTransactionLogger.kt:167,227,311,388 — LIMIT/OFFSET SQL injection via integer-to-string interpolation
+**What:** Three methods interpolate `limit` and `offset` (or just `limit`) directly into SQL strings:
+- line 167: `sql += " LIMIT $limit OFFSET $offset"` in `getTransactions()`
+- line 227: `sql += " LIMIT $limit OFFSET $offset"` in `getPlayerTransactions()`
+- line 311: `LIMIT $limit` in `getRecentTransactions()`
+- line 388: `LIMIT $limit` in `getTransactionsByType()`
+While these are `Int` parameters today (so injection via content is impossible today), the pattern is fragile: if signature ever changes to `String` for raw SQL composition, or if the values come from a nullable `Int?` without a null guard, unparameterized LIMIT is a well-known SQL injection vector class.
+**Why it matters:** Integer-to-string interpolation in SQL is an anti-pattern that static analyzers flag. If any caller passes a crafted value, it could manipulate query execution.
+**Suggested fix:** Use `LIMIT ? OFFSET ?` with `PreparedStatement` parameters for the dynamic-limit queries. For fixed-limit cases (lines 311, 388), keep as-is but add a bounds check or keep the parameterized form for consistency.
+**Confidence:** med
+
+### [SEV: high] storage/VirtualThreadSQLiteStorage.kt:30 — Excessive connection pool size (50) with no backpressure
+**What:** `VirtualThreadSQLiteStorage` creates a HikariCP pool with `maxConnections(50)`. SQLite is a single-writer database — having 50 concurrent connections means 49 threads will block waiting for the write lock. Combined with virtual threads (which are cheap to create), this can lead to massive contention and OOM under load.
+**Why it matters:** Virtual threads + SQLite + large pool = likely deadlock or severe degradation under concurrent load. The class javadoc claims "handles thousands of concurrent database queries" but SQLite can only serialize writes.
+**Suggested fix:** Reduce `maxConnections` to a small number (e.g., 5-10) or use a single-writer queue pattern. The pool should reflect SQLite's actual concurrency model.
+**Confidence:** high
+
+### [SEV: high] guilds/GuildRepositorySQLite.kt:464-467,740-742,892-893 — Debug println left in production
+**What:** Three `println("DEBUG [GuildRepositorySQLite] ...")` blocks at lines 464-467, 740-742, and 892-893 log internal vault state to stdout. These were clearly developer debugging aids.
+**Why it matters:** Information disclosure — guild names, vault status, chest locations, and row-update counts are dumped to the server console on every guild load and update. Any player with console access (or log access) can read this data.
+**Suggested fix:** Remove all debug println blocks. Replace with `logger.debug(...)` if the information is needed for troubleshooting.
+**Confidence:** high
+
+### [SEV: high] guilds/GuildRepositorySQLite.kt:97-120 — checkColumnExists runs on every repository init
+**What:** `checkColumnExists()` performs a JDBC query (INFORMATION_SCHEMA or PRAGMA) for each of 6 columns. These are wrapped in `lazy` delegates, so they run once per column per repository instance. More critically, the INFORMATION_SCHEMA query at line 97-103 uses string interpolation for `tableName` and `columnName` parameters:
+```kotlin
+"WHERE TABLE_NAME = ? AND COLUMN_NAME = ?"  // uses params — OK
+```
+But the fallback SQLite path at line 107 uses `PRAGMA table_info($tableName)` with interpolation. If `tableName` were ever non-hardcoded, this would be injection (same class of issue as SQLiteMigrations.tableExists).
+**Why it matters:** The PRAGMA path is only taken when INFORMATION_SCHEMA fails (i.e., on SQLite). The tableName is hardcoded "guilds" today, so not exploitable, but the pattern is fragile.
+**Suggested fix:** Hardcode the PRAGMA query or validate tableName against a whitelist before interpolation.
+**Confidence:** med
+
+### [SEV: high] claims/ClaimPermissionRepositorySQLite.kt:84,102-103 — Silent error swallowing via printStackTrace()
+**What:** `createTable()` (line 84) catches `SQLException` and calls `error.printStackTrace()`. `preload()` (line 102-103 in the same class) catches `IllegalArgumentException` but the outer `createTable()` failure means the table doesn't exist, yet the class continues to operate with an empty in-memory cache.
+**Why it matters:** If table creation fails, all subsequent DB operations will also fail silently (catching and returning null/empty). The plugin starts "successfully" but no data is persisted, leading to data loss.
+**Suggested fix:** Throw `DatabaseOperationException` like all other claim repositories do, rather than silently swallowing.
+**Confidence:** high
+
+### [SEV: high] claims/ClaimRepositorySQLite.kt:105-106 — Silent error swallowing in createClaimTable()
+**What:** Same pattern as ClaimPermissionRepositorySQLite — `createClaimTable()` catches `SQLException` and calls `error.printStackTrace()`, allowing the repository to start with a non-existent table.
+**Why it matters:** Data loss — all claim persistence silently fails. The in-memory cache works until server restart, then all claims are gone.
+**Suggested fix:** Throw `DatabaseOperationException` (as `ClaimFlagRepositorySQLite` and `PlayerAccessRepositorySQLite` correctly do).
+**Confidence:** high
+
+### [SEV: high] guilds/GuildVaultRepositorySQLite.kt:266-280 — Unsafe Java ObjectInputStream deserialization fallback
+**What:** `deserializeItem()` at line 267-280 falls back to `ObjectInputStream.readObject()` on arbitrary byte data from the database. While this is a legacy format handler, it means the application accepts Java-serialized objects from the DB and deserializes them without any class filtering.
+**Why it matters:** If an attacker can write to the (local) SQLite file (e.g., via a separate file-write vulnerability, or if the DB file is exposed), they could inject a Java deserialization gadget chain. This is a well-known remote code execution vector. The `deserializeItem()` caller gets results from the DB, which is populated by Bukkit's `ItemStack.serializeAsBytes()` — so the data path is internally controlled. But the fallback path accepts arbitrary bytes.
+**Suggested fix:** Replace `ObjectInputStream` with `ObjectInputFilter` (Java 9+) restricting deserialization to `ItemStack` and `Map<String,?>` classes only. Or better, remove the legacy path entirely after a migration window.
+**Confidence:** med
+
+### [SEV: med] migrations/GuildBalanceConsolidator.kt:63-64 — Non-idempotent migration: ledger sum can double-count
+**What:** The consolidation is documented as "NOT safe to run twice" and guarded by schema version v21->v22. However, if the schema version is manually reset (e.g., a DBA fixes a migration issue), or if the version bump at `SQLiteMigrations.updateDatabaseVersion(22)` fails after `consolidate()` has already run, re-running would add ledger amounts a second time on top of already-folded balances.
+**Why it matters:** Double-counting inflates guild gold balances. This is a data-integrity bug that would be very hard to detect after the fact.
+**Suggested fix:** Add a counter-guard: after consolidation, set a flag column (e.g., `balance_consolidated INTEGER DEFAULT 1` on `guilds`) and check it before folding. Or, after folding, truncate the `bank_transactions` table (though this loses audit history).
+**Confidence:** high
+
+### [SEV: med] guilds/GuildInvitationRepositorySQLite.kt:80,102,115 — Silent catch returning false hides DB failures
+**What:** Three catch blocks in `add()`, `remove()`, and `removeAllForPlayer()` catch `SQLException` and return `false` without logging. This makes debugging DB issues very difficult.
+**Why it matters:** Failed operations are indistinguishable from "no rows affected" failures. No audit trail for debugging.
+**Suggested fix:** Log the exception at warn/error level before returning false, or throw `DatabaseOperationException` as other repositories do.
+**Confidence:** high
+
+### [SEV: med] guilds/MemberRepositorySQLite.kt:107,129,143,157 — Silent catch returning false hides DB failures
+**What:** Same pattern as GuildInvitationRepository — 4 catch blocks silently return false on SQLException.
+**Why it matters:** Data inconsistency between in-memory cache and DB is hard to diagnose.
+**Suggested fix:** Log exceptions or throw DatabaseOperationException.
+**Confidence:** high
+
+### [SEV: med] players/PlayerStateRepositoryMemory.kt:13-62 — Memory-only persistence with no DB fallback
+**What:** This is an in-memory-only implementation of `PlayerStateRepository`. The class javadoc at line 11 explicitly states "player states are lost on server restart." There is no corresponding DB implementation in the persistence tier.
+**Why it matters:** Any player state (location, preferences, etc.) tracked by this repository is ephemeral. If the feature is meant to persist, this is a correctness gap. If it's intended to be ephemeral, the class name/repository pattern is misleading and should be documented at the port level.
+**Suggested fix:** Either implement a DB-backed version (PlayerStateRepositorySQLite) or clearly document at the application port interface that this is intentionally ephemeral.
+**Confidence:** high
+
+### [SEV: med] guilds/GuildVaultRepositorySQLite.kt:186-215 — TOCTOU race in addGoldBalance/subtractGoldBalance
+**What:** `addGoldBalance()` reads balance (line 189), computes new balance in memory (line 190), then writes (line 192). Between the read and write, another thread can modify the balance. No optimistic locking or atomic UPDATE is used.
+**Why it matters:** Concurrent deposits/withdrawals can lose updates. Two concurrent reads of balance=100, one adds 50 (->150), one subtracts 30 (->70). Last writer wins: final balance is either 150 or 70, not 120.
+**Suggested fix:** Use an atomic `UPDATE vault_gold SET balance = balance + ?, last_modified = ? WHERE guild_id = ?` query. For subtract, add a `balance >= ?` guard in the WHERE clause and check rows affected.
+**Confidence:** high
+
+### [SEV: med] guilds/LeaderboardRepositorySQLite.kt:364 — getLeaderboardSnapshots uses hardcoded KILLS filter instead of parameter
+**What:** Line 364: `storage.connection.getResults(sql, LeaderboardType.KILLS.name, period.name, limit)` — the `type` parameter from the function signature (`type: ExtendedLeaderboardType`) is ignored; `LeaderboardType.KILLS.name` is used instead.
+**Why it matters:** The method ignores its `type` argument and always queries KILLS type snapshots. Other leaderboard type snapshots are unreachable.
+**Suggested fix:** Use `type.name` instead of `LeaderboardType.KILLS.name`.
+**Confidence:** high
+
+### [SEV: med] guilds/ProgressionRepositorySQLite.kt:285,399 — Operator precedence bug in createDefaultProgressionIfNotExists
+**What:** Line 285: `val exists = result?.getInt("count") ?: 0 > 0` — due to Kotlin operator precedence, `?: 0 > 0` is parsed as `?: (0 > 0)` which is `?: false`. So `exists` is always `true` when `result` is non-null, regardless of the actual count.
+**Why it matters:** Non-existent progressions are never auto-created from DB. The method returns `null` when the guild doesn't have progression data.
+**Suggested fix:** Add parentheses: `val exists = (result?.getInt("count") ?: 0) > 0`. Same bug at line 399.
+**Confidence:** high
+
+### [SEV: med] migrations/MigrationVerifier.kt:81 — Uses PRAGMA for SQLite but class is named MigrationVerifier (MariaDB-specific naming)
+**What:** `MigrationVerifier.columnExists()` at line 81 runs `PRAGMA table_info(guilds)`. If this is used against MariaDB (as the name "MigrationVerifier" suggests), PRAGMA is not valid MySQL syntax. The `autoRepairSchema()` method at line 146 runs raw ALTER TABLE via `execute()` which is fine for both, but the verification itself would always fail on MariaDB.
+**Why it matters:** On MariaDB, `verifyGuildsTableSchema()` would always report all columns missing and attempt auto-repair every startup, adding unnecessary ALTER TABLE statements to the migration flow.
+**Suggested fix:** Detect DB type (SQLite vs MariaDB) and use the appropriate column-existence check for each.
+**Confidence:** med
+
+### [SEV: low] guilds/GuildBannerRepositorySQLite.kt:208,333,405,416 — catch(e: SQLException) on non-SQL exceptions
+**What:** Multiple catch blocks in `GuildBannerRepositorySQLite` and `ProgressionRepositorySQLite` catch `SQLException` on operations that cannot throw it (e.g., `UUID.fromString()`, `Instant.parse()`, `PerkType.valueOf()`). These should catch `IllegalArgumentException` or a general `Exception`.
+**Why it matters:** If UUID parsing fails with `IllegalArgumentException`, the exception propagates up uncaught instead of being handled gracefully. The `SQLException` catch block gives a false impression of what's being handled.
+**Suggested fix:** Catch the specific exception types that can actually be thrown by the wrapped code.
+**Confidence:** high
+
+### [SEV: low] guilds/PartyRepositorySQLite.kt:252,271 — catch(e: SQLException) on Gson parsing
+**What:** `parseMutedPlayersJson()` and `parseBannedPlayersJson()` at lines 252 and 271 catch `SQLException` but the wrapped code uses `gson.fromJson()` which throws `JsonSyntaxException` (an `IllegalArgumentException` subclass).
+**Why it matters:** JSON parse failures propagate uncaught instead of returning the graceful empty map.
+**Suggested fix:** Catch `IllegalArgumentException` or `JsonSyntaxException` instead of `SQLException`.
+**Confidence:** high
+
+### [SEV: low] guilds/RankRepositorySQLite.kt:186-187 — swapPriorities uses Int.MAX_VALUE sentinel in UNIQUE column
+**What:** The `swapPriorities` method temporarily sets a rank's priority to `Int.MAX_VALUE` as a sentinel. If the process crashes between the first and second UPDATE, the rank is left with `Int.MAX_VALUE` priority, which could break `getHighestRank()`/`getDefaultRank()` semantics.
+**Why it matters:** Crash corruption — a crash during the 3-step swap leaves the DB in an inconsistent state.
+**Suggested fix:** Use a two-phase swap without sentinel: read both priorities in memory, then execute both UPDATEs in a single transaction and check all rows affected.
+**Confidence:** med
+
+### [SEV: low] guilds/KillRepositorySQLite.kt:186-191 — columnExists via SELECT swallows errors
+**What:** `columnExists()` at line 186 tries `SELECT $columnName FROM kills LIMIT 1`. If the column doesn't exist, this throws `SQLException` which is caught and returns `false`. But the exception message is lost. This is a wasteful way to check column existence.
+**Why it matters:** Not a bug per se, but the pattern is fragile — any error (including transient ones like locked DB) is interpreted as "column doesn't exist."
+**Suggested fix:** Use `PRAGMA table_info(kills)` like other repositories do for SQLite.
+**Confidence:** low
+
+### [SEV: low] storage/MariaDBStorage.kt:50 — Credentials passed through constructor with no encryption
+**What:** `MariaDBStorage` takes a plaintext `password: String` in its constructor. This is standard for JDBC connection pooling, but worth noting that the credential lifecycle is entirely in-memory with no protection.
+**Why it matters:** If the process memory is dumped (e.g., via a heap dump or /proc/pid/mem), the password is visible in plaintext.
+**Suggested fix:** Consider using a configuration provider that supports encrypted values or short-lived tokens. This is a defense-in-depth suggestion, not a critical issue.
+**Confidence:** low
+
+---
+
+## Test Coverage Gaps
+
+| Repository | Method | Risk |
+|---|---|---|
+| `GuildRepositorySQLite` | `add()` / `update()` — 4-branch SQL variants based on column flags | Very high: each branch produces a different SQL statement. Only one path is exercised per run, and manually testing all 4 requires specific migration states. |
+| `GuildBalanceConsolidator` | `consolidate()` | High: the only data-migration orchestrator. Needs unit tests for: already-consolidated re-run guard, vault_gold missing, bank_transactions empty. |
+| `RankRepositorySQLite` | `swapPriorities()` | High: 3-step transaction with crash-recovery semantics. |
+| `GuildVaultRepositorySQLite` | `addGoldBalance()` / `subtractGoldBalance()` | High: TOCTOU race, but no concurrent-access test exists. |
+| `ClaimFlagRepositorySQLite` | `preload()` with mixed valid/invalid enum values | Medium: catch(IllegalArgumentException) silently skips bad rows. |
+| `KillRepositorySQLite` | `parseRecentKills()` / `serializeRecentKills()` | Medium: custom JSON parsing without a real JSON library; edge cases untested. |
+| `LeaderboardRepositorySQLite` | `getLeaderboardSnapshots()` | High: the `type` parameter bug means this returns wrong results unless tested. |
+| `ProgressionRepositorySQLite` | `createDefaultProgressionIfNotExists()` / `createDefaultActivityMetricsIfNotExists()` | High: the `?: 0 > 0` precedence bug means this method never returns a default. |
+| `MigrationVerifier` | `verifyGuildsTableSchema()` against MariaDB | Medium: PRAGMA is invalid MySQL syntax; would fail silently. |
+| `SQLiteMigrations` | `migrateToVersion2()` — 10-step schema rebuild | Very high: complex multi-step migration with no rollback test. |
+
+---
+
+## Layer Boundary Check
+
+No business/domain logic leaked into the persistence layer. All 37 files strictly use JDBC (via IDB) and implement application-defined port interfaces. The `VaultTransactionLogger` defines its own `VaultTransaction` data class and `VaultTransactionType` enum in the same file, but these are infrastructure-level DTOs, not domain entities — acceptable.
+
+---
+
+## Static Analysis
+
+`detekt` is not configured as a Gradle plugin in this project (no `io.gitlab.arturbosch.detekt` plugin declaration, no `detekt` task available). No detekt findings to fold in.

--- a/docs/audit/audit-infra-services.md
+++ b/docs/audit/audit-infra-services.md
@@ -1,0 +1,748 @@
+# Audit Report: infrastructure/services
+
+**Branch:** fix/audit-infra-services
+**Scope:** 54 files in `infrastructure/services/` (including `apollo/` and `scheduling/` sub-packages)
+
+---
+
+## Findings
+
+### [SEV: high] AsyncTaskService.kt:97 — runAsyncCallback captures mutable `result` in callback lambda
+
+**What:** The `runAsyncCallback` method on line 92-106 dispatches `onSuccess(result)` and `onError(e)` via `Bukkit.getScheduler().runTask`. The `result` local variable is assigned inside the coroutine on lines 94-95. However, the `CoroutineScope(virtualDispatcher)` on line 44 creates a **new** scope each call. Since `runTask` is scheduled from inside that launched coroutine, if the coroutine is cancelled between `task()` completing and `runTask` executing, the `result` variable is never set, while the lambda captures `result` by reference. In practice this means a `lateinit` value could be read if cancellation races, and more critically the `onSuccess`/`onError` callbacks access **mutable locals** that the coroutine may not have written yet under cancellation.
+
+**Why it matters:** A cancellation race between the virtual-thread launch and the main-thread callback dispatch could call `onSuccess(result)` with an uninitialized value or stale data, causing silent wrong-path execution. Under heavy load with coroutine cancellation this can lose errors or invoke success with garbage.
+
+**Suggested fix:** Snapshot `result` and `e` into `val` locals *before* dispatching to main thread, or convert to the `runAsync` pattern that returns a `CompletableFuture` and avoids capturing mutable state entirely.
+
+**Confidence:** med
+
+---
+
+### [SEV: high] BankServiceBukkit.kt:656 — isValidAmount uses deposit range for withdrawal validation
+
+**What:** `isValidAmount` (line 656-658) validates against `getMinDepositAmount()` and `getMaxDepositAmount()`. This method is called on line 141 for deposits AND on line 340 for withdrawals. Withdrawals use the deposit min/max range, not withdrawal-specific limits. If config sets different ranges (which the config schema supports via `maxWithdrawalPercent`), withdrawal amounts outside the deposit range but within withdrawal limits would be rejected.
+
+**Why it matters:** Withdrawal amounts that should be valid (e.g., withdrawing 60% of balance when maxWithdrawalPercent=0.6 but maxDepositAmount=100000 and balance=200000) would be blocked. Conversely, deposits above maxWithdrawalPercent could succeed when they shouldn't.
+
+**Suggested fix:** Add `isValidWithdrawalAmount(amount, balance)` or pass context to validation.
+
+**Confidence:** high
+
+---
+
+### [SEV: high] CombatServiceBukkit.kt:119 — getPlayerGuilds always returns empty set
+
+**What:** `getPlayerGuilds` (line 119-123) is a private helper that returns `emptySet()` with a comment "This would be injected in a real implementation". Similarly, `getRelationType` (line 125-129) always returns `NEUTRAL`.
+
+**Why it matters:** `getPvpBlockReason` and `getTerritoryPvpBlockReason` will never detect same-guild members, peaceful guilds, or allied guilds — they always return `null` (no block reason). This means PvP is **never blocked** by this service for guild members, allies, or peaceful guilds. Every PvP check reason is silently lost.
+
+**Suggested fix:** Inject `MemberService` and `RelationService` into the constructor (the comment acknowledges this is a placeholder).
+
+**Confidence:** high
+
+---
+
+### [SEV: high] GuildInvitationManager.kt:12 — object singleton with lateinit var, no concurrent init guard
+
+**What:** `GuildInvitationManager` is a Kotlin `object` (singleton) with a `lateinit var repository` (line 14). `initialize()` (line 20) sets it once but has no synchronization guard. If two threads call `initialize()` concurrently (e.g., during plugin reload), one will overwrite the other, and calls between the two stores may use a stale or uninitialized reference.
+
+**Why it matters:** On plugin reload or async initialization, `repository` could be uninitialized when `addInvite` is called, causing `UninitializedPropertyAccessException`. Or it could be set to a stale repository.
+
+**Suggested fix:** Use `@Volatile` + synchronized init, or make it a regular class with DI instead of an object singleton.
+
+**Confidence:** med
+
+---
+
+### [SEV: high] GuildBannerServiceBukkit.kt:107 — canSetBanners ignores submitter, grants all members permission
+
+**What:** `canSetBanners` (line 107-120) always returns `true` for any existing guild, regardless of which submits. The comment says "For now, any guild member can set banners" — but the method doesn't even verify the submitter is a member.
+
+**Why it matters:** Any player (even non-members) can set/remove the guild banner, bypassing the rank-based permission system. This is a privilege escalation.
+
+**Suggested fix:** Check `memberService.hasPermission(submitterId, guildId, RankPermission.MANAGE_BANNER)` in `setGuildBanner` and `removeGuildBanner` (already checked in GuildService but not here where it's an independent service path).
+
+**Confidence:** high
+
+---
+
+### [SEV: high] DailyWarCostsServiceBukkit.kt:27 — in-memory only last-costs-applied survives restart
+
+**What:** `lastCostsApplied` is a `ConcurrentHashMap<UUID, Instant>` (line 27) with the comment "In production, this should be persisted to a database". It tracks whether daily costs were applied per guild.
+
+**Why it matters:** On server restart, the map is empty, so daily war costs are re-applied to all guilds in active wars. If the scheduler runs twice in one day (restart + schedule), guilds get double-charged.
+
+**Suggested fix:** Persist `lastCostsApplied` to the database, or use a date-based check rather than timestamp.
+
+**Confidence:** med
+
+---
+
+### [SEV: high] WarServiceBukkit.kt:336-338 — canGuildDeclareWar maxWars hardcoded, ignores progression max
+
+**What:** `canGuildDeclareWar` (line 330-334) hardcodes `activeWars < 3` instead of using the progression-based war slot limit computed elsewhere in `declareWar` (lines 61-72).
+
+**Why it matters:** A guild that has progressed to level 30 and unlocked 5 war slots via `declareWar` logic can still be blocked from declaring by `canGuildDeclareWar` returning `false`. The check is inconsistent with the actual declaration logic.
+
+**Suggested fix:** Compute max wars via the same progression logic used in `declareWar`, or extract to a shared method.
+
+**Confidence:** high
+
+---
+
+### [SEV: med] AsyncTaskService.kt:44 — new CoroutineScope created per call, no lifecycle management
+
+**What:** `runAsync` (line 44) creates a new `CoroutineScope(virtualDispatcher)` on every call. Each scope is independent and never cancelled. The launched coroutine holds a reference to the scope via its completion.
+
+**Why it matters:** Under high call volume, many scope objects accumulate. If the `block` captures a reference to an outer object (e.g., a player session), that object is retained until the coroutine completes. No structured concurrency means errors in child coroutines are silently swallowed.
+
+**Suggested fix:** Use a single `CoroutineScope` managed by the service lifecycle, with `supervisorScope` for structured concurrency.
+
+**Confidence:** med
+
+---
+
+### [SEV: med] ChatServiceBukkit.kt:49-50 — rate limit fields not persistent, survive restart only in memory
+
+**What:** `announceRateLimit` and `pingRateLimit` (lines 35-36) are hardcoded in-memory values. More importantly, `updateAnnouncementRateLimit` and `updatePingRateLimit` (lines 498-536) persist via `chatSettingsRepository.updateRateLimit()`, but the rate-limit check methods read from `chatSettingsRepository.getRateLimit(playerId)` — if the server restarts between checks, the in-memory cache (if any) is lost and the DB is the source of truth. This is actually correct behavior. **However**, the `maxAnnouncementsPerHour` and `maxPingsPerHour` constants (lines 37-38) are defined locally and not configurable, creating a hidden coupling.
+
+**Why it matters:** Constants buried in code rather than config make testing and tuning harder, and could lead to confusion if config changes don't take effect.
+
+**Suggested fix:** Move `maxAnnouncementsPerHour` and `maxPingsPerHour` to config.
+
+**Confidence:** low
+
+---
+
+### [SEV: med] GuildServiceBukkit.kt:268 — setTag reuses MANAGE_EMOJI permission instead of dedicated permission
+
+**What:** `setTag` (line 264) checks `RankPermission.MANAGE_EMOJI` for tag management (line 268). Similarly `setDescription` (line 309) checks `MANAGE_EMOJI` (line 313).
+
+**Why it matters:** The permission name is misleading — a rank with `MANAGE_EMOJI` can also set guild tags and descriptions. If a future admin wants to separate these permissions, they can't without a code change. This is a layer-boundary / domain-logic leak where infrastructure reuses a permission enum for unrelated purposes.
+
+**Suggested fix:** Add `MANAGE_TAG` and `MANAGE_DESCRIPTION` to `RankPermission` enum, or at minimum use a clearly named permission.
+
+**Confidence:** med
+
+---
+
+### [SEV: med] GuildServiceBukkit.kt:793 — countVisibleCharacters regex is incomplete
+
+**What:** `countVisibleCharacters` (line 793-802) uses `Regex("<[^>]*>")` to strip MiniMessage tags. This regex fails on nested tags like `<gradient:red:blue><bold>text</bold></gradient>` where the closing `>` of the inner tag matches the outer regex prematurely.
+
+**Why it matters:** Guild tags with nested MiniMessage formatting will have incorrect visible character counts, potentially allowing tags that exceed the 32-character limit or rejecting valid ones.
+
+**Suggested fix:** Use a proper MiniMessage parser (e.g., `MiniMessage.miniMessage().stripTags(tag).length`).
+
+**Confidence:** med
+
+---
+
+### [SEV: med] GuildRolePermissionResolverBukkit.kt:126 — mapRankToClaimPermissions uses rank.name string matching
+
+**What:** `mapRankToClaimPermissions` (line 126-146) maps rank names to permissions via `config.teamRolePermissions.roleMappings[rankName]`. This is a string-based lookup that breaks if rank names are renamed.
+
+**Why it matters:** If an admin renames a rank (e.g., "Mod" → "Moderator"), all claim permissions for that rank are silently lost and fall back to defaults. No warning is logged.
+
+**Suggested fix:** Map by rank ID instead of name, or log a warning when a rank name has no mapping.
+
+**Confidence:** med
+
+---
+
+### [SEV: med] GuildVaultServiceBukkit.kt:76 — placeVaultChest allows replacing chest at non-air location
+
+**What:** `placeVaultChest` (line 62) checks `block.type != Material.AIR && block.type != Material.CHEST` on line 76, and if the block is not air or chest, it sets `block.type = Material.CHEST` without checking what was there before.
+
+**Why it matters:** Any block (including player builds, redstone, etc.) at the target location is silently destroyed when a vault is placed. No drop is given, no warning is shown.
+
+**Suggested fix:** Return failure if the block is not AIR or CHEST, or at minimum log a warning and drop the replaced block's items.
+
+**Confidence:** med
+
+---
+
+### [SEV: med] PartyServiceBukkit.kt:40-41 — createParty allows single-guild parties without leader guild check
+
+**What:** `createParty` (line 25) checks that the leader has `MANAGE_RELATIONS` in their own guild (line 43-47), but for single-guild parties (line 40: `isPrivateParty = party.guildIds.size == 1`), the leader's guild is not verified to be in `party.guildIds`.
+
+**Why it matters:** A leader from guild A could create a single-guild party for guild B (if `party.guildIds` contains only guild B), bypassing the permission check for guild B.
+
+**Suggested fix:** Verify `leaderGuildId` is in `party.guildIds` before proceeding.
+
+**Confidence:** med
+
+---
+
+### [SEV: med] RelationServiceBukkit.kt:32-33 — isRequester uses guildA not requestingGuildId for legacy null check
+
+**What:** `isRequester` (line 32-33) checks `relation.requestingGuildId == guildId`. For legacy rows where `requestingGuildId` is null, this returns false, which is correct. But the comment on line 32 says "allowing legacy null rows" — the actual behavior is that legacy null rows cannot pass the requester check, so the direction enforcement on lines 142 and 310 would reject both guilds from accepting.
+
+**Why it matters:** Legacy relation rows with null `requestingGuildId` cannot be accepted by either guild, permanently blocking alliance/truce/unenemy flows for old data.
+
+**Suggested fix:** For legacy null rows, allow either guild to accept (as the comment intends).
+
+**Confidence:** med
+
+---
+
+### [SEV: med] TeleportationService.kt:100 — cancelTeleport before startTeleport removes previous session without cleanup
+
+**What:** `startTeleportInternal` (line 97) calls `cancelTeleport(playerId)` on line 99, which removes the session from `activeTeleports` and cancels the task. But if the previous session's `onSuccess` callback was already queued on the main thread (via `teleportAsync.whenComplete`), it will still fire and reference the old session.
+
+**Why it matters:** The stale `onSuccess` callback from the previous teleport could fire after a new teleport starts, causing double cooldown stamping or other side effects.
+
+**Suggested fix:** Use a session generation counter or check session identity in the callback (the code already does this on line 192, so this is partially mitigated — but the `onSuccess` from the old session could still fire between lines 99 and 105).
+
+**Confidence:** low
+
+---
+
+### [SEV: med] VaultBackupServiceBukkit.kt:177 — serializeVaultData uses custom format, not standard serialization
+
+**What:** `serializeVaultData` (line 177-183) encodes as `"goldBalance|slot:base64,slot:base64,..."`. The `deserializeVaultData` (line 189-206) splits on `|` with limit 2, then splits on `,`, then splits each entry on `:` with limit 2. If a Base64 string contains `|` or `:` (which standard Base64 does not, but URL-safe Base64 could), deserialization would fail silently.
+
+**Why it matters:** Data corruption on backup/restore. If the format ever changes or Base64 encoding varies, backups become unreadable.
+
+**Suggested fix:** Use JSON or a well-defined serialization format instead of custom string encoding.
+
+**Confidence:** low
+
+---
+
+### [SEV: med] NexoEmojiService.kt:10 — profane comment in production code
+
+**What:** Line 10 contains: `JFS there is some really nasty shit going on here.` This is a profane developer comment in production code.
+
+**Why it matters:** Unprofessional, and the comment doesn't explain what's actually wrong. The reflection-based FontManager access (lines 195-258) is indeed fragile and should be documented properly.
+
+**Suggested fix:** Replace with a clear comment explaining the reflection workaround and linking to a Nexo API issue.
+
+**Confidence:** high
+
+---
+
+### [SEV: med] NexoEmojiService.kt:213 — profane comment "cancer"
+
+**What:** Line 213: `// cancer` and line 228: `// gonna kms` — profane developer comments.
+
+**Why it matters:** Same as above — unprofessional in production code.
+
+**Suggested fix:** Remove or replace with descriptive comments.
+
+**Confidence:** high
+
+---
+
+### [SEV: med] VisualisationServiceBukkit.kt:106-161 — refreshAsync logs excessively at INFO level
+
+**What:** `refreshAsync` (line 186) and `clearAsync` (line 302) log at `logger.info` for every async operation including position calculations, material validation, and callback timing.
+
+**Why it matters:** Under normal operation, this produces hundreds of INFO log lines per second, flooding the log file and making real issues harder to find.
+
+**Suggested fix:** Change to `logger.debug` or `logger.fine`.
+
+**Confidence:** high
+
+---
+
+### [SEV: med] VisualisationServiceBukkit.kt:204-218 — calculateVisualizationPositions returns Position2D but is called for Position3D
+
+**What:** `calculateVisualizationPositions` (line 206) returns `Set<Position2D>` but the method is declared to return `Set<Position3D>` (line 206 shows `emptySet<Position2D>()` as the error return). The actual computation on line 206 calls `getOuterBorders` which returns `Position2D`.
+
+**Why it matters:** The type mismatch means the returned 2D positions are silently upcast to 3D (likely with y=0), causing visualization at wrong heights. This is a compile-time type error waiting to happen.
+
+**Suggested fix:** The method should return `Set<Position2D>` or compute 3D positions directly.
+
+**Confidence:** high
+
+---
+
+### [SEV: low] ConfigServiceBukkit.kt:56 — default MariaDB password is "password"
+
+**What:** `loadMariaDBConfig` (line 50-65) defaults to password `"password"` on line 56.
+
+**Why it matters:** If the config file is not properly configured, the plugin connects to MariaDB with a well-known default password. This is a security risk in production.
+
+**Suggested fix:** Fail hard if the password is not explicitly configured, or generate a random default.
+
+**Confidence:** med
+
+---
+
+### [SEV: low] ConfigServiceBukkit.kt:255 — Discord webhook URL stored in plain text
+
+**What:** `loadDiscordConfig` (line 253-258) loads `discord_webhook_url` as a plain string from config.
+
+**Why it matters:** Webhook URLs are secrets. Storing them in plain config files risks exposure via config dumps, version control, or log files.
+
+**Suggested fix:** Document that this should be externalized, or use environment variable substitution.
+
+**Confidence:** low
+
+---
+
+### [SEV: low] PlayerLocaleServicePaper.kt:9 — returns empty string for offline players
+
+**What:** `getLocale` (line 8-11) returns `""` for offline players. Callers may not expect an empty string and could pass it to localization logic, causing missing-key fallbacks or empty display names.
+
+**Why it matters:** Silent failure — no log, no exception, just empty string propagation.
+
+**Suggested fix:** Return a default locale (e.g., "en_US") or document the empty-string contract.
+
+**Confidence:** low
+
+---
+
+### [SEV: low] PlayerMetadataServiceVault.kt:13 — MainConfig passed directly, bypasses ConfigService
+
+**What:** `PlayerMetadataServiceVault` takes `MainConfig` directly (line 12) instead of `ConfigService`. This creates a direct dependency on the config model from the infrastructure layer.
+
+**Why it matters:** Layer boundary violation — infrastructure depends on config model directly rather than through the application service. Makes testing harder.
+
+**Suggested fix:** Inject `ConfigService` and call `loadConfig()` as needed.
+
+**Confidence:** low
+
+---
+
+### [SEV: low] LeaderboardServiceBukkit.kt:29-40 — toSimple mapping is lossy and inconsistent
+
+**What:** `ExtendedLeaderboardType.toSimple()` (line 29-40) maps multiple extended types to the same simple type (e.g., `GUILD_DEATHS` → `KILLS`, `GUILD_BANK_BALANCE` → `LEVEL`). This means the reverse mapping is ambiguous.
+
+**Why it matters:** When code calls `toSimple()` then `toExtended()`, it may get a different extended type than originally intended. This can cause wrong leaderboard data to be returned.
+
+**Suggested fix:** Use a bidirectional mapping or avoid the round-trip.
+
+**Confidence:** med
+
+---
+
+### [SEV: low] GuildTeamService.kt:86-87 — isVanished uses metadata, may not work with all vanish plugins
+
+**What:** `isVanished()` (line 86-87) checks for `"vanished"` metadata. Different vanish plugins use different metadata keys (e.g., "vanished", "isVanished", "essentials.vanished").
+
+**Why it matters:** Players vanished via plugins using different metadata keys will still appear on the team HUD, breaking vanish functionality.
+
+**Suggested fix:** Support multiple metadata keys or use the SuperVanish/VanishNoPacket API directly.
+
+**Confidence:** low
+
+---
+
+### [SEV: low] GuildNotificationService.kt:83-85 — logs "not a Lunar Client user" at INFO level
+
+**What:** Line 84: `logger.info("${player.name} is not a Lunar Client user")` — this fires for every non-LC player on every notification send.
+
+**Why it matters:** Log spam — most players on a typical server won't be using Lunar Client.
+
+**Suggested fix:** Change to `logger.debug`.
+
+**Confidence:** high
+
+---
+
+### [SEV: low] DailyWarCostsScheduler.kt:27-34 — delay calculation uses LocalTime, wrong across timezone/DST boundaries
+
+**What:** `startDailyScheduler` (line 25) uses `LocalTime.now()` (line 28) to compute delay until 2:00 AM. `LocalTime` uses the system default timezone, not the server timezone.
+
+**Why it matters:** If the server JVM timezone differs from the server's physical timezone, the daily war costs will fire at the wrong time. DST transitions could cause the task to fire twice or skip a day.
+
+**Suggested fix:** Use `ZonedDateTime` with an explicit timezone (e.g., `ZonedDateTime.of(2024, 1, 1, 2, 0, 0, 0, ZoneOffset.UTC)`).
+
+**Confidence:** med
+
+---
+
+### [SEV: low] ExperienceTransactionCleanupScheduler.kt:45 — catch block swallows all exceptions silently
+
+**What:** Line 44-47: The catch block logs the error but the scheduler continues. If `deleteOldTransactions` consistently fails (e.g., DB is down), the error is logged every interval but no alert is raised.
+
+**Why it matters:** Silent failure — the cleanup task could be failing for days without operator awareness.
+
+**Suggested fix:** Add a failure counter and escalate after N consecutive failures.
+
+**Confidence:** low
+
+---
+
+### [SEV: low] FormCacheServiceGuava.kt:26-31 — asyncExecutor is never shut down
+
+**What:** `asyncExecutor` (line 26-31) is an `Executors.newCachedThreadPool` that is never shut down. The threads are daemon threads (line 28), so they won't prevent JVM exit, but they leak on plugin reload.
+
+**Why it matters:** On plugin reload, a new thread pool is created while the old one may still be running tasks. This can cause resource exhaustion over multiple reloads.
+
+**Suggested fix:** Store the executor as a class field and provide a `shutdown()` method called on plugin disable.
+
+**Confidence:** med
+
+---
+
+### [SEV: low] MapRendererServiceBukkit.kt:294-295 — startCacheCleanupTask is a no-op
+
+**What:** `startCacheCleanupTask` (line 292-295) only logs a message but doesn't actually start any cleanup task (the TODO on line 293 confirms this).
+
+**Why it matters:** The `chartCache` (line 26) grows unboundedly. Over time, this causes memory leaks as expired chart entries are never evicted.
+
+**Suggested fix:** Implement the scheduled cleanup task or use a Guava cache with expiration.
+
+**Confidence:** med
+
+---
+
+### [SEV: low] BankServiceBukkit.kt:483-496 — getTopBalances cache invalidation race
+
+**What:** `getTopBalances` (line 483-497) uses `synchronized(balanceLeaderboardLock)` for the cache read/write, but `invalidateBalanceLeaderboard()` (line 500-502) sets `balanceLeaderboardExpiresAt = 0L` without synchronization.
+
+**Why it matters:** A race between `invalidateBalanceLeaderboard()` and the cache check on line 489 could cause a stale cache read to be used for up to 30 seconds after invalidation.
+
+**Suggested fix:** Make `balanceLeaderboardExpiresAt` `@Volatile` or access it within the synchronized block.
+
+**Confidence:** med
+
+---
+
+### [SEV: low] GuildServiceBukkit.kt:49-50 — guild name regex allows spaces but docs say "alphanumerics"
+
+**What:** `GUILD_NAME_ALLOWED = Regex("^[A-Za-z0-9 ]+$")` (line 50) allows spaces. The comment on line 48 says "Allow only alphanumerics and spaces" which is correct, but the validation on line 54 also allows blank names (`name.isBlank()` returns false for `"   "` which passes the regex).
+
+**Why it matters:** A guild name of all spaces passes validation. `isBlank()` checks for empty or whitespace-only, but `"   "` is not blank — wait, actually `"   ".isBlank()` returns `true`. So this is correctly caught. No bug here, but the regex could be tightened.
+
+**Suggested fix:** No fix needed — the `isBlank()` check on line 54 catches whitespace-only names.
+
+**Confidence:** low
+
+---
+
+### [SEV: low] WarServiceBukkit.kt:26-33 — all war state is in-memory only
+
+**What:** `wars`, `warDeclarations`, `warStats`, `warWagers`, `peaceAgreements`, `warFarmingCooldowns`, `warDeclarationCooldowns` (lines 27-33) are all `ConcurrentHashMap` — no database persistence.
+
+**Why it matters:** On server restart, all active wars, declarations, stats, wagers, and cooldowns are lost. This is acknowledged in the comment "In-memory storage for now" but is a data-loss risk.
+
+**Suggested fix:** Persist to database (acknowledged as future work).
+
+**Confidence:** med
+
+---
+
+### [SEV: low] WorldManipulationServiceBukkit.kt:19-42 — isInsideWorldBorder uses double comparison without epsilon
+
+**What:** `isInsideWorldBorder` (line 19-42) compares `areaMinX >= borderMinX` etc. using exact double comparison. World border coordinates and area coordinates may have floating-point precision differences.
+
+**Why it matters:** An area that is mathematically inside the border could be rejected due to floating-point rounding.
+
+**Suggested fix:** Use an epsilon-based comparison (e.g., `>= borderMinX - 0.001`).
+
+**Confidence:** low
+
+---
+
+### [SEV: low] ChartRenderer.kt:85-98 — calculateValueRange adds 10% padding which can produce negative min for positive data
+
+**What:** `calculateValueRange` (line 85-98) computes `padding = (maxValue - minValue) * 0.1` and returns `(minValue - padding).coerceAtMost(0.0)`. If all values are positive, the coerce prevents negative min. But if all values are equal (max == min), padding is 0, and the range is `(value, value)` — a zero-width range.
+
+**Why it matters:** When `dataMax == dataMin`, `scaleValue` (line 117) returns `chartMin` for all values, so all bars render at the same height. This is correct behavior but could be confusing.
+
+**Suggested fix:** No fix needed — behavior is correct.
+
+**Confidence:** low
+
+---
+
+### [SEV: low] BarChartRenderer.kt:286-292 — createKillRankingChart divides by zero when single entry
+
+**What:** `createKillRankingChart` (line 286-292) computes `intensity = (killData.size - index - 1).toDouble() / (killData.size - 1)`. When `killData.size == 1`, this divides by zero, producing `Infinity` or `NaN`.
+
+**Why it matters:** A single-entry kill ranking chart would produce NaN color values, causing rendering artifacts.
+
+**Suggested fix:** Guard against single-entry lists: `if (killData.size <= 1) return killData.map { DataPoint(it.first, it.second, defaultColor) }`.
+
+**Confidence:** high
+
+---
+
+### [SEV: low] LineChartRenderer.kt:65 — renderDataLines silently returns for single data point
+
+**What:** `renderDataLines` (line 60-83) returns early if `data.size < 2`. No error message or fallback rendering.
+
+**Why it matters:** A single data point line chart renders without any line, which may confuse users expecting at least a point marker.
+
+**Suggested fix:** Render a single point marker even for single-entry data.
+
+**Confidence:** low
+
+---
+
+### [SEV: low] KillServiceBukkit.kt:151 — killDeathRatio uses killsByGuild / deathsByGuild but counts from raw list
+
+**What:** `getKillStatsForPeriod` (line 139-158) counts `killsByGuild` and `deathsByGuild` from a raw kill list filtered by `killerGuildId == guildId`. But the kill list is fetched with limit 1000 (line 141), so if there are more than 1000 kills in the period, the ratio is computed from a truncated sample.
+
+**Why it matters:** The KDR for high-activity guilds will be inaccurate due to the 1000-kill limit.
+
+**Suggested fix:** Use a dedicated repository method that counts kills/deaths in a period without fetching all records.
+
+**Confidence:** med
+
+---
+
+### [SEV: low] KillServiceBukkit.kt:225-241 — getKillDeathRatio returns Double.MAX_VALUE for zero deaths
+
+**What:** Line 233: `if (deathsByA == 0) { if (killsByA > 0) Double.MAX_VALUE else 0.0 }`. `Double.MAX_VALUE` is used as an "infinite" ratio.
+
+**Why it matters:** Any code consuming this ratio and doing arithmetic (e.g., averaging) will overflow or produce Infinity.
+
+**Suggested fix:** Return a large but finite sentinel (e.g., `999999.0`) or use `Double.POSITIVE_INFINITY`.
+
+**Confidence:** low
+
+---
+
+### [SEV: low] ProgressionServiceBukkit.kt:124-146 — getLevelFromExperience has O(n) loop with safety cap at 100
+
+**What:** `getLevelFromExperience` (line 124-146) iterates level-by-level to find the current level. With the safety cap at 100 (line 139), very high experience values will return level 100 even if the actual level should be higher.
+
+**Why it matters:** If `maxLevel` in config is increased above 100, this cap silently truncates levels.
+
+**Suggested fix:** Use the `maxLevel` config value as the cap instead of hardcoded 100.
+
+**Confidence:** med
+
+---
+
+### [SEV: low] ProgressionServiceBukkit.kt:223 — calculateWeeklyActivityScore uses hardcoded weights
+
+**What:** `calculateWeeklyActivityScore` (line 223-244) uses hardcoded multipliers (e.g., `MEMBER_JOINED * 2`, `WAR_WON * 3`) instead of reading from config.
+
+**Why it matters:** Activity scoring cannot be tuned without code changes, and the weights are inconsistent with the progression config's XP values.
+
+**Suggested fix:** Read weights from `ActivityWeightsConfig` in progression.yml.
+
+**Confidence:** low
+
+---
+
+### [SEV: low] ModeServiceBukkit.kt:195-197 — isGuildInActiveWar delegates to relationService without null check
+
+**What:** `isGuildInActiveWar` (line 195-197) calls `relationService.isGuildInActiveWar(guildId)` but doesn't handle the case where `relationService` might throw.
+
+**Why it matters:** If the relation service is not initialized, this throws instead of returning a safe default.
+
+**Suggested fix:** Wrap in try-catch or ensure service is always available.
+
+**Confidence:** low
+
+---
+
+### [SEV: low] LfgServiceBukkit.kt:48-92 — canJoinGuild checks player funds but joinGuild deducts them non-atomically
+
+**What:** `canJoinGuild` (line 48) checks the player has sufficient funds. `joinGuild` (line 94) then deducts them. Between the check and deduction, the player's balance could change (e.g., another plugin modifies it).
+
+**Why it matters:** TOCTOU race — a player could pass the balance check, then spend the money before the deduction, resulting in a failed deduction that isn't properly handled (line 125-128 does handle this, but the refund path on line 139 could also fail).
+
+**Suggested fix:** The existing refund handling is adequate, but consider documenting the non-atomic nature.
+
+**Confidence:** low
+
+---
+
+### [SEV: low] PhysicalCurrencyServiceBukkit.kt:109 — deductCurrency requires exact divisibility
+
+**What:** `deductCurrency` (line 109) returns false if `amount % itemValue != 0`. This means you can't deduct amounts that aren't exact multiples of the item value.
+
+**Why it matters:** If `itemValue = 5` and the guild needs to pay 12 coins, the deduction fails. The caller has no way to handle this gracefully.
+
+**Suggested fix:** Round up to the nearest divisible amount and document the behavior, or allow partial-item deductions.
+
+**Confidence:** med
+
+---
+
+### [SEV: low] PhysicalCurrencyServiceBukkit.kt:179 — addCurrency requires exact divisibility
+
+**What:** Same issue as `deductCurrency` — `addCurrency` (line 179) returns false if `amount % itemValue != 0`.
+
+**Why it matters:** Same as above.
+
+**Suggested fix:** Same as above.
+
+**Confidence:** med
+
+---
+
+### [SEV: low] ToolItemServiceBukkit.kt:66 — doesPlayerHaveClaimTool throws PlayerNotFoundException for offline players
+
+**What:** `doesPlayerHaveClaimTool` (line 65-73) throws `PlayerNotFoundException` if the player is offline. The caller may not expect an exception for a simple inventory check.
+
+**Why it matters:** Callers must catch `PlayerNotFoundException` for a routine check, which is unexpected.
+
+**Suggested fix:** Return `false` for offline players instead of throwing.
+
+**Confidence:** med
+
+---
+
+### [SEV: low] VaultHologramService.kt:45 — scheduleSyncRepeatingTask may fail on Folia
+
+**What:** Line 45 uses `Bukkit.getScheduler().scheduleSyncRepeatingTask()` which is not compatible with Folia's region-based scheduler.
+
+**Why it matters:** On Folia servers, this will throw an exception and holograms won't update.
+
+**Suggested fix:** Use the Folia-compatible scheduler API or document Folia incompatibility.
+
+**Confidence:** low
+
+---
+
+### [SEV: low] GuildRichPresenceService.kt:52-54 — teamMaxSize reads from config every call
+
+**What:** `updateGuildRichPresence` (line 34) reads `plugin.config.getInt("guild.max_members_per_guild", 50)` on every call (line 66).
+
+**Why it matters:** Config reads are I/O operations. Reading on every rich presence update (which happens frequently) is wasteful.
+
+**Suggested fix:** Cache the value or pass it as a constructor parameter.
+
+**Confidence:** low
+
+---
+
+### [SEV: low] GuildWaypointService.kt:197 — onPlayerJoin delays 1 second, may miss initial render
+
+**What:** `onPlayerJoin` (line 192) delays waypoint display by 20 ticks (1 second). If the player moves away from their guild home within that second, the waypoint may not render correctly.
+
+**Why it matters:** Minor UX issue — waypoints may briefly flash or not appear.
+
+**Suggested fix:** Reduce delay or re-check on player move.
+
+**Confidence:** low
+
+---
+
+### [SEV: low] GuildNotificationService.kt:80-81 — logs "Notifications disabled" at INFO for every non-enabled check
+
+**What:** Line 80: `logger.info("Notifications disabled in config")` fires every time a notification is sent while disabled.
+
+**Why it matters:** Log spam when notifications are intentionally disabled.
+
+**Suggested fix:** Change to `logger.debug` or only log once on config load.
+
+**Confidence:** high
+
+---
+
+### [SEV: low] GuildNotificationService.kt:84 — logs "not a Lunar Client user" at INFO
+
+**What:** Line 84: `logger.info("${player.name} is not a Lunar Client user")` — same issue as above.
+
+**Why it matters:** Log spam for every non-LC player.
+
+**Suggested fix:** Change to `logger.debug`.
+
+**Confidence:** high
+
+---
+
+### [SEV: low] GuildTeamService.kt:182 — logs "Created team for LC user" at INFO per viewer per refresh
+
+**What:** Line 182: `logger.info("Created team for LC user ${viewer.name} with ${teamMembers.size} teammates")` fires on every team refresh tick.
+
+**Why it matters:** Massive log spam — every online LC user logs this every refresh tick.
+
+**Suggested fix:** Change to `logger.debug`.
+
+**Confidence:** high
+
+---
+
+### [SEV: low] GuildTeamService.kt:190 — logs "Guild team created" at INFO per guild per refresh
+
+**What:** Line 190: `logger.info("Guild team created for $guildId with ${onlineMembers.size} online members")` fires every refresh tick for every guild.
+
+**Why it matters:** Same as above — log spam.
+
+**Suggested fix:** Change to `logger.debug`.
+
+**Confidence:** high
+
+---
+
+## Test Coverage Gaps
+
+| File | Untested Behavior | Suggested Test |
+|------|-------------------|----------------|
+| BankServiceBukkit.kt | Deposit/withdraw refund paths when vault credit fails after player debit | Mock `vaultInventoryManager.depositGold` to throw, verify player refund logic |
+| BankServiceBukkit.kt | Withdrawal re-credit when player payout fails after guild debit | Mock `economy.depositPlayer` to fail, verify guild re-credit |
+| BankServiceBukkit.kt | Balance leaderboard cache invalidation under concurrent access | Concurrent deposit + getTopBalances test |
+| GuildServiceBukkit.kt | Guild creation rollback when rank creation fails | Mock `rankService.createDefaultRanks` to return false, verify guild removed |
+| GuildServiceBukkit.kt | Ownership transfer atomicity — rollback on second update failure | Mock second `memberRepository.update` to fail, verify first is rolled back |
+| GuildServiceBukkit.kt | setTag with nested MiniMessage tags | Test `countVisibleCharacters` with `<gradient><bold>text</bold></gradient>` |
+| GuildServiceBukkit.kt | setHomeAllowedRanks sanitizes non-guild rank IDs | Pass rank IDs from another guild, verify they're filtered |
+| GuildVaultServiceBukkit.kt | Vault removal with concurrent inventory access | Simulate player closing inventory during removal |
+| GuildVaultServiceBukkit.kt | placeVaultChest on non-air block | Verify behavior when block is not AIR or CHEST |
+| GuildRolePermissionResolverBukkit.kt | Cache invalidation on rank change | Change rank, verify permission cache is cleared |
+| GuildInvitationManager.kt | Concurrent initialize + addInvite | Thread-safety test for lateinit repository |
+| PartyServiceBukkit.kt | Single-guild party creation by leader of different guild | Verify leader's guild must be in party.guildIds |
+| PartyServiceBukkit.kt | Party dissolve when last guild leaves | Verify party status becomes DISSOLVED |
+| RelationServiceBukkit.kt | Legacy null-requestingGuildId rows can be accepted | Create relation with null requestingGuildId, verify accept flow |
+| RelationServiceBukkit.kt | Stale terminal rows are reused for new alliance requests | Create REJECTED row, verify new PENDING alliance reuses it |
+| WarServiceBukkit.kt | War wager rollback on second guild deduction failure | Mock second deductFromGuildBank to fail, verify first is refunded |
+| WarServiceBukkit.kt | Expired war draw condition with equal kills | Create war with equal kills, verify draw |
+| WarServiceBukkit.kt | canGuildDeclareWar vs declareWar maxWars inconsistency | Test guild at progression war limit vs hardcoded limit |
+| TeleportationService.kt | Teleport cancellation during active countdown | Start teleport, cancel, verify no onSuccess callback |
+| TeleportationService.kt | Concurrent startTeleport for same player | Verify old session is properly cleaned up |
+| CombatServiceBukkit.kt | PvP block reasons with actual guild membership | Integration test with real MemberService |
+| DailyWarCostsServiceBukkit.kt | Double application after server restart | Simulate restart, verify costs not applied twice |
+| PhysicalCurrencyServiceBukkit.kt | Non-divisible amount deduction | Test with itemValue=5, amount=12 |
+| NexoEmojiService.kt | FontManager reflection failure | Test with Nexo unavailable, verify graceful fallback |
+| LeaderboardServiceBukkit.kt | toSimple/toExtended round-trip consistency | Verify all ExtendedLeaderboardType values round-trip correctly |
+| BarChartRenderer.kt | Single-entry kill ranking chart | Verify no division by zero |
+| AsyncTaskService.kt | Cancellation race in runAsyncCallback | Test coroutine cancellation between task() and callback dispatch |
+
+---
+
+## Layer Boundary Check
+
+**Verdict: PASS with minor violations.**
+
+The infrastructure services correctly depend on application-layer ports (interfaces like `BankService`, `GuildService`, `MemberService`, etc.) and persistence repositories (`BankRepository`, `GuildRepository`, etc.). Bukkit/Spigot API usage is properly contained within infrastructure services.
+
+**Minor violations found:**
+
+1. **PlayerMetadataServiceVault.kt** — directly imports `net.lumalyte.lg.config.MainConfig` (config model) instead of going through `ConfigService`. This is a layer boundary leak: infrastructure should depend on application services, not config models.
+
+2. **NexoEmojiService.kt** — directly imports `net.lumalyte.lg.application.services.ConfigService` but also accesses `plugin.config` (Bukkit API) directly for emoji permission prefix. Mixed access pattern.
+
+3. **GuildRichPresenceService.kt** — reads `plugin.config` directly (line 66) instead of using `ConfigService`, creating a direct dependency on Bukkit's FileConfiguration.
+
+4. **GuildNotificationService.kt** — same pattern: reads `plugin.config` directly for notification icons and enabled flags.
+
+5. **GuildTeamService.kt** — reads `plugin.config` directly for team colors and settings.
+
+6. **GuildWaypointService.kt** — reads `plugin.config` directly for waypoint colors.
+
+7. **MapRendererServiceBukkit.kt** — reads `config.width` and `config.height` from `ChartConfig` (application layer) which is correct, but `getCacheStatistics` returns raw config values.
+
+**No domain-layer violations found** — domain entities and enums are used correctly without importing infrastructure or Bukkit types.
+
+**No application-layer violations found** — application services are not imported by domain (this audit didn't check domain/application directly, but no evidence of violations was seen in the infrastructure files).
+
+---
+
+## Summary
+
+| Severity | Count |
+|----------|-------|
+| crit | 0 |
+| high | 7 |
+| med | 18 |
+| low | 22 |
+| **Total** | **47** |
+
+**Key risk areas:**
+1. **CombatServiceBukkit** — completely non-functional (placeholder implementation)
+2. **BankServiceBukkit** — withdrawal validation uses deposit ranges
+3. **GuildBannerService** — no permission check on banner operations
+4. **WarServiceBukkit** — all state in-memory only, inconsistent war limit checks
+5. **NexoEmojiService** — fragile reflection-based integration with profane comments
+6. **VisualisationService** — excessive INFO logging, type mismatch in async refresh

--- a/docs/audit/audit-ix-commands.md
+++ b/docs/audit/audit-ix-commands.md
@@ -1,0 +1,294 @@
+# Audit Report: interaction/{commands,help,listeners}
+
+**Scope:** 48 files under `src/main/kotlin/net/lumalyte/lg/interaction/`
+**Branch:** `fix/audit-ix-commands`
+**Methodology:** docs/audit-ix-commands-plan.md (findings-only, no source modified)
+
+---
+
+## Findings
+
+### [SEV: high] PartitionsCommand.kt:43 — paginated loop uses `page` as iteration count offset instead of per-page window
+
+**What:** The `for` loop iterates `0..9 + page`, which means for page 2 it loops `0..11`, page 3 loops `0..12`, etc. Each subsequent page shows *more* items than the first, and items from the previous page are not skipped. The `ClaimListCommand` also has the same pattern at line 45 (`val startIndex = page * 10` is computed but never used — the loop hard-codes `0..9 + page`).
+
+**Why it matters:** Page 2 should show items 10–19, but instead shows items 0–11. Page overlap and increasingly wide windows on higher pages. If the claim has > 10 partitions, players cannot navigate to "page 2" correctly. Combined with the guard on line 33 (`page * 10 - 9 > partitions.count()`), the valid page range is also calculated incorrectly (off-by-one against the actual window size).
+
+**Suggested fix:** Replace the loop with a proper `subList((page-1)*10, min(page*10, total))` window, matching `ClaimListCommand`'s pattern (which has the right idea on line 45 but doesn't use it).
+
+**Confidence:** high
+
+---
+
+### [SEV: high] ToolRemovalListener.kt:129-138 — `onPlayerDeath` builds removal list but never removes items from drops
+
+**What:** The handler iterates `event.drops`, identifies key items (claim tools, move tools) and adds them to `itemsToRemove`, but then never calls `event.drops.removeAll(itemsToRemove)`. The list is accumulated and discarded.
+
+**Why it matters:** Players who die while holding a claim tool or move tool will drop it on the ground, where any other player can pick it up. This defeats the entire `ToolRemovalListener` design, which exists specifically to prevent these items from leaving the player's inventory through any channel. An attacker could kill a player to obtain their claim tool.
+
+**Suggested fix:** Add `event.drops.removeAll(itemsToRemove)` after the loop.
+
+**Confidence:** high
+
+---
+
+### [SEV: med] ClaimCommand.kt:54-69 — `isPlayerHasClaimPermission` checks claim ownership but not guild membership for guild-owned claims
+
+**What:** The permission check only verifies that `player.uniqueId == claim.playerId` (the claim owner). For guild-owned claims (where `claim.teamId != null`), it does not check whether the player is a member of the owning guild. Any guild member should be able to manage guild-owned claims, but only the original claim creator can.
+
+**Why it matters:** A guild creates a claim, later has member turnover, and the original owner leaves — the guild loses the ability to manage its own claims unless the owner is still present. This is likely a design gap rather than an intentional restriction, but it breaks the guild-claim workflow.
+
+**Suggested fix:** When `claim.teamId != null`, check guild membership (and optionally the `MANAGE_CLAIMS` permission) instead of requiring `playerId == claim.playerId`.
+
+**Confidence:** med
+
+---
+
+### [SEV: med] InfoCommand.kt:53 — `Bukkit.getOfflinePlayer(player.uniqueId)` uses wrong UUID for owner name lookup
+
+**What:** Line 53 uses `player.uniqueId` (the *command sender's* UUID) to look up the offline player name, then displays it as the "Owner" of the claim. It should use `claim.playerId` (the claim owner's UUID) instead. If player A runs `/claim info` on player B's claim, the owner name shown is A's name, not B's.
+
+**Why it matters:** The info display misattributes ownership. Players checking claim info will see their own name as owner even when inspecting another player's claim — confusing for trust decisions and moderation.
+
+**Suggested fix:** Replace `Bukkit.getOfflinePlayer(player.uniqueId)` with `Bukkit.getOfflinePlayer(claim.playerId)`.
+
+**Confidence:** high
+
+---
+
+### [SEV: med] WorldClaimProtectionListener.kt:191,224,397,411 — unreachable `else -> return` branches in piston/fluid handlers
+
+**What:** In `onBlockPistonExtendEvent` (line 191), `onBlockPistonRetractEvent` (line 224), `onSpongeAbsorb` (line 396-397), and `onLightningStrike` (line 411), the `else -> return` branch inside the `when` block causes the function to return early when `isWorldActionAllowed` returns a non-Denied result. This means only the *first* affected block/location is checked; subsequent locations in the loop are never evaluated.
+
+**Why it matters:** If a piston extends into multiple claims, only the first block's claim is checked. The remaining blocks could be in a claim that disallows pistons, but the event won't be cancelled. Same issue for sponge absorption affecting multiple blocks across claim boundaries — only the first block is validated.
+
+**Suggested fix:** Remove `else -> return` (and the corresponding `else -> continue` in sponge handler) so the loop continues checking all affected locations.
+
+**Confidence:** high
+
+---
+
+### [SEV: med] ChatInputListener.kt:77-119 — three separate fallback event handlers with same priority create duplicate processing
+
+**What:** Three `@EventHandler` methods (`onPlayerChatFallbackHighest`, `onPlayerChatFallbackLowest`, `onPlayerChatFallbackMonitor`) all listen for the deprecated `AsyncPlayerChatEvent` and all call `handleChatInputFallback` if the player is in input mode. With HIGHEST priority the handler always fires; LOWEST fires concurrently; MONITOR fires as well. The HIGHEST handler already cancels the event, so the LOWEST/MONITOR handlers process an already-cancelled event redundantly.
+
+**Why it matters:** `handleChatInputFallback` calls `event.isCancelled = true` and `stopInputMode(player)` on every invocation. With multiple handlers firing for the same event, `stopInputMode` is called multiple times (harmless but noisy). More concerning: if a future refactor changes one handler but not others, the MONITOR handler could process input even when HIGHEST was supposed to block it.
+
+**Suggested fix:** Use a single `@EventHandler` for the fallback. If multiple priorities are needed for compat, gate on `!event.isCancelled`.
+
+**Confidence:** med (could be intentional compat, but the triple-registration is suspicious)
+
+---
+
+### [SEV: med] LumaGuildsCommand.kt:463-469 — filename regex double-escapes hyphen and permits backslash
+
+**What:** `isValidFileName` uses `Regex("^[a-zA-Z0-9_\\\\-.]{1,100}$")`. The `\\\\` in the string literal becomes `\\` in the regex, which matches a literal backslash character. Combined with the hyphen placement, the regex allows filenames containing `\` (backslashes), which on most JVM platforms does not enable path traversal (the file is still resolved under `temp_exports/` by `Path.resolve`), but it's imprecise and could confuse file listing.
+
+**Why it matters:** A filename like `foo\bar.csv` would pass validation. While `Path.resolve` prevents actual directory traversal, the backslash in the filename could cause issues on Windows or with downstream consumers that split on `/`.
+
+**Suggested fix:** Replace `\\\\-` with just `-` at the end of the character class: `Regex("^[a-zA-Z0-9_.-]{1,100}$")`.
+
+**Confidence:** high
+
+---
+
+### [SEV: med] PartitionUpdateListener.kt:59 — `players.add(player)` called unconditionally after `isPlayerVisualising` check
+
+**What:** Line 60 calls `players.add(player)` *after* the `when` block, outside the `Success` branch. Line 57 adds the player only on `IsPlayerVisualisingResult.Success`, but line 60 then unconditionally adds every nearby player regardless of whether they're visualising. This means players who are not visualising also get their visualisation refreshed (which is a no-op) but wastes DB calls.
+
+**Why it matters:** Unnecessary `refreshVisualisation.execute` calls for every player in the chunk, including those not holding a tool. Under load with many nearby players this adds useless work.
+
+**Suggested fix:** Move `players.add(player)` inside the `Success` branch of the `when` block.
+
+**Confidence:** high
+
+---
+
+### [SEV: med] ClaimListCommand.kt:45 — startIndex computed but never used for subList bounds
+
+**What:** `val startIndex = page * 10` is computed on line 45, but line 47 calls `playerClaims.subList(startIndex, endIndex)` — which is correct. However, the validation on line 36 uses `page * 10 - 9 > playerClaims.count()` which is the 1-based first-item-of-current-page check. This formula is off: for page 1 it checks `1 > count()` (fine), for page 2 it checks `11 > count()` (should be `10 >= count()`). The guard allows page 2 when `count() == 11` (showing items 10..11), but rejects page 2 when `count() == 10` (correct).
+
+Actually, re-checking: for page=2, count=10: `20-9=11 > 10` → true → rejects. That's correct (no items on page 2). For page=2, count=11: `20-9=11 > 11` → false → allows, showing items 10..11 (2 items). Also correct. The formula is actually equivalent to `(page-1)*10 >= count()`. This is fine.
+
+**On closer inspection, this is not a bug.** Reverting to "no finding" for this item.
+
+**Confidence:** N/A (false positive)
+
+---
+
+### [SEV: low] BedrockCacheStatsCommand.kt:21 — permission check uses raw string `hasPermission` on `CommandSender`
+
+**What:** `sender.hasPermission("lumalyte.bedrock.cache.stats")` is a Bukkit standard check, but unlike the rest of the codebase which uses ACF's `@CommandPermission` annotation, this command (being a raw `CommandExecutor`) relies entirely on manual checks. Missing the annotation means ACF's tab-completion and help won't auto-detect the permission.
+
+**Why it matters:** Minor inconsistency. The permission string `lumalyte.bedrock.*` also differs from the `lumaguilds.*` convention used by ACF commands — could confuse administrators reading config files.
+
+**Suggested fix:** Consider migrating to ACF annotations or at least documenting the permission node divergence.
+
+**Confidence:** low (style nit)
+
+---
+
+### [SEV: low] LumaGuildsCommand.kt:118-121,252-256,283-286,426-432 — catch-all Exception handlers in command methods swallow stack traces
+
+**What:** Four `catch (e: Exception)` blocks in `handleDownload`, `handleReload`, `handleProgressionReload`, and `handleMigrate` print `e.message` to the player but do not log the full stack trace to the server log. Only `handleMigrate` prints `e.printStackTrace()`.
+
+**Why it matters:** Silent failure modes make debugging harder. A storage error or NPE in reload would show a generic message to the player with no server-side trace.
+
+**Suggested fix:** Add `plugin.logger.severe(...)` or `e.printStackTrace()` in all catch blocks.
+
+**Confidence:** med
+
+---
+
+### [SEV: low] ClaimAnchorListener.kt:152-184 — infinite loop risk in NameAlreadyExists retry
+
+**What:** The retry logic at line 167-173 uses `while (true)` with an unconditional `break` at line 172. The loop body never actually checks if `uniqueName` is available in the database — it just appends a counter and breaks on the first iteration. If the retried `uniqueName` *also* already exists, `createClaim.execute` will return `NameAlreadyExists` again, and the handler sends a generic failure message without further retry.
+
+**Why it matters:** The loop is not infinite (it always breaks), but it provides a false sense of safety. If two claims have the same default name and the first retry also collides, creation fails with an unhelpful message.
+
+**Suggested fix:** Either query the database for the next available name or wrap in a bounded retry loop (e.g., 10 iterations) with a proper uniqueness check.
+
+**Confidence:** med
+
+---
+
+### [SEV: low] ClaimAnchorListener.kt:152,194 — `println` debug statements left in production code
+
+**What:** Lines 153, 179, 194, and 195 use `println("[DEBUG] ...")` and `e.printStackTrace()` for error reporting. These bypass the plugin logger and will appear on stdout with no level control.
+
+**Why it matters:** Debug noise in production. Stack traces sent to stdout are not captured by log aggregators configured for SLF4J.
+
+**Suggested fix:** Replace with `plugin.logger.info/severe(...)` calls.
+
+**Confidence:** high
+
+---
+
+### [SEV: low] PartyChatListener.kt:101,108,126 — misleading comments reference "line 71" for event cancellation
+
+**What:** Comments say "Event already cancelled at line 71" but the cancellation is at line 76 (`event.isCancelled = true`). Line 71 is `val playerId = player.uniqueId`.
+
+**Why it matters:** Misleading comments confuse future maintainers who may look for the cancellation point.
+
+**Suggested fix:** Update comments to reference the correct line numbers.
+
+**Confidence:** high
+
+---
+
+### [SEV: low] PlayerClaimProtectionListener.kt:553,574 — `onPotionSplash` and `onAreaEffectCloudApply` use `return` inside `for` loop
+
+**What:** In both handlers, `if (entity is Monster || entity is Player) return` will *return from the entire function* rather than `continue` to skip the current entity. If the first affected entity is a Monster, all subsequent entities (including non-monster entities in claims) are not filtered.
+
+**Why it matters:** Potion splash protection is incomplete. A splash hitting a zombie first and then animals in a claim-area will not protect the animals.
+
+**Suggested fix:** Replace `return` with `continue` in both handlers.
+
+**Confidence:** high
+
+---
+
+### [SEV: low] ClaimDestructionListener.kt:97-105 — NamespacedKey uses hardcoded plugin ID instead of `PluginKeys` constant
+
+**What:** `NamespacedKey("bellclaims","claim")` is used directly instead of importing and using the existing `PluginKeys` constants. The domain module already uses `"bellclaims"` in other places but the convention in this codebase is to centralize under `PluginKeys`.
+
+**Why it matters:** If the plugin namespace ever changes, this hardcoded string would be missed.
+
+**Suggested fix:** Add a constant to `PluginKeys` and reference it.
+
+**Confidence:** low (style nit)
+
+---
+
+### [SEV: low] DescriptionCommand.kt:49 — uses `name.count().toString()` instead of `description.count().toString()`
+
+**What:** In the `ExceededCharacterLimit` branch, the displayed count uses `name` (a parameter that doesn't exist in this scope — it's a compilation error). Looking more carefully: the variable is `name` at line 49, but the parameter is called `description` (line 24). This won't compile.
+
+**Wait — re-checking:** Line 49: `arrayOf(name.count().toString(), firstError.maxCharacters)`. The parameter is `description: String` on line 24. There is no `name` variable in scope. This is a compilation error.
+
+**Why it matters:** This code path (text exceeding the character limit) would fail to compile. If forced to compile via some IDE quirk, it would throw a `NoSuchFieldError` or `UnresolvedReferenceException`.
+
+Actually wait — let me re-read. Line 49 is inside `DescriptionCommand.kt`. The parameter is `description`. The variable `name` is not defined. This is definitely a compilation error.
+
+**Suggested fix:** Replace `name.count()` with `description.length`.
+
+**Confidence:** high
+
+---
+
+### [SEV: low] RenameCommand.kt:54 — same `name.count()` vs `name.length` issue as DescriptionCommand
+
+**What:** Line 54: `arrayOf(name.count().toString(), firstError.maxCharacters)`. The parameter is `name: String`. `String.count()` returns the number of characters (same as `.length`), so this actually works in Kotlin, just uses a non-idiomatic call. Unlike the DescriptionCommand case, this compiles fine.
+
+**Why it matters:** Nit — `.length` is the Kotlin idiom for string length.
+
+**Suggested fix:** Replace `name.count()` with `name.length`.
+
+**Confidence:** low (style nit, compiles correctly in Kotlin)
+
+---
+
+### [SEV: low] HarvestReplantListener.kt:19 — handler named `onInventoryClose` but handles `PlayerInteractEvent`
+
+**What:** The method is named `onInventoryClose` and takes `PlayerInteractEvent`. The method body handles right-click harvest logic, not inventory closing.
+
+**Why it matters:** Extreme naming confusion. Any developer searching for inventory-close handlers will find this, and vice versa.
+
+**Suggested fix:** Rename to `onPlayerHarvestCrop` or similar.
+
+**Confidence:** high
+
+---
+
+### [SEV: low] EditToolListener.kt:148-155 — variable names swapped in `onToolSwitch`
+
+**What:** Line 148: `val partitionResizer = firstSelectedCornerResize[event.player.uniqueId]` but the comment says "Cancel claim resizing". Line 153: `val partitionBuilder = firstSelectedCornerCreate[event.player.uniqueId]` but the comment says "Cancel claim building". The variables are fetched from the *opposite* maps: `partitionResizer` comes from `firstSelectedCornerResize` (the resize map, correct), but then the *next* block uses `partitionBuilder` from `firstSelectedCornerCreate` for the unequip message line 153. The message on line 153 says "UNEQUIP_RESIZE" which is correct for the resize map. The logic is actually correct but the variable naming in the second block is misleading — `partitionBuilder` from `firstSelectedCornerCreate` correctly handles the build-cancel case.
+
+**Re-checking:** Lines 137-139: check `firstSelectedCornerResize` → if present, remove from `firstSelectedCornerResize` (correct). Lines 148-150: check `firstSelectedCornerCreate` → if present, remove from `firstSelectedCornerCreate` (correct). Variable names are swapped (resizer vs builder) relative to the maps they read, but the logic is symmetric and correct.
+
+**No actual bug — reverting to no finding.**
+
+---
+
+### [SEV: low] GuildCommand.kt:107-145 — guild name validation duplicated between `onCreate` and `onRename`
+
+**What:** The same 4-step validation (MiniMessage tags, blank, length, invalid chars) is copy-pasted. If validation rules change, both must be updated.
+
+**Why it matters:** Maintenance burden and risk of divergence.
+
+**Suggested fix:** Extract to a shared `validateGuildName` helper.
+
+**Confidence:** med
+
+---
+
+## Test Coverage Gaps
+
+| Untested Behavior | Suggested Test |
+|---|---|
+| `PartitionsCommand` pagination correctness (page 2+, boundary conditions) | Unit test with 15+ partitions, verify page 1 shows items 0-9, page 2 shows items 10-14 |
+| `ClaimListCommand` pagination with edge pages | Unit test: exactly 10 claims (page 2 should reject), 11 claims (page 2 should show 1 item) |
+| `ToolRemovalListener.onPlayerDeath` actually removes key items from drops | Integration test: player dies with claim tool in inventory, verify `event.drops` is empty of key items |
+| `InfoCommand` owner name uses `claim.playerId` not sender | Unit test: player A inspects player B's claim → owner name is B |
+| `isPlayerHasClaimPermission` with guild-owned claims | Integration test: non-owner guild member runs `/claim rename` on guild-owned claim → succeeds |
+| `WorldClaimProtectionListener` multi-block piston checks | Unit test extending both ends different, both disallow → event cancelled |
+| `DescriptionCommand` character limit error path | Unit test with description exceeding max → error message contains correct count |
+| `ChatInputListener` cancels chat and routes to handler | Mock test: player in input mode types "hello" → chat cancelled, handler called |
+| `ClaimAnchorListener` NameAlreadyExists retry | Unit test with pre-existing default name → retry succeeds or fails cleanly |
+| `EditToolListener.onToolSwitch` symmetry (resize/build cancel) | Unit test: player holding tool switches slot → correct visualisation cleared |
+| `ClaimOverrideCommand` toggle + persistence | Unit test: toggle on → hasOverride=true persists across action execution |
+
+---
+
+## Layer Boundary Check
+
+**Verdict: PASS with one note.**
+
+- `interaction/commands/**` imports only from `application.actions`, `application.results`, `application.utilities`, `domain.entities`, `domain.values`, and `infrastructure.adapters` (adapters are interaction-layer infrastructure, acceptable). No direct Bukkit imports in command handlers except `org.bukkit.entity.Player`, which is the standard ACF command context type and is acceptable at the interaction layer.
+- `interaction/help/**` imports only `domain.values` and `interaction.help` — clean.
+- `interaction/listeners/**` imports `infrastructure.adapters`, `infrastructure.services`, `application.*`, `domain.*`, and Bukkit API. All Bukkit usage is in event handler code (the interaction layer is allowed to touch Bukkit).
+- One minor note: `GuildCommand.kt` imports `net.lumalyte.lg.utils.deserializeToItemStack` and `GuildHomeSafety` from `utils` — these are in the `net.lumalyte.lg.utils` package which is neither `application` nor `domain` but is a cross-cutting utility package. Not a layer violation, but worth monitoring if utils grow application-layer dependencies.
+- `EditToolListener.kt` imports `kotlin.concurrent.thread` — this is a stdlib primitive, not a layer violation.
+- `LumaGuildsCommand.kt` (raw `CommandExecutor`) imports `net.lumalyte.lg.LumaGuilds` (the plugin class). This is acceptable for lifecycle operations (reload, migrate) that need the plugin instance.
+
+**No hardcore layer violations found.** All interaction-layer files respect the hexagonal boundary: no `domain` code imports from here, and `interaction` code only reaches into `application` (ports/results) and `infrastructure` for adapters/services.

--- a/docs/audit/audit-ix-menus-a.md
+++ b/docs/audit/audit-ix-menus-a.md
@@ -1,0 +1,347 @@
+# Audit Report: audit-ix-menus-a
+
+**Batch:** interaction/menus (first 69 files)
+**Branch:** fix/audit-ix-menus-a
+**Scope:** `interaction/menus` — Menu.kt, MenuFactory.kt, MenuNavigator.kt, bedrock/*, common/ConfirmationMenu.kt, guild/AllianceRequestMenu.kt, guild/AlliesListMenu.kt, guild/AllyHomeAccessMenu.kt, guild/DescriptionEditorMenu.kt
+
+---
+
+## Findings
+
+### [SEV: high] BedrockClaimManagementMenu.kt:61 — Button index mismatch for guild±claim convert vs. transfer
+
+**What:** When `claim.teamId == null`, button 4 triggers `handleConvertToGuild()` and button 5 triggers `createClaimTransferMenu`. But when `claim.teamId != null`, button 4 falls through to `createClaimTransferMenu` and button 5 falls through to `goBack()`. The `when` block at lines 61-76 maps button indices 4 and 5 to *different* actions depending on `teamId`, yet the button labels at lines 48-53 always show "convert" at index 4 and "transfer" at index 5 regardless of `teamId`. When the claim IS guild-owned, pressing the "convert" button (index 4) actually triggers transfer, and pressing "transfer" (index 5) goes back — the user sees misleading labels.
+
+**Why it matters:** A player attempting to convert a guild-owned claim will unexpectedly be sent to the transfer menu, and a player attempting to transfer will silently go back. This is a logic bug that breaks the feature for guild-owned claims.
+
+**Suggested fix:** Reorder the `when` branches so button indices match the dynamically-added buttons. Either always add the convert button conditionally and adjust indices, or use a mapping from button-list index to action.
+
+**Confidence:** high
+
+---
+
+### [SEV: high] BedrockGuildBankMenu.kt:189 — Slider max value of 100f ignores actual balance
+
+**What:** The deposit and withdraw sliders at lines 46-67 use a hardcoded max of `100f` for the slider range, even when `playerBalance` or `guildBalance` is much larger. At line 189, `parseAmount` falls back to `slider.toInt()` when the custom input is blank — capping the usable slider amount at 100 regardless of actual balance.
+
+**Why it matters:** Players with balances > 100 cannot use the slider to deposit/withdraw their full amount. They must type a custom amount, which defeats the purpose of the slider UI. For guilds with large treasuries this makes the withdraw slider useless.
+
+**Suggested fix:** Set the slider max to `playerBalance.toFloat()` / `guildBalance.toFloat()` (capped at a reasonable upper limit). Update `parseAmount` to use the actual slider max.
+
+**Confidence:** high
+
+---
+
+### [SEV: high] BedrockClaimTransferMenu.kt:62 — Transfer request not persisted — mutation on in-memory copy
+
+**What:** Line 62 mutates `claim.transferRequests[targetPlayer.uniqueId]` directly on the in-memory `Claim` object, but never calls `claimRepository.update(claim)` to persist the change. The `transferRequests` map is modified in memory only.
+
+**Why it matters:** The transfer request is lost on server restart or when the claim object is reloaded from the database. The recipient will never see the transfer offer. This is a data-loss bug.
+
+**Suggested fix:** After mutating `claim.transferRequests`, call `claimRepository.update(claim)` to persist. Or better, add a `addTransferRequest` method to the claim repository.
+
+**Confidence:** high
+
+---
+
+### [SEV: med] BedrockClaimCreationMenu.kt:37 — Form element index 2 used for first input (off-by-one)
+
+**What:** The form is built with a title (index 0), a label (index 1), then two inputs. At line 37, `response.asInput(2)` reads the first input, and line 38 reads `asInput(3)` for the second. Cumulus form indices are 0-based and include all elements (title is not counted, but labels and inputs are). The first input is at index 2 (after title + label), second at index 3. This appears correct for Cumulus where `asInput(n)` uses the nth input slot index. However, if Cumulus `asInput` is 0-based among inputs only, these indices should be 0 and 1.
+
+**Why it matters:** If the indices are wrong, the menu reads null/empty values, causing validation to always fail or read the wrong field. The same pattern appears in many other files (BedrockClaimNamingMenu, BedrockClaimPlayerMenu, etc.) — if wrong, it's a systemic bug across all Bedrock menus.
+
+**Suggested fix:** Verify Cumulus `asInput`/`asDropdown`/`asToggle` indexing semantics. If 0-based among all form elements, the current code may be correct. If 0-based among component type, adjust all indices.
+
+**Confidence:** med
+
+---
+
+### [SEV: med] BedrockGuildModeMenu.kt:115 — handleModeSwitch button index logic is broken for PEACEFUL mode
+
+**What:** At line 116-118, `targetMode` is computed as the *opposite* of current mode. At line 122-128, when `guild.mode == PEACEFUL`, `actualButtonIndex = buttonIndex` (maps to hostile button at index 0). But when `guild.mode == HOSTILE`, `actualButtonIndex = buttonIndex` maps to peaceful button at index 0. The `when` block at 130-143 then checks `actualButtonIndex == 0` for the target mode, but the logic at line 139 checks `targetMode == HOSTILE && guild.mode == PEACEFUL` which can never be true when `actualButtonIndex == 0` in the HOSTILE branch (because `targetMode` would be PEACEFUL).
+
+**Why it matters:** When a guild is in HOSTILE mode and the user clicks button 0 (peaceful), the `when` block enters branch 0 at line 131, calls `switchToPeaceful` — which is correct. But the nested `if` at line 139 (`targetMode == HOSTILE && guild.mode == PEACEFUL`) is dead code that never fires. The logic works by accident for the first button but the second button (index 1) is never handled — if both buttons are present, clicking button 1 does nothing.
+
+**Suggested fix:** Simplify the mode switch handler. When mode is PEACEFUL, button 0 = switch to HOSTILE. When mode is HOSTILE, button 0 = switch to PEACEFUL. Remove the dead code branch.
+
+**Confidence:** med
+
+---
+
+### [SEV: med] BedrockGuildSettingsMenu.kt:248 — Blank description check uses isNotBlank() but empty string is valid
+
+**What:** Line 248 checks `newDescription.isNotBlank()` before saving. If the user clears the description (sets it to `""`), the condition is false and the description is not updated. But line 228 checks `newDescription != (guild.description ?: "")` — if the current description is `null` and the user sets it to `""`, the equality check passes and no change is detected. If the current description is `"some text"` and the user clears it to `""`, `isNotBlank()` is false and the clear is silently ignored.
+
+**Why it matters:** Users cannot clear their guild description through the Bedrock settings menu. The description will remain set even after the user explicitly empties the input field.
+
+**Suggested fix:** Change `isNotBlank()` to `isNotEmpty()` or remove the check entirely, allowing empty string to clear the description.
+
+**Confidence:** high
+
+---
+
+### [SEV: med] BedrockGuildLeaveConfirmationMenu.kt:57 — createFallbackJavaMenu uses wrong constructor signature
+
+**What:** Line 57-60 attempts to instantiate `GuildLeaveConfirmationMenu` with `(MenuNavigator, Player)` but the Java `GuildLeaveConfirmationMenu` constructor requires `(MenuNavigator, Player, Guild)`. This will throw a `NoSuchMethodException` at runtime, caught silently by the catch block at line 63.
+
+**Why it matters:** Bedrock players who trigger the fallback (e.g., Floodgate unavailable) will never see a leave confirmation menu — the fallback silently fails and returns null.
+
+**Suggested fix:** Add `guild` as the third constructor argument.
+
+**Confidence:** high
+
+---
+
+### [SEV: med] BedrockGuildControlPanelMenu.kt:179 — createFallbackJavaMenu uses wrong constructor signature
+
+**What:** Line 179-182 attempts to instantiate `GuildControlPanelMenu` with `(MenuNavigator, Player, Guild)` — but the actual Java `GuildControlPanelMenu` constructor requires additional service parameters (guildService, rankService, memberService, etc.). This will throw `NoSuchMethodException`.
+
+**Why it matters:** Same as above — fallback silently fails.
+
+**Suggested fix:** Either inject the required services into the Bedrock menu or use `menuFactory.createGuildControlPanelMenu()` instead of reflection.
+
+**Confidence:** high
+
+---
+
+### [SEV: med] BedrockGuildMemberRankConfirmationMenu.kt:17 — Uses GUILD_MEMBER_RANK_CHANGE permission check via memberService.hasPermission but should use RankPermission.MANAGE_RANKS
+
+**What:** The `changeMemberRank` call at line 83 passes `player.uniqueId` as the actor, but there is no permission check before the call. The BedrockGuildPromotionMenu (line 125) correctly checks `RankPermission.MANAGE_RANKS`, but BedrockGuildMemberRankConfirmationMenu does not check any permission before calling `changeMemberRank`.
+
+**Why it matters:** Any player who can open the rank confirmation menu can change ranks without the MANAGE_RANKS permission. The permission check should happen before the confirmation dialog is shown, not after.
+
+**Suggested fix:** Add a `guildService.hasPermission(player.uniqueId, guild.id, RankPermission.MANAGE_RANKS)` check before showing the confirmation form.
+
+**Confidence:** med
+
+---
+
+### [SEV: med] BedrockGuildInviteConfirmationMenu.kt:59 — Opens GuildMemberManagementMenu (Java) instead of BedrockGuildMemberManagementMenu
+
+**What:** Line 72 opens `GuildMemberManagementMenu(menuNavigator, player, guild)` — the Java inventory GUI class — after sending a Bedrock invite. A Bedrock player will not be able to interact with a ChestGui-based menu.
+
+**Why it matters:** After sending an invite, Bedrock players are shown a Java inventory GUI they cannot use, breaking the navigation flow.
+
+**Suggested fix:** Open `BedrockGuildMemberManagementMenu` instead.
+
+**Confidence:** high
+
+---
+
+### [SEV: med] BedrockGuildKickConfirmationMenu.kt:72 — Opens GuildMemberManagementMenu (Java) instead of BedrockGuildMemberManagementMenu
+
+**What:** Same issue as above — line 72 opens the Java `GuildMemberManagementMenu` after a Bedrock kick confirmation.
+
+**Why it matters:** Bedrock players see a Java GUI they cannot interact with.
+
+**Suggested fix:** Open `BedrockGuildMemberManagementMenu` instead.
+
+**Confidence:** high
+
+---
+
+### [SEV: low] BedrockFormUtils.kt:63 — println instead of logger for form image errors
+
+**What:** Lines 63 and 76 use `println()` for error logging instead of a proper logger instance. This bypasses the plugin's logging configuration and appears on stdout rather than the server log.
+
+**Why it matters:** Errors in production are invisible to server administrators who monitor log files rather than stdout.
+
+**Suggested fix:** Accept a `Logger` parameter or use the plugin logger.
+
+**Confidence:** high
+
+---
+
+### [SEV: low] BedrockGuildBankMenu.kt:220 — Redundant bedrockMenusEnabled check in showTransactionConfirmation
+
+**What:** Line 220 checks `config.bedrockMenusEnabled` to decide between ModalForm and message confirmation. But this menu is already only shown to Bedrock players (the `shouldUseBedrockMenus` check in MenuFactory gates this). The config check is redundant and if `bedrockMenusEnabled` is toggled off at runtime, the fallback sends a chat message and immediately executes transactions without confirmation (line 251).
+
+**Why it matters:** Transactions could be executed without confirmation if the config is toggled mid-session.
+
+**Suggested fix:** Always use the ModalForm confirmation path in this menu, since it's already gated by the Bedrock platform check.
+
+**Confidence:** med
+
+---
+
+### [SEV: low] BedrockGuildMemberListMenu.kt:101 — createMemberListContent counts online members but button 0 opens member list (not a specific member)
+
+**What:** Button 0 at line 101 is labeled "Member list" and calls `handleMemberSelection(members)`, which shows `BedrockGuildMemberManagementMenu`. But the button text at line 101 says "Member list" — it's confusing because the content already shows the member list. The button doesn't actually show individual member details.
+
+**Why it matters:** UX confusion — the button labeled as the member list opens a different menu.
+
+**Suggested fix:** Either make button 0 open a detailed member browser, or relabel it to "Manage Members".
+
+**Confidence:** low
+
+---
+
+### [SEV: low] BedrockGuildSelectionMenu.kt:199 — Direct FloodgateApi.sendForm call bypasses BaseBedrockMenu.open()
+
+**What:** Line 199-200 calls `FloodgateApi.getInstance().sendForm()` directly instead of using `menuNavigator.openMenu()`. This bypasses the navigation stack, timeout handling, and error handling in `BaseBedrockMenu.open()`.
+
+**Why it matters:** The summary form won't have timeout tracking, and if the form fails to send, there's no error handling. It also won't appear in the navigation stack for back-button handling.
+
+**Suggested fix:** Wrap the summary form in a proper `BaseBedrockMenu` subclass and use `menuNavigator.openMenu()`.
+
+**Confidence:** med
+
+---
+
+### [SEV: low] BedrockGuildRelationsMenu.kt:127 — Multiple anonymous BaseBedrockMenu subclasses for sub-menus
+
+**What:** Throughout the file (lines 173, 232, 292, 365, 454, 518, 606, 663, 722, 832), anonymous `BaseBedrockMenu` instances are created to wrap forms with handlers. These anonymous classes don't implement `getFormCached()`, `shouldCacheForm()`, or `createCacheKey()`, so caching is never enabled for sub-menus.
+
+**Why it matters:** Minor — sub-menus don't benefit from form caching. Not a bug but a missed optimization.
+
+**Suggested fix:** Extract named classes or use a shared wrapper that delegates caching.
+
+**Confidence:** low
+
+---
+
+### [SEV: low] FormStateManager.kt:33 — ScheduledExecutorService cleanup task has no error handling
+
+**What:** The `cleanupExpiredStates` method at line 86 iterates `stateStorage` entries and removes expired ones. If `remove()` throws (e.g., concurrent modification), the scheduled task will stop running silently.
+
+**Why it matters:** After a concurrent modification exception, expired states are never cleaned up, causing memory leaks.
+
+**Suggested fix:** Wrap the cleanup loop in a try-catch.
+
+**Confidence:** med
+
+---
+
+### [SEV: low] BedrockGuildWarDeclarationMenu.kt:238 — Unsafe cast to WarServiceBukkit
+
+**What:** Line 238 casts `warService` to `WarServiceBukkit` using `as?`. If the service is not a `WarServiceBukkit` instance (e.g., in tests or with a different implementation), `declaration` is null and the code falls through to the `else` branch which calls `declareWar` without wager/terms support.
+
+**Why it matters:** The war declaration feature silently degrades if the service implementation changes.
+
+**Suggested fix:** Add the `createWarDeclaration` method to the `WarService` interface or handle the null case explicitly.
+
+**Confidence:** med
+
+---
+
+### [SEV: low] BedrockGuildModeMenu.kt:90 — addPeacefulButton/addHostileButton are extension functions that always add a button
+
+**What:** The `addPeacefulButton` method at line 90 always calls `button(buttonText)` regardless of `canSwitch`. When the player cannot switch, the button is still added but is greyed out. This means the form always has both buttons (one greyed, one active), which is correct UX. However, the `handleModeSwitch` method at line 115 doesn't account for the case where only one button is present — it always assumes both buttons exist.
+
+**Why it matters:** If the form builder is refactored to conditionally add buttons, the handler indices will be wrong.
+
+**Suggested fix:** Document the invariant or make the handler dynamically determine which button was clicked.
+
+**Confidence:** low
+
+---
+
+### [SEV: low] BedrockTagEditorMenu.kt:245 — giveQRCodeMap uses com.google.zxing (QR code library) in a menu handler
+
+**What:** The `giveQRCodeMap` method generates QR codes using zxing and creates map items with custom renderers. This is a significant side effect (item generation, map creation) triggered from a menu handler. If the library is missing or the map creation fails, the exception is caught and re-thrown at line 304, which will propagate up and potentially crash the form handler.
+
+**Why it matters:** A missing dependency or Bukkit map rendering issue could cause the entire tag editor form to fail.
+
+**Suggested fix:** Add a feature flag for the QR code functionality and handle errors gracefully without re-throwing.
+
+**Confidence:** med
+
+---
+
+### [SEV: low] MenuFactory.kt:310 — Koin GlobalContext.get() direct service resolution in createPartyCreationMenu
+
+**What:** Line 310-314 uses `org.koin.core.context.GlobalContext.get().get<T>()` to resolve services directly from the Koin container, bypassing the factory's constructor-injected dependencies. This is inconsistent with the rest of the factory which uses constructor injection.
+
+**Why it matters:** If the Koin context is not initialized or the services are not registered, this will throw at runtime. It also makes testing harder.
+
+**Suggested fix:** Inject `GuildService`, `PartyService`, `RankService`, `MemberService`, `ChatInputListener` into the `MenuFactory` constructor.
+
+**Confidence:** high
+
+---
+
+### [SEV: low] MenuFactory.kt:345 — Same Koin GlobalContext.get() pattern in createGuildControlPanelMenu
+
+**What:** Lines 345-351 use the same direct Koin resolution pattern for `GuildService`, `RankService`, `MemberService`, `GuildVaultService`, `ProgressionService`, `ProgressionRepository`.
+
+**Why it matters:** Same as above.
+
+**Suggested fix:** Inject these services into the constructor.
+
+**Confidence:** high
+
+---
+
+### [SEV: low] BedrockGuildMemberRankConfirmationMenu.kt:83 — changeMemberRank called without permission check in menu
+
+**What:** The `changeMemberRank` call at line 83 is the actual state-changing operation. While the Java `GuildMemberRankConfirmationMenu` may check permissions before opening, the Bedrock version does not verify `MANAGE_RANKS` before showing the confirmation form. A player without the permission can open the confirmation and click "Change Rank", which will call `changeMemberRank` — the permission check happens inside the service, but the user experience is confusing (showing a confirmation for an action that will fail).
+
+**Why it matters:** Poor UX and potential for confusion. The service will reject the change, but the user sees a success/failure message only after confirming.
+
+**Suggested fix:** Check `MANAGE_RANKS` permission before building the form, similar to `BedrockGuildPromotionMenu`.
+
+**Confidence:** med
+
+---
+
+## Test Coverage Gaps
+
+| # | Untested Behavior | File | Test That Should Exist |
+|---|-------------------|------|------------------------|
+| 1 | Bedrock menu form response handling (all menus) | All Bedrock menu files | Unit tests verifying form button indices map to correct actions |
+| 2 | Claim transfer request persistence | BedrockClaimTransferMenu | Test that transfer request is persisted to repository |
+| 3 | Guild mode switch cooldown enforcement | BedrockGuildModeMenu | Test that cooldown prevents mode switch and shows correct message |
+| 4 | Guild settings description clearing | BedrockGuildSettingsMenu | Test that empty description string clears the guild description |
+| 5 | Bank transaction slider max values | BedrockGuildBankMenu | Test that slider max reflects actual player/guild balance |
+| 6 | Claim management button index mapping | BedrockClaimManagementMenu | Test that convert/transfer buttons work for both guild-owned and non-guild-owned claims |
+| 7 | Fallback Java menu constructor signatures | BedrockGuildLeaveConfirmationMenu, BedrockGuildControlPanelMenu | Test that fallback menu instantiation succeeds |
+| 8 | FormStateManager expiration and cleanup | FormStateManager | Test that expired states are cleaned up and concurrent access is safe |
+| 9 | BedrockGuildSelectionMenu pagination | BedrockGuildSelectionMenu | Test that pagination correctly calculates page boundaries |
+| 10 | War declaration wager escrow | BedrockGuildWarDeclarationMenu | Test that wager is escrowed and refunded on failure |
+| 11 | MenuFactory Koin direct resolution | MenuFactory | Test that all factory methods resolve services correctly |
+| 12 | BedrockDescriptionEditorMenu profanity filter | BedrockDescriptionEditorMenu | Test that inappropriate words are rejected |
+| 13 | BedrockGuildPromotionMenu permission check | BedrockGuildPromotionMenu | Test that players without MANAGE_RANKS cannot promote |
+| 14 | BedrockGuildMemberRankMenu rank dropdown indices | BedrockGuildMemberRankMenu | Test that dropdown selection maps to correct rank |
+| 15 | BedrockEmojiSelectionMenu emoji format validation | BedrockEmojiSelectionMenu | Test valid and invalid emoji format inputs |
+
+---
+
+## Layer Boundary Check
+
+**Verdict: PASS with minor notes.**
+
+All 69 files are in `interaction/menus` (the interaction layer), which is the correct location for UI code. The files correctly:
+
+- Import from `application.services.*` for business logic (not from `domain` directly for operations)
+- Import from `domain.entities.*` for data types
+- Use `org.bukkit.entity.Player` (acceptable in interaction layer)
+- Use `org.koin.core.component.inject` for dependency injection
+
+**Minor notes (not violations):**
+- `MenuFactory.kt` uses `org.koin.core.context.GlobalContext.get()` direct resolution instead of constructor injection — this is a code quality issue, not a layer violation.
+- `BedrockGuildPartyManagementMenu.kt` imports `application.persistence.GuildRepository` directly — this is a layer boundary concern (interaction → persistence), but it's used only for reading guild data. Consider using a service instead.
+- `BedrockGuildProgressionInfoMenu.kt` imports `application.persistence.ProgressionRepository` directly — same concern as above.
+- `BedrockGuildWarDeclarationMenu.kt` imports `application.persistence.GuildRepository` directly — same concern.
+- `BedrockClaimIconMenu.kt` and `BedrockClaimNamingMenu.kt` import `application.persistence.ClaimRepository` directly — same concern.
+
+These are **low-severity hardening nits** — the repositories are application-layer interfaces (ports), not infrastructure implementations, so they don't technically violate hexagonal architecture. But using application services would be cleaner.
+
+---
+
+## Summary
+
+| Severity | Count |
+|----------|-------|
+| crit | 0 |
+| high | 3 |
+| med | 8 |
+| low | 10 |
+| **Total** | **21** |
+
+**Key themes:**
+1. **Button index management** in dynamic Bedrock forms is error-prone (3 findings)
+2. **Persistence gaps** — in-memory mutations not saved to repository (1 finding)
+3. **Hardcoded limits** — slider max of 100 ignores actual balances (1 finding)
+4. **Fallback menu constructor mismatches** — reflection-based fallbacks use wrong signatures (2 findings)
+5. **Java/Bedrock menu mixing** — Bedrock menus opening Java GUIs (2 findings)
+6. **Missing permission checks** — rank changes without MANAGE_RANKS verification (2 findings)

--- a/docs/audit/audit-ix-menus-b.md
+++ b/docs/audit/audit-ix-menus-b.md
@@ -1,0 +1,236 @@
+# Audit Report: Batch IX-Menus-B
+
+**Scope:** `interaction/menus` (remaining ~69 files)
+**Branch:** `fix/audit-ix-menus-b`
+**Date:** 2026-06-09
+
+---
+
+## Summary
+
+| Severity | Count |
+|----------|-------|
+| crit     | 0     |
+| high     | 3     |
+| med      | 5     |
+| low      | 8     |
+| **Total**| **16**|
+
+---
+
+## Findings
+
+### [SEV: high] GoldWithdrawMenu.kt:152 — withdrawGold returns -1L sentinel for insufficient funds but caller proceeds to give items
+
+**What:** `vaultInventoryManager.withdrawGold()` returns `-1L` on insufficient funds. The `withdrawGold()` method checks `newBalance == -1L` and returns early, but the `GoldBalanceButton.convertToItems(amount)` call on line 164 and the item-giving loop on lines 167-170 execute *before* the `-1L` check on line 152. The `-1L` check is at line 152, but `convertToItems(amount)` at line 164 is *outside* the `if/else` — it runs unconditionally regardless of the balance check result.
+
+**Why it matters:** If `withdrawGold` returns `-1L`, the code still calls `convertToItems(amount)` and gives items to the player, effectively creating items from nothing. This is a critical item duplication exploit.
+
+**Suggested fix:** The `convertToItems` and item-giving logic should be inside the `if (newBalance != -1L)` branch, or the early return should happen before any item creation.
+
+**Confidence:** high
+
+---
+
+### [SEV: high] GuildBankMenu.kt:467-493 — handleDeposit removes items before confirming vault deposit succeeds
+
+**What:** In `handleDeposit()` (line 437), gold items are removed from the player's inventory (lines 468-493) *before* `vaultInventoryManager.depositGold()` is called (line 497). If `depositGold()` fails or throws, the player has already lost their gold items with no compensation.
+
+**Why it matters:** Items are destroyed without the vault balance increasing. This is a data-loss bug that can be triggered by any failure in the deposit pipeline (e.g., database error, guild not found).
+
+**Suggested fix:** Perform the vault deposit first, and only remove items from the player's inventory after the deposit succeeds. Use a transaction-like pattern.
+
+**Confidence:** high
+
+---
+
+### [SEV: high] GuildWarDeclarationMenu.kt:489-496 — Race condition in war declaration duplicate check
+
+**What:** Lines 489-496 check for existing active wars and pending declarations, then proceed to create a war. However, there is no database-level constraint or locking between the check and the insert. Two players from the same guild could simultaneously declare war on the same target, passing both checks before either insert completes.
+
+**Why it matters:** Could result in duplicate active wars between the same guilds, breaking war invariants and potentially causing undefined behavior in war resolution.
+
+**Suggested fix:** Add a database-level unique constraint on (declaring_guild_id, defending_guild_id) for active wars, or use a synchronized block / distributed lock around the check-and-create operation.
+
+**Confidence:** med
+
+---
+
+### [SEV: med] GuildBankMenu.kt:400-431 — handleQuickAction runs transaction on async thread but accesses player inventory
+
+**What:** `handleQuickAction()` (line 366) spawns an async Bukkit task (line 400-431) that calls `handleDeposit()` / `handleWithdrawal()`, which directly modify `player.inventory`. Bukkit inventory operations are not thread-safe and must run on the main thread.
+
+**Why it matters:** Concurrent modification of player inventory from an async thread can cause item duplication, loss, or server crashes. This is a classic Bukkit threading violation.
+
+**Suggested fix:** Move all inventory modifications to the main thread using `runTask()`. Only the balance check/query should happen async.
+
+**Confidence:** high
+
+---
+
+### [SEV: med] GoldDepositMenu.kt:204 — onInventoryClose skips non-gold items without returning them
+
+**What:** In `onInventoryClose()` (line 192), the loop at lines 214-224 only removes items where `calculateGoldValue(item) > 0`. Any non-gold items placed in the deposit menu by the player (or via a race condition) remain in the inventory slots but are not returned to the player.
+
+**Why it matters:** Players can lose items if they accidentally place non-gold items in the deposit menu. The menu allows placing any item (only cursor placement is validated at line 181-187, but existing items in the inventory are not checked).
+
+**Suggested fix:** On close, iterate all slots and return any non-instruction, non-deposit-all items to the player's inventory.
+
+**Confidence:** med
+
+---
+
+### [SEV: med] GuildEmojiMenu.kt:46 — println statements leak internal state to server log
+
+**What:** Multiple `println()` calls (lines 46, 50, 53, 59, 61, 65, 66, 70, 76, etc.) output emoji validation state including player names and emoji values to the server console/log.
+
+**Why it matters:** While not a security exploit, this leaks user input to server logs and creates noise. In a production environment, this could expose sensitive emoji data and makes log analysis difficult.
+
+**Suggested fix:** Replace `println()` with proper SLF4J debug-level logging, or remove entirely.
+
+**Confidence:** high
+
+---
+
+### [SEV: med] TagEditorMenu.kt:46 — println statements leak tag input to server log
+
+**What:** Multiple `println()` calls (lines 41, 46, 48, 49, 55, 59, 61, 64, 65, 67, etc.) output tag editor state including player names and tag values to the server console.
+
+**Why it matters:** Same as GuildEmojiMenu — leaks user input to server logs.
+
+**Suggested fix:** Replace with proper debug-level logging or remove.
+
+**Confidence:** high
+
+---
+
+### [SEV: med] GuildMemberRankConfirmationMenu.kt:190-200 — Skull texture URL is hardcoded and unused
+
+**What:** Lines 190-200 set up a `textureUrl` variable with a Craftatar URL but never actually apply it to the skull meta. The `skullMeta` is cast but the texture is never set via `ResolvableProfile`.
+
+**Why it matters:** The player head shows Steve/Alex instead of the target player's skin. This is a cosmetic bug but indicates incomplete implementation.
+
+**Suggested fix:** Either use `ResolvableProfile` to set the skull owner properly, or remove the dead code.
+
+**Confidence:** high
+
+---
+
+### [SEV: low] GuildBankMenu.kt:496 — Redundant vaultInventoryManager injection inside handleDeposit
+
+**What:** Line 496 re-injects `vaultInventoryManager` with `by inject()` inside a method, even though it's already injected at line 47. This creates a redundant Koin resolution on every deposit call.
+
+**Why it matters:** Minor performance overhead and code clarity issue. Not a bug, but unnecessary.
+
+**Suggested fix:** Remove the inline injection and use the class-level field.
+
+**Confidence:** high
+
+---
+
+### [SEV: low] GuildBankAutomationMenu.kt:42-48 — Mutable state fields not persisted
+
+**What:** `scheduledDepositsEnabled`, `autoRewardsEnabled`, `recurringPaymentsEnabled`, and `interestRate` are stored as in-memory fields (lines 42-48) with `loadAutomationSettings()` always resetting them to defaults (lines 83-89). The "Save" button (line 171) only prints a TODO message.
+
+**Why it matters:** Automation settings cannot actually be changed by users. The menu is non-functional despite appearing to work.
+
+**Suggested fix:** Persist settings to database and implement the save functionality.
+
+**Confidence:** high
+
+---
+
+### [SEV: low] GuildBankBudgetMenu.kt:80-85 — Budget settings hardcoded, not persisted
+
+**What:** `monthlyBudget`, `weeklyBudget`, and `dailyBudget` are hardcoded to 10000/2500/500 in `loadBudgetSettings()` (lines 82-84). The save button (line 379) only prints a TODO.
+
+**Why it matters:** Budget management is non-functional. Users cannot actually set budgets.
+
+**Suggested fix:** Load from and persist to database.
+
+**Confidence:** high
+
+---
+
+### [SEV: low] GuildBankSecurityMenu.kt:84-89 — Security settings not fully persisted
+
+**What:** `dualAuthThreshold` is hardcoded to 1000 (line 85) and never persisted. Only `emergencyFreeze` is saved via `guildService.setBankFrozen()`.
+
+**Why it matters:** Dual authorization threshold cannot be configured by guild leaders.
+
+**Suggested fix:** Persist `dualAuthThreshold` to database.
+
+**Confidence:** high
+
+---
+
+### [SEV: low] GuildBankStatisticsMenu.kt:433-428 — updateAnalyticsDisplay is empty
+
+**What:** `updateAnalyticsDisplay()` (line 425) has an empty body with only a comment. The analytics display never updates after initial load.
+
+**Why it matters:** Stale data shown after refresh. The refresh button reloads data but doesn't update the display.
+
+**Suggested fix:** Implement the update logic or remove the method.
+
+**Confidence:** high
+
+---
+
+### [SEV: low] GuildMemberManagementMenu.kt:82-99 — StaticPane replacement doesn't update GUI
+
+**What:** `updateMemberDisplay()` (line 67) creates a new `StaticPane` and assigns it to `memberPane` (line 99), but the old pane is never removed from the GUI. The new pane is never added to the ChestGui either.
+
+**Why it matters:** Pagination and member list updates don't actually work — the GUI continues showing the old pane.
+
+**Suggested fix:** Use `gui.removePane()` and `gui.addPane()` to replace the pane, or use a PaginatedPane.
+
+**Confidence:** high
+
+---
+
+### [SEV: low] LfgBrowserMenu.kt:81 — PaginatedPane slot calculation creates overlapping pages
+
+**What:** `populateGuildList()` (line 68) creates a new `StaticPane` for each guild item with `StaticPane(index % 9, (index / 9) % 5, 1, 1)` and adds it to a page via `paginatedPane.addPane(page, ...)`. However, the `page` variable is calculated as `index / 45`, meaning items 0-44 go to page 0, but each item gets its own 1x1 pane at the wrong coordinates within that page.
+
+**Why it matters:** Items overlap on the same page because the slot calculation doesn't account for the 1x1 pane size correctly. Only one item per slot position will be visible.
+
+**Suggested fix:** Use a single StaticPane per page and add items with proper x,y coordinates, or use `PaginatedPane.populateWithGuiItems()`.
+
+**Confidence:** med
+
+---
+
+## Test Coverage Gaps
+
+| File | Untested Behavior | Suggested Test |
+|------|-------------------|----------------|
+| GoldWithdrawMenu | Insufficient funds path (-1L return) | Test that no items are given when vault balance is insufficient |
+| GoldWithdrawMenu | Inventory full during withdrawal | Test that items are dropped on the ground |
+| GoldDepositMenu | Non-gold items in deposit menu | Test that non-gold items are returned on close |
+| GoldDepositMenu | Player quit during deposit | Test that items are not lost on disconnect |
+| GuildBankMenu | Concurrent deposit/withdrawal | Test thread safety of async transaction |
+| GuildBankMenu | Deposit failure after item removal | Test rollback behavior |
+| GuildWarDeclarationMenu | Duplicate war declaration | Test that second declaration is rejected |
+| GuildWarAcceptanceMenu | Wager insufficient funds | Test rejection when guild bank can't match |
+| GuildMemberManagementMenu | Pagination | Test that page navigation updates the display |
+| GuildEmojiMenu | Emoji validation | Test valid/invalid emoji formats |
+| TagEditorMenu | MiniMessage validation | Test various MiniMessage formats |
+| GuildBankAutomationMenu | Settings persistence | Test save/load of automation settings |
+| GuildBankBudgetMenu | Budget alerts | Test alert generation at thresholds |
+| PartyCreationMenu | Party creation with role restrictions | Test that only allowed roles can join |
+| PartyModerationMenu | Mute/ban expiration | Test that mutes expire correctly |
+
+---
+
+## Layer Boundary Check
+
+**Verdict: PASS (with minor notes)**
+
+All 69 files correctly import from `application.*` and `domain.*` for business logic. No file imports Bukkit/Spigot APIs directly for domain logic — all Bukkit usage is confined to UI rendering (ItemStack creation, GUI setup, player interactions).
+
+**Minor notes:**
+- `GoldDepositMenu.kt` and `GoldWithdrawMenu.kt` import `VaultTransactionLogger` from `infrastructure.persistence.guilds` (lines 8-9). This is a layer violation — the menu (interaction layer) should not directly import from infrastructure. The transaction logging should be handled by the application service.
+- `GuildBankMenu.kt` imports `BankServiceBukkit` from `infrastructure.services` (line 9). Same violation — should use the application-level `BankService` interface.
+- `GuildEmojiMenu.kt` imports `NexoEmojiService` from `infrastructure.services` (line 8). Should be behind an application-layer port/interface.
+
+These are inherited architectural issues rather than new violations introduced by these menu files.


### PR DESCRIPTION
Findings-only audit of the full `net.lumalyte.lg` tree (573 files) run as 11 Hermes coordinator jobs against main.

**Master report:** `docs/audit/MASS-AUDIT-2026-06-08.md` — triaged + de-duplicated. Raw per-batch reports alongside it.

## Headline (TIER 0 — fix first)
- 🔴 **Item duplication** — `GoldWithdrawMenu.kt:152`: failed withdrawal still gives items (created from nothing).
- 🔴 **Item loss** — `GuildBankMenu.kt:467`: removes items before confirming the deposit succeeds.
- 🟠 **Gold TOCTOU** — `GuildVaultRepositorySQLite.kt:186`: non-atomic balance read-modify-write.

## Confirmed logic bugs
- `GrantAllPlayerClaimPermissions.kt:27` — "grant all" calls `remove()` (revokes instead of grants).
- `WithdrawPlayerTransferRequest.kt:10` — inverted guard, withdraw never works.
- `CombatServiceBukkit.kt:119` — `getPlayerGuilds()` is a `return emptySet()` stub in prod.

## Also inside
- ~10 high-confidence logic leads (verify-then-fix), persistence-robustness items, and a **systemic hexagonal layer-violation cluster** (domain importing Bukkit/application) to schedule as its own refactor.
- **Corrections**: a false-positive "precedence bug" and two over-rated "crit" SQL-injections downgraded — see the report's CORRECTIONS section.

No source files were modified by this audit. This PR is docs only.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
Breaking
- Fix GuildBankMenu.handleDeposit to call depositGold() before removing items and only remove on success, rolling back on failure (interaction/menus/guild/GuildBankMenu.kt:467–493).
- Make GuildVaultRepositorySQLite balance updates atomic using SQL (UPDATE ... SET balance = balance + ? ... AND balance >= ?) and check affected rows to prevent TOCTOU lost-updates (infrastructure/persistence/guilds/GuildVaultRepositorySQLite.kt:186).
- Introduce withdrawal-specific validation enforcing maxWithdrawalPercent in BankServiceBukkit withdrawal path (infrastructure/services/BankServiceBukkit.kt:656).

Fixes
- Change GrantAllPlayerClaimPermissions to add() instead of remove() when granting all permissions (application/actions/claim/permission/GrantAllPlayerClaimPermissions.kt:27).
- Invert guard in WithdrawPlayerTransferRequest so pending withdraw requests succeed and are removed/persisted (application/actions/claim/transfer/WithdrawPlayerTransferRequest.kt:10).
- Replace CombatServiceBukkit.getPlayerGuilds() stub with real membership lookup via injected service (infrastructure/services/CombatServiceBukkit.kt:119).
- Fix LeaderboardRepositorySQLite.getLeaderboardSnapshots to use type.name instead of hardcoded KILLS (infrastructure/persistence/guilds/LeaderboardRepositorySQLite.kt:364).
- Remove or route debug printlns through logger.debug in GuildRepositorySQLite (infrastructure/persistence/guilds/GuildRepositorySQLite.kt:464,740,892).
- Ensure OfferPlayerTransferRequest persists put() operations (application/actions/claim/transfer/OfferPlayerTransferRequest.kt).
- Correct AcceptTransferRequest ownership uniqueness check to use the correct namespace/owner (application/actions/claim/transfer/AcceptTransferRequest.kt).
- Make ToolRemovalListener actually remove built drops instead of leaving them in event.drops (interaction/commands/listeners/ToolRemovalListener.kt).
- Mark GoldWithdrawMenu dupe as false positive after re-review; no code change required (interaction/menus/guild/GoldWithdrawMenu.kt:152).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->