### PR TITLE
fix(chat): select authorized guild for announcements

### DIFF
--- a/src/main/kotlin/net/lumalyte/lg/LumaGuilds.kt
+++ b/src/main/kotlin/net/lumalyte/lg/LumaGuilds.kt
@@ -811,6 +811,8 @@ class LumaGuilds : JavaPlugin() {
         commandManager.registerCommand(PartyChatCommand())
         commandManager.registerCommand(QuickGuildChatCommand())
         commandManager.registerCommand(QuickAllyChatCommand())
+        commandManager.registerCommand(QuickModChatCommand())
+        commandManager.registerCommand(QuickAnnounceCommand())
 
         // Register LumaGuilds admin command
         getCommand("lumaguilds")?.setExecutor(LumaGuildsCommand())

--- a/src/main/kotlin/net/lumalyte/lg/LumaGuilds.kt
+++ b/src/main/kotlin/net/lumalyte/lg/LumaGuilds.kt
@@ -809,6 +809,8 @@ class LumaGuilds : JavaPlugin() {
     private fun registerNonClaimCommands() {
         commandManager.registerCommand(GuildCommand())
         commandManager.registerCommand(PartyChatCommand())
+        commandManager.registerCommand(QuickGuildChatCommand())
+        commandManager.registerCommand(QuickAllyChatCommand())
 
         // Register LumaGuilds admin command
         getCommand("lumaguilds")?.setExecutor(LumaGuildsCommand())

--- a/src/main/kotlin/net/lumalyte/lg/application/services/ChatService.kt
+++ b/src/main/kotlin/net/lumalyte/lg/application/services/ChatService.kt
@@ -39,10 +39,10 @@ interface ChatService {
      * @return true if the announcement was sent successfully, false otherwise.
      */
     fun sendGuildAnnouncement(
-    guildId: UUID,
-    announcerId: UUID,
-    message: String,
-    colorDigit: Char,
+            guildId: UUID,
+            announcerId: UUID,
+            message: String,
+            colorDigit: Char,
     ): Boolean
     
     /**

--- a/src/main/kotlin/net/lumalyte/lg/application/services/ChatService.kt
+++ b/src/main/kotlin/net/lumalyte/lg/application/services/ChatService.kt
@@ -38,7 +38,8 @@ interface ChatService {
      * @param colorDigit A Minecraft color digit (0-9) for the header; defaults to '6' (gold).
      * @return true if the announcement was sent successfully, false otherwise.
      */
-    fun sendGuildAnnouncement(guildId: UUID,
+    fun sendGuildAnnouncement(
+        guildId: UUID,
         announcerId: UUID,
         message: String,
         colorDigit: Char,

--- a/src/main/kotlin/net/lumalyte/lg/application/services/ChatService.kt
+++ b/src/main/kotlin/net/lumalyte/lg/application/services/ChatService.kt
@@ -38,8 +38,7 @@ interface ChatService {
      * @param colorDigit A Minecraft color digit (0-9) for the header; defaults to '6' (gold).
      * @return true if the announcement was sent successfully, false otherwise.
      */
-    fun sendGuildAnnouncement(
-        guildId: UUID,
+    fun sendGuildAnnouncement(guildId: UUID,
         announcerId: UUID,
         message: String,
         colorDigit: Char,

--- a/src/main/kotlin/net/lumalyte/lg/application/services/ChatService.kt
+++ b/src/main/kotlin/net/lumalyte/lg/application/services/ChatService.kt
@@ -35,7 +35,8 @@ interface ChatService {
      * @param guildId The ID of the guild.
      * @param announcerId The ID of the player making the announcement.
      * @param message The announcement message.
-     * @param colorDigit A Minecraft color digit (0-9) for the header; defaults to '6' (gold).
+     * @param colorDigit A numeric Minecraft color code (0-9) for the header;
+     * invalid values fall back to '6' (gold).
      * @return true if the announcement was sent successfully, false otherwise.
      */
     fun sendGuildAnnouncement(

--- a/src/main/kotlin/net/lumalyte/lg/application/services/ChatService.kt
+++ b/src/main/kotlin/net/lumalyte/lg/application/services/ChatService.kt
@@ -39,7 +39,10 @@ interface ChatService {
      * @return true if the announcement was sent successfully, false otherwise.
      */
     fun sendGuildAnnouncement(
-        guildId: UUID, announcerId: UUID, message: String, colorDigit: Char,
+        guildId: UUID,
+        announcerId: UUID,
+        message: String,
+        colorDigit: Char,
     ): Boolean
     
     /**

--- a/src/main/kotlin/net/lumalyte/lg/application/services/ChatService.kt
+++ b/src/main/kotlin/net/lumalyte/lg/application/services/ChatService.kt
@@ -28,6 +28,19 @@ interface ChatService {
      * @return true if the announcement was sent successfully, false otherwise.
      */
     fun sendGuildAnnouncement(guildId: UUID, announcerId: UUID, message: String): Boolean
+
+    /**
+     * Sends a guild announcement to all guild members with a custom color.
+     *
+     * @param guildId The ID of the guild.
+     * @param announcerId The ID of the player making the announcement.
+     * @param message The announcement message.
+     * @param colorDigit A Minecraft color digit (0-9) for the header; defaults to '6' (gold).
+     * @return true if the announcement was sent successfully, false otherwise.
+     */
+    fun sendGuildAnnouncement(
+        guildId: UUID, announcerId: UUID, message: String, colorDigit: Char,
+    ): Boolean
     
     /**
      * Sends a ping to all guild members with sound notification.

--- a/src/main/kotlin/net/lumalyte/lg/application/services/ChatService.kt
+++ b/src/main/kotlin/net/lumalyte/lg/application/services/ChatService.kt
@@ -39,10 +39,10 @@ interface ChatService {
      * @return true if the announcement was sent successfully, false otherwise.
      */
     fun sendGuildAnnouncement(
-    guildId: UUID,
-    announcerId: UUID,
-    message: String,
-    colorDigit: Char,
+        guildId: UUID,
+        announcerId: UUID,
+        message: String,
+        colorDigit: Char,
     ): Boolean
     
     /**

--- a/src/main/kotlin/net/lumalyte/lg/application/services/ChatService.kt
+++ b/src/main/kotlin/net/lumalyte/lg/application/services/ChatService.kt
@@ -39,10 +39,10 @@ interface ChatService {
      * @return true if the announcement was sent successfully, false otherwise.
      */
     fun sendGuildAnnouncement(
-        guildId: UUID,
-        announcerId: UUID,
-        message: String,
-        colorDigit: Char,
+    guildId: UUID,
+    announcerId: UUID,
+    message: String,
+    colorDigit: Char,
     ): Boolean
     
     /**

--- a/src/main/kotlin/net/lumalyte/lg/application/services/ChatService.kt
+++ b/src/main/kotlin/net/lumalyte/lg/application/services/ChatService.kt
@@ -39,12 +39,7 @@ interface ChatService {
      * invalid values fall back to '6' (gold).
      * @return true if the announcement was sent successfully, false otherwise.
      */
-    fun sendGuildAnnouncement(
-        guildId: UUID,
-        announcerId: UUID,
-        message: String,
-        colorDigit: Char,
-    ): Boolean
+    fun sendGuildAnnouncement(guildId: UUID, announcerId: UUID, message: String, colorDigit: Char): Boolean
     
     /**
      * Sends a ping to all guild members with sound notification.

--- a/src/main/kotlin/net/lumalyte/lg/application/services/ChatService.kt
+++ b/src/main/kotlin/net/lumalyte/lg/application/services/ChatService.kt
@@ -39,10 +39,10 @@ interface ChatService {
      * @return true if the announcement was sent successfully, false otherwise.
      */
     fun sendGuildAnnouncement(
-            guildId: UUID,
-            announcerId: UUID,
-            message: String,
-            colorDigit: Char,
+        guildId: UUID,
+        announcerId: UUID,
+        message: String,
+        colorDigit: Char,
     ): Boolean
     
     /**

--- a/src/main/kotlin/net/lumalyte/lg/domain/values/ChatChannel.kt
+++ b/src/main/kotlin/net/lumalyte/lg/domain/values/ChatChannel.kt
@@ -14,7 +14,10 @@ enum class ChatChannel {
     
     /** Party chat channel */
     PARTY,
-    
+
+    /** Guild moderator chat channel */
+    MODCHAT,
+
     /** Public/global chat channel */
     PUBLIC
 }

--- a/src/main/kotlin/net/lumalyte/lg/domain/values/ChatChannel.kt
+++ b/src/main/kotlin/net/lumalyte/lg/domain/values/ChatChannel.kt
@@ -15,7 +15,7 @@ enum class ChatChannel {
     /** Party chat channel */
     PARTY,
 
-    /** Guild moderator chat channel */
+    /** Guild moderator chat channel. */
     MODCHAT,
 
     /** Public/global chat channel */

--- a/src/main/kotlin/net/lumalyte/lg/infrastructure/services/ChatServiceBukkit.kt
+++ b/src/main/kotlin/net/lumalyte/lg/infrastructure/services/ChatServiceBukkit.kt
@@ -271,6 +271,12 @@ class ChatServiceBukkit(
         } else {
             ""
         }
+        val modGuildTag = if (channel == ChatChannel.MODCHAT) {
+            val modGuild = getModeratorGuild(senderId)
+            modGuild?.let { GuildDisplayUtils.createGuildTag(it, brackets = false) } ?: ""
+        } else {
+            ""
+        }
         
         return when (channel) {
             ChatChannel.GUILD -> {
@@ -291,8 +297,8 @@ class ChatServiceBukkit(
                 formatPartyMessage(senderId, senderName, processedMessage, guildTag)
             }
             ChatChannel.MODCHAT ->
-                if (guildTag.isNotEmpty()) {
-                    "§1[M] $guildTag §9$senderName:§r $processedMessage"
+                if (modGuildTag.isNotEmpty()) {
+                    "§1[M] $modGuildTag §9$senderName:§r $processedMessage"
                 } else {
                     "§1[M] §9$senderName:§r $processedMessage"
                 }
@@ -304,6 +310,18 @@ class ChatServiceBukkit(
                 }
             }
         }
+    }
+
+    private fun getModeratorGuild(playerId: UUID): Guild? {
+        val moderatorGuildId =
+            memberService.getPlayerGuilds(playerId).firstOrNull { guildId ->
+                memberService.hasPermission(
+                    playerId,
+                    guildId,
+                    RankPermission.MODERATE_CHAT,
+                )
+            }
+        return moderatorGuildId?.let { guildService.getGuild(it) }
     }
 
     private fun formatPartyMessage(senderId: UUID, senderName: String, message: String, guildTag: String): String {

--- a/src/main/kotlin/net/lumalyte/lg/infrastructure/services/ChatServiceBukkit.kt
+++ b/src/main/kotlin/net/lumalyte/lg/infrastructure/services/ChatServiceBukkit.kt
@@ -237,7 +237,12 @@ class ChatServiceBukkit(
             }
             ChatChannel.MODCHAT -> {
                 val senderGuilds = memberService.getPlayerGuilds(senderId)
-                senderGuilds.flatMap { guildId ->
+                val modGuilds = senderGuilds.filter { guildId ->
+                    memberService.hasPermission(
+                        senderId, guildId, RankPermission.MODERATE_CHAT,
+                    )
+                }
+                modGuilds.flatMap { guildId ->
                     getOnlineGuildMembers(guildId).filter { playerId ->
                         memberService.hasPermission(
                             playerId, guildId, RankPermission.MODERATE_CHAT,

--- a/src/main/kotlin/net/lumalyte/lg/infrastructure/services/ChatServiceBukkit.kt
+++ b/src/main/kotlin/net/lumalyte/lg/infrastructure/services/ChatServiceBukkit.kt
@@ -29,10 +29,6 @@ class ChatServiceBukkit(
     private val partyRepository: PartyRepository
 ) : ChatService {
 
-    private companion object {
-        const val UNKNOWN_PLAYER = "Unknown"
-    }
-
     private val logger = LoggerFactory.getLogger(ChatServiceBukkit::class.java)
     
     // Rate limiting configuration (in milliseconds)
@@ -75,8 +71,7 @@ class ChatServiceBukkit(
     override fun sendGuildAnnouncement(guildId: UUID, announcerId: UUID, message: String): Boolean =
         sendGuildAnnouncement(guildId, announcerId, message, '6')
 
-    override fun sendGuildAnnouncement(
-        guildId: UUID,
+    override fun sendGuildAnnouncement(guildId: UUID,
         announcerId: UUID,
         message: String,
         colorDigit: Char,
@@ -589,5 +584,9 @@ class ChatServiceBukkit(
 
         // No automatic party assignment - players are in GLOBAL chat by default
         return null
+    }
+
+    private companion object {
+        const val UNKNOWN_PLAYER = "Unknown"
     }
 }

--- a/src/main/kotlin/net/lumalyte/lg/infrastructure/services/ChatServiceBukkit.kt
+++ b/src/main/kotlin/net/lumalyte/lg/infrastructure/services/ChatServiceBukkit.kt
@@ -28,7 +28,11 @@ class ChatServiceBukkit(
     private val preferenceRepository: PlayerPartyPreferenceRepository,
     private val partyRepository: PartyRepository
 ) : ChatService {
-    
+
+    private companion object {
+        const val UNKNOWN_PLAYER = "Unknown"
+    }
+
     private val logger = LoggerFactory.getLogger(ChatServiceBukkit::class.java)
     
     // Rate limiting configuration (in milliseconds)
@@ -78,7 +82,7 @@ class ChatServiceBukkit(
         colorDigit: Char,
     ): Boolean {
         val guild = validateAnnouncementPreconditions(announcerId, guildId) ?: return false
-        val name = Bukkit.getPlayer(announcerId)?.name ?: "Unknown"
+        val name = Bukkit.getPlayer(announcerId)?.name ?: UNKNOWN_PLAYER
         val fmt = "§$colorDigit[§l${GuildDisplayUtils.createGuildTag(guild)} ANNOUNCEMENT§r§$colorDigit]§r\n" +
             "§e$name:§r $message"
         return try {
@@ -128,7 +132,7 @@ class ChatServiceBukkit(
                 return false
             }
             
-            val pingerName = Bukkit.getPlayer(pingerId)?.name ?: "Unknown"
+            val pingerName = Bukkit.getPlayer(pingerId)?.name ?: UNKNOWN_PLAYER
             val guildDisplayName = GuildDisplayUtils.createGuildTag(guild)
             
             val formattedMessage = if (message != null) {
@@ -254,7 +258,7 @@ class ChatServiceBukkit(
     }
     
     override fun formatMessage(senderId: UUID, message: String, channel: ChatChannel): String {
-        val senderName = Bukkit.getPlayer(senderId)?.name ?: "Unknown"
+        val senderName = Bukkit.getPlayer(senderId)?.name ?: UNKNOWN_PLAYER
         val processedMessage = processEmojis(senderId, message)
         
         // Get sender's primary guild for context

--- a/src/main/kotlin/net/lumalyte/lg/infrastructure/services/ChatServiceBukkit.kt
+++ b/src/main/kotlin/net/lumalyte/lg/infrastructure/services/ChatServiceBukkit.kt
@@ -69,31 +69,30 @@ class ChatServiceBukkit(
     }
     
     override fun sendGuildAnnouncement(
-        guildId: UUID, announcerId: UUID, message: String,
-    ): Boolean = sendGuildAnnouncement(guildId, announcerId, message, '6')
+    guildId: UUID,
+    announcerId: UUID,
+    message: String,
+    ): Boolean =
+        sendGuildAnnouncement(guildId, announcerId, message, '6')
 
     override fun sendGuildAnnouncement(
-        guildId: UUID,
-        announcerId: UUID,
-        message: String,
-        colorDigit: Char,
+    guildId: UUID,
+    announcerId: UUID,
+    message: String,
+    colorDigit: Char,
     ): Boolean {
-        val guild = validateAnnouncementPreconditions(announcerId, guildId) ?: return false
-
+        val guild = validateAnnouncementPreconditions(announcerId, guildId)
+            ?: return false
         return try {
-            val announcerName = Bukkit.getPlayer(announcerId)?.name ?: "Unknown"
-            val guildDisplayName = GuildDisplayUtils.createGuildTag(guild)
-            val colorCode = "§$colorDigit"
-            val formatted = "$colorCode[§l${guildDisplayName} ANNOUNCEMENT§r$colorCode]§r\n" +
-                "§e$announcerName:§r $message"
-
+            val name = Bukkit.getPlayer(announcerId)?.name ?: "Unknown"
+            val tag = GuildDisplayUtils.createGuildTag(guild)
+            val c = "§$colorDigit"
+            val fmt = "$c[§l${tag} ANNOUNCEMENT§r$c]§r\n§e$name:§r $message"
             val recipients = getOnlineGuildMembers(guildId)
-            val count = broadcastMessageWithSound(recipients, formatted, true)
+            val sent = broadcastMessageWithSound(recipients, fmt, true)
             updateAnnouncementRateLimit(announcerId)
-            logger.info(
-                "Guild announcement from $announcerId delivered to $count members of guild $guildId",
-            )
-            count > 0
+            logger.info("Announce from $announcerId to $sent guild members")
+            sent > 0
         } catch (e: Exception) {
             logger.error("Error sending guild announcement", e)
             false

--- a/src/main/kotlin/net/lumalyte/lg/infrastructure/services/ChatServiceBukkit.kt
+++ b/src/main/kotlin/net/lumalyte/lg/infrastructure/services/ChatServiceBukkit.kt
@@ -69,23 +69,21 @@ class ChatServiceBukkit(
     }
     
     override fun sendGuildAnnouncement(
-            guildId: UUID,
-            announcerId: UUID,
-            message: String,
+        guildId: UUID,
+        announcerId: UUID,
+        message: String,
     ): Boolean =
         sendGuildAnnouncement(guildId, announcerId, message, '6')
 
     override fun sendGuildAnnouncement(
-            guildId: UUID,
-            announcerId: UUID,
-            message: String,
-            colorDigit: Char,
+        guildId: UUID,
+        announcerId: UUID,
+        message: String,
+        colorDigit: Char,
     ): Boolean {
-        val guild = validateAnnouncementPreconditions(announcerId, guildId)
-            ?: return false
+        val guild = validateAnnouncementPreconditions(announcerId, guildId) ?: return false
         val name = Bukkit.getPlayer(announcerId)?.name ?: "Unknown"
-        val c = "§$colorDigit"
-        val fmt = "$c[§l${GuildDisplayUtils.createGuildTag(guild)} ANNOUNCEMENT§r$c]§r\n" +
+        val fmt = "§$colorDigit[§l${GuildDisplayUtils.createGuildTag(guild)} ANNOUNCEMENT§r§$colorDigit]§r\n" +
             "§e$name:§r $message"
         return try {
             val n = broadcastMessageWithSound(getOnlineGuildMembers(guildId), fmt, true)

--- a/src/main/kotlin/net/lumalyte/lg/infrastructure/services/ChatServiceBukkit.kt
+++ b/src/main/kotlin/net/lumalyte/lg/infrastructure/services/ChatServiceBukkit.kt
@@ -79,7 +79,8 @@ class ChatServiceBukkit(
     ): Boolean {
         val guild = validateAnnouncementPreconditions(announcerId, guildId) ?: return false
         val name = Bukkit.getPlayer(announcerId)?.name ?: UNKNOWN_PLAYER
-        val fmt = "§$colorDigit[§l${GuildDisplayUtils.createGuildTag(guild)} ANNOUNCEMENT§r§$colorDigit]§r\n" +
+        val fmt =
+            "§$colorDigit[§l${GuildDisplayUtils.createGuildTag(guild)} ANNOUNCEMENT§r§$colorDigit]§r\n" +
             "§e$name:§r $message"
         return try {
             val n = broadcastMessageWithSound(getOnlineGuildMembers(guildId), fmt, true)

--- a/src/main/kotlin/net/lumalyte/lg/infrastructure/services/ChatServiceBukkit.kt
+++ b/src/main/kotlin/net/lumalyte/lg/infrastructure/services/ChatServiceBukkit.kt
@@ -69,30 +69,29 @@ class ChatServiceBukkit(
     }
     
     override fun sendGuildAnnouncement(
-    guildId: UUID,
-    announcerId: UUID,
-    message: String,
+            guildId: UUID,
+            announcerId: UUID,
+            message: String,
     ): Boolean =
         sendGuildAnnouncement(guildId, announcerId, message, '6')
 
     override fun sendGuildAnnouncement(
-    guildId: UUID,
-    announcerId: UUID,
-    message: String,
-    colorDigit: Char,
+            guildId: UUID,
+            announcerId: UUID,
+            message: String,
+            colorDigit: Char,
     ): Boolean {
         val guild = validateAnnouncementPreconditions(announcerId, guildId)
             ?: return false
+        val name = Bukkit.getPlayer(announcerId)?.name ?: "Unknown"
+        val c = "§$colorDigit"
+        val fmt = "$c[§l${GuildDisplayUtils.createGuildTag(guild)} ANNOUNCEMENT§r$c]§r\n" +
+            "§e$name:§r $message"
         return try {
-            val name = Bukkit.getPlayer(announcerId)?.name ?: "Unknown"
-            val tag = GuildDisplayUtils.createGuildTag(guild)
-            val c = "§$colorDigit"
-            val fmt = "$c[§l${tag} ANNOUNCEMENT§r$c]§r\n§e$name:§r $message"
-            val recipients = getOnlineGuildMembers(guildId)
-            val sent = broadcastMessageWithSound(recipients, fmt, true)
+            val n = broadcastMessageWithSound(getOnlineGuildMembers(guildId), fmt, true)
             updateAnnouncementRateLimit(announcerId)
-            logger.info("Announce from $announcerId to $sent guild members")
-            sent > 0
+            logger.info("Announce from $announcerId to $n members")
+            n > 0
         } catch (e: Exception) {
             logger.error("Error sending guild announcement", e)
             false

--- a/src/main/kotlin/net/lumalyte/lg/infrastructure/services/ChatServiceBukkit.kt
+++ b/src/main/kotlin/net/lumalyte/lg/infrastructure/services/ChatServiceBukkit.kt
@@ -68,49 +68,53 @@ class ChatServiceBukkit(
         }
     }
     
-    override fun sendGuildAnnouncement(guildId: UUID, announcerId: UUID, message: String): Boolean {
-        return sendGuildAnnouncement(guildId, announcerId, message, '6')
-    }
+    override fun sendGuildAnnouncement(
+        guildId: UUID, announcerId: UUID, message: String,
+    ): Boolean = sendGuildAnnouncement(guildId, announcerId, message, '6')
 
     override fun sendGuildAnnouncement(
-        guildId: UUID, announcerId: UUID, message: String, colorDigit: Char,
+        guildId: UUID,
+        announcerId: UUID,
+        message: String,
+        colorDigit: Char,
     ): Boolean {
-        try {
-            if (!canSendAnnouncements(announcerId, guildId)) {
-                logger.warn("Player $announcerId cannot send announcements for guild $guildId")
-                return false
-            }
+        val guild = validateAnnouncementPreconditions(announcerId, guildId) ?: return false
 
-            if (isAnnouncementRateLimited(announcerId)) {
-                logger.warn("Player $announcerId is rate limited for announcements")
-                return false
-            }
-
-            val guild = guildService.getGuild(guildId)
-            if (guild == null) {
-                logger.warn("Guild $guildId not found")
-                return false
-            }
-
+        return try {
             val announcerName = Bukkit.getPlayer(announcerId)?.name ?: "Unknown"
             val guildDisplayName = GuildDisplayUtils.createGuildTag(guild)
-
             val colorCode = "§$colorDigit"
-            val formattedMessage = "$colorCode[§l${guildDisplayName} ANNOUNCEMENT§r$colorCode]§r\n" +
-                    "§e$announcerName:§r $message"
+            val formatted = "$colorCode[§l${guildDisplayName} ANNOUNCEMENT§r$colorCode]§r\n" +
+                "§e$announcerName:§r $message"
 
             val recipients = getOnlineGuildMembers(guildId)
-            val deliveredCount = broadcastMessageWithSound(recipients, formattedMessage, true)
-
-            // Update rate limit
+            val count = broadcastMessageWithSound(recipients, formatted, true)
             updateAnnouncementRateLimit(announcerId)
-
-            logger.info("Guild announcement from $announcerId delivered to $deliveredCount members of guild $guildId")
-            return deliveredCount > 0
+            logger.info(
+                "Guild announcement from $announcerId delivered to $count members of guild $guildId",
+            )
+            count > 0
         } catch (e: Exception) {
-            // Service operation - catching all exceptions to prevent service failure
             logger.error("Error sending guild announcement", e)
-            return false
+            false
+        }
+    }
+
+    private fun validateAnnouncementPreconditions(
+        announcerId: UUID, guildId: UUID,
+    ): net.lumalyte.lg.domain.entities.Guild? {
+        if (!canSendAnnouncements(announcerId, guildId)) {
+            logger.warn("Player $announcerId cannot send announcements for guild $guildId")
+            return null
+        }
+        if (isAnnouncementRateLimited(announcerId)) {
+            logger.warn("Player $announcerId is rate limited for announcements")
+            return null
+        }
+        return guildService.getGuild(guildId).also { guild ->
+            if (guild == null) {
+                logger.warn("Guild $guildId not found")
+            }
         }
     }
     

--- a/src/main/kotlin/net/lumalyte/lg/infrastructure/services/ChatServiceBukkit.kt
+++ b/src/main/kotlin/net/lumalyte/lg/infrastructure/services/ChatServiceBukkit.kt
@@ -71,7 +71,8 @@ class ChatServiceBukkit(
     override fun sendGuildAnnouncement(guildId: UUID, announcerId: UUID, message: String): Boolean =
         sendGuildAnnouncement(guildId, announcerId, message, '6')
 
-    override fun sendGuildAnnouncement(guildId: UUID,
+    override fun sendGuildAnnouncement(
+        guildId: UUID,
         announcerId: UUID,
         message: String,
         colorDigit: Char,

--- a/src/main/kotlin/net/lumalyte/lg/infrastructure/services/ChatServiceBukkit.kt
+++ b/src/main/kotlin/net/lumalyte/lg/infrastructure/services/ChatServiceBukkit.kt
@@ -4,6 +4,7 @@ import net.lumalyte.lg.application.persistence.ChatSettingsRepository
 import net.lumalyte.lg.application.persistence.PlayerPartyPreferenceRepository
 import net.lumalyte.lg.application.persistence.PartyRepository
 import net.lumalyte.lg.application.services.*
+import net.lumalyte.lg.domain.entities.Guild
 import net.lumalyte.lg.domain.entities.RelationType
 import net.lumalyte.lg.domain.entities.RankPermission
 import net.lumalyte.lg.domain.values.*
@@ -71,18 +72,10 @@ class ChatServiceBukkit(
     override fun sendGuildAnnouncement(guildId: UUID, announcerId: UUID, message: String): Boolean =
         sendGuildAnnouncement(guildId, announcerId, message, '6')
 
-    override fun sendGuildAnnouncement(
-        guildId: UUID,
-        announcerId: UUID,
-        message: String,
-        colorDigit: Char,
-    ): Boolean {
-        val guild = validateAnnouncementPreconditions(announcerId, guildId) ?: return false
+    override fun sendGuildAnnouncement(guildId: UUID, announcerId: UUID, message: String, colorDigit: Char): Boolean {
+        val guild = validateAnnouncement(announcerId, guildId) ?: return false
         val name = Bukkit.getPlayer(announcerId)?.name ?: UNKNOWN_PLAYER
-        val headerColor = colorDigit.takeIf { it in '0'..'9' } ?: '6'
-        val fmt =
-            "§$headerColor[§l${GuildDisplayUtils.createGuildTag(guild)} ANNOUNCEMENT§r§$headerColor]§r\n" +
-                "§e$name:§r $message"
+        val fmt = formatAnnouncement(guild, name, message, colorDigit)
         return try {
             val n = broadcastMessageWithSound(getOnlineGuildMembers(guildId), fmt, true)
             updateAnnouncementRateLimit(announcerId)
@@ -94,22 +87,27 @@ class ChatServiceBukkit(
         }
     }
 
-    private fun validateAnnouncementPreconditions(
-        announcerId: UUID, guildId: UUID,
-    ): net.lumalyte.lg.domain.entities.Guild? {
+    private fun formatAnnouncement(guild: Guild, name: String, message: String, colorDigit: Char): String {
+        val headerColor = colorDigit.takeIf { it in '0'..'9' } ?: '6'
+        return "§$headerColor[§l${GuildDisplayUtils.createGuildTag(guild)} ANNOUNCEMENT§r§$headerColor]§r\n" +
+            "§e$name:§r $message"
+    }
+
+    private fun validateAnnouncement(announcerId: UUID, guildId: UUID): Guild? {
+        val guild: Guild?
         if (!canSendAnnouncements(announcerId, guildId)) {
             logger.warn("Player $announcerId cannot send announcements for guild $guildId")
-            return null
-        }
-        if (isAnnouncementRateLimited(announcerId)) {
+            guild = null
+        } else if (isAnnouncementRateLimited(announcerId)) {
             logger.warn("Player $announcerId is rate limited for announcements")
-            return null
-        }
-        return guildService.getGuild(guildId).also { guild ->
+            guild = null
+        } else {
+            guild = guildService.getGuild(guildId)
             if (guild == null) {
                 logger.warn("Guild $guildId not found")
             }
         }
+        return guild
     }
     
     override fun sendGuildPing(guildId: UUID, pingerId: UUID, message: String?): Boolean {
@@ -235,15 +233,20 @@ class ChatServiceBukkit(
             }
             ChatChannel.MODCHAT -> {
                 val senderGuilds = memberService.getPlayerGuilds(senderId)
-                val modGuilds = senderGuilds.filter { guildId ->
-                    memberService.hasPermission(
-                        senderId, guildId, RankPermission.MODERATE_CHAT,
-                    )
-                }
+                val modGuilds =
+                    senderGuilds.filter { guildId ->
+                        memberService.hasPermission(
+                            senderId,
+                            guildId,
+                            RankPermission.MODERATE_CHAT,
+                        )
+                    }
                 modGuilds.flatMap { guildId ->
                     getOnlineGuildMembers(guildId).filter { playerId ->
                         memberService.hasPermission(
-                            playerId, guildId, RankPermission.MODERATE_CHAT,
+                            playerId,
+                            guildId,
+                            RankPermission.MODERATE_CHAT,
                         )
                     }
                 }.toSet()
@@ -287,13 +290,12 @@ class ChatServiceBukkit(
             ChatChannel.PARTY -> {
                 formatPartyMessage(senderId, senderName, processedMessage, guildTag)
             }
-            ChatChannel.MODCHAT -> {
+            ChatChannel.MODCHAT ->
                 if (guildTag.isNotEmpty()) {
                     "§1[M] $guildTag §9$senderName:§r $processedMessage"
                 } else {
                     "§1[M] §9$senderName:§r $processedMessage"
                 }
-            }
             ChatChannel.PUBLIC -> {
                 if (guildTag.isNotEmpty()) {
                     "$guildTag §7$senderName:§r $processedMessage"

--- a/src/main/kotlin/net/lumalyte/lg/infrastructure/services/ChatServiceBukkit.kt
+++ b/src/main/kotlin/net/lumalyte/lg/infrastructure/services/ChatServiceBukkit.kt
@@ -69,35 +69,42 @@ class ChatServiceBukkit(
     }
     
     override fun sendGuildAnnouncement(guildId: UUID, announcerId: UUID, message: String): Boolean {
+        return sendGuildAnnouncement(guildId, announcerId, message, '6')
+    }
+
+    override fun sendGuildAnnouncement(
+        guildId: UUID, announcerId: UUID, message: String, colorDigit: Char,
+    ): Boolean {
         try {
             if (!canSendAnnouncements(announcerId, guildId)) {
                 logger.warn("Player $announcerId cannot send announcements for guild $guildId")
                 return false
             }
-            
+
             if (isAnnouncementRateLimited(announcerId)) {
                 logger.warn("Player $announcerId is rate limited for announcements")
                 return false
             }
-            
+
             val guild = guildService.getGuild(guildId)
             if (guild == null) {
                 logger.warn("Guild $guildId not found")
                 return false
             }
-            
+
             val announcerName = Bukkit.getPlayer(announcerId)?.name ?: "Unknown"
             val guildDisplayName = GuildDisplayUtils.createGuildTag(guild)
-            
-            val formattedMessage = "§6[§l${guildDisplayName} ANNOUNCEMENT§r§6]§r\n" +
+
+            val colorCode = "§$colorDigit"
+            val formattedMessage = "$colorCode[§l${guildDisplayName} ANNOUNCEMENT§r$colorCode]§r\n" +
                     "§e$announcerName:§r $message"
-            
+
             val recipients = getOnlineGuildMembers(guildId)
             val deliveredCount = broadcastMessageWithSound(recipients, formattedMessage, true)
-            
+
             // Update rate limit
             updateAnnouncementRateLimit(announcerId)
-            
+
             logger.info("Guild announcement from $announcerId delivered to $deliveredCount members of guild $guildId")
             return deliveredCount > 0
         } catch (e: Exception) {
@@ -157,6 +164,10 @@ class ChatServiceBukkit(
                 ChatChannel.GUILD -> currentSettings.copy(guildChatVisible = !currentSettings.guildChatVisible)
                 ChatChannel.ALLY -> currentSettings.copy(allyChatVisible = !currentSettings.allyChatVisible)
                 ChatChannel.PARTY -> currentSettings.copy(partyChatVisible = !currentSettings.partyChatVisible)
+                ChatChannel.MODCHAT -> {
+                    logger.warn("Cannot toggle visibility for mod chat channel")
+                    return false
+                }
                 ChatChannel.PUBLIC -> {
                     logger.warn("Cannot toggle visibility for public channel")
                     return false
@@ -170,6 +181,7 @@ class ChatServiceBukkit(
                     ChatChannel.GUILD -> newSettings.guildChatVisible
                     ChatChannel.ALLY -> newSettings.allyChatVisible
                     ChatChannel.PARTY -> newSettings.partyChatVisible
+                    ChatChannel.MODCHAT -> false
                     ChatChannel.PUBLIC -> false
                 }
                 logger.info("Player $playerId toggled $channel chat visibility to $visibilityState")
@@ -223,6 +235,16 @@ class ChatServiceBukkit(
                     getVisibilitySettings(playerId).partyChatVisible
                 }.toSet()
             }
+            ChatChannel.MODCHAT -> {
+                val senderGuilds = memberService.getPlayerGuilds(senderId)
+                senderGuilds.flatMap { guildId ->
+                    getOnlineGuildMembers(guildId).filter { playerId ->
+                        memberService.hasPermission(
+                            playerId, guildId, RankPermission.MODERATE_CHAT,
+                        )
+                    }
+                }.toSet()
+            }
             ChatChannel.PUBLIC -> {
                 // Return all online players for public chat
                 Bukkit.getOnlinePlayers().map { it.uniqueId }.toSet()
@@ -261,6 +283,13 @@ class ChatServiceBukkit(
             }
             ChatChannel.PARTY -> {
                 formatPartyMessage(senderId, senderName, processedMessage, guildTag)
+            }
+            ChatChannel.MODCHAT -> {
+                if (guildTag.isNotEmpty()) {
+                    "§1[M] $guildTag §9$senderName:§r $processedMessage"
+                } else {
+                    "§1[M] §9$senderName:§r $processedMessage"
+                }
             }
             ChatChannel.PUBLIC -> {
                 if (guildTag.isNotEmpty()) {

--- a/src/main/kotlin/net/lumalyte/lg/infrastructure/services/ChatServiceBukkit.kt
+++ b/src/main/kotlin/net/lumalyte/lg/infrastructure/services/ChatServiceBukkit.kt
@@ -79,9 +79,10 @@ class ChatServiceBukkit(
     ): Boolean {
         val guild = validateAnnouncementPreconditions(announcerId, guildId) ?: return false
         val name = Bukkit.getPlayer(announcerId)?.name ?: UNKNOWN_PLAYER
+        val headerColor = colorDigit.takeIf { it in '0'..'9' } ?: '6'
         val fmt =
-            "§$colorDigit[§l${GuildDisplayUtils.createGuildTag(guild)} ANNOUNCEMENT§r§$colorDigit]§r\n" +
-            "§e$name:§r $message"
+            "§$headerColor[§l${GuildDisplayUtils.createGuildTag(guild)} ANNOUNCEMENT§r§$headerColor]§r\n" +
+                "§e$name:§r $message"
         return try {
             val n = broadcastMessageWithSound(getOnlineGuildMembers(guildId), fmt, true)
             updateAnnouncementRateLimit(announcerId)

--- a/src/main/kotlin/net/lumalyte/lg/infrastructure/services/ChatServiceBukkit.kt
+++ b/src/main/kotlin/net/lumalyte/lg/infrastructure/services/ChatServiceBukkit.kt
@@ -68,11 +68,7 @@ class ChatServiceBukkit(
         }
     }
     
-    override fun sendGuildAnnouncement(
-        guildId: UUID,
-        announcerId: UUID,
-        message: String,
-    ): Boolean =
+    override fun sendGuildAnnouncement(guildId: UUID, announcerId: UUID, message: String): Boolean =
         sendGuildAnnouncement(guildId, announcerId, message, '6')
 
     override fun sendGuildAnnouncement(

--- a/src/main/kotlin/net/lumalyte/lg/interaction/commands/GuildCommand.kt
+++ b/src/main/kotlin/net/lumalyte/lg/interaction/commands/GuildCommand.kt
@@ -968,14 +968,13 @@ class GuildCommand : BaseCommand(), KoinComponent {
     @Subcommand("modchat")
     @CommandPermission("lumaguilds.guild.chat")
     fun onModChat(player: Player) {
-        val playerId = player.uniqueId
-        val guilds = guildService.getPlayerGuilds(playerId)
+        val guilds = guildService.getPlayerGuilds(player.uniqueId)
         if (guilds.isEmpty()) {
             player.sendMessage("§c❌ You are not in a guild!")
             return
         }
         if (!memberService.hasPermission(
-                playerId, guilds.first().id, RankPermission.MODERATE_CHAT,
+                player.uniqueId, guilds.first().id, RankPermission.MODERATE_CHAT,
             )
         ) {
             player.sendMessage("§c❌ Only guild moderators can use mod chat!")

--- a/src/main/kotlin/net/lumalyte/lg/interaction/commands/GuildCommand.kt
+++ b/src/main/kotlin/net/lumalyte/lg/interaction/commands/GuildCommand.kt
@@ -965,6 +965,33 @@ class GuildCommand : BaseCommand(), KoinComponent {
         }
     }
 
+    @Subcommand("modchat")
+    @CommandPermission("lumaguilds.guild.chat")
+    fun onModChat(player: Player) {
+        val playerId = player.uniqueId
+        val guilds = guildService.getPlayerGuilds(playerId)
+        if (guilds.isEmpty()) {
+            player.sendMessage("§c❌ You are not in a guild!")
+            return
+        }
+        val primaryGuildId = guilds.first().id
+        if (!memberService.hasPermission(
+                playerId, primaryGuildId, RankPermission.MODERATE_CHAT,
+            )
+        ) {
+            player.sendMessage("§c❌ Only guild moderators can use mod chat!")
+            return
+        }
+
+        val nowEnabled = guildChatListener.toggleModChat(player)
+        if (nowEnabled) {
+            player.sendMessage("§9✅ §1Mod chat §9enabled§9! Messages go to guild moderators.")
+            player.sendMessage("§7Run §f/g modchat §7again to return to normal chat.")
+        } else {
+            player.sendMessage("§7Mod chat §cdisabled§7. Your messages go to main chat.")
+        }
+    }
+
     @Subcommand("info")
     @CommandCompletion("@guildsorplayers")
     fun onInfo(player: Player, @Optional targetGuild: String?) {

--- a/src/main/kotlin/net/lumalyte/lg/interaction/commands/GuildCommand.kt
+++ b/src/main/kotlin/net/lumalyte/lg/interaction/commands/GuildCommand.kt
@@ -968,23 +968,15 @@ class GuildCommand : BaseCommand(), KoinComponent {
     @Subcommand("modchat")
     @CommandPermission("lumaguilds.guild.chat")
     fun onModChat(player: Player) {
-        val guilds = guildService.getPlayerGuilds(player.uniqueId)
-        if (guilds.isEmpty()) {
-            player.sendMessage("§c❌ You are not in a guild!")
-            return
-        }
-        if (!memberService.hasPermission(
-                player.uniqueId, guilds.first().id, RankPermission.MODERATE_CHAT,
+        val result = guildChatListener.toggleModChat(player)
+        when (result) {
+            null -> {} // resolveModChatChannel already sent the error message
+            true -> player.sendMessage(
+                "§9✅ §1Mod chat §9enabled§9! Run /g modchat again to disable.",
             )
-        ) {
-            player.sendMessage("§c❌ Only guild moderators can use mod chat!")
-            return
-        }
-        val nowEnabled = guildChatListener.toggleModChat(player)
-        if (nowEnabled) {
-            player.sendMessage("§9✅ §1Mod chat §9enabled§9! Run /g modchat again to disable.")
-        } else {
-            player.sendMessage("§7Mod chat §cdisabled§7. Your messages go to main chat.")
+            false -> player.sendMessage(
+                "§7Mod chat §cdisabled§7. Your messages go to main chat.",
+            )
         }
     }
 

--- a/src/main/kotlin/net/lumalyte/lg/interaction/commands/GuildCommand.kt
+++ b/src/main/kotlin/net/lumalyte/lg/interaction/commands/GuildCommand.kt
@@ -974,19 +974,16 @@ class GuildCommand : BaseCommand(), KoinComponent {
             player.sendMessage("§c❌ You are not in a guild!")
             return
         }
-        val primaryGuildId = guilds.first().id
         if (!memberService.hasPermission(
-                playerId, primaryGuildId, RankPermission.MODERATE_CHAT,
+                playerId, guilds.first().id, RankPermission.MODERATE_CHAT,
             )
         ) {
             player.sendMessage("§c❌ Only guild moderators can use mod chat!")
             return
         }
-
         val nowEnabled = guildChatListener.toggleModChat(player)
         if (nowEnabled) {
-            player.sendMessage("§9✅ §1Mod chat §9enabled§9! Messages go to guild moderators.")
-            player.sendMessage("§7Run §f/g modchat §7again to return to normal chat.")
+            player.sendMessage("§9✅ §1Mod chat §9enabled§9! Run /g modchat again to disable.")
         } else {
             player.sendMessage("§7Mod chat §cdisabled§7. Your messages go to main chat.")
         }

--- a/src/main/kotlin/net/lumalyte/lg/interaction/commands/QuickAllyChatCommand.kt
+++ b/src/main/kotlin/net/lumalyte/lg/interaction/commands/QuickAllyChatCommand.kt
@@ -1,7 +1,9 @@
 package net.lumalyte.lg.interaction.commands
 
 import co.aikar.commands.BaseCommand
-import co.aikar.commands.annotation.*
+import co.aikar.commands.annotation.CommandAlias
+import co.aikar.commands.annotation.CommandPermission
+import co.aikar.commands.annotation.Default
 import net.lumalyte.lg.application.services.ChatService
 import net.lumalyte.lg.application.services.GuildService
 import net.lumalyte.lg.domain.values.ChatChannel
@@ -10,17 +12,19 @@ import org.koin.core.component.KoinComponent
 import org.koin.core.component.inject
 
 /**
- * Quick ally chat: /ac <message> sends one message to ally chat without
- * changing the player's current chat channel (which /g allychat permanently toggles).
+ * Quick ally chat: `/ac <message>` sends one message to ally chat without
+ * changing the player's current chat channel (which `/g allychat` permanently
+ * toggles).
  *
- * /ac alone shows help text.
+ * `/ac` alone shows help text.
  */
 @CommandAlias("ac")
-class QuickAllyChatCommand : BaseCommand(), KoinComponent {
+internal class QuickAllyChatCommand : BaseCommand(), KoinComponent {
 
     private val chatService: ChatService by inject()
     private val guildService: GuildService by inject()
 
+    /** Shows usage help when `/ac` is typed without arguments. */
     @Default
     @CommandPermission("lumaguilds.guild.chat")
     fun onDefault(player: Player) {
@@ -35,6 +39,7 @@ class QuickAllyChatCommand : BaseCommand(), KoinComponent {
         player.sendMessage("§7To toggle permanent ally chat mode, use §f/g allychat§7.")
     }
 
+    /** Routes a one-shot message to ally chat via [ChatService.routeMessage]. */
     @Default
     @CommandPermission("lumaguilds.guild.chat")
     fun onMessage(player: Player, vararg message: String) {
@@ -53,7 +58,9 @@ class QuickAllyChatCommand : BaseCommand(), KoinComponent {
 
         val success = chatService.routeMessage(playerId, text, ChatChannel.ALLY)
         if (!success) {
-            player.sendMessage("§e⚠️ No allied guild members are currently online to receive your message.")
+            player.sendMessage(
+                "§e⚠️ No allied guild members are currently online to receive your message.",
+            )
         }
         // No success echo — the message is routed to recipients (including sender)
     }

--- a/src/main/kotlin/net/lumalyte/lg/interaction/commands/QuickAllyChatCommand.kt
+++ b/src/main/kotlin/net/lumalyte/lg/interaction/commands/QuickAllyChatCommand.kt
@@ -27,11 +27,7 @@ internal class QuickAllyChatCommand : BaseCommand(), KoinComponent {
     @Default
     @CommandPermission("lumaguilds.guild.chat")
     fun onDefault(player: Player) {
-        val guilds = guildService.getPlayerGuilds(player.uniqueId)
-        if (guilds.isEmpty()) {
-            player.sendMessage("§c❌ You are not in a guild!")
-            return
-        }
+        if (!player.requireGuildMembership(guildService)) return
         player.sendMessage("§3=== Quick Ally Chat ===")
         player.sendMessage("§7Use §f/gac <message> §7to send a single message to ally chat.")
         player.sendMessage("§7Your chat channel won't change — you stay in your current chat.")
@@ -43,11 +39,7 @@ internal class QuickAllyChatCommand : BaseCommand(), KoinComponent {
     @CommandPermission("lumaguilds.guild.chat")
     fun onMessage(player: Player, vararg message: String) {
         val playerId = player.uniqueId
-        val guilds = guildService.getPlayerGuilds(playerId)
-        if (guilds.isEmpty()) {
-            player.sendMessage("§c❌ You are not in a guild!")
-            return
-        }
+        if (!player.requireGuildMembership(guildService)) return
 
         val text = message.joinToString(" ")
         if (text.isBlank()) {

--- a/src/main/kotlin/net/lumalyte/lg/interaction/commands/QuickAllyChatCommand.kt
+++ b/src/main/kotlin/net/lumalyte/lg/interaction/commands/QuickAllyChatCommand.kt
@@ -16,9 +16,9 @@ import org.koin.core.component.inject
  * changing the player's current chat channel (which `/g allychat` permanently
  * toggles).
  *
- * `/ac` alone shows help text.
+ * `/gac` alone shows help text.
  */
-@CommandAlias("ac")
+@CommandAlias("gac")
 internal class QuickAllyChatCommand : BaseCommand(), KoinComponent {
     private val chatService: ChatService by inject()
     private val guildService: GuildService by inject()
@@ -33,7 +33,7 @@ internal class QuickAllyChatCommand : BaseCommand(), KoinComponent {
             return
         }
         player.sendMessage("§3=== Quick Ally Chat ===")
-        player.sendMessage("§7Use §f/ac <message> §7to send a single message to ally chat.")
+        player.sendMessage("§7Use §f/gac <message> §7to send a single message to ally chat.")
         player.sendMessage("§7Your chat channel won't change — you stay in your current chat.")
         player.sendMessage("§7To toggle permanent ally chat mode, use §f/g allychat§7.")
     }

--- a/src/main/kotlin/net/lumalyte/lg/interaction/commands/QuickAllyChatCommand.kt
+++ b/src/main/kotlin/net/lumalyte/lg/interaction/commands/QuickAllyChatCommand.kt
@@ -1,0 +1,60 @@
+package net.lumalyte.lg.interaction.commands
+
+import co.aikar.commands.BaseCommand
+import co.aikar.commands.annotation.*
+import net.lumalyte.lg.application.services.ChatService
+import net.lumalyte.lg.application.services.GuildService
+import net.lumalyte.lg.domain.values.ChatChannel
+import org.bukkit.entity.Player
+import org.koin.core.component.KoinComponent
+import org.koin.core.component.inject
+
+/**
+ * Quick ally chat: /ac <message> sends one message to ally chat without
+ * changing the player's current chat channel (which /g allychat permanently toggles).
+ *
+ * /ac alone shows help text.
+ */
+@CommandAlias("ac")
+class QuickAllyChatCommand : BaseCommand(), KoinComponent {
+
+    private val chatService: ChatService by inject()
+    private val guildService: GuildService by inject()
+
+    @Default
+    @CommandPermission("lumaguilds.guild.chat")
+    fun onDefault(player: Player) {
+        val guilds = guildService.getPlayerGuilds(player.uniqueId)
+        if (guilds.isEmpty()) {
+            player.sendMessage("§c❌ You are not in a guild!")
+            return
+        }
+        player.sendMessage("§3=== Quick Ally Chat ===")
+        player.sendMessage("§7Use §f/ac <message> §7to send a single message to ally chat.")
+        player.sendMessage("§7Your chat channel won't change — you stay in your current chat.")
+        player.sendMessage("§7To toggle permanent ally chat mode, use §f/g allychat§7.")
+    }
+
+    @Default
+    @CommandPermission("lumaguilds.guild.chat")
+    fun onMessage(player: Player, vararg message: String) {
+        val playerId = player.uniqueId
+        val guilds = guildService.getPlayerGuilds(playerId)
+        if (guilds.isEmpty()) {
+            player.sendMessage("§c❌ You are not in a guild!")
+            return
+        }
+
+        val text = message.joinToString(" ")
+        if (text.isBlank()) {
+            player.sendMessage("§c❌ Message cannot be empty.")
+            return
+        }
+
+        val success = chatService.routeMessage(playerId, text, ChatChannel.ALLY)
+        if (!success) {
+            player.sendMessage("§e⚠️ No allied guild members are currently online to receive your message.")
+        }
+        // No success echo — the message is routed to recipients (including sender)
+    }
+}

--- a/src/main/kotlin/net/lumalyte/lg/interaction/commands/QuickAllyChatCommand.kt
+++ b/src/main/kotlin/net/lumalyte/lg/interaction/commands/QuickAllyChatCommand.kt
@@ -20,7 +20,6 @@ import org.koin.core.component.inject
  */
 @CommandAlias("ac")
 internal class QuickAllyChatCommand : BaseCommand(), KoinComponent {
-
     private val chatService: ChatService by inject()
     private val guildService: GuildService by inject()
 

--- a/src/main/kotlin/net/lumalyte/lg/interaction/commands/QuickAllyChatCommand.kt
+++ b/src/main/kotlin/net/lumalyte/lg/interaction/commands/QuickAllyChatCommand.kt
@@ -12,7 +12,7 @@ import org.koin.core.component.KoinComponent
 import org.koin.core.component.inject
 
 /**
- * Quick ally chat: `/ac <message>` sends one message to ally chat without
+ * Quick ally chat: `/gac <message>` sends one message to ally chat without
  * changing the player's current chat channel (which `/g allychat` permanently
  * toggles).
  *
@@ -23,7 +23,7 @@ internal class QuickAllyChatCommand : BaseCommand(), KoinComponent {
     private val chatService: ChatService by inject()
     private val guildService: GuildService by inject()
 
-    /** Shows usage help when `/ac` is typed without arguments. */
+    /** Shows usage help when `/gac` is typed without arguments. */
     @Default
     @CommandPermission("lumaguilds.guild.chat")
     fun onDefault(player: Player) {

--- a/src/main/kotlin/net/lumalyte/lg/interaction/commands/QuickAnnounceCommand.kt
+++ b/src/main/kotlin/net/lumalyte/lg/interaction/commands/QuickAnnounceCommand.kt
@@ -49,7 +49,8 @@ internal class QuickAnnounceCommand : BaseCommand(), KoinComponent {
         val guildId = requireAnnouncementPermission(player) ?: return
         val (colorDigit, message) = parseAnnouncementInput(args)
         if (message.isBlank()) {
-            val msg = if (args.isEmpty()) {
+            val msg =
+                if (args.isEmpty()) {
                 "§c❌ Provide a message. Usage: /ga [&color] <message>"
             } else {
                 "§c❌ Message cannot be empty."

--- a/src/main/kotlin/net/lumalyte/lg/interaction/commands/QuickAnnounceCommand.kt
+++ b/src/main/kotlin/net/lumalyte/lg/interaction/commands/QuickAnnounceCommand.kt
@@ -76,25 +76,11 @@ internal class QuickAnnounceCommand : BaseCommand(), KoinComponent {
     }
 
     private fun requireAnnouncementPermission(player: Player): UUID? {
-        val guilds = guildService.getPlayerGuilds(player.uniqueId)
-        return if (guilds.isEmpty()) {
-            player.sendMessage("§c❌ You are not in a guild!")
-            null
-        } else {
-            val authorizedGuild =
-                guilds.firstOrNull { guild ->
-                    memberService.hasPermission(
-                        player.uniqueId,
-                        guild.id,
-                        RankPermission.SEND_ANNOUNCEMENTS,
-                    )
-                }
-            if (authorizedGuild == null) {
-                player.sendMessage("§c❌ You don't have permission to send announcements!")
-                null
-            } else {
-                authorizedGuild.id
-            }
-        }
+        return player.requireGuildForPermission(
+            guildService,
+            memberService,
+            RankPermission.SEND_ANNOUNCEMENTS,
+            "§c❌ You don't have permission to send announcements!",
+        )?.id
     }
 }

--- a/src/main/kotlin/net/lumalyte/lg/interaction/commands/QuickAnnounceCommand.kt
+++ b/src/main/kotlin/net/lumalyte/lg/interaction/commands/QuickAnnounceCommand.kt
@@ -1,0 +1,109 @@
+package net.lumalyte.lg.interaction.commands
+
+import co.aikar.commands.BaseCommand
+import co.aikar.commands.annotation.CommandAlias
+import co.aikar.commands.annotation.CommandPermission
+import co.aikar.commands.annotation.Default
+import net.lumalyte.lg.application.services.ChatService
+import net.lumalyte.lg.application.services.GuildService
+import net.lumalyte.lg.application.services.MemberService
+import net.lumalyte.lg.domain.entities.RankPermission
+import org.bukkit.entity.Player
+import org.koin.core.component.KoinComponent
+import org.koin.core.component.inject
+
+/**
+ * Guild announcement: `/ga <message>` sends a highlighted announcement to all
+ * guild members. Only usable by members with the SEND_ANNOUNCEMENTS permission.
+ *
+ * Color override: `/ga &<0-9> <message>` uses the chosen Minecraft color code.
+ * Default color is 6 (gold).
+ *
+ * Available colors: &0 black, &1 dark blue, &2 dark green, &3 dark aqua,
+ * &4 dark red, &5 dark purple, &6 gold (default), &7 gray, &8 dark gray,
+ * &9 blue.
+ */
+@CommandAlias("ga")
+internal class QuickAnnounceCommand : BaseCommand(), KoinComponent {
+
+    private val chatService: ChatService by inject()
+    private val guildService: GuildService by inject()
+    private val memberService: MemberService by inject()
+
+    /** Shows usage help when `/ga` is typed without arguments. */
+    @Default
+    @CommandPermission("lumaguilds.guild.chat")
+    fun onDefault(player: Player) {
+        val playerId = player.uniqueId
+        val guilds = guildService.getPlayerGuilds(playerId)
+        if (guilds.isEmpty()) {
+            player.sendMessage("§c❌ You are not in a guild!")
+            return
+        }
+        val primaryGuildId = guilds.first().id
+        if (!memberService.hasPermission(
+                playerId, primaryGuildId, RankPermission.SEND_ANNOUNCEMENTS,
+            )
+        ) {
+            player.sendMessage("§c❌ You don't have permission to send announcements!")
+            return
+        }
+        player.sendMessage("§6=== Guild Announcements ===")
+        player.sendMessage("§7Use §f/ga <message> §7to announce to all guild members.")
+        player.sendMessage("§7Add a color code: §f/ga &c <message> §7for custom colors.")
+        player.sendMessage("§7Colors: §0&0 §1&1 §2&2 §3&3 §4&4 §5&5 §6&6 §7&7 §8&8 §9&9")
+        player.sendMessage("§7Default is §6&6 §7(gold). Cooldown: 5 minutes.")
+    }
+
+    /** Sends an announcement with optional color override. First arg may be `&` + digit. */
+    @Default
+    @CommandPermission("lumaguilds.guild.chat")
+    fun onAnnounce(player: Player, vararg args: String) {
+        val playerId = player.uniqueId
+        val guilds = guildService.getPlayerGuilds(playerId)
+        if (guilds.isEmpty()) {
+            player.sendMessage("§c❌ You are not in a guild!")
+            return
+        }
+
+        val primaryGuild = guilds.first()
+        val guildId = primaryGuild.id
+
+        if (!memberService.hasPermission(
+                playerId, guildId, RankPermission.SEND_ANNOUNCEMENTS,
+            )
+        ) {
+            player.sendMessage("§c❌ You don't have permission to send announcements!")
+            return
+        }
+
+        if (args.isEmpty()) {
+            player.sendMessage("§c❌ Provide a message. §7Usage: /ga [&color] <message>")
+            return
+        }
+
+        // Parse optional color prefix: first arg may be "&" + single digit 0-9
+        val colorDigit: Char
+        val message: String
+        if (args[0].matches(Regex("&[0-9]"))) {
+            colorDigit = args[0][1]
+            message = args.drop(1).joinToString(" ")
+        } else {
+            colorDigit = '6' // default gold
+            message = args.joinToString(" ")
+        }
+
+        if (message.isBlank()) {
+            player.sendMessage("§c❌ Message cannot be empty.")
+            return
+        }
+
+        val success = chatService.sendGuildAnnouncement(
+            guildId, playerId, message, colorDigit,
+        )
+        if (!success) {
+            player.sendMessage("§c❌ Failed to send announcement.")
+        }
+        // No success echo — the announcement is broadcast to all guild members
+    }
+}

--- a/src/main/kotlin/net/lumalyte/lg/interaction/commands/QuickAnnounceCommand.kt
+++ b/src/main/kotlin/net/lumalyte/lg/interaction/commands/QuickAnnounceCommand.kt
@@ -76,20 +76,24 @@ internal class QuickAnnounceCommand : BaseCommand(), KoinComponent {
     }
 
     private fun requireAnnouncementPermission(player: Player): UUID? {
-        val guild = guildService.getPlayerGuilds(player.uniqueId).firstOrNull()
-        return if (guild == null) {
+        val guilds = guildService.getPlayerGuilds(player.uniqueId)
+        return if (guilds.isEmpty()) {
             player.sendMessage("§c❌ You are not in a guild!")
             null
-        } else if (!memberService.hasPermission(
-                player.uniqueId,
-                guild.id,
-                RankPermission.SEND_ANNOUNCEMENTS,
-            )
-        ) {
-            player.sendMessage("§c❌ You don't have permission to send announcements!")
-            null
         } else {
-            guild.id
+            val authorizedGuild = guilds.firstOrNull { guild ->
+                memberService.hasPermission(
+                    player.uniqueId,
+                    guild.id,
+                    RankPermission.SEND_ANNOUNCEMENTS,
+                )
+            }
+            if (authorizedGuild == null) {
+                player.sendMessage("§c❌ You don't have permission to send announcements!")
+                null
+            } else {
+                authorizedGuild.id
+            }
         }
     }
 }

--- a/src/main/kotlin/net/lumalyte/lg/interaction/commands/QuickAnnounceCommand.kt
+++ b/src/main/kotlin/net/lumalyte/lg/interaction/commands/QuickAnnounceCommand.kt
@@ -11,21 +11,20 @@ import net.lumalyte.lg.domain.entities.RankPermission
 import org.bukkit.entity.Player
 import org.koin.core.component.KoinComponent
 import org.koin.core.component.inject
+import java.util.UUID
 
 /**
  * Guild announcement: `/ga <message>` sends a highlighted announcement to all
- * guild members. Only usable by members with the SEND_ANNOUNCEMENTS permission.
+ * guild members. Only usable by members with SEND_ANNOUNCEMENTS permission.
  *
  * Color override: `/ga &<0-9> <message>` uses the chosen Minecraft color code.
  * Default color is 6 (gold).
  *
- * Available colors: &0 black, &1 dark blue, &2 dark green, &3 dark aqua,
- * &4 dark red, &5 dark purple, &6 gold (default), &7 gray, &8 dark gray,
- * &9 blue.
+ * Colors: &0 black, &1 dark blue, &2 dark green, &3 dark aqua,
+ * &4 dark red, &5 dark purple, &6 gold, &7 gray, &8 dark gray, &9 blue.
  */
 @CommandAlias("ga")
 internal class QuickAnnounceCommand : BaseCommand(), KoinComponent {
-
     private val chatService: ChatService by inject()
     private val guildService: GuildService by inject()
     private val memberService: MemberService by inject()
@@ -34,20 +33,8 @@ internal class QuickAnnounceCommand : BaseCommand(), KoinComponent {
     @Default
     @CommandPermission("lumaguilds.guild.chat")
     fun onDefault(player: Player) {
-        val playerId = player.uniqueId
-        val guilds = guildService.getPlayerGuilds(playerId)
-        if (guilds.isEmpty()) {
-            player.sendMessage("§c❌ You are not in a guild!")
-            return
-        }
-        val primaryGuildId = guilds.first().id
-        if (!memberService.hasPermission(
-                playerId, primaryGuildId, RankPermission.SEND_ANNOUNCEMENTS,
-            )
-        ) {
-            player.sendMessage("§c❌ You don't have permission to send announcements!")
-            return
-        }
+        val guildId = requireAnnouncementPermission(player) ?: return
+        // Rate limit not checked for help display
         player.sendMessage("§6=== Guild Announcements ===")
         player.sendMessage("§7Use §f/ga <message> §7to announce to all guild members.")
         player.sendMessage("§7Add a color code: §f/ga &c <message> §7for custom colors.")
@@ -59,51 +46,47 @@ internal class QuickAnnounceCommand : BaseCommand(), KoinComponent {
     @Default
     @CommandPermission("lumaguilds.guild.chat")
     fun onAnnounce(player: Player, vararg args: String) {
-        val playerId = player.uniqueId
-        val guilds = guildService.getPlayerGuilds(playerId)
-        if (guilds.isEmpty()) {
-            player.sendMessage("§c❌ You are not in a guild!")
-            return
-        }
-
-        val primaryGuild = guilds.first()
-        val guildId = primaryGuild.id
-
-        if (!memberService.hasPermission(
-                playerId, guildId, RankPermission.SEND_ANNOUNCEMENTS,
-            )
-        ) {
-            player.sendMessage("§c❌ You don't have permission to send announcements!")
-            return
-        }
+        val guildId = requireAnnouncementPermission(player) ?: return
 
         if (args.isEmpty()) {
             player.sendMessage("§c❌ Provide a message. §7Usage: /ga [&color] <message>")
             return
         }
 
-        // Parse optional color prefix: first arg may be "&" + single digit 0-9
-        val colorDigit: Char
-        val message: String
-        if (args[0].matches(Regex("&[0-9]"))) {
-            colorDigit = args[0][1]
-            message = args.drop(1).joinToString(" ")
-        } else {
-            colorDigit = '6' // default gold
-            message = args.joinToString(" ")
-        }
-
+        val (colorDigit, message) = parseAnnouncementInput(args)
         if (message.isBlank()) {
             player.sendMessage("§c❌ Message cannot be empty.")
             return
         }
 
-        val success = chatService.sendGuildAnnouncement(
-            guildId, playerId, message, colorDigit,
-        )
-        if (!success) {
+        val ok = chatService.sendGuildAnnouncement(guildId, player.uniqueId, message, colorDigit)
+        if (!ok) {
             player.sendMessage("§c❌ Failed to send announcement.")
         }
-        // No success echo — the announcement is broadcast to all guild members
+    }
+
+    private data class AnnouncementInput(val colorDigit: Char, val message: String)
+
+    private fun parseAnnouncementInput(args: Array<out String>): AnnouncementInput {
+        val colorRegex = Regex("&[0-9]")
+        return if (args[0].matches(colorRegex)) {
+            AnnouncementInput(args[0][1], args.drop(1).joinToString(" "))
+        } else {
+            AnnouncementInput('6', args.joinToString(" "))
+        }
+    }
+
+    private fun requireAnnouncementPermission(player: Player): UUID? {
+        val guilds = guildService.getPlayerGuilds(player.uniqueId)
+        if (guilds.isEmpty()) {
+            player.sendMessage("§c❌ You are not in a guild!")
+            return null
+        }
+        val guildId = guilds.first().id
+        if (!memberService.hasPermission(player.uniqueId, guildId, RankPermission.SEND_ANNOUNCEMENTS)) {
+            player.sendMessage("§c❌ You don't have permission to send announcements!")
+            return null
+        }
+        return guildId
     }
 }

--- a/src/main/kotlin/net/lumalyte/lg/interaction/commands/QuickAnnounceCommand.kt
+++ b/src/main/kotlin/net/lumalyte/lg/interaction/commands/QuickAnnounceCommand.kt
@@ -47,18 +47,14 @@ internal class QuickAnnounceCommand : BaseCommand(), KoinComponent {
     @CommandPermission("lumaguilds.guild.chat")
     fun onAnnounce(player: Player, vararg args: String) {
         val guildId = requireAnnouncementPermission(player) ?: return
-
-        if (args.isEmpty()) {
-            player.sendMessage("§c❌ Provide a message. §7Usage: /ga [&color] <message>")
-            return
-        }
-
         val (colorDigit, message) = parseAnnouncementInput(args)
         if (message.isBlank()) {
-            player.sendMessage("§c❌ Message cannot be empty.")
+            player.sendMessage(
+                if (args.isEmpty()) "§c❌ Provide a message. Usage: /ga [&color] <message>"
+                else "§c❌ Message cannot be empty.",
+            )
             return
         }
-
         val ok = chatService.sendGuildAnnouncement(guildId, player.uniqueId, message, colorDigit)
         if (!ok) {
             player.sendMessage("§c❌ Failed to send announcement.")
@@ -77,16 +73,18 @@ internal class QuickAnnounceCommand : BaseCommand(), KoinComponent {
     }
 
     private fun requireAnnouncementPermission(player: Player): UUID? {
-        val guilds = guildService.getPlayerGuilds(player.uniqueId)
-        if (guilds.isEmpty()) {
+        val guild = guildService.getPlayerGuilds(player.uniqueId).firstOrNull()
+        return if (guild == null) {
             player.sendMessage("§c❌ You are not in a guild!")
-            return null
-        }
-        val guildId = guilds.first().id
-        if (!memberService.hasPermission(player.uniqueId, guildId, RankPermission.SEND_ANNOUNCEMENTS)) {
+            null
+        } else if (!memberService.hasPermission(
+                player.uniqueId, guild.id, RankPermission.SEND_ANNOUNCEMENTS,
+            )
+        ) {
             player.sendMessage("§c❌ You don't have permission to send announcements!")
-            return null
+            null
+        } else {
+            guild.id
         }
-        return guildId
     }
 }

--- a/src/main/kotlin/net/lumalyte/lg/interaction/commands/QuickAnnounceCommand.kt
+++ b/src/main/kotlin/net/lumalyte/lg/interaction/commands/QuickAnnounceCommand.kt
@@ -81,13 +81,14 @@ internal class QuickAnnounceCommand : BaseCommand(), KoinComponent {
             player.sendMessage("§c❌ You are not in a guild!")
             null
         } else {
-            val authorizedGuild = guilds.firstOrNull { guild ->
-                memberService.hasPermission(
-                    player.uniqueId,
-                    guild.id,
-                    RankPermission.SEND_ANNOUNCEMENTS,
-                )
-            }
+            val authorizedGuild =
+                guilds.firstOrNull { guild ->
+                    memberService.hasPermission(
+                        player.uniqueId,
+                        guild.id,
+                        RankPermission.SEND_ANNOUNCEMENTS,
+                    )
+                }
             if (authorizedGuild == null) {
                 player.sendMessage("§c❌ You don't have permission to send announcements!")
                 null

--- a/src/main/kotlin/net/lumalyte/lg/interaction/commands/QuickAnnounceCommand.kt
+++ b/src/main/kotlin/net/lumalyte/lg/interaction/commands/QuickAnnounceCommand.kt
@@ -51,10 +51,10 @@ internal class QuickAnnounceCommand : BaseCommand(), KoinComponent {
         if (message.isBlank()) {
             val msg =
                 if (args.isEmpty()) {
-                "§c❌ Provide a message. Usage: /ga [&color] <message>"
-            } else {
-                "§c❌ Message cannot be empty."
-            }
+                    "§c❌ Provide a message. Usage: /ga [&color] <message>"
+                } else {
+                    "§c❌ Message cannot be empty."
+                }
             player.sendMessage(msg)
             return
         }

--- a/src/main/kotlin/net/lumalyte/lg/interaction/commands/QuickAnnounceCommand.kt
+++ b/src/main/kotlin/net/lumalyte/lg/interaction/commands/QuickAnnounceCommand.kt
@@ -37,7 +37,7 @@ internal class QuickAnnounceCommand : BaseCommand(), KoinComponent {
         // Rate limit not checked for help display
         player.sendMessage("§6=== Guild Announcements ===")
         player.sendMessage("§7Use §f/ga <message> §7to announce to all guild members.")
-        player.sendMessage("§7Add a color code: §f/ga &c <message> §7for custom colors.")
+        player.sendMessage("§7Add a color code: §f/ga &4 <message> §7for custom colors.")
         player.sendMessage("§7Colors: §0&0 §1&1 §2&2 §3&3 §4&4 §5&5 §6&6 §7&7 §8&8 §9&9")
         player.sendMessage("§7Default is §6&6 §7(gold). Cooldown: 5 minutes.")
     }
@@ -68,7 +68,7 @@ internal class QuickAnnounceCommand : BaseCommand(), KoinComponent {
 
     private fun parseAnnouncementInput(args: Array<out String>): AnnouncementInput {
         val colorRegex = Regex("&[0-9]")
-        return if (args[0].matches(colorRegex)) {
+        return if (args.isNotEmpty() && args[0].matches(colorRegex)) {
             AnnouncementInput(args[0][1], args.drop(1).joinToString(" "))
         } else {
             AnnouncementInput('6', args.joinToString(" "))

--- a/src/main/kotlin/net/lumalyte/lg/interaction/commands/QuickAnnounceCommand.kt
+++ b/src/main/kotlin/net/lumalyte/lg/interaction/commands/QuickAnnounceCommand.kt
@@ -49,10 +49,12 @@ internal class QuickAnnounceCommand : BaseCommand(), KoinComponent {
         val guildId = requireAnnouncementPermission(player) ?: return
         val (colorDigit, message) = parseAnnouncementInput(args)
         if (message.isBlank()) {
-            player.sendMessage(
-                if (args.isEmpty()) "§c❌ Provide a message. Usage: /ga [&color] <message>"
-                else "§c❌ Message cannot be empty.",
-            )
+            val msg = if (args.isEmpty()) {
+                "§c❌ Provide a message. Usage: /ga [&color] <message>"
+            } else {
+                "§c❌ Message cannot be empty."
+            }
+            player.sendMessage(msg)
             return
         }
         val ok = chatService.sendGuildAnnouncement(guildId, player.uniqueId, message, colorDigit)
@@ -78,7 +80,9 @@ internal class QuickAnnounceCommand : BaseCommand(), KoinComponent {
             player.sendMessage("§c❌ You are not in a guild!")
             null
         } else if (!memberService.hasPermission(
-                player.uniqueId, guild.id, RankPermission.SEND_ANNOUNCEMENTS,
+                player.uniqueId,
+                guild.id,
+                RankPermission.SEND_ANNOUNCEMENTS,
             )
         ) {
             player.sendMessage("§c❌ You don't have permission to send announcements!")

--- a/src/main/kotlin/net/lumalyte/lg/interaction/commands/QuickChatGuard.kt
+++ b/src/main/kotlin/net/lumalyte/lg/interaction/commands/QuickChatGuard.kt
@@ -1,0 +1,59 @@
+package net.lumalyte.lg.interaction.commands
+
+import net.lumalyte.lg.application.services.GuildService
+import net.lumalyte.lg.application.services.MemberService
+import net.lumalyte.lg.domain.entities.Guild
+import net.lumalyte.lg.domain.entities.RankPermission
+import org.bukkit.entity.Player
+
+internal fun Player.requireGuildMembership(guildService: GuildService): Boolean {
+    val guilds = guildService.getPlayerGuilds(uniqueId)
+    return if (guilds.isEmpty()) {
+        sendMessage("§c❌ You are not in a guild!")
+        false
+    } else {
+        true
+    }
+}
+
+internal fun Player.requireGuildPermission(
+    guildService: GuildService,
+    memberService: MemberService,
+    permission: RankPermission,
+    noPermissionMessage: String,
+): Boolean {
+    return requireGuildForPermission(
+        guildService,
+        memberService,
+        permission,
+        noPermissionMessage,
+    ) != null
+}
+
+internal fun Player.requireGuildForPermission(
+    guildService: GuildService,
+    memberService: MemberService,
+    permission: RankPermission,
+    noPermissionMessage: String,
+): Guild? {
+    val guilds = guildService.getPlayerGuilds(uniqueId)
+    return if (guilds.isEmpty()) {
+        sendMessage("§c❌ You are not in a guild!")
+        null
+    } else {
+        val authorizedGuild =
+            guilds.firstOrNull { guild ->
+                memberService.hasPermission(
+                    uniqueId,
+                    guild.id,
+                    permission,
+                )
+            }
+        if (authorizedGuild == null) {
+            sendMessage(noPermissionMessage)
+            null
+        } else {
+            authorizedGuild
+        }
+    }
+}

--- a/src/main/kotlin/net/lumalyte/lg/interaction/commands/QuickGuildChatCommand.kt
+++ b/src/main/kotlin/net/lumalyte/lg/interaction/commands/QuickGuildChatCommand.kt
@@ -1,0 +1,60 @@
+package net.lumalyte.lg.interaction.commands
+
+import co.aikar.commands.BaseCommand
+import co.aikar.commands.annotation.*
+import net.lumalyte.lg.application.services.ChatService
+import net.lumalyte.lg.application.services.GuildService
+import net.lumalyte.lg.domain.values.ChatChannel
+import org.bukkit.entity.Player
+import org.koin.core.component.KoinComponent
+import org.koin.core.component.inject
+
+/**
+ * Quick guild chat: /gc <message> sends one message to guild chat without
+ * changing the player's current chat channel (which /g chat permanently toggles).
+ *
+ * /gc alone shows help text.
+ */
+@CommandAlias("gc")
+class QuickGuildChatCommand : BaseCommand(), KoinComponent {
+
+    private val chatService: ChatService by inject()
+    private val guildService: GuildService by inject()
+
+    @Default
+    @CommandPermission("lumaguilds.guild.chat")
+    fun onDefault(player: Player) {
+        val guilds = guildService.getPlayerGuilds(player.uniqueId)
+        if (guilds.isEmpty()) {
+            player.sendMessage("§c❌ You are not in a guild!")
+            return
+        }
+        player.sendMessage("§2=== Quick Guild Chat ===")
+        player.sendMessage("§7Use §f/gc <message> §7to send a single message to guild chat.")
+        player.sendMessage("§7Your chat channel won't change — you stay in your current chat.")
+        player.sendMessage("§7To toggle permanent guild chat mode, use §f/g chat§7.")
+    }
+
+    @Default
+    @CommandPermission("lumaguilds.guild.chat")
+    fun onMessage(player: Player, vararg message: String) {
+        val playerId = player.uniqueId
+        val guilds = guildService.getPlayerGuilds(playerId)
+        if (guilds.isEmpty()) {
+            player.sendMessage("§c❌ You are not in a guild!")
+            return
+        }
+
+        val text = message.joinToString(" ")
+        if (text.isBlank()) {
+            player.sendMessage("§c❌ Message cannot be empty.")
+            return
+        }
+
+        val success = chatService.routeMessage(playerId, text, ChatChannel.GUILD)
+        if (!success) {
+            player.sendMessage("§e⚠️ No guild members are currently online to receive your message.")
+        }
+        // No success echo — the message is routed to recipients (including sender)
+    }
+}

--- a/src/main/kotlin/net/lumalyte/lg/interaction/commands/QuickGuildChatCommand.kt
+++ b/src/main/kotlin/net/lumalyte/lg/interaction/commands/QuickGuildChatCommand.kt
@@ -27,11 +27,7 @@ internal class QuickGuildChatCommand : BaseCommand(), KoinComponent {
     @Default
     @CommandPermission("lumaguilds.guild.chat")
     fun onDefault(player: Player) {
-        val guilds = guildService.getPlayerGuilds(player.uniqueId)
-        if (guilds.isEmpty()) {
-            player.sendMessage("§c❌ You are not in a guild!")
-            return
-        }
+        if (!player.requireGuildMembership(guildService)) return
         player.sendMessage("§2=== Quick Guild Chat ===")
         player.sendMessage("§7Use §f/gc <message> §7to send a single message to guild chat.")
         player.sendMessage("§7Your chat channel won't change — you stay in your current chat.")
@@ -43,11 +39,7 @@ internal class QuickGuildChatCommand : BaseCommand(), KoinComponent {
     @CommandPermission("lumaguilds.guild.chat")
     fun onMessage(player: Player, vararg message: String) {
         val playerId = player.uniqueId
-        val guilds = guildService.getPlayerGuilds(playerId)
-        if (guilds.isEmpty()) {
-            player.sendMessage("§c❌ You are not in a guild!")
-            return
-        }
+        if (!player.requireGuildMembership(guildService)) return
 
         val text = message.joinToString(" ")
         if (text.isBlank()) {

--- a/src/main/kotlin/net/lumalyte/lg/interaction/commands/QuickGuildChatCommand.kt
+++ b/src/main/kotlin/net/lumalyte/lg/interaction/commands/QuickGuildChatCommand.kt
@@ -20,7 +20,6 @@ import org.koin.core.component.inject
  */
 @CommandAlias("gc")
 internal class QuickGuildChatCommand : BaseCommand(), KoinComponent {
-
     private val chatService: ChatService by inject()
     private val guildService: GuildService by inject()
 

--- a/src/main/kotlin/net/lumalyte/lg/interaction/commands/QuickGuildChatCommand.kt
+++ b/src/main/kotlin/net/lumalyte/lg/interaction/commands/QuickGuildChatCommand.kt
@@ -1,7 +1,9 @@
 package net.lumalyte.lg.interaction.commands
 
 import co.aikar.commands.BaseCommand
-import co.aikar.commands.annotation.*
+import co.aikar.commands.annotation.CommandAlias
+import co.aikar.commands.annotation.CommandPermission
+import co.aikar.commands.annotation.Default
 import net.lumalyte.lg.application.services.ChatService
 import net.lumalyte.lg.application.services.GuildService
 import net.lumalyte.lg.domain.values.ChatChannel
@@ -10,17 +12,19 @@ import org.koin.core.component.KoinComponent
 import org.koin.core.component.inject
 
 /**
- * Quick guild chat: /gc <message> sends one message to guild chat without
- * changing the player's current chat channel (which /g chat permanently toggles).
+ * Quick guild chat: `/gc <message>` sends one message to guild chat without
+ * changing the player's current chat channel (which `/g chat` permanently
+ * toggles).
  *
- * /gc alone shows help text.
+ * `/gc` alone shows help text.
  */
 @CommandAlias("gc")
-class QuickGuildChatCommand : BaseCommand(), KoinComponent {
+internal class QuickGuildChatCommand : BaseCommand(), KoinComponent {
 
     private val chatService: ChatService by inject()
     private val guildService: GuildService by inject()
 
+    /** Shows usage help when `/gc` is typed without arguments. */
     @Default
     @CommandPermission("lumaguilds.guild.chat")
     fun onDefault(player: Player) {
@@ -35,6 +39,7 @@ class QuickGuildChatCommand : BaseCommand(), KoinComponent {
         player.sendMessage("§7To toggle permanent guild chat mode, use §f/g chat§7.")
     }
 
+    /** Routes a one-shot message to guild chat via [ChatService.routeMessage]. */
     @Default
     @CommandPermission("lumaguilds.guild.chat")
     fun onMessage(player: Player, vararg message: String) {
@@ -53,7 +58,9 @@ class QuickGuildChatCommand : BaseCommand(), KoinComponent {
 
         val success = chatService.routeMessage(playerId, text, ChatChannel.GUILD)
         if (!success) {
-            player.sendMessage("§e⚠️ No guild members are currently online to receive your message.")
+            player.sendMessage(
+                "§e⚠️ No guild members are currently online to receive your message.",
+            )
         }
         // No success echo — the message is routed to recipients (including sender)
     }

--- a/src/main/kotlin/net/lumalyte/lg/interaction/commands/QuickModChatCommand.kt
+++ b/src/main/kotlin/net/lumalyte/lg/interaction/commands/QuickModChatCommand.kt
@@ -1,0 +1,87 @@
+package net.lumalyte.lg.interaction.commands
+
+import co.aikar.commands.BaseCommand
+import co.aikar.commands.annotation.CommandAlias
+import co.aikar.commands.annotation.CommandPermission
+import co.aikar.commands.annotation.Default
+import net.lumalyte.lg.application.services.ChatService
+import net.lumalyte.lg.application.services.GuildService
+import net.lumalyte.lg.application.services.MemberService
+import net.lumalyte.lg.domain.entities.RankPermission
+import net.lumalyte.lg.domain.values.ChatChannel
+import org.bukkit.entity.Player
+import org.koin.core.component.KoinComponent
+import org.koin.core.component.inject
+
+/**
+ * Quick mod chat: `/gmc <message>` sends one message to guild moderators
+ * without changing the player's current chat channel.
+ *
+ * `/gmc` alone shows help text. Only usable by guild moderators.
+ */
+@CommandAlias("gmc")
+internal class QuickModChatCommand : BaseCommand(), KoinComponent {
+
+    private val chatService: ChatService by inject()
+    private val guildService: GuildService by inject()
+    private val memberService: MemberService by inject()
+
+    /** Shows usage help when `/gmc` is typed without arguments. */
+    @Default
+    @CommandPermission("lumaguilds.guild.chat")
+    fun onDefault(player: Player) {
+        val playerId = player.uniqueId
+        val guilds = guildService.getPlayerGuilds(playerId)
+        if (guilds.isEmpty()) {
+            player.sendMessage("§c❌ You are not in a guild!")
+            return
+        }
+        val primaryGuildId = guilds.first().id
+        if (!memberService.hasPermission(
+                playerId, primaryGuildId, RankPermission.MODERATE_CHAT,
+            )
+        ) {
+            player.sendMessage("§c❌ Only guild moderators can use mod chat!")
+            return
+        }
+        player.sendMessage("§1=== Quick Mod Chat ===")
+        player.sendMessage("§7Use §f/gmc <message> §7to send a message to guild moderators.")
+        player.sendMessage("§7Only guild moderators will see your message.")
+        player.sendMessage("§7To toggle mod chat mode, use §f/g modchat§7.")
+    }
+
+    /** Routes a one-shot message to mod chat via [ChatService.routeMessage]. */
+    @Default
+    @CommandPermission("lumaguilds.guild.chat")
+    fun onMessage(player: Player, vararg message: String) {
+        val playerId = player.uniqueId
+        val guilds = guildService.getPlayerGuilds(playerId)
+        if (guilds.isEmpty()) {
+            player.sendMessage("§c❌ You are not in a guild!")
+            return
+        }
+
+        val primaryGuildId = guilds.first().id
+        if (!memberService.hasPermission(
+                playerId, primaryGuildId, RankPermission.MODERATE_CHAT,
+            )
+        ) {
+            player.sendMessage("§c❌ Only guild moderators can use mod chat!")
+            return
+        }
+
+        val text = message.joinToString(" ")
+        if (text.isBlank()) {
+            player.sendMessage("§c❌ Message cannot be empty.")
+            return
+        }
+
+        val success = chatService.routeMessage(playerId, text, ChatChannel.MODCHAT)
+        if (!success) {
+            player.sendMessage(
+                "§e⚠️ No guild moderators are currently online to receive your message.",
+            )
+        }
+        // No success echo — the message is routed to recipients (including sender)
+    }
+}

--- a/src/main/kotlin/net/lumalyte/lg/interaction/commands/QuickModChatCommand.kt
+++ b/src/main/kotlin/net/lumalyte/lg/interaction/commands/QuickModChatCommand.kt
@@ -21,7 +21,6 @@ import org.koin.core.component.inject
  */
 @CommandAlias("gmc")
 internal class QuickModChatCommand : BaseCommand(), KoinComponent {
-
     private val chatService: ChatService by inject()
     private val guildService: GuildService by inject()
     private val memberService: MemberService by inject()
@@ -30,20 +29,7 @@ internal class QuickModChatCommand : BaseCommand(), KoinComponent {
     @Default
     @CommandPermission("lumaguilds.guild.chat")
     fun onDefault(player: Player) {
-        val playerId = player.uniqueId
-        val guilds = guildService.getPlayerGuilds(playerId)
-        if (guilds.isEmpty()) {
-            player.sendMessage("§c❌ You are not in a guild!")
-            return
-        }
-        val primaryGuildId = guilds.first().id
-        if (!memberService.hasPermission(
-                playerId, primaryGuildId, RankPermission.MODERATE_CHAT,
-            )
-        ) {
-            player.sendMessage("§c❌ Only guild moderators can use mod chat!")
-            return
-        }
+        if (!requireModChatPermission(player)) return
         player.sendMessage("§1=== Quick Mod Chat ===")
         player.sendMessage("§7Use §f/gmc <message> §7to send a message to guild moderators.")
         player.sendMessage("§7Only guild moderators will see your message.")
@@ -54,21 +40,7 @@ internal class QuickModChatCommand : BaseCommand(), KoinComponent {
     @Default
     @CommandPermission("lumaguilds.guild.chat")
     fun onMessage(player: Player, vararg message: String) {
-        val playerId = player.uniqueId
-        val guilds = guildService.getPlayerGuilds(playerId)
-        if (guilds.isEmpty()) {
-            player.sendMessage("§c❌ You are not in a guild!")
-            return
-        }
-
-        val primaryGuildId = guilds.first().id
-        if (!memberService.hasPermission(
-                playerId, primaryGuildId, RankPermission.MODERATE_CHAT,
-            )
-        ) {
-            player.sendMessage("§c❌ Only guild moderators can use mod chat!")
-            return
-        }
+        if (!requireModChatPermission(player)) return
 
         val text = message.joinToString(" ")
         if (text.isBlank()) {
@@ -76,12 +48,24 @@ internal class QuickModChatCommand : BaseCommand(), KoinComponent {
             return
         }
 
-        val success = chatService.routeMessage(playerId, text, ChatChannel.MODCHAT)
+        val success = chatService.routeMessage(player.uniqueId, text, ChatChannel.MODCHAT)
         if (!success) {
             player.sendMessage(
                 "§e⚠️ No guild moderators are currently online to receive your message.",
             )
         }
-        // No success echo — the message is routed to recipients (including sender)
+    }
+
+    private fun requireModChatPermission(player: Player): Boolean {
+        val guilds = guildService.getPlayerGuilds(player.uniqueId)
+        if (guilds.isEmpty()) {
+            player.sendMessage("§c❌ You are not in a guild!")
+            return false
+        }
+        if (!memberService.hasPermission(player.uniqueId, guilds.first().id, RankPermission.MODERATE_CHAT)) {
+            player.sendMessage("§c❌ Only guild moderators can use mod chat!")
+            return false
+        }
+        return true
     }
 }

--- a/src/main/kotlin/net/lumalyte/lg/interaction/commands/QuickModChatCommand.kt
+++ b/src/main/kotlin/net/lumalyte/lg/interaction/commands/QuickModChatCommand.kt
@@ -57,22 +57,11 @@ internal class QuickModChatCommand : BaseCommand(), KoinComponent {
     }
 
     private fun requireModChatPermission(player: Player): Boolean {
-        val guilds = guildService.getPlayerGuilds(player.uniqueId)
-        return if (guilds.isEmpty()) {
-            player.sendMessage("§c❌ You are not in a guild!")
-            false
-        } else if (guilds.none { guild ->
-                memberService.hasPermission(
-                    player.uniqueId,
-                    guild.id,
-                    RankPermission.MODERATE_CHAT,
-                )
-            }
-        ) {
-            player.sendMessage("§c❌ Only guild moderators can use mod chat!")
-            false
-        } else {
-            true
-        }
+        return player.requireGuildPermission(
+            guildService,
+            memberService,
+            RankPermission.MODERATE_CHAT,
+            "§c❌ Only guild moderators can use mod chat!",
+        )
     }
 }

--- a/src/main/kotlin/net/lumalyte/lg/interaction/commands/QuickModChatCommand.kt
+++ b/src/main/kotlin/net/lumalyte/lg/interaction/commands/QuickModChatCommand.kt
@@ -57,15 +57,18 @@ internal class QuickModChatCommand : BaseCommand(), KoinComponent {
     }
 
     private fun requireModChatPermission(player: Player): Boolean {
-        val guilds = guildService.getPlayerGuilds(player.uniqueId)
-        if (guilds.isEmpty()) {
+        val guild = guildService.getPlayerGuilds(player.uniqueId).firstOrNull()
+        return if (guild == null) {
             player.sendMessage("§c❌ You are not in a guild!")
-            return false
-        }
-        if (!memberService.hasPermission(player.uniqueId, guilds.first().id, RankPermission.MODERATE_CHAT)) {
+            false
+        } else if (!memberService.hasPermission(
+                player.uniqueId, guild.id, RankPermission.MODERATE_CHAT,
+            )
+        ) {
             player.sendMessage("§c❌ Only guild moderators can use mod chat!")
-            return false
+            false
+        } else {
+            true
         }
-        return true
     }
 }

--- a/src/main/kotlin/net/lumalyte/lg/interaction/commands/QuickModChatCommand.kt
+++ b/src/main/kotlin/net/lumalyte/lg/interaction/commands/QuickModChatCommand.kt
@@ -62,7 +62,9 @@ internal class QuickModChatCommand : BaseCommand(), KoinComponent {
             player.sendMessage("§c❌ You are not in a guild!")
             false
         } else if (!memberService.hasPermission(
-                player.uniqueId, guild.id, RankPermission.MODERATE_CHAT,
+                player.uniqueId,
+                guild.id,
+                RankPermission.MODERATE_CHAT,
             )
         ) {
             player.sendMessage("§c❌ Only guild moderators can use mod chat!")

--- a/src/main/kotlin/net/lumalyte/lg/interaction/commands/QuickModChatCommand.kt
+++ b/src/main/kotlin/net/lumalyte/lg/interaction/commands/QuickModChatCommand.kt
@@ -57,15 +57,15 @@ internal class QuickModChatCommand : BaseCommand(), KoinComponent {
     }
 
     private fun requireModChatPermission(player: Player): Boolean {
-        val guild = guildService.getPlayerGuilds(player.uniqueId).firstOrNull()
-        return if (guild == null) {
+        val guilds = guildService.getPlayerGuilds(player.uniqueId)
+        return if (guilds.isEmpty()) {
             player.sendMessage("§c❌ You are not in a guild!")
             false
-        } else if (!memberService.hasPermission(
-                player.uniqueId,
-                guild.id,
-                RankPermission.MODERATE_CHAT,
-            )
+        } else if (guilds.none { guild ->
+                memberService.hasPermission(
+                    player.uniqueId, guild.id, RankPermission.MODERATE_CHAT,
+                )
+            }
         ) {
             player.sendMessage("§c❌ Only guild moderators can use mod chat!")
             false

--- a/src/main/kotlin/net/lumalyte/lg/interaction/commands/QuickModChatCommand.kt
+++ b/src/main/kotlin/net/lumalyte/lg/interaction/commands/QuickModChatCommand.kt
@@ -63,7 +63,9 @@ internal class QuickModChatCommand : BaseCommand(), KoinComponent {
             false
         } else if (guilds.none { guild ->
                 memberService.hasPermission(
-                    player.uniqueId, guild.id, RankPermission.MODERATE_CHAT,
+                    player.uniqueId,
+                    guild.id,
+                    RankPermission.MODERATE_CHAT,
                 )
             }
         ) {

--- a/src/main/kotlin/net/lumalyte/lg/interaction/help/HelpTopics.kt
+++ b/src/main/kotlin/net/lumalyte/lg/interaction/help/HelpTopics.kt
@@ -54,7 +54,9 @@ object HelpTopics {
             summary = "Toggle guild and ally chat, and customize how your tag appears in messages.",
             commands = listOf(
                 HelpCommandEntry("/g chat", "Toggle guild chat on/off.", "/g chat"),
+                HelpCommandEntry("/gc <message>", "Send one message to guild chat.", "/gc "),
                 HelpCommandEntry("/g allychat", "Toggle ally chat on/off.", "/g allychat"),
+                HelpCommandEntry("/ac <message>", "Send one message to ally chat.", "/ac "),
             ),
         ),
         HelpTopic(

--- a/src/main/kotlin/net/lumalyte/lg/interaction/help/HelpTopics.kt
+++ b/src/main/kotlin/net/lumalyte/lg/interaction/help/HelpTopics.kt
@@ -56,7 +56,10 @@ object HelpTopics {
                 HelpCommandEntry("/g chat", "Toggle guild chat on/off.", "/g chat"),
                 HelpCommandEntry("/gc <message>", "Send one message to guild chat.", "/gc "),
                 HelpCommandEntry("/g allychat", "Toggle ally chat on/off.", "/g allychat"),
-                HelpCommandEntry("/ac <message>", "Send one message to ally chat.", "/ac "),
+                HelpCommandEntry("/gac <message>", "Send one message to ally chat.", "/gac "),
+                HelpCommandEntry("/g modchat", "Toggle mod chat on/off (moderators).", "/g modchat"),
+                HelpCommandEntry("/gmc <message>", "Send one message to mod chat.", "/gmc "),
+                HelpCommandEntry("/ga [color] <msg>", "Send a guild announcement.", "/ga "),
             ),
         ),
         HelpTopic(

--- a/src/main/kotlin/net/lumalyte/lg/interaction/listeners/GuildChatListener.kt
+++ b/src/main/kotlin/net/lumalyte/lg/interaction/listeners/GuildChatListener.kt
@@ -77,7 +77,9 @@ class GuildChatListener : Listener, KoinComponent {
             return false
         }
 
-        if (current != null && current.id != allyChannelId) previousChannelId[player.uniqueId] = current.id
+        if (current != null && canCachePrevious(current.id)) {
+            previousChannelId[player.uniqueId] = current.id
+        }
         rose.switchChannel(guildChannel)
         return true
     }
@@ -110,7 +112,9 @@ class GuildChatListener : Listener, KoinComponent {
             return false
         }
 
-        if (current != null && current.id != guildChannelId) previousChannelId[player.uniqueId] = current.id
+        if (current != null && canCachePrevious(current.id)) {
+            previousChannelId[player.uniqueId] = current.id
+        }
         rose.switchChannel(allyChannel)
         return true
     }
@@ -170,15 +174,37 @@ class GuildChatListener : Listener, KoinComponent {
     private fun restorePreviousChannel(player: Player, rose: RosePlayer) {
         val prevId = previousChannelId.remove(player.uniqueId)
         val api = RoseChatAPI.getInstance() ?: return
-        val target = prevId?.let { api.channelManager.getChannel(it) } ?: api.defaultChannel
+        val restored = prevId?.let { api.channelManager.getChannel(it) }
+        val target = getRestoredChannel(player.uniqueId, restored, api.defaultChannel)
         if (target != null) {
             rose.switchChannel(target)
         }
     }
 
+    private fun getRestoredChannel(playerId: UUID, restored: Channel?, defaultChannel: Channel?): Channel? {
+        return if (restored?.id == modChatChannelId && !canUseModChat(playerId)) {
+            defaultChannel
+        } else {
+            restored ?: defaultChannel
+        }
+    }
+
     private fun savePreviousChannel(current: Channel?, playerId: UUID) {
-        if (current != null && current.id != guildChannelId && current.id != allyChannelId) {
+        if (current != null && canCachePrevious(current.id)) {
             previousChannelId[playerId] = current.id
+        }
+    }
+
+    private fun canCachePrevious(channelId: String): Boolean {
+        return channelId != guildChannelId &&
+            channelId != allyChannelId &&
+            channelId != modChatChannelId
+    }
+
+    private fun canUseModChat(playerId: UUID): Boolean {
+        val guilds = guildService.getPlayerGuilds(playerId)
+        return guilds.any { guild ->
+            memberService.hasPermission(playerId, guild.id, RankPermission.MODERATE_CHAT)
         }
     }
 

--- a/src/main/kotlin/net/lumalyte/lg/interaction/listeners/GuildChatListener.kt
+++ b/src/main/kotlin/net/lumalyte/lg/interaction/listeners/GuildChatListener.kt
@@ -139,11 +139,8 @@ class GuildChatListener : Listener, KoinComponent {
         val api = RoseChatAPI.getInstance()
         val ch = api?.channelManager?.getChannel(modChatChannelId)
         val guilds = guildService.getPlayerGuilds(player.uniqueId)
-        val g = guilds.firstOrNull {
-            guild ->
-            memberService.hasPermission(
-                player.uniqueId, guild.id, RankPermission.MODERATE_CHAT,
-            )
+        val g = guilds.firstOrNull { guild ->
+            memberService.hasPermission(player.uniqueId, guild.id, RankPermission.MODERATE_CHAT)
         }
         return when {
             api == null -> {
@@ -162,7 +159,9 @@ class GuildChatListener : Listener, KoinComponent {
                 player.sendMessage("§c❌ Only guild moderators can use mod chat!")
                 null
             }
-            else -> ch
+            else -> {
+                ch
+            }
         }
     }
 

--- a/src/main/kotlin/net/lumalyte/lg/interaction/listeners/GuildChatListener.kt
+++ b/src/main/kotlin/net/lumalyte/lg/interaction/listeners/GuildChatListener.kt
@@ -124,42 +124,42 @@ class GuildChatListener : Listener, KoinComponent {
     fun toggleModChat(player: Player): Boolean {
         val rose = RosePlayer(player)
         val modChannel = resolveModChatChannel(player) ?: return false
-
-        val current = rose.playerData?.currentChannel
-        if (current === modChannel) {
+        return if (rose.playerData?.currentChannel === modChannel) {
             restorePreviousChannel(player, rose)
-            return false
+            false
+        } else {
+            savePreviousChannel(rose.playerData?.currentChannel, player.uniqueId)
+            rose.switchChannel(modChannel)
+            true
         }
-        savePreviousChannel(current, player.uniqueId)
-        rose.switchChannel(modChannel)
-        return true
     }
 
     private fun resolveModChatChannel(player: Player): Channel? {
         val api = RoseChatAPI.getInstance()
-        if (api == null) {
-            player.sendMessage("§c❌ RoseChat is not loaded — mod chat unavailable.")
-            return null
+        val ch = api?.channelManager?.getChannel(modChatChannelId)
+        val g = guildService.getPlayerGuilds(player.uniqueId).firstOrNull()
+        val ok = g != null && memberService.hasPermission(
+            player.uniqueId, g.id, RankPermission.MODERATE_CHAT,
+        )
+        return when {
+            api == null -> {
+                player.sendMessage("§c❌ RoseChat is not loaded — mod chat unavailable.")
+                null
+            }
+            ch == null -> {
+                player.sendMessage("§c❌ Mod chat channel not configured.")
+                null
+            }
+            g == null -> {
+                player.sendMessage("§c❌ You are not in a guild!")
+                null
+            }
+            !ok -> {
+                player.sendMessage("§c❌ Only guild moderators can use mod chat!")
+                null
+            }
+            else -> ch
         }
-        val channel = api.channelManager.getChannel(modChatChannelId)
-        if (channel == null) {
-            player.sendMessage("§c❌ Mod chat channel '$modChatChannelId' is not configured in RoseChat.")
-            return null
-        }
-        val playerId = player.uniqueId
-        val guilds = guildService.getPlayerGuilds(playerId)
-        if (guilds.isEmpty()) {
-            player.sendMessage("§c❌ You are not in a guild!")
-            return null
-        }
-        if (!memberService.hasPermission(
-                playerId, guilds.first().id, RankPermission.MODERATE_CHAT,
-            )
-        ) {
-            player.sendMessage("§c❌ Only guild moderators can use mod chat!")
-            return null
-        }
-        return channel
     }
 
     private fun restorePreviousChannel(player: Player, rose: RosePlayer) {

--- a/src/main/kotlin/net/lumalyte/lg/interaction/listeners/GuildChatListener.kt
+++ b/src/main/kotlin/net/lumalyte/lg/interaction/listeners/GuildChatListener.kt
@@ -4,6 +4,8 @@ import dev.rosewood.rosechat.api.RoseChatAPI
 import dev.rosewood.rosechat.chat.channel.Channel
 import dev.rosewood.rosechat.message.RosePlayer
 import net.lumalyte.lg.application.services.GuildService
+import net.lumalyte.lg.application.services.MemberService
+import net.lumalyte.lg.domain.entities.RankPermission
 import org.bukkit.Bukkit
 import org.bukkit.entity.Player
 import org.bukkit.event.Listener
@@ -25,6 +27,7 @@ import java.util.concurrent.ConcurrentHashMap
 class GuildChatListener : Listener, KoinComponent {
 
     private val guildService: GuildService by inject()
+    private val memberService: MemberService by inject()
 
     private val logger = LoggerFactory.getLogger(GuildChatListener::class.java)
 
@@ -33,6 +36,9 @@ class GuildChatListener : Listener, KoinComponent {
 
     /** ID of the RoseChat channel that targets allied guilds. Must match channels.yml. */
     private val allyChannelId = "guild-ally"
+
+    /** ID of the RoseChat channel for guild moderators. Must match channels.yml. */
+    private val modChatChannelId = "guild-modchat"
 
     /** Caches the channel a player was in before they switched into guild/ally chat, so toggle-off restores it. */
     private val previousChannelId: MutableMap<UUID, String> = ConcurrentHashMap()
@@ -107,6 +113,48 @@ class GuildChatListener : Listener, KoinComponent {
 
         if (current != null && current.id != guildChannelId) previousChannelId[player.uniqueId] = current.id
         rose.switchChannel(allyChannel)
+        return true
+    }
+
+    fun toggleModChat(player: Player): Boolean {
+        val api = RoseChatAPI.getInstance()
+        if (api == null) {
+            player.sendMessage("§c❌ RoseChat is not loaded — mod chat unavailable.")
+            return false
+        }
+
+        val rose = RosePlayer(player)
+        val current: Channel? = rose.playerData?.currentChannel
+        val modChannel: Channel? = api.channelManager.getChannel(modChatChannelId)
+
+        if (modChannel == null) {
+            player.sendMessage("§c❌ Mod chat channel '$modChatChannelId' is not configured in RoseChat.")
+            return false
+        }
+
+        // Must be in a guild with MODERATE_CHAT permission
+        val playerId = player.uniqueId
+        val guilds = guildService.getPlayerGuilds(playerId)
+        if (guilds.isEmpty()) {
+            player.sendMessage("§c❌ You are not in a guild!")
+            return false
+        }
+        val primaryGuildId = guilds.first().id
+        if (!memberService.hasPermission(playerId, primaryGuildId, RankPermission.MODERATE_CHAT)) {
+            player.sendMessage("§c❌ Only guild moderators can use mod chat!")
+            return false
+        }
+
+        if (current === modChannel) {
+            val prevId = previousChannelId.remove(player.uniqueId)
+            val target = prevId?.let { api.channelManager.getChannel(it) } ?: api.defaultChannel
+            if (target != null) rose.switchChannel(target)
+            return false
+        }
+
+        if (current != null && current.id != guildChannelId && current.id != allyChannelId)
+            previousChannelId[player.uniqueId] = current.id
+        rose.switchChannel(modChannel)
         return true
     }
 

--- a/src/main/kotlin/net/lumalyte/lg/interaction/listeners/GuildChatListener.kt
+++ b/src/main/kotlin/net/lumalyte/lg/interaction/listeners/GuildChatListener.kt
@@ -138,25 +138,22 @@ class GuildChatListener : Listener, KoinComponent {
         val api = RoseChatAPI.getInstance()
         val ch = api?.channelManager?.getChannel(modChatChannelId)
         val g = guildService.getPlayerGuilds(player.uniqueId).firstOrNull()
-        val ok = g != null && memberService.hasPermission(
-            player.uniqueId, g.id, RankPermission.MODERATE_CHAT,
-        )
+        val ok = g != null
+            && memberService.hasPermission(
+                player.uniqueId, g.id, RankPermission.MODERATE_CHAT,
+            )
         return when {
-            api == null -> {
+            api == null -> null.also {
                 player.sendMessage("§c❌ RoseChat is not loaded — mod chat unavailable.")
-                null
             }
-            ch == null -> {
+            ch == null -> null.also {
                 player.sendMessage("§c❌ Mod chat channel not configured.")
-                null
             }
-            g == null -> {
+            g == null -> null.also {
                 player.sendMessage("§c❌ You are not in a guild!")
-                null
             }
-            !ok -> {
+            !ok -> null.also {
                 player.sendMessage("§c❌ Only guild moderators can use mod chat!")
-                null
             }
             else -> ch
         }

--- a/src/main/kotlin/net/lumalyte/lg/interaction/listeners/GuildChatListener.kt
+++ b/src/main/kotlin/net/lumalyte/lg/interaction/listeners/GuildChatListener.kt
@@ -143,6 +143,7 @@ class GuildChatListener : Listener, KoinComponent {
             guilds.firstOrNull { guild ->
                 memberService.hasPermission(player.uniqueId, guild.id, RankPermission.MODERATE_CHAT)
             }
+        @Suppress("OptionalWhenBraces")
         return when {
             api == null -> {
                 player.sendMessage("§c❌ RoseChat is not loaded — mod chat unavailable.")

--- a/src/main/kotlin/net/lumalyte/lg/interaction/listeners/GuildChatListener.kt
+++ b/src/main/kotlin/net/lumalyte/lg/interaction/listeners/GuildChatListener.kt
@@ -139,23 +139,28 @@ class GuildChatListener : Listener, KoinComponent {
         val api = RoseChatAPI.getInstance()
         val ch = api?.channelManager?.getChannel(modChatChannelId)
         val guilds = guildService.getPlayerGuilds(player.uniqueId)
-        val g = guilds.firstOrNull { guild ->
+        val g = guilds.firstOrNull {
+            guild ->
             memberService.hasPermission(
                 player.uniqueId, guild.id, RankPermission.MODERATE_CHAT,
             )
         }
         return when {
             api == null -> {
-                player.sendMessage("§c❌ RoseChat is not loaded — mod chat unavailable."); null
+                player.sendMessage("§c❌ RoseChat is not loaded — mod chat unavailable.")
+                null
             }
             ch == null -> {
-                player.sendMessage("§c❌ Mod chat channel not configured."); null
+                player.sendMessage("§c❌ Mod chat channel not configured.")
+                null
             }
             guilds.isEmpty() -> {
-                player.sendMessage("§c❌ You are not in a guild!"); null
+                player.sendMessage("§c❌ You are not in a guild!")
+                null
             }
             g == null -> {
-                player.sendMessage("§c❌ Only guild moderators can use mod chat!"); null
+                player.sendMessage("§c❌ Only guild moderators can use mod chat!")
+                null
             }
             else -> ch
         }

--- a/src/main/kotlin/net/lumalyte/lg/interaction/listeners/GuildChatListener.kt
+++ b/src/main/kotlin/net/lumalyte/lg/interaction/listeners/GuildChatListener.kt
@@ -119,11 +119,12 @@ class GuildChatListener : Listener, KoinComponent {
      * Toggles mod chat mode for a player. Only guild members with MODERATE_CHAT
      * permission can use this. Uses RoseChat for channel switching.
      *
-     * @return true if mod chat is now ON, false if now OFF.
+     * @return true if mod chat is now ON, false if toggled OFF,
+     *         null if unavailable (error message already sent).
      */
-    fun toggleModChat(player: Player): Boolean {
+    fun toggleModChat(player: Player): Boolean? {
+        val modChannel = resolveModChatChannel(player) ?: return null
         val rose = RosePlayer(player)
-        val modChannel = resolveModChatChannel(player) ?: return false
         return if (rose.playerData?.currentChannel === modChannel) {
             restorePreviousChannel(player, rose)
             false
@@ -137,10 +138,12 @@ class GuildChatListener : Listener, KoinComponent {
     private fun resolveModChatChannel(player: Player): Channel? {
         val api = RoseChatAPI.getInstance()
         val ch = api?.channelManager?.getChannel(modChatChannelId)
-        val g = guildService.getPlayerGuilds(player.uniqueId).firstOrNull()
-        val ok = g != null && memberService.hasPermission(
-            player.uniqueId, g.id, RankPermission.MODERATE_CHAT,
-        )
+        val guilds = guildService.getPlayerGuilds(player.uniqueId)
+        val g = guilds.firstOrNull { guild ->
+            memberService.hasPermission(
+                player.uniqueId, guild.id, RankPermission.MODERATE_CHAT,
+            )
+        }
         return when {
             api == null -> {
                 player.sendMessage("§c❌ RoseChat is not loaded — mod chat unavailable."); null
@@ -148,10 +151,10 @@ class GuildChatListener : Listener, KoinComponent {
             ch == null -> {
                 player.sendMessage("§c❌ Mod chat channel not configured."); null
             }
-            g == null -> {
+            guilds.isEmpty() -> {
                 player.sendMessage("§c❌ You are not in a guild!"); null
             }
-            !ok -> {
+            g == null -> {
                 player.sendMessage("§c❌ Only guild moderators can use mod chat!"); null
             }
             else -> ch

--- a/src/main/kotlin/net/lumalyte/lg/interaction/listeners/GuildChatListener.kt
+++ b/src/main/kotlin/net/lumalyte/lg/interaction/listeners/GuildChatListener.kt
@@ -160,7 +160,9 @@ class GuildChatListener : Listener, KoinComponent {
                 player.sendMessage("§c❌ Only guild moderators can use mod chat!")
                 null
             }
-            else -> ch
+            else -> {
+                ch
+            }
         }
     }
 

--- a/src/main/kotlin/net/lumalyte/lg/interaction/listeners/GuildChatListener.kt
+++ b/src/main/kotlin/net/lumalyte/lg/interaction/listeners/GuildChatListener.kt
@@ -139,9 +139,10 @@ class GuildChatListener : Listener, KoinComponent {
         val api = RoseChatAPI.getInstance()
         val ch = api?.channelManager?.getChannel(modChatChannelId)
         val guilds = guildService.getPlayerGuilds(player.uniqueId)
-        val g = guilds.firstOrNull { guild ->
-            memberService.hasPermission(player.uniqueId, guild.id, RankPermission.MODERATE_CHAT)
-        }
+        val g =
+            guilds.firstOrNull { guild ->
+                memberService.hasPermission(player.uniqueId, guild.id, RankPermission.MODERATE_CHAT)
+            }
         return when {
             api == null -> {
                 player.sendMessage("§c❌ RoseChat is not loaded — mod chat unavailable.")
@@ -159,9 +160,7 @@ class GuildChatListener : Listener, KoinComponent {
                 player.sendMessage("§c❌ Only guild moderators can use mod chat!")
                 null
             }
-            else -> {
-                ch
-            }
+            else -> ch
         }
     }
 

--- a/src/main/kotlin/net/lumalyte/lg/interaction/listeners/GuildChatListener.kt
+++ b/src/main/kotlin/net/lumalyte/lg/interaction/listeners/GuildChatListener.kt
@@ -138,22 +138,21 @@ class GuildChatListener : Listener, KoinComponent {
         val api = RoseChatAPI.getInstance()
         val ch = api?.channelManager?.getChannel(modChatChannelId)
         val g = guildService.getPlayerGuilds(player.uniqueId).firstOrNull()
-        val ok = g != null
-            && memberService.hasPermission(
-                player.uniqueId, g.id, RankPermission.MODERATE_CHAT,
-            )
+        val ok = g != null && memberService.hasPermission(
+            player.uniqueId, g.id, RankPermission.MODERATE_CHAT,
+        )
         return when {
-            api == null -> null.also {
-                player.sendMessage("§c❌ RoseChat is not loaded — mod chat unavailable.")
+            api == null -> {
+                player.sendMessage("§c❌ RoseChat is not loaded — mod chat unavailable."); null
             }
-            ch == null -> null.also {
-                player.sendMessage("§c❌ Mod chat channel not configured.")
+            ch == null -> {
+                player.sendMessage("§c❌ Mod chat channel not configured."); null
             }
-            g == null -> null.also {
-                player.sendMessage("§c❌ You are not in a guild!")
+            g == null -> {
+                player.sendMessage("§c❌ You are not in a guild!"); null
             }
-            !ok -> null.also {
-                player.sendMessage("§c❌ Only guild moderators can use mod chat!")
+            !ok -> {
+                player.sendMessage("§c❌ Only guild moderators can use mod chat!"); null
             }
             else -> ch
         }

--- a/src/main/kotlin/net/lumalyte/lg/interaction/listeners/GuildChatListener.kt
+++ b/src/main/kotlin/net/lumalyte/lg/interaction/listeners/GuildChatListener.kt
@@ -37,7 +37,6 @@ class GuildChatListener : Listener, KoinComponent {
     /** ID of the RoseChat channel that targets allied guilds. Must match channels.yml. */
     private val allyChannelId = "guild-ally"
 
-    /** ID of the RoseChat channel for guild moderators. Must match channels.yml. */
     private val modChatChannelId = "guild-modchat"
 
     /** Caches the channel a player was in before they switched into guild/ally chat, so toggle-off restores it. */
@@ -116,46 +115,66 @@ class GuildChatListener : Listener, KoinComponent {
         return true
     }
 
+    /**
+     * Toggles mod chat mode for a player. Only guild members with MODERATE_CHAT
+     * permission can use this. Uses RoseChat for channel switching.
+     *
+     * @return true if mod chat is now ON, false if now OFF.
+     */
     fun toggleModChat(player: Player): Boolean {
+        val rose = RosePlayer(player)
+        val modChannel = resolveModChatChannel(player) ?: return false
+
+        val current = rose.playerData?.currentChannel
+        if (current === modChannel) {
+            restorePreviousChannel(player, rose)
+            return false
+        }
+        savePreviousChannel(current, player.uniqueId)
+        rose.switchChannel(modChannel)
+        return true
+    }
+
+    private fun resolveModChatChannel(player: Player): Channel? {
         val api = RoseChatAPI.getInstance()
         if (api == null) {
             player.sendMessage("§c❌ RoseChat is not loaded — mod chat unavailable.")
-            return false
+            return null
         }
-
-        val rose = RosePlayer(player)
-        val current: Channel? = rose.playerData?.currentChannel
-        val modChannel: Channel? = api.channelManager.getChannel(modChatChannelId)
-
-        if (modChannel == null) {
+        val channel = api.channelManager.getChannel(modChatChannelId)
+        if (channel == null) {
             player.sendMessage("§c❌ Mod chat channel '$modChatChannelId' is not configured in RoseChat.")
-            return false
+            return null
         }
-
-        // Must be in a guild with MODERATE_CHAT permission
         val playerId = player.uniqueId
         val guilds = guildService.getPlayerGuilds(playerId)
         if (guilds.isEmpty()) {
             player.sendMessage("§c❌ You are not in a guild!")
-            return false
+            return null
         }
-        val primaryGuildId = guilds.first().id
-        if (!memberService.hasPermission(playerId, primaryGuildId, RankPermission.MODERATE_CHAT)) {
+        if (!memberService.hasPermission(
+                playerId, guilds.first().id, RankPermission.MODERATE_CHAT,
+            )
+        ) {
             player.sendMessage("§c❌ Only guild moderators can use mod chat!")
-            return false
+            return null
         }
+        return channel
+    }
 
-        if (current === modChannel) {
-            val prevId = previousChannelId.remove(player.uniqueId)
-            val target = prevId?.let { api.channelManager.getChannel(it) } ?: api.defaultChannel
-            if (target != null) rose.switchChannel(target)
-            return false
+    private fun restorePreviousChannel(player: Player, rose: RosePlayer) {
+        val prevId = previousChannelId.remove(player.uniqueId)
+        val api = RoseChatAPI.getInstance() ?: return
+        val target = prevId?.let { api.channelManager.getChannel(it) } ?: api.defaultChannel
+        if (target != null) {
+            rose.switchChannel(target)
         }
+    }
 
-        if (current != null && current.id != guildChannelId && current.id != allyChannelId)
-            previousChannelId[player.uniqueId] = current.id
-        rose.switchChannel(modChannel)
-        return true
+    private fun savePreviousChannel(current: Channel?, playerId: UUID) {
+        if (current != null && current.id != guildChannelId && current.id != allyChannelId) {
+            previousChannelId[playerId] = current.id
+        }
     }
 
     fun isInGuildChatMode(playerId: UUID): Boolean {

--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -26,6 +26,12 @@ commands:
     description: Party chat commands
     usage: /pc <subcommand> [args]
     aliases: [pchat, partychat]
+  gc:
+    description: Send a quick message to guild chat without changing your chat channel
+    usage: /gc [message]
+  ac:
+    description: Send a quick message to ally chat without changing your chat channel
+    usage: /ac [message]
   lumaguilds:
     description: LumaGuilds administrative commands
     usage: /lumaguilds <subcommand> [args]

--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -29,9 +29,15 @@ commands:
   gc:
     description: Send a quick message to guild chat without changing your chat channel
     usage: /gc [message]
-  ac:
+  gac:
     description: Send a quick message to ally chat without changing your chat channel
-    usage: /ac [message]
+    usage: /gac [message]
+  gmc:
+    description: Send a quick message to guild mod chat (moderators only)
+    usage: /gmc [message]
+  ga:
+    description: Send a guild announcement (moderators only)
+    usage: /ga [color] <message>
   lumaguilds:
     description: LumaGuilds administrative commands
     usage: /lumaguilds <subcommand> [args]

--- a/wiki/docs/players/chat.md
+++ b/wiki/docs/players/chat.md
@@ -17,9 +17,9 @@ Toggle guild and ally chat, and customize how your tag appears in messages.
 | Command | Permission | Description |
 |---------|------------|-------------|
 | `/g chat` | `lumaguilds.guild.chat` | Toggle guild chat on/off. |
-| `/gc <message>` | `lumaguilds.guild.chat` | Send one guild chat message (no toggle). |
+| `/gc <message>` | `lumaguilds.guild.chat` | Send one guild msg (no toggle). |
 | `/g allychat` | `lumaguilds.guild.chat` | Toggle ally chat on/off. |
-| `/ac <message>` | `lumaguilds.guild.chat` | Send one ally chat message (no toggle). |
+| `/ac <message>` | `lumaguilds.guild.chat` | Send one ally msg (no toggle). |
 
 ## How it works
 

--- a/wiki/docs/players/chat.md
+++ b/wiki/docs/players/chat.md
@@ -19,7 +19,10 @@ Toggle guild and ally chat, and customize how your tag appears in messages.
 | `/g chat` | `lumaguilds.guild.chat` | Toggle guild chat on/off. |
 | `/gc <message>` | `lumaguilds.guild.chat` | Send one guild msg (no toggle). |
 | `/g allychat` | `lumaguilds.guild.chat` | Toggle ally chat on/off. |
-| `/ac <message>` | `lumaguilds.guild.chat` | Send one ally msg (no toggle). |
+| `/gac <message>` | `lumaguilds.guild.chat` | Send one ally msg (no toggle). |
+| `/g modchat` | `lumaguilds.guild.chat` | Toggle mod chat on/off (moderators). |
+| `/gmc <message>` | `lumaguilds.guild.chat` | Send one mod msg (no toggle). |
+| `/ga [&color] <msg>` | `lumaguilds.guild.chat` | Send announcement (moderators). |
 
 ## How it works
 
@@ -39,8 +42,15 @@ Use `/g allychat` to enter ally chat. Same on/off behavior as guild chat. Only m
 chat channel. You stay in global (or wherever you were). Great for a quick
 \"brb\" or \"meet at spawn\" to your guildmates.
 
-`/ac <message>` does the same for ally chat — no toggle in, message, toggle
+`/gac <message>` does the same for ally chat — no toggle in, message, toggle
 out needed.
+
+`/gmc <message>` sends a single message to guild moderators without changing
+your channel. Only moderators can send or receive mod chat messages.
+
+`/ga [&color] <message>` sends a highlighted announcement to all guild
+members. Supports color codes &0 through &9 (default &6 gold). Only
+moderators with SEND_ANNOUNCEMENTS permission can use this.
 
 ## How tag formatting renders
 

--- a/wiki/docs/players/chat.md
+++ b/wiki/docs/players/chat.md
@@ -17,7 +17,9 @@ Toggle guild and ally chat, and customize how your tag appears in messages.
 | Command | Permission | Description |
 |---------|------------|-------------|
 | `/g chat` | `lumaguilds.guild.chat` | Toggle guild chat on/off. |
-| `/g allychat` | `lumaguilds.guild.allychat` | Toggle ally chat on/off. |
+| `/gc <message>` | `lumaguilds.guild.chat` | Send one message to guild chat (no toggle). |
+| `/g allychat` | `lumaguilds.guild.chat` | Toggle ally chat on/off. |
+| `/ac <message>` | `lumaguilds.guild.chat` | Send one message to ally chat (no toggle). |
 
 ## How it works
 
@@ -30,6 +32,12 @@ Run `/g chat` once to enter guild chat. Type your messages. Run `/g chat` again 
 ## Toggling ally chat
 
 Use `/g allychat` to enter ally chat. Same on/off behavior as guild chat. Only members of guilds you have an ACTIVE alliance with can read your messages. Useful for coordinating with allied guilds without spamming global.
+
+## One-shot messages (no toggle)
+
+`/gc <message>` sends a single message to guild chat without changing your chat channel. You stay in global (or wherever you were). Great for a quick \"brb\" or \"meet at spawn\" to your guildmates.
+
+`/ac <message>` does the same for ally chat. No need to toggle in, message, toggle out.
 
 ## How tag formatting renders
 

--- a/wiki/docs/players/chat.md
+++ b/wiki/docs/players/chat.md
@@ -17,9 +17,9 @@ Toggle guild and ally chat, and customize how your tag appears in messages.
 | Command | Permission | Description |
 |---------|------------|-------------|
 | `/g chat` | `lumaguilds.guild.chat` | Toggle guild chat on/off. |
-| `/gc <message>` | `lumaguilds.guild.chat` | Send one message to guild chat (no toggle). |
+| `/gc <message>` | `lumaguilds.guild.chat` | Send one guild chat message (no toggle). |
 | `/g allychat` | `lumaguilds.guild.chat` | Toggle ally chat on/off. |
-| `/ac <message>` | `lumaguilds.guild.chat` | Send one message to ally chat (no toggle). |
+| `/ac <message>` | `lumaguilds.guild.chat` | Send one ally chat message (no toggle). |
 
 ## How it works
 
@@ -35,9 +35,12 @@ Use `/g allychat` to enter ally chat. Same on/off behavior as guild chat. Only m
 
 ## One-shot messages (no toggle)
 
-`/gc <message>` sends a single message to guild chat without changing your chat channel. You stay in global (or wherever you were). Great for a quick \"brb\" or \"meet at spawn\" to your guildmates.
+`/gc <message>` sends a single message to guild chat without changing your
+chat channel. You stay in global (or wherever you were). Great for a quick
+\"brb\" or \"meet at spawn\" to your guildmates.
 
-`/ac <message>` does the same for ally chat. No need to toggle in, message, toggle out.
+`/ac <message>` does the same for ally chat — no toggle in, message, toggle
+out needed.
 
 ## How tag formatting renders
 

--- a/wiki/docs/players/chat.md
+++ b/wiki/docs/players/chat.md
@@ -20,9 +20,9 @@ Toggle guild and ally chat, and customize how your tag appears in messages.
 | `/gc <message>` | `lumaguilds.guild.chat` | Send one guild msg (no toggle). |
 | `/g allychat` | `lumaguilds.guild.chat` | Toggle ally chat on/off. |
 | `/gac <message>` | `lumaguilds.guild.chat` | Send one ally msg (no toggle). |
-| `/g modchat` | `lumaguilds.guild.chat` | Toggle mod chat on/off (moderators). |
+| `/g modchat` | `lumaguilds.guild.chat` | Toggle mod chat (moderators). |
 | `/gmc <message>` | `lumaguilds.guild.chat` | Send one mod msg (no toggle). |
-| `/ga [&color] <msg>` | `lumaguilds.guild.chat` | Send announcement (moderators). |
+| `/ga [&color] <msg>` | `lumaguilds.guild.chat` | Send announcement. |
 
 ## How it works
 


### PR DESCRIPTION
## Summary

- Adds the quick chat command work from PR #68 under a branch owned by BoggersTheFish.
- Fixes guild announcements so multi-guild players announce from a guild where they actually have `SEND_ANNOUNCEMENTS`.
- Keeps announcement color overrides numeric-only and falls back to gold for invalid color chars.

## Why

CodeRabbit flagged that `QuickAnnounceCommand.requireAnnouncementPermission` selected the first guild from an unordered set. That could deny a valid moderator or send an announcement from the wrong guild when the player belongs to multiple guilds.

## Validation

- `git diff --check HEAD^..HEAD`

`./gradlew test` could not complete locally because `libs/RoseChat-RC-2.jar` is not present, leaving existing RoseChat symbols unresolved during Kotlin compilation.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Fixes
- Select a guild the player can actually announce from when handling quick guild announcements, rather than relying on an arbitrary guild from the membership set.
- Validate guild announcement color overrides as numeric-only and fall back to gold when the provided color digit is invalid.
- Route mod-chat toggling and recipient selection through permission checks so only guild members with `MODERATE_CHAT` can enter or receive `MODCHAT`.
- Keep chat formatting and recipient handling consistent by reusing a shared unknown-player label and blocking unsupported visibility toggles.

## Features
- Register quick guild chat, ally chat, mod chat, and announcement commands in the plugin bootstrap and command metadata.
- Add one-shot `/gc`, `/gac`, `/gmc`, and `/ga` command handlers with usage/help responses and message routing.
- Extend chat service APIs and Bukkit chat handling to support guild announcements with custom header colors.
- Document the new chat commands and update the in-game help topic list to include the new quick chat flows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->