### PR TITLE
fix: owner (priority 0) implicitly has all rank permissions

### DIFF
--- a/src/main/kotlin/net/lumalyte/lg/infrastructure/services/GuildServiceBukkit.kt
+++ b/src/main/kotlin/net/lumalyte/lg/infrastructure/services/GuildServiceBukkit.kt
@@ -598,6 +598,8 @@ class GuildServiceBukkit(
         if (adminOverrideService.hasOverride(playerId)) return true
         val member = memberRepository.getByPlayerAndGuild(playerId, guildId) ?: return false
         val rank = rankRepository.getById(member.rankId) ?: return false
+        // Owner (priority 0) implicitly has all permissions.
+        if (rank.priority == 0) return true
         return rank.permissions.contains(permission)
     }
     

--- a/src/main/kotlin/net/lumalyte/lg/infrastructure/services/MemberServiceBukkit.kt
+++ b/src/main/kotlin/net/lumalyte/lg/infrastructure/services/MemberServiceBukkit.kt
@@ -439,6 +439,9 @@ class MemberServiceBukkit(
         if (adminOverrideService.hasOverride(playerId)) return true
         val member = memberRepository.getByPlayerAndGuild(playerId, guildId) ?: return false
         val rank = rankRepository.getById(member.rankId) ?: return false
+        // Owner (priority 0) implicitly has all permissions, even those added
+        // after guild creation — avoids stale permission sets for old guilds.
+        if (rank.priority == 0) return true
         return rank.permissions.contains(permission)
     }
 }

--- a/src/main/kotlin/net/lumalyte/lg/infrastructure/services/RankServiceBukkit.kt
+++ b/src/main/kotlin/net/lumalyte/lg/infrastructure/services/RankServiceBukkit.kt
@@ -226,6 +226,8 @@ class RankServiceBukkit(
     
     override fun hasPermission(playerId: UUID, guildId: UUID, permission: RankPermission): Boolean {
         val rank = getPlayerRank(playerId, guildId) ?: return false
+        // Owner (priority 0) implicitly has all permissions.
+        if (rank.priority == 0) return true
         return rank.permissions.contains(permission)
     }
     

--- a/src/test/kotlin/net/lumalyte/lg/infrastructure/services/GuildServiceBannermanTest.kt
+++ b/src/test/kotlin/net/lumalyte/lg/infrastructure/services/GuildServiceBannermanTest.kt
@@ -114,7 +114,7 @@ internal class GuildServiceBannermanTest {
                 id = UUID.randomUUID(),
                 guildId = testGuildId,
                 name = "Member",
-                priority = 0,
+                priority = 1,
                 permissions = emptySet(),
             )
     }

--- a/src/test/kotlin/net/lumalyte/lg/infrastructure/services/GuildServiceJoinFeeTest.kt
+++ b/src/test/kotlin/net/lumalyte/lg/infrastructure/services/GuildServiceJoinFeeTest.kt
@@ -105,7 +105,7 @@ class GuildServiceJoinFeeTest {
             id = UUID.randomUUID(),
             guildId = testGuildId,
             name = "Member",
-            priority = 0,
+            priority = 1,
             permissions = emptySet()
         )
     }


### PR DESCRIPTION
Owner rank gets RankPermission.values().toSet() at guild creation, but permissions added later (EDIT_SHOP_STOCK etc.) are missing for old guilds. All three hasPermission() impls now return true for priority 0 (owner).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
Fixes
- Grant guild owner ranks (`RankPermission.priority == 0`) implicit access to all rank permissions in `MemberServiceBukkit`, `GuildServiceBukkit`, and `RankServiceBukkit`, ensuring permission checks succeed for older guilds with stale stored permission sets.
- Update guild permission tests to set `memberRank.priority` to `1` instead of `0` so fixtures reflect that priority `0` now represents the owner rank.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->