### PR TITLE
fix(build): move Sonatype snapshots to end of repo list

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -11,7 +11,6 @@ repositories {
     mavenLocal()
     mavenCentral()
     maven("https://repo.papermc.io/repository/maven-public/")
-    maven("https://oss.sonatype.org/content/repositories/snapshots")
     maven("https://oss.sonatype.org/content/repositories/central")
     maven("https://repo.aikar.co/content/groups/aikar/")
     maven("https://jitpack.io")
@@ -30,6 +29,14 @@ repositories {
         name = "lunarclient-public"
         url = uri("https://repo.lunarclient.dev/")
     }
+    // Sonatype OSS snapshots — kept as last-resort fallback because
+    // the domain has frequent outages (HTTP 504).  All key SNAPSHOT
+    // deps are covered by dedicated repos above:
+    //   - PlaceholderAPI → JitPack
+    //   - Geyser / Floodgate / Cumulus → OpenCollab
+    //   - ACF / IDB → Aikar
+    //   - CombatLogX → SirBlobman
+    maven("https://oss.sonatype.org/content/repositories/snapshots")
 }
 
 dependencies {


### PR DESCRIPTION
## Summary
Sonatype OSS snapshot repo (`oss.sonatype.org/content/repositories/snapshots`) had an outage returning HTTP 504, blocking ALL CI (Build Gradle, Unit Test, release).

## Root Cause
Gradle resolves repos in order. Sonatype was listed early (line 14) and all three failing deps reached it first:
- `com.github.placeholderapi:placeholderapi:2.11.6` → Sonatype 504 → JitPack never tried
- `org.geysermc.geyser:api:2.9.4-SNAPSHOT` → Sonatype 504 → OpenCollab never tried
- `org.geysermc.floodgate:api:2.2.5-SNAPSHOT` → Sonatype 504 → OpenCollab never tried

All three deps exist on dedicated repos already listed:
- PlaceholderAPI → JitPack (exact same coordinates)
- Geyser/Floodgate/Cumulus → OpenCollab (`repo.opencollab.dev/main/`)
- ACF/IDB → Aikar (`repo.aikar.co`)
- CombatLogX → SirBlobman (`nexus.sirblobman.xyz`)

## Fix
Move `oss.sonatype.org/content/repositories/snapshots` to the **end** of the repository list. Dedicated repos now resolve first. Sonatype remains as a last-resort fallback.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

Fixes
- Reorder `build.gradle.kts` repository resolution so `oss.sonatype.org/content/repositories/snapshots` is checked last, preserving it only as a fallback after dedicated SNAPSHOT repositories.

Features
- Annotate the Sonatype fallback entry with guidance explaining why it remains last and which dependencies are expected to resolve from other repositories first.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->