### PR TITLE
feat(api): expose GuildLookup via Bukkit ServicesManager for shop integrations

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -40,7 +40,7 @@ jobs:
     # with EnthusiaMarket's CI.
     - name: Cache RoseChat jar
       id: rosechat-cache
-      uses: actions/cache@v4
+      uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
       with:
         path: libs/RoseChat-RC-2.jar
         key: rosechat-jar-prehook-${{ env.ROSECHAT_PREHOOK_REF }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -25,28 +25,34 @@ jobs:
         java-version: '21'
         distribution: 'temurin'
 
-    - name: Resolve RoseChat commit SHA
-      id: rosechat-sha
-      run: |
-        SHA=$(git ls-remote https://github.com/BadgersMC/Enthusia-RoseChat.git refs/heads/master | cut -f1)
-        echo "sha=$SHA" >> "$GITHUB_OUTPUT"
-
+    # RoseChat <-> LumaGuilds is a circular compile dependency: RoseChat master now
+    # carries a LumaGuilds channel hook (needs the LumaGuilds jar to compile), and
+    # LumaGuilds needs the RoseChat jar to compile its chat listeners. Both resolve
+    # the other via compileOnly files('libs/...'), so building RoseChat master here
+    # fails ("package net.lumalyte.lg does not exist"). Build RoseChat at the last
+    # PRE-HOOK commit instead: it needs no LumaGuilds jar and still exposes every
+    # RoseChat API LumaGuilds compiles against. Keep ROSECHAT_PREHOOK_REF in sync
+    # with EnthusiaMarket's CI.
     - name: Cache RoseChat jar
       id: rosechat-cache
       uses: actions/cache@v4
       with:
         path: libs/RoseChat-RC-2.jar
-        key: rosechat-jar-${{ steps.rosechat-sha.outputs.sha }}
+        key: rosechat-jar-prehook-3fe078a
 
-    - name: Build RoseChat dependency
+    - name: Build RoseChat (pre-hook) dependency
       if: steps.rosechat-cache.outputs.cache-hit != 'true'
+      env:
+        ROSECHAT_PREHOOK_REF: 3fe078a   # last RoseChat commit before the LumaGuilds hook
       run: |
-        git clone --depth=1 https://github.com/BadgersMC/Enthusia-RoseChat.git /tmp/rosechat
+        git clone https://github.com/BadgersMC/Enthusia-RoseChat.git /tmp/rosechat
         cd /tmp/rosechat
+        git checkout "$ROSECHAT_PREHOOK_REF"
         chmod +x gradlew
         ./gradlew shadowJar --no-daemon
         mkdir -p "$GITHUB_WORKSPACE/libs"
-        cp build/libs/RoseChat-RC-2.jar "$GITHUB_WORKSPACE/libs/RoseChat-RC-2.jar"
+        ROSE_JAR=$(ls build/libs/RoseChat-RC-2*.jar | grep -v -- '-sources\|-javadoc' | head -1)
+        cp "$ROSE_JAR" "$GITHUB_WORKSPACE/libs/RoseChat-RC-2.jar"
 
     - name: Build Gradle using shadowJar
       env:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -11,6 +11,11 @@ jobs:
   build:
     runs-on: ubuntu-latest
 
+    # Single source of truth: the cache key and the build step both read this, so
+    # bumping the ref can't silently reuse a stale cached jar.
+    env:
+      ROSECHAT_PREHOOK_REF: 3fe078a   # last RoseChat commit before the LumaGuilds hook
+
     permissions:
       contents: read
       packages: read
@@ -38,12 +43,10 @@ jobs:
       uses: actions/cache@v4
       with:
         path: libs/RoseChat-RC-2.jar
-        key: rosechat-jar-prehook-3fe078a
+        key: rosechat-jar-prehook-${{ env.ROSECHAT_PREHOOK_REF }}
 
     - name: Build RoseChat (pre-hook) dependency
       if: steps.rosechat-cache.outputs.cache-hit != 'true'
-      env:
-        ROSECHAT_PREHOOK_REF: 3fe078a   # last RoseChat commit before the LumaGuilds hook
       run: |
         git clone https://github.com/BadgersMC/Enthusia-RoseChat.git /tmp/rosechat
         cd /tmp/rosechat

--- a/.github/workflows/unit-test.yml
+++ b/.github/workflows/unit-test.yml
@@ -28,28 +28,30 @@ jobs:
         java-version: '21'
         distribution: 'temurin'
 
-    - name: Resolve RoseChat commit SHA
-      id: rosechat-sha
-      run: |
-        SHA=$(git ls-remote https://github.com/BadgersMC/Enthusia-RoseChat.git refs/heads/master | cut -f1)
-        echo "sha=$SHA" >> "$GITHUB_OUTPUT"
-
+    # See build.yml: RoseChat master carries a LumaGuilds hook that needs the
+    # LumaGuilds jar, so build RoseChat at the last PRE-HOOK commit to break the
+    # circular compile dependency. Keep ROSECHAT_PREHOOK_REF in sync with build.yml
+    # and EnthusiaMarket's CI.
     - name: Cache RoseChat jar
       id: rosechat-cache
       uses: actions/cache@v4
       with:
         path: libs/RoseChat-RC-2.jar
-        key: rosechat-jar-${{ steps.rosechat-sha.outputs.sha }}
+        key: rosechat-jar-prehook-3fe078a
 
-    - name: Build RoseChat dependency
+    - name: Build RoseChat (pre-hook) dependency
       if: steps.rosechat-cache.outputs.cache-hit != 'true'
+      env:
+        ROSECHAT_PREHOOK_REF: 3fe078a   # last RoseChat commit before the LumaGuilds hook
       run: |
-        git clone --depth=1 https://github.com/BadgersMC/Enthusia-RoseChat.git /tmp/rosechat
+        git clone https://github.com/BadgersMC/Enthusia-RoseChat.git /tmp/rosechat
         cd /tmp/rosechat
+        git checkout "$ROSECHAT_PREHOOK_REF"
         chmod +x gradlew
         ./gradlew shadowJar --no-daemon
         mkdir -p "$GITHUB_WORKSPACE/libs"
-        cp build/libs/RoseChat-RC-2.jar "$GITHUB_WORKSPACE/libs/RoseChat-RC-2.jar"
+        ROSE_JAR=$(ls build/libs/RoseChat-RC-2*.jar | grep -v -- '-sources\|-javadoc' | head -1)
+        cp "$ROSE_JAR" "$GITHUB_WORKSPACE/libs/RoseChat-RC-2.jar"
 
     - name: Test with Gradle
       env:

--- a/.github/workflows/unit-test.yml
+++ b/.github/workflows/unit-test.yml
@@ -38,7 +38,7 @@ jobs:
     # and EnthusiaMarket's CI.
     - name: Cache RoseChat jar
       id: rosechat-cache
-      uses: actions/cache@v4
+      uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
       with:
         path: libs/RoseChat-RC-2.jar
         key: rosechat-jar-prehook-${{ env.ROSECHAT_PREHOOK_REF }}

--- a/.github/workflows/unit-test.yml
+++ b/.github/workflows/unit-test.yml
@@ -14,6 +14,10 @@ jobs:
   build:
     runs-on: ubuntu-latest
 
+    # Single source of truth: cache key + build step both read this (see build.yml).
+    env:
+      ROSECHAT_PREHOOK_REF: 3fe078a   # last RoseChat commit before the LumaGuilds hook
+
     permissions:
       contents: read
       packages: read
@@ -37,12 +41,10 @@ jobs:
       uses: actions/cache@v4
       with:
         path: libs/RoseChat-RC-2.jar
-        key: rosechat-jar-prehook-3fe078a
+        key: rosechat-jar-prehook-${{ env.ROSECHAT_PREHOOK_REF }}
 
     - name: Build RoseChat (pre-hook) dependency
       if: steps.rosechat-cache.outputs.cache-hit != 'true'
-      env:
-        ROSECHAT_PREHOOK_REF: 3fe078a   # last RoseChat commit before the LumaGuilds hook
       run: |
         git clone https://github.com/BadgersMC/Enthusia-RoseChat.git /tmp/rosechat
         cd /tmp/rosechat

--- a/src/main/kotlin/net/lumalyte/lg/LumaGuilds.kt
+++ b/src/main/kotlin/net/lumalyte/lg/LumaGuilds.kt
@@ -82,6 +82,11 @@ class LumaGuilds : JavaPlugin() {
         // Start Koin with modular architecture
         startKoin { modules(appModule(this@LumaGuilds, storage, claimsEnabled)) }
 
+        // Expose the cross-plugin GuildLookup API via Bukkit's ServicesManager so
+        // consumers (EnthusiaMarket) read guild data without reaching into our Koin
+        // container from their classloader (which LinkageErrors on kotlin.reflect.KClass).
+        registerGuildLookupService()
+
         // Initialize Apollo AFTER Koin is started (requires Koin DI)
         initialiseApolloIntegration()
 
@@ -1166,6 +1171,39 @@ class LumaGuilds : JavaPlugin() {
             pluginScope.cancel()
         }
 
+        // Withdraw the cross-plugin GuildLookup API.
+        try {
+            Bukkit.getServicesManager().unregister(net.lumalyte.lg.api.GuildLookup::class.java, this)
+        } catch (e: Exception) {
+            logger.warning("Failed to unregister GuildLookup service: ${e.message}")
+        }
+
         logColored("🛑 LumaGuilds disabled")
+    }
+
+    /**
+     * Builds a [net.lumalyte.lg.api.GuildLookupImpl] from the Koin-resolved
+     * services and registers it in Bukkit's ServicesManager. Resolution happens
+     * here, inside LumaGuilds' own classloader, so the Koin/KClass boundary is
+     * never crossed by a consumer plugin.
+     */
+    private fun registerGuildLookupService() {
+        try {
+            val lookup = net.lumalyte.lg.api.GuildLookupImpl(
+                get().get(),
+                get().get(),
+                get().get(),
+                get().get(),
+            )
+            Bukkit.getServicesManager().register(
+                net.lumalyte.lg.api.GuildLookup::class.java,
+                lookup,
+                this,
+                org.bukkit.plugin.ServicePriority.Normal,
+            )
+            logColored("✓ Registered GuildLookup API for shop integrations")
+        } catch (e: Exception) {
+            logger.severe("Failed to register GuildLookup service: ${e.message}")
+        }
     }
 }

--- a/src/main/kotlin/net/lumalyte/lg/api/GuildLookup.kt
+++ b/src/main/kotlin/net/lumalyte/lg/api/GuildLookup.kt
@@ -1,0 +1,70 @@
+package net.lumalyte.lg.api
+
+import java.util.UUID
+
+/**
+ * Stable, cross-plugin integration surface for reading LumaGuilds guild data.
+ *
+ * LumaGuilds registers an implementation in Bukkit's ServicesManager at enable,
+ * so consumers (EnthusiaMarket) access it via:
+ *
+ *     Bukkit.getServicesManager().load(GuildLookup::class.java)
+ *
+ * This deliberately avoids reaching into LumaGuilds' Koin container from another
+ * plugin's classloader: a reified Koin `get<T>()` carries a `kotlin.reflect.KClass`
+ * in its signature, and that type resolves to different Class objects across the
+ * two plugin classloaders, producing a JVM loader-constraint LinkageError. Every
+ * method here uses only JDK types plus [GuildSummary], all loaded from the shared
+ * join-classpath, so the boundary is safe.
+ *
+ * All `permission` strings are [net.lumalyte.lg.domain.entities.RankPermission]
+ * enum names (e.g. "EDIT_SHOP_STOCK").
+ */
+interface GuildLookup {
+
+    /** Guild ids the player is a member of (may be empty). */
+    fun getPlayerGuildIds(playerId: UUID): Set<UUID>
+
+    /** Summary for [guildId], or null if no such guild. */
+    fun getGuild(guildId: UUID): GuildSummary?
+
+    /** Summaries for every guild. */
+    fun getAllGuilds(): List<GuildSummary>
+
+    /** True if [playerId] is a member of [guildId]. */
+    fun isMember(playerId: UUID, guildId: UUID): Boolean
+
+    /**
+     * True if [playerId] holds the given [RankPermission][net.lumalyte.lg.domain.entities.RankPermission]
+     * (passed by enum name) in [guildId]. Unknown permission names return false.
+     */
+    fun hasShopPermission(playerId: UUID, guildId: UUID, permission: String): Boolean
+
+    /**
+     * True if [playerId]'s rank in [guildId] is at least as high as the rank named
+     * [rankName] (lower priority number = higher rank). Case-insensitive on the
+     * rank name. Returns false if the player has no rank or the named rank is absent.
+     */
+    fun hasRankAtLeast(playerId: UUID, guildId: UUID, rankName: String): Boolean
+
+    /** Guild bank balance for [guildId], or 0 if unknown. */
+    fun getBankBalance(guildId: UUID): Long
+
+    /** Withdraw [amount] from [guildId]'s bank as [actorId]. True on success. */
+    fun bankWithdraw(guildId: UUID, actorId: UUID, amount: Int, reason: String): Boolean
+
+    /** Deposit [amount] into [guildId]'s bank as [actorId]. True on success. */
+    fun bankDeposit(guildId: UUID, actorId: UUID, amount: Int, reason: String): Boolean
+}
+
+/**
+ * Minimal guild projection for consumers — only the fields integrations need,
+ * so the boundary doesn't expose the full domain entity. Tag/emoji are the raw
+ * stored values (consumers normalise formatting themselves).
+ */
+data class GuildSummary(
+    val id: UUID,
+    val name: String,
+    val tag: String?,
+    val emoji: String?,
+)

--- a/src/main/kotlin/net/lumalyte/lg/api/GuildLookup.kt
+++ b/src/main/kotlin/net/lumalyte/lg/api/GuildLookup.kt
@@ -50,11 +50,20 @@ interface GuildLookup {
     /** Guild bank balance for [guildId], or 0 if unknown. */
     fun getBankBalance(guildId: UUID): Long
 
-    /** Withdraw [amount] from [guildId]'s bank as [actorId]. True on success. */
-    fun bankWithdraw(guildId: UUID, actorId: UUID, amount: Int, reason: String): Boolean
+    /**
+     * Withdraw [amount] from [guildId]'s bank as [actorId]. True on success.
+     *
+     * Amounts are `Long` for a uniform API, but LumaGuilds' bank is Int-bounded
+     * internally, so amounts that are non-positive or exceed `Int.MAX_VALUE`
+     * (~2.1B) are rejected (return false).
+     */
+    fun bankWithdraw(guildId: UUID, actorId: UUID, amount: Long, reason: String): Boolean
 
-    /** Deposit [amount] into [guildId]'s bank as [actorId]. True on success. */
-    fun bankDeposit(guildId: UUID, actorId: UUID, amount: Int, reason: String): Boolean
+    /**
+     * Deposit [amount] into [guildId]'s bank as [actorId]. True on success.
+     * Same Int-bounded constraint as [bankWithdraw].
+     */
+    fun bankDeposit(guildId: UUID, actorId: UUID, amount: Long, reason: String): Boolean
 }
 
 /**

--- a/src/main/kotlin/net/lumalyte/lg/api/GuildLookup.kt
+++ b/src/main/kotlin/net/lumalyte/lg/api/GuildLookup.kt
@@ -1,3 +1,9 @@
+// This is a deliberately public, cross-plugin integration API: the interface is
+// loaded by other plugins via ServicesManager and GuildSummary is its transfer
+// type, so the "library entities should not be public" / "public data class"
+// detekt rules don't apply here.
+@file:Suppress("LibraryEntitiesShouldNotBePublic", "ForbiddenPublicDataClass")
+
 package net.lumalyte.lg.api
 
 import java.util.UUID
@@ -21,7 +27,6 @@ import java.util.UUID
  * enum names (e.g. "EDIT_SHOP_STOCK").
  */
 interface GuildLookup {
-
     /** Guild ids the player is a member of (may be empty). */
     fun getPlayerGuildIds(playerId: UUID): Set<UUID>
 
@@ -72,8 +77,12 @@ interface GuildLookup {
  * stored values (consumers normalise formatting themselves).
  */
 data class GuildSummary(
+    /** Guild's unique id. */
     val id: UUID,
+    /** Display name. */
     val name: String,
+    /** Raw stored tag (consumer normalises formatting), or null. */
     val tag: String?,
+    /** Raw stored emoji (consumer normalises formatting), or null. */
     val emoji: String?,
 )

--- a/src/main/kotlin/net/lumalyte/lg/api/GuildLookupImpl.kt
+++ b/src/main/kotlin/net/lumalyte/lg/api/GuildLookupImpl.kt
@@ -1,3 +1,8 @@
+// Must be public (registered in Bukkit's ServicesManager and consumed by other
+// plugins); it mirrors the GuildLookup interface so the function count and the
+// guard-clause return counts are inherent to that contract.
+@file:Suppress("LibraryEntitiesShouldNotBePublic", "TooManyFunctions", "ReturnCount")
+
 package net.lumalyte.lg.api
 
 import net.lumalyte.lg.application.services.BankService
@@ -21,17 +26,13 @@ class GuildLookupImpl(
     private val banks: BankService,
 ) : GuildLookup {
 
-    override fun getPlayerGuildIds(playerId: UUID): Set<UUID> =
-        members.getPlayerGuilds(playerId)
+    override fun getPlayerGuildIds(playerId: UUID): Set<UUID> = members.getPlayerGuilds(playerId)
 
-    override fun getGuild(guildId: UUID): GuildSummary? =
-        guilds.getGuild(guildId)?.toSummary()
+    override fun getGuild(guildId: UUID): GuildSummary? = guilds.getGuild(guildId)?.toSummary()
 
-    override fun getAllGuilds(): List<GuildSummary> =
-        guilds.getAllGuilds().map { it.toSummary() }
+    override fun getAllGuilds(): List<GuildSummary> = guilds.getAllGuilds().map { it.toSummary() }
 
-    override fun isMember(playerId: UUID, guildId: UUID): Boolean =
-        members.getMember(playerId, guildId) != null
+    override fun isMember(playerId: UUID, guildId: UUID): Boolean = members.getMember(playerId, guildId) != null
 
     override fun hasShopPermission(playerId: UUID, guildId: UUID, permission: String): Boolean {
         val perm = try {
@@ -55,8 +56,7 @@ class GuildLookupImpl(
         return playerRank.priority <= targetRank.priority
     }
 
-    override fun getBankBalance(guildId: UUID): Long =
-        banks.getBalance(guildId).toLong()
+    override fun getBankBalance(guildId: UUID): Long = banks.getBalance(guildId).toLong()
 
     override fun bankWithdraw(guildId: UUID, actorId: UUID, amount: Long, reason: String): Boolean {
         val intAmount = amount.toIntBankAmountOrNull() ?: return false
@@ -68,9 +68,7 @@ class GuildLookupImpl(
         return banks.deposit(guildId, actorId, intAmount, reason) != null
     }
 
-    /** LumaGuilds' bank is Int-bounded; reject non-positive or out-of-range amounts. */
-    private fun Long.toIntBankAmountOrNull(): Int? =
-        if (this <= 0 || this > Int.MAX_VALUE) null else toInt()
+    private fun Long.toIntBankAmountOrNull(): Int? = if (this <= 0 || this > Int.MAX_VALUE) null else toInt()
 
     private fun Guild.toSummary() = GuildSummary(id, name, tag, emoji)
 }

--- a/src/main/kotlin/net/lumalyte/lg/api/GuildLookupImpl.kt
+++ b/src/main/kotlin/net/lumalyte/lg/api/GuildLookupImpl.kt
@@ -1,0 +1,68 @@
+package net.lumalyte.lg.api
+
+import net.lumalyte.lg.application.services.BankService
+import net.lumalyte.lg.application.services.GuildService
+import net.lumalyte.lg.application.services.MemberService
+import net.lumalyte.lg.application.services.RankService
+import net.lumalyte.lg.domain.entities.Guild
+import net.lumalyte.lg.domain.entities.RankPermission
+import java.util.UUID
+
+/**
+ * [GuildLookup] backed by LumaGuilds' internal application services. Constructed
+ * and registered in Bukkit's ServicesManager by the plugin at enable, so all the
+ * Koin resolution happens inside LumaGuilds' own classloader (safe) and consumers
+ * only ever touch the [GuildLookup] interface.
+ */
+class GuildLookupImpl(
+    private val guilds: GuildService,
+    private val members: MemberService,
+    private val ranks: RankService,
+    private val banks: BankService,
+) : GuildLookup {
+
+    override fun getPlayerGuildIds(playerId: UUID): Set<UUID> =
+        members.getPlayerGuilds(playerId)
+
+    override fun getGuild(guildId: UUID): GuildSummary? =
+        guilds.getGuild(guildId)?.toSummary()
+
+    override fun getAllGuilds(): List<GuildSummary> =
+        guilds.getAllGuilds().map { it.toSummary() }
+
+    override fun isMember(playerId: UUID, guildId: UUID): Boolean =
+        members.getMember(playerId, guildId) != null
+
+    override fun hasShopPermission(playerId: UUID, guildId: UUID, permission: String): Boolean {
+        val perm = try {
+            RankPermission.valueOf(permission)
+        } catch (_: IllegalArgumentException) {
+            return false
+        }
+        return try {
+            members.hasPermission(playerId, guildId, perm)
+        } catch (_: Exception) {
+            false
+        }
+    }
+
+    override fun hasRankAtLeast(playerId: UUID, guildId: UUID, rankName: String): Boolean {
+        val playerRankId = members.getPlayerRankId(playerId, guildId) ?: return false
+        val guildRanks = ranks.listRanks(guildId)
+        val playerRank = guildRanks.find { it.id == playerRankId } ?: return false
+        val targetRank = guildRanks.find { it.name.equals(rankName, ignoreCase = true) } ?: return false
+        // Lower priority number = higher rank (0 = Owner).
+        return playerRank.priority <= targetRank.priority
+    }
+
+    override fun getBankBalance(guildId: UUID): Long =
+        banks.getBalance(guildId).toLong()
+
+    override fun bankWithdraw(guildId: UUID, actorId: UUID, amount: Int, reason: String): Boolean =
+        banks.withdraw(guildId, actorId, amount, reason) != null
+
+    override fun bankDeposit(guildId: UUID, actorId: UUID, amount: Int, reason: String): Boolean =
+        banks.deposit(guildId, actorId, amount, reason) != null
+
+    private fun Guild.toSummary() = GuildSummary(id, name, tag, emoji)
+}

--- a/src/main/kotlin/net/lumalyte/lg/api/GuildLookupImpl.kt
+++ b/src/main/kotlin/net/lumalyte/lg/api/GuildLookupImpl.kt
@@ -58,11 +58,19 @@ class GuildLookupImpl(
     override fun getBankBalance(guildId: UUID): Long =
         banks.getBalance(guildId).toLong()
 
-    override fun bankWithdraw(guildId: UUID, actorId: UUID, amount: Int, reason: String): Boolean =
-        banks.withdraw(guildId, actorId, amount, reason) != null
+    override fun bankWithdraw(guildId: UUID, actorId: UUID, amount: Long, reason: String): Boolean {
+        val intAmount = amount.toIntBankAmountOrNull() ?: return false
+        return banks.withdraw(guildId, actorId, intAmount, reason) != null
+    }
 
-    override fun bankDeposit(guildId: UUID, actorId: UUID, amount: Int, reason: String): Boolean =
-        banks.deposit(guildId, actorId, amount, reason) != null
+    override fun bankDeposit(guildId: UUID, actorId: UUID, amount: Long, reason: String): Boolean {
+        val intAmount = amount.toIntBankAmountOrNull() ?: return false
+        return banks.deposit(guildId, actorId, intAmount, reason) != null
+    }
+
+    /** LumaGuilds' bank is Int-bounded; reject non-positive or out-of-range amounts. */
+    private fun Long.toIntBankAmountOrNull(): Int? =
+        if (this <= 0 || this > Int.MAX_VALUE) null else toInt()
 
     private fun Guild.toSummary() = GuildSummary(id, name, tag, emoji)
 }

--- a/src/test/kotlin/net/lumalyte/lg/api/GuildLookupImplTest.kt
+++ b/src/test/kotlin/net/lumalyte/lg/api/GuildLookupImplTest.kt
@@ -50,11 +50,15 @@ class GuildLookupImplTest {
     }
 
     @Test
-    fun `isMember reflects member presence`() {
+    fun `isMember true when member exists`() {
         every { members.getMember(playerId, guildId) } returns Member(
             playerId = playerId, guildId = guildId, rankId = UUID.randomUUID(), joinedAt = Instant.now(),
         )
         assertTrue(lookup.isMember(playerId, guildId))
+    }
+
+    @Test
+    fun `isMember false when member absent`() {
         every { members.getMember(playerId, guildId) } returns null
         assertFalse(lookup.isMember(playerId, guildId))
     }
@@ -71,6 +75,14 @@ class GuildLookupImplTest {
     }
 
     @Test
+    fun `hasShopPermission returns false when service throws`() {
+        every {
+            members.hasPermission(playerId, guildId, RankPermission.EDIT_SHOP_STOCK)
+        } throws RuntimeException("db down")
+        assertFalse(lookup.hasShopPermission(playerId, guildId, "EDIT_SHOP_STOCK"))
+    }
+
+    @Test
     fun `hasRankAtLeast true when player priority not below target`() {
         val playerRankId = UUID.randomUUID()
         val officerRankId = UUID.randomUUID()
@@ -83,18 +95,54 @@ class GuildLookupImplTest {
     }
 
     @Test
+    fun `hasRankAtLeast false when player rank is lower authority than target`() {
+        val playerRankId = UUID.randomUUID()
+        val officerRankId = UUID.randomUUID()
+        every { members.getPlayerRankId(playerId, guildId) } returns playerRankId
+        every { ranks.listRanks(guildId) } returns setOf(
+            Rank(id = playerRankId, guildId = guildId, name = "Member", priority = 3),
+            Rank(id = officerRankId, guildId = guildId, name = "Officer", priority = 2),
+        )
+        assertFalse(lookup.hasRankAtLeast(playerId, guildId, "Officer"))
+    }
+
+    @Test
+    fun `hasRankAtLeast false when target rank not found`() {
+        val playerRankId = UUID.randomUUID()
+        every { members.getPlayerRankId(playerId, guildId) } returns playerRankId
+        every { ranks.listRanks(guildId) } returns setOf(
+            Rank(id = playerRankId, guildId = guildId, name = "Member", priority = 3),
+        )
+        assertFalse(lookup.hasRankAtLeast(playerId, guildId, "Officer"))
+    }
+
+    @Test
     fun `hasRankAtLeast false when player has no rank`() {
         every { members.getPlayerRankId(playerId, guildId) } returns null
         assertFalse(lookup.hasRankAtLeast(playerId, guildId, "Officer"))
     }
 
     @Test
-    fun `bank operations delegate and translate result`() {
+    fun `getBankBalance delegates and widens to Long`() {
         every { banks.getBalance(guildId) } returns 4200
         assertEquals(4200L, lookup.getBankBalance(guildId))
+    }
+
+    @Test
+    fun `bankWithdraw translates non-null result to true`() {
         every { banks.withdraw(guildId, playerId, 100, "r") } returns mockk()
         assertTrue(lookup.bankWithdraw(guildId, playerId, 100, "r"))
+    }
+
+    @Test
+    fun `bankDeposit translates null result to false`() {
         every { banks.deposit(guildId, playerId, 50, "r") } returns null
         assertFalse(lookup.bankDeposit(guildId, playerId, 50, "r"))
+    }
+
+    @Test
+    fun `bank amounts beyond Int range are rejected without hitting the service`() {
+        assertFalse(lookup.bankWithdraw(guildId, playerId, Int.MAX_VALUE.toLong() + 1, "r"))
+        assertFalse(lookup.bankDeposit(guildId, playerId, 0, "r"))
     }
 }

--- a/src/test/kotlin/net/lumalyte/lg/api/GuildLookupImplTest.kt
+++ b/src/test/kotlin/net/lumalyte/lg/api/GuildLookupImplTest.kt
@@ -1,0 +1,100 @@
+package net.lumalyte.lg.api
+
+import io.mockk.every
+import io.mockk.mockk
+import net.lumalyte.lg.application.services.BankService
+import net.lumalyte.lg.application.services.GuildService
+import net.lumalyte.lg.application.services.MemberService
+import net.lumalyte.lg.application.services.RankService
+import net.lumalyte.lg.domain.entities.Guild
+import net.lumalyte.lg.domain.entities.Member
+import net.lumalyte.lg.domain.entities.Rank
+import net.lumalyte.lg.domain.entities.RankPermission
+import java.time.Instant
+import java.util.UUID
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+
+class GuildLookupImplTest {
+
+    private val guildId = UUID.randomUUID()
+    private val playerId = UUID.randomUUID()
+    private val guilds = mockk<GuildService>()
+    private val members = mockk<MemberService>()
+    private val ranks = mockk<RankService>()
+    private val banks = mockk<BankService>()
+    private val lookup = GuildLookupImpl(guilds, members, ranks, banks)
+
+    @Test
+    fun `getGuild maps entity to summary`() {
+        every { guilds.getGuild(guildId) } returns Guild(
+            id = guildId, name = "TestGuild", createdAt = Instant.now(), tag = "&aTAG", emoji = ":x:",
+        )
+        val summary = lookup.getGuild(guildId)
+        assertEquals(GuildSummary(guildId, "TestGuild", "&aTAG", ":x:"), summary)
+    }
+
+    @Test
+    fun `getGuild returns null when absent`() {
+        every { guilds.getGuild(guildId) } returns null
+        assertNull(lookup.getGuild(guildId))
+    }
+
+    @Test
+    fun `getPlayerGuildIds delegates to member service`() {
+        every { members.getPlayerGuilds(playerId) } returns setOf(guildId)
+        assertEquals(setOf(guildId), lookup.getPlayerGuildIds(playerId))
+    }
+
+    @Test
+    fun `isMember reflects member presence`() {
+        every { members.getMember(playerId, guildId) } returns Member(
+            playerId = playerId, guildId = guildId, rankId = UUID.randomUUID(), joinedAt = Instant.now(),
+        )
+        assertTrue(lookup.isMember(playerId, guildId))
+        every { members.getMember(playerId, guildId) } returns null
+        assertFalse(lookup.isMember(playerId, guildId))
+    }
+
+    @Test
+    fun `hasShopPermission maps enum name and delegates`() {
+        every { members.hasPermission(playerId, guildId, RankPermission.EDIT_SHOP_STOCK) } returns true
+        assertTrue(lookup.hasShopPermission(playerId, guildId, "EDIT_SHOP_STOCK"))
+    }
+
+    @Test
+    fun `hasShopPermission returns false for unknown permission name`() {
+        assertFalse(lookup.hasShopPermission(playerId, guildId, "NOT_A_PERMISSION"))
+    }
+
+    @Test
+    fun `hasRankAtLeast true when player priority not below target`() {
+        val playerRankId = UUID.randomUUID()
+        val officerRankId = UUID.randomUUID()
+        every { members.getPlayerRankId(playerId, guildId) } returns playerRankId
+        every { ranks.listRanks(guildId) } returns setOf(
+            Rank(id = playerRankId, guildId = guildId, name = "Owner", priority = 0),
+            Rank(id = officerRankId, guildId = guildId, name = "Officer", priority = 2),
+        )
+        assertTrue(lookup.hasRankAtLeast(playerId, guildId, "officer"))
+    }
+
+    @Test
+    fun `hasRankAtLeast false when player has no rank`() {
+        every { members.getPlayerRankId(playerId, guildId) } returns null
+        assertFalse(lookup.hasRankAtLeast(playerId, guildId, "Officer"))
+    }
+
+    @Test
+    fun `bank operations delegate and translate result`() {
+        every { banks.getBalance(guildId) } returns 4200
+        assertEquals(4200L, lookup.getBankBalance(guildId))
+        every { banks.withdraw(guildId, playerId, 100, "r") } returns mockk()
+        assertTrue(lookup.bankWithdraw(guildId, playerId, 100, "r"))
+        every { banks.deposit(guildId, playerId, 50, "r") } returns null
+        assertFalse(lookup.bankDeposit(guildId, playerId, 50, "r"))
+    }
+}

--- a/src/test/kotlin/net/lumalyte/lg/api/GuildLookupImplTest.kt
+++ b/src/test/kotlin/net/lumalyte/lg/api/GuildLookupImplTest.kt
@@ -1,3 +1,17 @@
+// Test-idiom detekt rules don't fit JUnit/mockk tests (backtick names, in-line
+// expected values, one assertion-helper per case).
+@file:Suppress(
+    "FunctionNaming",
+    "FunctionMaxLength",
+    "MagicNumber",
+    "UndocumentedPublicFunction",
+    "UndocumentedPublicClass",
+    "TooManyFunctions",
+    "NoEmptyFirstLineInClassBody",
+    "MultilineExpressionWrapping",
+    "StringLiteralDuplication",
+)
+
 package net.lumalyte.lg.api
 
 import io.mockk.every


### PR DESCRIPTION
﻿## Problem

EnthusiaMarket read guild data by reaching into LumaGuilds'' Koin container from its own classloader (`GlobalContext.get().get<MemberService>()`). The reified Koin `get<T>()` carries a `kotlin.reflect.KClass` in its method signature, and that type resolves to **different `Class` objects** across the two plugin classloaders. The JVM rejects the call with a loader-constraint `LinkageError`, crashing `/em guild policy` (and any other path that touches guild data).

## Fix

Expose a stable, classloader-safe integration API via Bukkit''s **ServicesManager** — the same mechanism LumaGuilds already uses to consume EnthusiaMarket''s `ShopGuildLookup`, just in the other direction.

- `net.lumalyte.lg.api.GuildLookup` (interface) + `GuildSummary` — JDK types only, so the boundary never carries a `KClass`.
- `GuildLookupImpl` — delegates to the internal `GuildService` / `MemberService` / `RankService` / `BankService`. All Koin resolution stays inside LumaGuilds'' own classloader.
- Registered in `ServicesManager` at enable, unregistered at disable.

Consumers do: `Bukkit.getServicesManager().load(GuildLookup::class.java)`.

## Tests

`GuildLookupImplTest` — delegation + mapping (summary projection, permission-name resolution, rank-priority, bank ops). Full `./gradlew test` green.

## Coordination

EnthusiaMarket''s consumer-side change is in **BadgersMC/EnthusiaMarket** (`fix/lumaguilds-servicesmanager-api`). Both must be deployed together: this PR makes the service available; EM switches to loading it. LumaGuilds loads BEFORE EM (required dependency), so the service is registered before EM enables.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Fixes
- plugin shutdown: unregister GuildLookup service via Bukkit.getServicesManager().unregister(this) or by unregistering the stored GuildLookupImpl to avoid leaking the service across plugin reloads

## Features
- plugin enable: register GuildLookupImpl with Bukkit.getServicesManager to expose a classloader-safe GuildLookup API for external plugins
- api module: add net.lumalyte.lg.api.GuildLookup interface and GuildSummary projection using only JDK types to avoid kotlin.reflect.KClass across plugin boundaries
- api module: implement getPlayerGuildIds, getGuild, getAllGuilds for consumer guild queries
- membership check: implement isMember delegated to MemberService
- permissions: implement hasShopPermission returning false for unknown permission names or on service errors
- rank checks: implement hasRankAtLeast with case-insensitive rank lookup and false for missing target or missing player rank
- bank API: implement getBankBalance, bankWithdraw, bankDeposit delegating to BankService and widening balances to Long
- bank validation: accept Long amounts in API and reject non-positive or out-of-Int-range amounts
- tests: add GuildLookupImplTest covering mapping, delegation, permission/rank edge cases, and bank validation with all tests passing
- CI: pin RoseChat pre-hook ref in workflows to stabilize caching and build steps
<!-- end of auto-generated comment: release notes by coderabbit.ai -->