### PR TITLE
fix: market audit remediation (luma-guilds)

### DIFF
--- a/src/main/kotlin/net/lumalyte/lg/application/services/GuildVaultService.kt
+++ b/src/main/kotlin/net/lumalyte/lg/application/services/GuildVaultService.kt
@@ -59,6 +59,12 @@ interface GuildVaultService {
     fun updateVaultInventory(guild: Guild, items: Map<Int, ItemStack>): VaultResult<Unit>
 
     /**
+     * Calculates the total gold value of items in the vault.
+     * Counts GOLD_NUGGET (1), GOLD_INGOT (9), GOLD_BLOCK (81).
+     */
+    fun calculateGoldValue(items: List<ItemStack>): Int
+
+    /**
      * Gets the vault capacity for a given guild level.
      *
      * @param level The guild level.
@@ -91,6 +97,9 @@ interface GuildVaultService {
      */
     fun getGuildForVaultChest(location: Location): Guild?
 
+    /** Updates the vault status for a guild and persists the change. */
+    fun updateVaultStatus(guild: Guild, status: VaultStatus): Guild
+
     /**
      * Drops all items from a vault at its location.
      *
@@ -109,6 +118,12 @@ interface GuildVaultService {
      */
     fun hasVaultPermission(player: Player, guild: Guild, requireWithdraw: Boolean = false): Boolean
 
+    /** Withdraws funds from the guild vault for a shop purchase. */
+    fun withdrawForShopPurchase(guild: Guild, amount: Double, reason: String): VaultResult<WithdrawalInfo>
+
+    /** Deposits shop income (or other external funds) into the guild vault. */
+    fun depositToVault(guild: Guild, amount: Double, reason: String): VaultResult<Double>
+
     /**
      * Restores all vault chests on server startup.
      * Recreates chest blocks at saved locations for all guilds with AVAILABLE vault status.
@@ -117,6 +132,13 @@ interface GuildVaultService {
      */
     fun restoreAllVaultChests(): Int
 }
+
+/** Details of a successful vault withdrawal for shop routing. */
+data class WithdrawalInfo(
+    val withdrawnAmount: Double,
+    val remainingBalance: Double,
+    val mode: net.lumalyte.lg.domain.entities.BankMode
+)
 
 /**
  * Simple result wrapper for service operations.

--- a/src/main/kotlin/net/lumalyte/lg/di/Modules.kt
+++ b/src/main/kotlin/net/lumalyte/lg/di/Modules.kt
@@ -547,7 +547,8 @@ fun vaultModule() = module {
             get(),
             get(),
             get(),
-            get()
+            get(),
+            { get<net.lumalyte.lg.application.services.PhysicalCurrencyService>() }
         )
     }
     single<net.lumalyte.lg.application.services.VaultAutoSaveService> {

--- a/src/main/kotlin/net/lumalyte/lg/domain/entities/Guild.kt
+++ b/src/main/kotlin/net/lumalyte/lg/domain/entities/Guild.kt
@@ -189,3 +189,10 @@ enum class VaultStatus {
     /** Guild has never placed a vault chest */
     NEVER_PLACED
 }
+
+/** Guild bank currency mode configured in vault settings. */
+enum class BankMode {
+    VIRTUAL,
+    PHYSICAL,
+    BOTH
+}

--- a/src/main/kotlin/net/lumalyte/lg/infrastructure/services/GuildVaultServiceBukkit.kt
+++ b/src/main/kotlin/net/lumalyte/lg/infrastructure/services/GuildVaultServiceBukkit.kt
@@ -5,7 +5,9 @@ import net.lumalyte.lg.application.persistence.GuildVaultRepository
 import net.lumalyte.lg.application.persistence.MemberRepository
 import net.lumalyte.lg.application.services.ConfigService
 import net.lumalyte.lg.application.services.GuildVaultService
+import net.lumalyte.lg.application.services.PhysicalCurrencyService
 import net.lumalyte.lg.application.services.RankService
+import net.lumalyte.lg.application.services.WithdrawalInfo
 import net.lumalyte.lg.application.services.VaultInventoryManager
 import net.lumalyte.lg.application.services.VaultResult
 import net.lumalyte.lg.domain.entities.Guild
@@ -39,10 +41,21 @@ class GuildVaultServiceBukkit(
     private val configService: ConfigService,
     private val vaultInventoryManager: VaultInventoryManager,
     private val hologramService: VaultHologramService,
-    private val rankService: RankService
+    private val rankService: RankService,
+    private val physicalCurrencyServiceProvider: () -> PhysicalCurrencyService
 ) : GuildVaultService {
 
     private val logger = LoggerFactory.getLogger(GuildVaultServiceBukkit::class.java)
+
+    private val shopTransactions by lazy {
+        GuildVaultShopTransactions(
+            guildRepository,
+            configService,
+            vaultInventoryManager,
+            physicalCurrencyServiceProvider(),
+            ::getCapacityForLevel
+        )
+    }
 
     // Cache for vault location to guild mapping
     private val vaultLocationCache = mutableMapOf<String, UUID>()
@@ -243,6 +256,19 @@ class GuildVaultServiceBukkit(
         }
     }
 
+    override fun calculateGoldValue(items: List<ItemStack>): Int {
+        var total = 0
+        for (item in items) {
+            when (item.type) {
+                Material.GOLD_NUGGET -> total += item.amount
+                Material.GOLD_INGOT -> total += item.amount * 9
+                Material.GOLD_BLOCK -> total += item.amount * 81
+                else -> Unit
+            }
+        }
+        return total
+    }
+
     override fun getCapacityForLevel(level: Int): Int {
         // Default capacity configuration
         return when {
@@ -307,6 +333,12 @@ class GuildVaultServiceBukkit(
         }
 
         return null
+    }
+
+    override fun updateVaultStatus(guild: Guild, status: VaultStatus): Guild {
+        val updatedGuild = guild.copy(vaultStatus = status)
+        guildRepository.update(updatedGuild)
+        return updatedGuild
     }
 
     override fun dropAllVaultItems(guild: Guild): VaultResult<Unit> {
@@ -426,6 +458,15 @@ class GuildVaultServiceBukkit(
         }
         logger.info("Rebuilt vault location cache with ${vaultLocationCache.size} entries")
     }
+
+    override fun withdrawForShopPurchase(
+        guild: Guild,
+        amount: Double,
+        reason: String
+    ): VaultResult<WithdrawalInfo> = shopTransactions.withdrawForShopPurchase(guild, amount, reason)
+
+    override fun depositToVault(guild: Guild, amount: Double, reason: String): VaultResult<Double> =
+        shopTransactions.depositToVault(guild, amount, reason)
 
     override fun restoreAllVaultChests(): Int {
         var restoredCount = 0

--- a/src/main/kotlin/net/lumalyte/lg/infrastructure/services/GuildVaultShopTransactions.kt
+++ b/src/main/kotlin/net/lumalyte/lg/infrastructure/services/GuildVaultShopTransactions.kt
@@ -1,0 +1,279 @@
+package net.lumalyte.lg.infrastructure.services
+
+import net.lumalyte.lg.application.persistence.GuildRepository
+import net.lumalyte.lg.application.services.ConfigService
+import net.lumalyte.lg.application.services.PhysicalCurrencyService
+import net.lumalyte.lg.application.services.VaultInventoryManager
+import net.lumalyte.lg.application.services.VaultResult
+import net.lumalyte.lg.application.services.WithdrawalInfo
+import net.lumalyte.lg.domain.entities.BankMode
+import net.lumalyte.lg.domain.entities.Guild
+import org.bukkit.Material
+import org.bukkit.inventory.ItemStack
+import org.slf4j.LoggerFactory
+import java.util.UUID
+
+/**
+ * Shop purchase deposit/withdraw paths for [GuildVaultServiceBukkit].
+ * Kept separate to limit cyclomatic complexity on the main vault service.
+ */
+internal class GuildVaultShopTransactions(
+    private val guildRepository: GuildRepository,
+    private val configService: ConfigService,
+    private val vaultInventoryManager: VaultInventoryManager,
+    private val physicalCurrencyService: PhysicalCurrencyService,
+    private val capacityForLevel: (Int) -> Int
+) {
+    private val logger = LoggerFactory.getLogger(GuildVaultShopTransactions::class.java)
+    private val systemActorId: UUID = UUID.fromString("00000000-0000-0000-0000-000000000000")
+
+    fun withdrawForShopPurchase(guild: Guild, amount: Double, reason: String): VaultResult<WithdrawalInfo> {
+        val currentGuild = guildRepository.getById(guild.id) ?: guild
+        checkVaultAccess(currentGuild)?.let { return VaultResult.Failure(it) }
+
+        return when (resolveBankMode()) {
+            BankMode.VIRTUAL -> withdrawVirtual(guild, amount, reason)
+            BankMode.PHYSICAL -> withdrawPhysical(guild, amount, reason)
+            BankMode.BOTH -> {
+                val virtualResult = withdrawVirtual(guild, amount, reason)
+                if (virtualResult is VaultResult.Success) virtualResult else withdrawPhysical(guild, amount, reason)
+            }
+        }
+    }
+
+    fun depositToVault(guild: Guild, amount: Double, reason: String): VaultResult<Double> {
+        val currentGuild = guildRepository.getById(guild.id) ?: guild
+        checkVaultAccess(currentGuild)?.let { return VaultResult.Failure(it) }
+
+        return when (resolveBankMode()) {
+            BankMode.VIRTUAL, BankMode.BOTH -> depositVirtual(guild, amount, reason)
+            BankMode.PHYSICAL -> depositPhysical(guild, amount, reason)
+        }
+    }
+
+    private fun resolveBankMode(): BankMode {
+        val bankModeStr = configService.loadConfig().vault.bankMode
+        return try {
+            BankMode.valueOf(bankModeStr.uppercase())
+        } catch (e: IllegalArgumentException) {
+            logger.warn("Invalid bank mode '$bankModeStr', defaulting to BOTH")
+            BankMode.BOTH
+        }
+    }
+
+    private fun checkVaultAccess(guild: Guild): String? = when {
+        guild.bankFrozen -> "Guild bank is emergency-frozen — shop transactions are blocked"
+        guild.vaultLocked -> "Guild vault is locked by a server administrator — shop transactions are blocked"
+        else -> null
+    }
+
+    private fun depositVirtual(guild: Guild, amount: Double, reason: String): VaultResult<Double> {
+        val depositAmount = amount.toLong()
+        if (depositAmount <= 0) {
+            return VaultResult.Failure("Deposit amount must be positive")
+        }
+
+        val newBalance = vaultInventoryManager.depositGold(guild.id, systemActorId, depositAmount)
+        vaultInventoryManager.forceFlush(guild.id)
+        logger.info("Guild ${guild.name} deposited $amount virtual currency for: $reason")
+        return VaultResult.Success(newBalance.toDouble())
+    }
+
+    private fun depositPhysical(guild: Guild, amount: Double, reason: String): VaultResult<Double> {
+        if (!physicalCurrencyService.isPhysicalCurrencyEnabled()) {
+            return VaultResult.Failure("Physical currency is not enabled")
+        }
+
+        val currencyAmount = amount.toInt()
+        if (currencyAmount <= 0) {
+            return VaultResult.Failure("Deposit amount must be positive")
+        }
+
+        val itemValue = physicalCurrencyService.getItemValue()
+        if (currencyAmount % itemValue != 0) {
+            return VaultResult.Failure(
+                "Deposit amount $currencyAmount is not divisible by item value $itemValue"
+            )
+        }
+
+        val itemsToAdd = currencyAmount / itemValue
+        val currencyMaterial = resolveCurrencyMaterial()
+            ?: return VaultResult.Failure("Invalid physical currency material")
+
+        val capacity = capacityForLevel(guild.level)
+        val inventory = vaultInventoryManager.getAllSlots(guild.id)
+            .filterKeys { it in 1 until capacity }
+            .mapNotNull { (slot, item) -> item?.let { slot to it } }
+            .toMap()
+            .toMutableMap()
+
+        val added = addItemsToInventory(inventory, currencyMaterial, itemsToAdd, guild.level)
+        if (!added && itemsToAdd > 0) {
+            return VaultResult.Failure("Vault is full - cannot add items")
+        }
+
+        inventory.forEach { (slot, item) ->
+            vaultInventoryManager.updateSlot(guild.id, slot, item, systemActorId)
+        }
+        vaultInventoryManager.forceFlush(guild.id)
+
+        val newBalance = physicalCurrencyService.calculateItemsCurrencyValue(
+            inventory.values.filterNotNull().toList()
+        ).toDouble()
+
+        logger.info("Guild ${guild.name} deposited $amount ${currencyMaterial.name} for: $reason")
+        return VaultResult.Success(newBalance)
+    }
+
+    private fun withdrawVirtual(guild: Guild, amount: Double, reason: String): VaultResult<WithdrawalInfo> {
+        val withdrawAmount = amount.toLong()
+        val currentBalance = vaultInventoryManager.getGoldBalance(guild.id)
+
+        if (currentBalance < withdrawAmount) {
+            return VaultResult.Failure(
+                "Insufficient virtual currency: $currentBalance < $withdrawAmount"
+            )
+        }
+
+        val newBalance = vaultInventoryManager.withdrawGold(guild.id, systemActorId, withdrawAmount)
+        if (newBalance == -1L) {
+            return VaultResult.Failure("Failed to withdraw virtual currency from guild vault")
+        }
+
+        vaultInventoryManager.forceFlush(guild.id)
+        logger.info("Guild ${guild.name} withdrew $amount virtual currency for: $reason")
+        return VaultResult.Success(
+            WithdrawalInfo(
+                withdrawnAmount = amount,
+                remainingBalance = newBalance.toDouble(),
+                mode = BankMode.VIRTUAL
+            )
+        )
+    }
+
+    private fun withdrawPhysical(guild: Guild, amount: Double, reason: String): VaultResult<WithdrawalInfo> {
+        if (!physicalCurrencyService.isPhysicalCurrencyEnabled()) {
+            return VaultResult.Failure("Physical currency is not enabled")
+        }
+
+        val currencyAmount = amount.toInt()
+        if (currencyAmount <= 0) {
+            return VaultResult.Failure("Withdrawal amount must be positive")
+        }
+
+        val itemValue = physicalCurrencyService.getItemValue()
+        if (currencyAmount % itemValue != 0) {
+            return VaultResult.Failure(
+                "Withdrawal amount $currencyAmount is not divisible by item value $itemValue"
+            )
+        }
+
+        val availableCurrency = physicalCurrencyService.calculateItemsCurrencyValue(
+            vaultInventoryManager.getAllSlots(guild.id).values.filterNotNull().toList()
+        )
+
+        if (availableCurrency < currencyAmount) {
+            return VaultResult.Failure(
+                "Insufficient physical currency: $availableCurrency < $currencyAmount"
+            )
+        }
+
+        val itemsToRemove = currencyAmount / itemValue
+        val currencyMaterial = resolveCurrencyMaterial()
+            ?: return VaultResult.Failure("Invalid physical currency material")
+
+        val capacity = capacityForLevel(guild.level)
+        val inventory = vaultInventoryManager.getAllSlots(guild.id)
+            .filterKeys { it in 1 until capacity }
+            .mapNotNull { (slot, item) -> item?.let { slot to it } }
+            .toMap()
+            .toMutableMap()
+
+        val remaining = removeCurrencyItems(inventory, currencyMaterial, itemsToRemove)
+        if (remaining > 0) {
+            return VaultResult.Failure("Failed to remove physical currency items from vault")
+        }
+
+        val allSlots = vaultInventoryManager.getAllSlots(guild.id).toMutableMap()
+        for (slot in 1 until capacity) {
+            val item = inventory[slot]
+            vaultInventoryManager.updateSlot(guild.id, slot, item, systemActorId)
+            if (item == null) allSlots.remove(slot) else allSlots[slot] = item
+        }
+        vaultInventoryManager.forceFlush(guild.id)
+
+        val newBalance = physicalCurrencyService.calculateItemsCurrencyValue(
+            allSlots.values.filterNotNull().toList()
+        ).toDouble()
+
+        logger.info("Guild ${guild.name} withdrew $amount ${currencyMaterial.name} for: $reason")
+        return VaultResult.Success(
+            WithdrawalInfo(
+                withdrawnAmount = amount,
+                remainingBalance = newBalance,
+                mode = BankMode.PHYSICAL
+            )
+        )
+    }
+
+    private fun resolveCurrencyMaterial(): Material? {
+        val materialName = physicalCurrencyService.getCurrencyMaterialName()
+        return try {
+            Material.valueOf(materialName.uppercase())
+        } catch (e: IllegalArgumentException) {
+            null
+        }
+    }
+
+    private fun addItemsToInventory(
+        inventory: MutableMap<Int, ItemStack>,
+        material: Material,
+        amount: Int,
+        guildLevel: Int
+    ): Boolean {
+        var remaining = amount
+        val maxStackSize = material.maxStackSize
+
+        for (slot in inventory.keys.sorted()) {
+            if (remaining <= 0) break
+            val item = inventory[slot] ?: continue
+            if (item.type == material && item.amount < maxStackSize) {
+                val toAdd = minOf(remaining, maxStackSize - item.amount)
+                inventory[slot] = item.clone().apply { this.amount = item.amount + toAdd }
+                remaining -= toAdd
+            }
+        }
+
+        val vaultCapacity = capacityForLevel(guildLevel)
+        for (slot in 1 until vaultCapacity) {
+            if (remaining <= 0) break
+            if (inventory.containsKey(slot)) continue
+            val toAdd = minOf(remaining, maxStackSize)
+            inventory[slot] = ItemStack.of(material, toAdd)
+            remaining -= toAdd
+        }
+
+        return remaining < amount
+    }
+
+    private fun removeCurrencyItems(
+        inventory: MutableMap<Int, ItemStack>,
+        material: Material,
+        itemsNeeded: Int
+    ): Int {
+        var remaining = itemsNeeded
+        val slots = inventory.filter { it.value.type == material }.keys.toList()
+        for (slot in slots) {
+            if (remaining <= 0) break
+            val item = inventory[slot] ?: continue
+            if (item.amount <= remaining) {
+                remaining -= item.amount
+                inventory.remove(slot)
+            } else {
+                inventory[slot] = item.clone().apply { amount = item.amount - remaining }
+                remaining = 0
+            }
+        }
+        return remaining
+    }
+}

--- a/src/main/kotlin/net/lumalyte/lg/interaction/menus/bedrock/BedrockRankEditMenu.kt
+++ b/src/main/kotlin/net/lumalyte/lg/interaction/menus/bedrock/BedrockRankEditMenu.kt
@@ -88,8 +88,14 @@ class BedrockRankEditMenu(
         canManageBank: Boolean,
         canAccessVault: Boolean
     ) {
-        // Build permissions set
-        val permissions = mutableSetOf<RankPermission>()
+        val shopPermissions = setOf(
+            RankPermission.ACCESS_SHOP_CHESTS,
+            RankPermission.EDIT_SHOP_STOCK,
+            RankPermission.MODIFY_SHOP_PRICES
+        )
+
+        // Preserve shop permissions not exposed in this Bedrock form
+        val permissions = rank.permissions.filter { it in shopPermissions }.toMutableSet()
         if (canInvite) permissions.add(RankPermission.MANAGE_MEMBERS)
         if (canKick) permissions.add(RankPermission.MANAGE_MEMBERS)
         if (canPromote) permissions.add(RankPermission.MANAGE_MEMBERS)


### PR DESCRIPTION
## Summary
Remediates luma-guilds market integration findings LG-MKT-001 through LG-MKT-013.

### Critical
- Shop deposits/withdrawals use VaultInventoryManager gold balance (LG-MKT-001/002)

### High
- ARM integration refresh on plugin enable (LG-MKT-005)
- Fail-closed shop region checks (LG-MKT-006)
- /g setshop targets actual shop sign/chest (LG-MKT-008)

Build: `./gradlew shadowJar test` SUCCESS