### PR TITLE
feat: guild name/tag content filter with leet-speak normalization

### DIFF
--- a/src/main/kotlin/net/lumalyte/lg/config/MainConfig.kt
+++ b/src/main/kotlin/net/lumalyte/lg/config/MainConfig.kt
@@ -55,6 +55,9 @@ data class GuildConfig(
     var createGuildCost: Int = 0,
     var disbandRefundPercent: Double = 0.5,
     
+    // Name filtering (profanity / inappropriate content)
+    var nameFilter: NameFilterConfig = NameFilterConfig(),
+    
     // Mode Switching
     var peacefulModeEnabled: Boolean = true,
     var modeSwitchingEnabled: Boolean = true, // If false, guilds cannot switch between peaceful/hostile modes
@@ -445,3 +448,38 @@ data class MariaDBPoolConfig(
 enum class ImageSource {
     URL, RESOURCE_PACK
 }
+
+data class NameFilterConfig(
+    var enabled: Boolean = false,
+    // Regex patterns to block. Applied after normalization. Use \b for word boundaries.
+    var blockedPatterns: List<String> = listOf(
+        "\\bn[i1]gg[3e]r",
+        "\\bf[a@4]gg?[0o]t",
+        "\\btr[a@4]nn?[y1]",
+        "\\bf[a@4]g",
+        "\\bsh[i1]t",
+        "\\b([a@4][s\\$]{2})\\b",
+        "\\bb[i1]tch",
+        "\\bcunt",
+        "\\bd[i1]ck",
+        "\\bwh[0o]r[3e]",
+        "\\bsl[uü]t",
+        "\\bk[y1]ke",
+        "\\bch[i1]nk",
+        "\\bw[0o]p",
+        "\\bg[0o]ok",
+        "\\br[3e]t[a@4]rd",
+        "\\bh[i1]tl[3e]r",
+        "\\bn[a@4][z\\$][i1]",
+        "\\bp[3e]d[0o]",
+        "\\br[a@4]p[3e]"
+    ),
+    var normalization: NameFilterNormalization = NameFilterNormalization()
+)
+
+data class NameFilterNormalization(
+    // Map leet-speak characters: @→a, 1→i, 0→o, $→s, 3→e, 4→a, etc.
+    var leetMap: Boolean = true,
+    // Collapse repeated characters: "heeelllooo" → "hello"
+    var collapseRepeats: Boolean = true
+)

--- a/src/main/kotlin/net/lumalyte/lg/infrastructure/services/GuildServiceBukkit.kt
+++ b/src/main/kotlin/net/lumalyte/lg/infrastructure/services/GuildServiceBukkit.kt
@@ -6,6 +6,7 @@ import net.lumalyte.lg.application.persistence.MembershipHistoryRepository
 import net.lumalyte.lg.application.persistence.RankRepository
 import net.lumalyte.lg.application.persistence.RelationRepository
 import net.lumalyte.lg.application.services.AdminOverrideService
+import net.lumalyte.lg.application.services.ConfigService
 import net.lumalyte.lg.application.services.GuildService
 import net.lumalyte.lg.domain.entities.DepartureReason
 import net.lumalyte.lg.domain.entities.Guild
@@ -19,6 +20,7 @@ import net.lumalyte.lg.domain.events.GuildDisbandedEvent
 import net.lumalyte.lg.domain.events.GuildHomeSetEvent
 import net.lumalyte.lg.domain.events.GuildTrackingChangedEvent
 import net.lumalyte.lg.utils.serializeToString
+import net.lumalyte.lg.utils.GuildNameFilter
 import org.bukkit.Bukkit
 import org.koin.core.component.KoinComponent
 import org.koin.core.component.inject
@@ -46,6 +48,8 @@ class GuildServiceBukkit(
 
     private val logger = LoggerFactory.getLogger(GuildServiceBukkit::class.java)
 
+    private val configService: ConfigService by inject()
+
     companion object {
         // Allow only alphanumerics and spaces. Blocks color codes (&r, etc.),
         // punctuation [&!@#$%^&*()"',.] and any other non-[a-zA-Z0-9 ] char.
@@ -54,7 +58,10 @@ class GuildServiceBukkit(
 
     private fun isGuildNameValid(name: String): Boolean {
         if (name.isBlank() || name.length > 32) return false
-        return GUILD_NAME_ALLOWED.matches(name)
+        if (!GUILD_NAME_ALLOWED.matches(name)) return false
+        val filterConfig = configService.loadConfig().guild.nameFilter
+        if (GuildNameFilter.checkName(name, filterConfig) != null) return false
+        return true
     }
 
     override fun createGuild(name: String, ownerId: UUID, banner: String?): Guild? {
@@ -275,7 +282,7 @@ class GuildServiceBukkit(
         // If tag is provided, validate MiniMessage format
         tag?.let { tagValue ->
             // Reject interactive MiniMessage event tags (click/hover/insertion) — defense in depth
-            net.lumalyte.lg.utils.GuildTagValidator.rejectionReason(tagValue)?.let { reason ->
+            net.lumalyte.lg.utils.GuildTagValidator.rejectionReason(tagValue, configService.loadConfig().guild.nameFilter)?.let { reason ->
                 logger.warn("Rejected guild tag with interactive MiniMessage tag for guild $guildId: $reason")
                 return false
             }

--- a/src/main/kotlin/net/lumalyte/lg/interaction/commands/GuildCommand.kt
+++ b/src/main/kotlin/net/lumalyte/lg/interaction/commands/GuildCommand.kt
@@ -24,6 +24,7 @@ import net.lumalyte.lg.interaction.menus.MenuNavigator
 import net.lumalyte.lg.interaction.menus.guild.*
 import net.lumalyte.lg.utils.deserializeToItemStack
 import net.lumalyte.lg.utils.GuildHomeSafety
+import net.lumalyte.lg.utils.GuildNameFilter
 import org.bukkit.Bukkit
 import org.bukkit.Location
 import org.bukkit.command.Command
@@ -118,6 +119,13 @@ class GuildCommand : BaseCommand(), KoinComponent {
             return
         }
 
+        // Check name filter (profanity/inappropriate content)
+        val nameFilterConfig = configService.loadConfig().guild.nameFilter
+        GuildNameFilter.checkName(name, nameFilterConfig)?.let { reason ->
+            player.sendMessage("§c❌ $reason")
+            return
+        }
+
         val guild = guildService.createGuild(name, playerId, banner)
         if (guild != null) {
             player.sendMessage("§a✅ Guild '$name' created successfully!")
@@ -198,6 +206,13 @@ class GuildCommand : BaseCommand(), KoinComponent {
             player.sendMessage("§7 • Basic punctuation: ' & -")
             player.sendMessage("§7")
             player.sendMessage("§e💡 TIP: Use §6/guild tag §eto add colors and formatting!")
+            return
+        }
+
+        // Check name filter (profanity/inappropriate content)
+        val nameFilterConfig = configService.loadConfig().guild.nameFilter
+        GuildNameFilter.checkName(newName, nameFilterConfig)?.let { reason ->
+            player.sendMessage("§c❌ $reason")
             return
         }
 
@@ -1588,7 +1603,8 @@ class GuildCommand : BaseCommand(), KoinComponent {
             return
         }
 
-        net.lumalyte.lg.utils.GuildTagValidator.rejectionReason(tag)?.let { reason ->
+        val nameFilterConfig2 = configService.loadConfig().guild.nameFilter
+        net.lumalyte.lg.utils.GuildTagValidator.rejectionReason(tag, nameFilterConfig2)?.let { reason ->
             player.sendMessage("§c❌ $reason")
             return
         }

--- a/src/main/kotlin/net/lumalyte/lg/interaction/menus/bedrock/BedrockTagEditorMenu.kt
+++ b/src/main/kotlin/net/lumalyte/lg/interaction/menus/bedrock/BedrockTagEditorMenu.kt
@@ -1,6 +1,7 @@
 package net.lumalyte.lg.interaction.menus.bedrock
 
 import net.lumalyte.lg.application.services.GuildService
+import net.lumalyte.lg.application.services.ConfigService
 import net.lumalyte.lg.application.services.ValidationResult
 import net.lumalyte.lg.application.services.ValidatorType
 import net.lumalyte.lg.domain.entities.Guild
@@ -27,6 +28,7 @@ class BedrockTagEditorMenu(
 ) : BaseBedrockMenu(menuNavigator, player, logger) {
 
     private val guildService: GuildService by inject()
+    private val configService: ConfigService by inject()
 
     override fun getForm(): Form {
         val currentTag = guildService.getTag(guild.id)
@@ -151,7 +153,7 @@ class BedrockTagEditorMenu(
                         }
 
                         // Reject interactive MiniMessage event tags (click/hover/insertion)
-                        net.lumalyte.lg.utils.GuildTagValidator.rejectionReason(value)?.let {
+                        net.lumalyte.lg.utils.GuildTagValidator.rejectionReason(value, configService.loadConfig().guild.nameFilter)?.let {
                             return@getValidator ValidationResult.invalid(it)
                         }
 

--- a/src/main/kotlin/net/lumalyte/lg/interaction/menus/guild/TagEditorMenu.kt
+++ b/src/main/kotlin/net/lumalyte/lg/interaction/menus/guild/TagEditorMenu.kt
@@ -4,6 +4,7 @@ import com.github.stefvanschie.inventoryframework.gui.GuiItem
 import com.github.stefvanschie.inventoryframework.gui.type.ChestGui
 import com.github.stefvanschie.inventoryframework.pane.StaticPane
 import net.lumalyte.lg.application.services.GuildService
+import net.lumalyte.lg.application.services.ConfigService
 import net.lumalyte.lg.domain.entities.Guild
 import net.lumalyte.lg.interaction.listeners.ChatInputListener
 import net.lumalyte.lg.interaction.listeners.ChatInputHandler
@@ -30,6 +31,7 @@ class TagEditorMenu(private val menuNavigator: MenuNavigator, private val player
     private val guildService: GuildService by inject()
     private val menuItemBuilder: MenuItemBuilder by inject()
     private val chatInputListener: ChatInputListener by inject()
+    private val configService: ConfigService by inject()
 
     // State for the tag input
     private var currentTag: String? = null
@@ -357,7 +359,7 @@ class TagEditorMenu(private val menuNavigator: MenuNavigator, private val player
         }
 
         // Reject interactive MiniMessage event tags (click/hover/insertion)
-        net.lumalyte.lg.utils.GuildTagValidator.rejectionReason(tag)?.let { return it }
+        net.lumalyte.lg.utils.GuildTagValidator.rejectionReason(tag, configService.loadConfig().guild.nameFilter)?.let { return it }
 
         // Try to parse with MiniMessage
         try {

--- a/src/main/kotlin/net/lumalyte/lg/utils/GuildNameFilter.kt
+++ b/src/main/kotlin/net/lumalyte/lg/utils/GuildNameFilter.kt
@@ -1,8 +1,8 @@
 package net.lumalyte.lg.utils
 
-import net.lumalyte.lg.config.NameFilterConfig
 import net.kyori.adventure.text.minimessage.MiniMessage
 import net.kyori.adventure.text.serializer.plain.PlainTextComponentSerializer
+import net.lumalyte.lg.config.NameFilterConfig
 
 /**
  * Validates guild names and tags for inappropriate content.
@@ -16,18 +16,19 @@ import net.kyori.adventure.text.serializer.plain.PlainTextComponentSerializer
  */
 object GuildNameFilter {
 
-    private val LEET_MAP = mapOf(
-        '@' to 'a', '4' to 'a',
-        '3' to 'e',
-        '1' to 'i', '!' to 'i',
-        '0' to 'o',
-        '$' to 's', '5' to 's',
-        '7' to 't',
-        '2' to 'z',
-        '8' to 'b',
-        '6' to 'g',
-        '9' to 'g',
-    )
+    private val LEET_MAP =
+        mapOf(
+            '@' to 'a', '4' to 'a',
+            '3' to 'e',
+            '1' to 'i', '!' to 'i',
+            '0' to 'o',
+            '$' to 's', '5' to 's',
+            '7' to 't',
+            '2' to 'z',
+            '8' to 'b',
+            '6' to 'g',
+            '9' to 'g',
+        )
 
     /**
      * Checks plain text (guild name) against the filter.
@@ -71,7 +72,7 @@ object GuildNameFilter {
                 if (Regex(pattern, RegexOption.IGNORE_CASE).containsMatchIn(text)) {
                     return "Name contains inappropriate content."
                 }
-            } catch (e: Exception) {
+            } catch (e: IllegalArgumentException) {
                 // Malformed regex in config — skip it, don't crash
                 continue
             }

--- a/src/main/kotlin/net/lumalyte/lg/utils/GuildNameFilter.kt
+++ b/src/main/kotlin/net/lumalyte/lg/utils/GuildNameFilter.kt
@@ -29,7 +29,7 @@ object GuildNameFilter {
             '9' to 'g',
         )
 
-    private val logger = java.util.logging.Logger.getLogger(GuildNameFilter::class.java.name)
+    private val LOGGER = java.util.logging.Logger.getLogger(GuildNameFilter::class.java.name)
 
     /**
      * Checks plain text (guild name) against the filter.
@@ -75,7 +75,7 @@ object GuildNameFilter {
                 }
             } catch (e: IllegalArgumentException) {
                 // Malformed regex in config — log and skip, don't crash
-                logger.warning("Skipping malformed name filter pattern: $pattern — ${e.message}")
+                LOGGER.warning("Skipping malformed name filter pattern: $pattern — ${e.message}")
                 continue
             }
         }
@@ -86,9 +86,9 @@ object GuildNameFilter {
         return try {
             val component = MiniMessage.miniMessage().deserialize(tag)
             PlainTextComponentSerializer.plainText().serialize(component)
-        } catch (e: RuntimeException) {
+        } catch (e: IllegalArgumentException) {
             // Unparseable MiniMessage — strip tags with regex as fallback
-            logger.fine("MiniMessage parse failed for tag, falling back to regex strip: ${e.message}")
+            LOGGER.fine("MiniMessage parse failed for tag, falling back to regex strip: ${e.message}")
             tag.replace(Regex("<[^>]*>"), "")
         }
     }

--- a/src/main/kotlin/net/lumalyte/lg/utils/GuildNameFilter.kt
+++ b/src/main/kotlin/net/lumalyte/lg/utils/GuildNameFilter.kt
@@ -15,7 +15,6 @@ import net.lumalyte.lg.config.NameFilterConfig
  * [GuildTagValidator].
  */
 object GuildNameFilter {
-
     private val LEET_MAP =
         mapOf(
             '@' to 'a', '4' to 'a',
@@ -73,7 +72,9 @@ object GuildNameFilter {
                     return "Name contains inappropriate content."
                 }
             } catch (e: IllegalArgumentException) {
-                // Malformed regex in config — skip it, don't crash
+                // Malformed regex in config — log warning, skip it, don't crash
+                java.util.logging.Logger.getLogger(GuildNameFilter::class.java.name)
+                    .warning { "Skipping malformed name filter pattern: $pattern" }
                 continue
             }
         }
@@ -84,7 +85,7 @@ object GuildNameFilter {
         return try {
             val component = MiniMessage.miniMessage().deserialize(tag)
             PlainTextComponentSerializer.plainText().serialize(component)
-        } catch (e: Exception) {
+        } catch (e: RuntimeException) {
             // Unparseable MiniMessage — strip tags with regex as fallback
             tag.replace(Regex("<[^>]*>"), "")
         }

--- a/src/main/kotlin/net/lumalyte/lg/utils/GuildNameFilter.kt
+++ b/src/main/kotlin/net/lumalyte/lg/utils/GuildNameFilter.kt
@@ -1,0 +1,91 @@
+package net.lumalyte.lg.utils
+
+import net.lumalyte.lg.config.NameFilterConfig
+import net.kyori.adventure.text.minimessage.MiniMessage
+import net.kyori.adventure.text.serializer.plain.PlainTextComponentSerializer
+
+/**
+ * Validates guild names and tags for inappropriate content.
+ *
+ * Applies configurable normalization (leet-speak mapping, repeat collapsing)
+ * before checking against configurable regex blocklist patterns.
+ *
+ * Guild tags have MiniMessage formatting stripped before content checking.
+ * Structural validation (interactive tags, length, emptiness) remains in
+ * [GuildTagValidator].
+ */
+object GuildNameFilter {
+
+    private val LEET_MAP = mapOf(
+        '@' to 'a', '4' to 'a',
+        '3' to 'e',
+        '1' to 'i', '!' to 'i',
+        '0' to 'o',
+        '$' to 's', '5' to 's',
+        '7' to 't',
+        '2' to 'z',
+        '8' to 'b',
+        '6' to 'g',
+        '9' to 'g',
+    )
+
+    /**
+     * Checks plain text (guild name) against the filter.
+     * Returns a rejection reason string if blocked, null if acceptable.
+     */
+    fun checkName(name: String, config: NameFilterConfig): String? {
+        if (!config.enabled || config.blockedPatterns.isEmpty()) return null
+        val normalized = normalize(name, config)
+        return matchBlocked(normalized, config.blockedPatterns)
+    }
+
+    /**
+     * Checks a MiniMessage-formatted guild tag against the filter.
+     * Strips formatting first, then checks the visible text content.
+     * Returns a rejection reason if blocked, null if acceptable.
+     */
+    fun checkTag(tag: String, config: NameFilterConfig): String? {
+        if (!config.enabled || config.blockedPatterns.isEmpty()) return null
+        val plainText = stripMiniMessage(tag)
+        val normalized = normalize(plainText, config)
+        return matchBlocked(normalized, config.blockedPatterns)
+    }
+
+    private fun normalize(text: String, config: NameFilterConfig): String {
+        var result = text.lowercase()
+
+        if (config.normalization.leetMap) {
+            result = result.map { LEET_MAP[it] ?: it }.joinToString("")
+        }
+
+        if (config.normalization.collapseRepeats) {
+            result = result.replace(Regex("(.)\\1{2,}"), "$1$1")
+        }
+
+        return result
+    }
+
+    private fun matchBlocked(text: String, patterns: List<String>): String? {
+        for (pattern in patterns) {
+            try {
+                if (Regex(pattern, RegexOption.IGNORE_CASE).containsMatchIn(text)) {
+                    return "Name contains inappropriate content."
+                }
+            } catch (e: Exception) {
+                // Malformed regex in config — skip it, don't crash
+                continue
+            }
+        }
+        return null
+    }
+
+    private fun stripMiniMessage(tag: String): String {
+        return try {
+            val component = MiniMessage.miniMessage().deserialize(tag)
+            PlainTextComponentSerializer.plainText().serialize(component)
+        } catch (e: Exception) {
+            // Unparseable MiniMessage — strip tags with regex as fallback
+            tag.replace(Regex("<[^>]*>"), "")
+        }
+    }
+}

--- a/src/main/kotlin/net/lumalyte/lg/utils/GuildNameFilter.kt
+++ b/src/main/kotlin/net/lumalyte/lg/utils/GuildNameFilter.kt
@@ -29,6 +29,8 @@ object GuildNameFilter {
             '9' to 'g',
         )
 
+    private val logger = java.util.logging.Logger.getLogger(GuildNameFilter::class.java.name)
+
     /**
      * Checks plain text (guild name) against the filter.
      * Returns a rejection reason string if blocked, null if acceptable.
@@ -72,9 +74,8 @@ object GuildNameFilter {
                     return "Name contains inappropriate content."
                 }
             } catch (e: IllegalArgumentException) {
-                // Malformed regex in config — log warning, skip it, don't crash
-                java.util.logging.Logger.getLogger(GuildNameFilter::class.java.name)
-                    .warning { "Skipping malformed name filter pattern: $pattern" }
+                // Malformed regex in config — log and skip, don't crash
+                logger.warning("Skipping malformed name filter pattern: $pattern — ${e.message}")
                 continue
             }
         }
@@ -87,6 +88,7 @@ object GuildNameFilter {
             PlainTextComponentSerializer.plainText().serialize(component)
         } catch (e: RuntimeException) {
             // Unparseable MiniMessage — strip tags with regex as fallback
+            logger.fine("MiniMessage parse failed for tag, falling back to regex strip: ${e.message}")
             tag.replace(Regex("<[^>]*>"), "")
         }
     }

--- a/src/main/kotlin/net/lumalyte/lg/utils/GuildTagValidator.kt
+++ b/src/main/kotlin/net/lumalyte/lg/utils/GuildTagValidator.kt
@@ -1,13 +1,19 @@
 package net.lumalyte.lg.utils
 
+import net.lumalyte.lg.config.NameFilterConfig
+
 /**
- * Validates guild tag input for unsafe MiniMessage content.
+ * Validates guild tag input for unsafe MiniMessage content AND filters
+ * inappropriate visible text content after stripping formatting.
  *
  * Guild tags are plain display text and may carry color/formatting only. Interactive
  * MiniMessage tags (click/hover/insertion and other event actions) must never be stored,
  * otherwise a tag rendered next to a player's name could run commands, open URLs, or
  * inject text on click/hover. Color and decoration tags (e.g. <red>, <bold>, <gradient>)
  * remain allowed.
+ *
+ * After structural validation, visible text content is checked through
+ * [GuildNameFilter.checkTag] against the configured blocklist.
  */
 object GuildTagValidator {
 
@@ -24,16 +30,21 @@ object GuildTagValidator {
 
     /**
      * Returns a user-facing rejection reason if the tag contains a disallowed interactive
-     * MiniMessage tag, or null if the tag is acceptable.
+     * MiniMessage tag OR inappropriate visible text content, or null if the tag is acceptable.
      */
-    fun rejectionReason(tag: String): String? {
-        val match = disallowedPattern.find(tag) ?: return null
-        val tagName = match.groupValues[1].lowercase()
-        return "Guild tags cannot contain interactive '$tagName' tags. Use colors and formatting only."
+    fun rejectionReason(tag: String, nameFilterConfig: NameFilterConfig): String? {
+        val match = disallowedPattern.find(tag)
+        if (match != null) {
+            val tagName = match.groupValues[1].lowercase()
+            return "Guild tags cannot contain interactive '$tagName' tags. Use colors and formatting only."
+        }
+        return GuildNameFilter.checkTag(tag, nameFilterConfig)
     }
 
     /**
-     * Convenience check: true if the tag is free of disallowed interactive tags.
+     * Convenience check: true if the tag is free of disallowed interactive tags
+     * AND inappropriate content.
      */
-    fun isAllowed(tag: String): Boolean = rejectionReason(tag) == null
+    fun isAllowed(tag: String, nameFilterConfig: NameFilterConfig): Boolean =
+        rejectionReason(tag, nameFilterConfig) == null
 }


### PR DESCRIPTION
### Guild name & tag content filter

Config-driven filter that catches leet-speak variants of blocked patterns.

**Layers:**
- **GuildNameFilter.kt** — leet-map, repeat collapse, word-boundary regex
- **Config** — `NameFilterConfig` + `NameFilterNormalization`, disabled by default
- **Service** — `isGuildNameValid()` + `setTag()` both check filter
- **Commands** — create/rename/tag get early user-facing rejection
- **Menus** — TagEditorMenu + BedrockTagEditorMenu validate tags

**Config (config.yml):**
```yaml
guild:
  nameFilter:
    enabled: false
    blockedPatterns: [...18 patterns...]
    normalization:
      leetMap: true
      collapseRepeats: true
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

Features
- Add configurable guild name and tag filtering via `guild.nameFilter`, including enable flag, blocked regex patterns, and normalization options.
- Normalize guild names and tags with leet-speak mapping and optional repeat collapsing before blocklist matching.
- Strip MiniMessage formatting from tags before applying content checks.
- Apply the filter across guild create, rename, tag commands, editor menus, and Bukkit service validation.

Fixes
- Reject malformed blocklist regex patterns safely by logging and skipping them instead of failing validation.
- Keep structural tag restrictions in place while adding visible-text filtering for guild tags.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->