### PR TITLE
feat: auto-bump patch version on release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -8,23 +8,42 @@ jobs:
   release:
     runs-on: ubuntu-latest
     permissions:
-      contents: write  # create release + upload asset
+      contents: write
     env:
       ROSECHAT_PREHOOK_REF: 3fe078a
 
     steps:
       - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0  # need tags for version bump
 
       - uses: actions/setup-java@v4
         with:
           distribution: temurin
           java-version: 21
 
-      # RoseChat <-> LumaGuilds circular compileOnly dependency:
-      # LumaGuilds needs RoseChat jar to compile chat listeners.
-      # RoseChat master carries a LumaGuilds hook (needs LG jar).
-      # Build RoseChat at the last PRE-HOOK commit: no LG dep needed,
-      # still exposes every RoseChat API LumaGuilds compiles against.
+      - name: Bump version
+        id: bump
+        run: |
+          # Find latest tag matching v*.*.*
+          LATEST=$(git tag -l 'v[0-9]*.[0-9]*.[0-9]*' --sort=-v:refname | head -1)
+          if [ -z "$LATEST" ]; then
+            # No tags yet — read base from build.gradle.kts
+            BASE=$(grep -oP 'version\s*=\s*findProperty.*\?\s*:\s*"\K[^"]+' build.gradle.kts)
+            MAJOR=$(echo "$BASE" | cut -d. -f1)
+            MINOR=$(echo "$BASE" | cut -d. -f2)
+            PATCH=$(echo "$BASE" | cut -d. -f3)
+          else
+            # Strip leading 'v'
+            VER="${LATEST#v}"
+            MAJOR=$(echo "$VER" | cut -d. -f1)
+            MINOR=$(echo "$VER" | cut -d. -f2)
+            PATCH=$(echo "$VER" | cut -d. -f3)
+          fi
+          NEXT="${MAJOR}.${MINOR}.$((PATCH + 1))"
+          echo "Latest tag: ${LATEST:-none}, bumping to v$NEXT"
+          echo "version=$NEXT" >> "$GITHUB_OUTPUT"
+
       - name: Cache RoseChat jar
         id: rosechat-cache
         uses: actions/cache@v4
@@ -45,20 +64,14 @@ jobs:
           cp "$ROSE_JAR" "$GITHUB_WORKSPACE/libs/RoseChat-RC-2.jar"
 
       - name: Build shadowJar
-        run: ./gradlew shadowJar --no-daemon
-
-      - name: Read version
-        id: version
-        run: |
-          VER=$(grep '^version = ' build.gradle.kts | sed 's/.*"\(.*\)".*/\1/')
-          echo "version=$VER" >> "$GITHUB_OUTPUT"
+        run: ./gradlew shadowJar --no-daemon -PreleaseVersion=${{ steps.bump.outputs.version }}
 
       - name: Create Release
         uses: softprops/action-gh-release@v2
         with:
-          tag_name: v${{ steps.version.outputs.version }}
-          name: LumaGuilds v${{ steps.version.outputs.version }}
-          files: build/libs/LumaGuilds-${{ steps.version.outputs.version }}.jar
+          tag_name: v${{ steps.bump.outputs.version }}
+          name: LumaGuilds v${{ steps.bump.outputs.version }}
+          files: build/libs/LumaGuilds-${{ steps.bump.outputs.version }}.jar
           generate_release_notes: true
           fail_on_unmatched_files: true
           make_latest: true

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -5,7 +5,7 @@ plugins {
 }
 
 group = "net.lumalyte.lg"
-version = "2.1.0"
+version = findProperty("releaseVersion")?.toString() ?: "2.1.0"
 
 repositories {
     mavenLocal()


### PR DESCRIPTION
Each merge to main now gets a unique release tag.

**Changes:**
- `build.gradle.kts`: `version` reads from `-PreleaseVersion=X.Y.Z` gradle property (falls back to `2.1.0`)
- `release.yml`: finds latest `v*` tag, bumps patch, passes to Gradle via `-PreleaseVersion`

**Example:**
- Latest tag `v2.1.0` → next merge creates `v2.1.1` release
- Next merge → `v2.1.2`, etc.

No more overwriting the same `v2.1.0` release.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

Features
- Automatically bump the patch release version on merges to `main` by reading the latest `v*` tag and passing the next version into Gradle.
- Publish each release with a unique tag, name, and artifact filename based on the computed patch version.

Fixes
- Read `project.version` from the optional `-PreleaseVersion=X.Y.Z` Gradle property and fall back to `2.1.0` when unset.
- Keep the release workflow aligned with the computed version instead of reusing a fixed `v2.1.0` tag.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->