### PR TITLE
fix: register GuildLookup in Bukkit ServicesManager at enable

### DIFF
--- a/src/main/kotlin/net/lumalyte/lg/LumaGuilds.kt
+++ b/src/main/kotlin/net/lumalyte/lg/LumaGuilds.kt
@@ -24,6 +24,7 @@ import net.milkbowl.vault.chat.Chat
 import net.kyori.adventure.text.Component
 import net.kyori.adventure.text.format.NamedTextColor
 import org.bukkit.Bukkit
+import org.bukkit.plugin.ServicePriority
 import org.bukkit.plugin.java.JavaPlugin
 import org.bukkit.scheduler.BukkitScheduler
 import org.koin.core.context.GlobalContext.startKoin
@@ -81,6 +82,23 @@ class LumaGuilds : JavaPlugin() {
 
         // Start Koin with modular architecture
         startKoin { modules(appModule(this@LumaGuilds, storage, claimsEnabled)) }
+
+        // Register GuildLookup in Bukkit's ServicesManager so EnthusiaMarket
+        // (and other plugins) can query guild membership, permissions, and
+        // bank balances via the public API.
+        val guildLookup = net.lumalyte.lg.api.GuildLookupImpl(
+            get().get<net.lumalyte.lg.application.services.GuildService>(),
+            get().get<net.lumalyte.lg.application.services.MemberService>(),
+            get().get<net.lumalyte.lg.application.services.RankService>(),
+            get().get<net.lumalyte.lg.application.services.BankService>()
+        )
+        Bukkit.getServicesManager().register(
+            net.lumalyte.lg.api.GuildLookup::class.java,
+            guildLookup,
+            this,
+            ServicePriority.Normal
+        )
+        logColored("✓ GuildLookup registered in ServicesManager for cross-plugin integration")
 
         // Initialize Apollo AFTER Koin is started (requires Koin DI)
         initialiseApolloIntegration()


### PR DESCRIPTION
## Problem
`GuildLookup` is the cross-plugin integration API that EnthusiaMarket loads via `Bukkit.getServicesManager().load(GuildLookup::class.java)`. The interface docstring says LumaGuilds registers it at enable, but the code was **never implemented**.

This means:
- EnthusiaMarket's `LumaGuildsGuildProvider.lookup` is always null
- `guildOf()` returns null for all players
- `hasShopPermission()` returns false for everyone
- Guild stall purchase option never renders
- All guild bank operations fail
- All guild shop features are silently non-functional

## Fix
Construct `GuildLookupImpl` from Koin-resolved `GuildService`, `MemberService`, `RankService`, and `BankService`, then register it in Bukkit's `ServicesManager` immediately after `startKoin()`. One file, 18 lines added.

## Verification
- `./gradlew compileKotlin` passes
- `./gradlew shadowJar` produces 17MB jar
- `./gradlew test` — all tests pass
- Jar confirmed to contain `GuildLookup.class` and the registration string in `LumaGuilds.class`