### PR TITLE
fix(allyhome): restore own-guild allyhome access reverted in ARM purge

### DIFF
--- a/src/main/kotlin/net/lumalyte/lg/interaction/commands/GuildCommand.kt
+++ b/src/main/kotlin/net/lumalyte/lg/interaction/commands/GuildCommand.kt
@@ -573,9 +573,10 @@ class GuildCommand : BaseCommand(), KoinComponent {
             player.sendMessage("§cNo guild named '$guildName' found.")
             return null
         }
+        // Own guild's ally-home is a valid target: members with USE_ALLY_HOMES (or the owner)
+        // may teleport to it. The ally-relation check below only applies to other guilds.
         if (targetGuild.id == ownGuild.id) {
-            player.sendMessage("§cUse §6/guild home §cfor your own guild's home.")
-            return null
+            return targetGuild
         }
         val relationService: net.lumalyte.lg.application.services.RelationService by inject()
         if (relationService.getRelationType(ownGuild.id, targetGuild.id)
@@ -596,9 +597,20 @@ class GuildCommand : BaseCommand(), KoinComponent {
             player.sendMessage("§c${targetGuild.name} has no ally home set.")
             return null
         }
-        if (!guildService.canUseAllyHome(player.uniqueId, ownGuild.id, targetGuild.id)) {
-            player.sendMessage("§c❌ You don't have permission to use ${targetGuild.name}'s ally home.")
-            player.sendMessage("§7Your rank may lack USE_ALLY_HOMES, or that guild has not granted access.")
+        val isOwnGuild = targetGuild.id == ownGuild.id
+        val allowed = if (isOwnGuild) {
+            guildService.canUseOwnAllyHome(player.uniqueId, ownGuild.id)
+        } else {
+            guildService.canUseAllyHome(player.uniqueId, ownGuild.id, targetGuild.id)
+        }
+        if (!allowed) {
+            if (isOwnGuild) {
+                player.sendMessage("§c❌ You don't have permission to use your guild's ally home.")
+                player.sendMessage("§7Your rank needs the USE_ALLY_HOMES permission.")
+            } else {
+                player.sendMessage("§c❌ You don't have permission to use ${targetGuild.name}'s ally home.")
+                player.sendMessage("§7Your rank may lack USE_ALLY_HOMES, or that guild has not granted access.")
+            }
             return null
         }
         if (teleportationService.hasActiveTeleport(player.uniqueId)) {


### PR DESCRIPTION
## Summary
Restores own-guild allyhome teleport access that was inadvertently reverted in commit `85c001a` (the ARM/ARM-Bridge/ItemShops purge).

## What broke
- `resolveAllyTarget` was rejecting own-guild with "Use /guild home for your own guild"
- `resolveAllyHomeLocation` only checked cross-guild `canUseAllyHome`, never `canUseOwnAllyHome`

## Fix
- `resolveAllyTarget`: allow own-guild as valid target (skip ally-relation check)
- `resolveAllyHomeLocation`: use `canUseOwnAllyHome` for own-guild, `canUseAllyHome` for other guilds

Owners and members with `USE_ALLY_HOMES` rank permission can now `/g allyhome <ownGuild>` again.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

Breaking
- Remove legacy ARM/ItemShops bridge, shop-service stubs, and `/guild setshop`, leaving vault/shop integration to the new balance flow.

Fixes
- Restore `/guild allyhome <ownGuild>` for owners and members with `USE_ALLY_HOMES` by allowing same-guild targets and using a dedicated own-guild permission check.
- Switch guild bank reads/writes, wager handling, menus, placeholders, and leaderboard output to the unified vault-gold source of truth.
- Add relation cleanup and stale-request recovery so expired pending treaties and terminal rows no longer block new relation changes.
- Migrate legacy guild balances into `vault_gold` and zero out old `guilds.bank_balance` values on upgrade.

Features
- Add guild bank balance and leaderboard permissions plus top-balance queries for services, repositories, and commands.
- Add relation maintenance scheduling on startup and periodic stale-row cleanup.
- Add tests covering ally-home access, treaty lifecycle edge cases, and guild balance consolidation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->