### PR TITLE
fix(build): remove redundant sonatype central proxy

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -11,7 +11,6 @@ repositories {
     mavenLocal()
     mavenCentral()
     maven("https://repo.papermc.io/repository/maven-public/")
-    maven("https://oss.sonatype.org/content/repositories/central")
     maven("https://repo.aikar.co/content/groups/aikar/")
     maven("https://jitpack.io")
     maven("https://repo.codemc.io/repository/maven-snapshots/")


### PR DESCRIPTION
## Summary
Removes `oss.sonatype.org/content/repositories/central` from the repositories list.

## Why
Sonatype OSS is experiencing a complete domain outage (HTTP 504 for all URLs). The `central` proxy is redundant — `mavenCentral()` at line 12 already points to the same Maven Central backend. The only purpose `oss.sonatype.org/content/repositories/central` serves today is acting as a single point of failure that block-kills Gradle resolution before it reaches dedicated repos (JitPack, OpenCollab, SirBlobman, etc.).

Continuation of #70 — the merge of #70 only moved snapshots to the end but missed the removal of central on the amended commit.