### PR TITLE
Expose active guild visuals for Market integrations

### DIFF
--- a/src/main/kotlin/net/lumalyte/lg/LumaGuilds.kt
+++ b/src/main/kotlin/net/lumalyte/lg/LumaGuilds.kt
@@ -103,8 +103,7 @@ class LumaGuilds : JavaPlugin() {
         val guildVisualLookup = net.lumalyte.lg.api.GuildVisualLookupImpl(
             get().get<net.lumalyte.lg.application.services.GuildService>(),
             get().get<net.lumalyte.lg.application.services.MemberService>(),
-            get().get<net.lumalyte.lg.application.services.RankService>(),
-            get().get<net.lumalyte.lg.application.services.GuildBannerService>()
+            get().get<net.lumalyte.lg.application.services.RankService>()
         )
         Bukkit.getServicesManager().register(
             net.lumalyte.lg.api.GuildVisualLookup::class.java,

--- a/src/main/kotlin/net/lumalyte/lg/LumaGuilds.kt
+++ b/src/main/kotlin/net/lumalyte/lg/LumaGuilds.kt
@@ -100,6 +100,20 @@ class LumaGuilds : JavaPlugin() {
         )
         logColored("✓ GuildLookup registered in ServicesManager for cross-plugin integration")
 
+        val guildVisualLookup = net.lumalyte.lg.api.GuildVisualLookupImpl(
+            get().get<net.lumalyte.lg.application.services.GuildService>(),
+            get().get<net.lumalyte.lg.application.services.MemberService>(),
+            get().get<net.lumalyte.lg.application.services.RankService>(),
+            get().get<net.lumalyte.lg.application.services.GuildBannerService>()
+        )
+        Bukkit.getServicesManager().register(
+            net.lumalyte.lg.api.GuildVisualLookup::class.java,
+            guildVisualLookup,
+            this,
+            ServicePriority.Normal
+        )
+        logColored("✓ GuildVisualLookup registered in ServicesManager for cross-plugin integration")
+
         // Initialize Apollo AFTER Koin is started (requires Koin DI)
         initialiseApolloIntegration()
 

--- a/src/main/kotlin/net/lumalyte/lg/api/GuildVisualLookup.kt
+++ b/src/main/kotlin/net/lumalyte/lg/api/GuildVisualLookup.kt
@@ -1,0 +1,31 @@
+// This is a deliberately public, cross-plugin integration API. Transfer types
+// contain only JDK values and are shared through Paper's join-classpath.
+@file:Suppress("LibraryEntitiesShouldNotBePublic", "ForbiddenPublicDataClass")
+
+package net.lumalyte.lg.api
+
+import java.util.UUID
+
+/** Stable, read-only public presentation data for guild integrations. */
+interface GuildVisualLookup {
+    /** Public visual data for [guildId], or null when the guild does not exist. */
+    fun getGuildVisual(guildId: UUID): GuildVisualSummary?
+}
+
+/** Public guild visual data without persistence or Bukkit implementation types. */
+data class GuildVisualSummary(
+    val leaderId: UUID?,
+    val banner: GuildBannerDesignSummary?,
+)
+
+/** Bounded active banner design in Minecraft layer order. */
+data class GuildBannerDesignSummary(
+    val baseColor: String,
+    val patterns: List<GuildBannerPatternSummary>,
+)
+
+/** One public banner layer. */
+data class GuildBannerPatternSummary(
+    val type: String,
+    val color: String,
+)

--- a/src/main/kotlin/net/lumalyte/lg/api/GuildVisualLookup.kt
+++ b/src/main/kotlin/net/lumalyte/lg/api/GuildVisualLookup.kt
@@ -14,18 +14,24 @@ interface GuildVisualLookup {
 
 /** Public guild visual data without persistence or Bukkit implementation types. */
 data class GuildVisualSummary(
+    /** Current leader UUID, or null when leadership cannot be resolved. */
     val leaderId: UUID?,
+    /** Active public banner design, or null when the guild has no usable banner. */
     val banner: GuildBannerDesignSummary?,
 )
 
 /** Bounded active banner design in Minecraft layer order. */
 data class GuildBannerDesignSummary(
+    /** Minecraft dye color used by the banner item itself. */
     val baseColor: String,
+    /** Pattern layers in the order Minecraft applies them. */
     val patterns: List<GuildBannerPatternSummary>,
 )
 
 /** One public banner layer. */
 data class GuildBannerPatternSummary(
+    /** Stable Bukkit banner pattern name. */
     val type: String,
+    /** Minecraft dye color for this layer. */
     val color: String,
 )

--- a/src/main/kotlin/net/lumalyte/lg/api/GuildVisualLookupImpl.kt
+++ b/src/main/kotlin/net/lumalyte/lg/api/GuildVisualLookupImpl.kt
@@ -40,8 +40,10 @@ class GuildVisualLookupImpl(
             ?.let { GuildBannerDesignSummary(it, patterns) }
     }
 
-    private fun bannerBaseColor(typeName: String): String? = typeName.removeSuffix("_BANNER")
+    private fun bannerBaseColor(typeName: String): String? {
+        return typeName.removeSuffix("_BANNER")
             .takeIf { typeName.endsWith("_BANNER") && it in SUPPORTED_COLORS }
+    }
 
     private fun bannerPatterns(metadata: BannerMeta): List<GuildBannerPatternSummary> =
         metadata.patterns.map { pattern ->

--- a/src/main/kotlin/net/lumalyte/lg/api/GuildVisualLookupImpl.kt
+++ b/src/main/kotlin/net/lumalyte/lg/api/GuildVisualLookupImpl.kt
@@ -40,8 +40,7 @@ class GuildVisualLookupImpl(
             ?.let { GuildBannerDesignSummary(it, patterns) }
     }
 
-    private fun bannerBaseColor(typeName: String): String? =
-        typeName.removeSuffix("_BANNER")
+    private fun bannerBaseColor(typeName: String): String? = typeName.removeSuffix("_BANNER")
             .takeIf { typeName.endsWith("_BANNER") && it in SUPPORTED_COLORS }
 
     private fun bannerPatterns(metadata: BannerMeta): List<GuildBannerPatternSummary> =

--- a/src/main/kotlin/net/lumalyte/lg/api/GuildVisualLookupImpl.kt
+++ b/src/main/kotlin/net/lumalyte/lg/api/GuildVisualLookupImpl.kt
@@ -17,45 +17,58 @@ class GuildVisualLookupImpl(
 ) : GuildVisualLookup {
     override fun getGuildVisual(guildId: UUID): GuildVisualSummary? {
         val guild = guilds.getGuild(guildId) ?: return null
-        val leaderId = ranks.getHighestRank(guildId)
-            ?.let { members.getMembersByRank(guildId, it.id) }
-            ?.map { it.playerId }
-            ?.minByOrNull(UUID::toString)
+        val leaderId =
+            ranks.getHighestRank(guildId)
+                ?.let { members.getMembersByRank(guildId, it.id) }
+                ?.map { it.playerId }
+                ?.minByOrNull(UUID::toString)
         val banner = guild.banner?.let(::projectBanner)
         return GuildVisualSummary(leaderId, banner)
     }
 
-    private fun projectBanner(serialized: String): GuildBannerDesignSummary? {
-        val item = serialized.deserializeToItemStack() ?: return null
-        val baseColor = item.type.name.removeSuffix("_BANNER")
-            .takeIf { item.type.name.endsWith("_BANNER") && it in SUPPORTED_COLORS }
-            ?: return null
-        val meta = item.itemMeta as? BannerMeta ?: return null
-        val patterns = meta.patterns.map { pattern ->
-            GuildBannerPatternSummary(
-                pattern.pattern.key.key.uppercase(),
-                pattern.color.name,
-            )
+    private fun projectBanner(serialized: String): GuildBannerDesignSummary? =
+        serialized.deserializeToItemStack()?.let { item ->
+            (item.itemMeta as? BannerMeta)?.let { metadata ->
+                projectBannerMetadata(item.type.name, metadata)
+            }
         }
-        if (patterns.size > MAX_BANNER_PATTERNS || patterns.any { it.type !in SUPPORTED_PATTERNS }) return null
-        return GuildBannerDesignSummary(baseColor, patterns)
+
+    private fun projectBannerMetadata(typeName: String, metadata: BannerMeta): GuildBannerDesignSummary? {
+        val baseColor = bannerBaseColor(typeName)
+        val patterns = bannerPatterns(metadata)
+        return baseColor?.takeIf { patternsAreSupported(patterns) }
+            ?.let { GuildBannerDesignSummary(it, patterns) }
     }
+
+    private fun bannerBaseColor(typeName: String): String? =
+        typeName.removeSuffix("_BANNER")
+            .takeIf { typeName.endsWith("_BANNER") && it in SUPPORTED_COLORS }
+
+    private fun bannerPatterns(metadata: BannerMeta): List<GuildBannerPatternSummary> =
+        metadata.patterns.map { pattern ->
+            GuildBannerPatternSummary(pattern.pattern.key.key.uppercase(), pattern.color.name)
+        }
+
+    private fun patternsAreSupported(patterns: List<GuildBannerPatternSummary>): Boolean =
+        patterns.size <= MAX_BANNER_PATTERNS && patterns.all { it.type in SUPPORTED_PATTERNS }
 
     private companion object {
         const val MAX_BANNER_PATTERNS = 6
-        val SUPPORTED_COLORS = setOf(
-            "WHITE", "ORANGE", "MAGENTA", "LIGHT_BLUE", "YELLOW", "LIME", "PINK", "GRAY",
-            "LIGHT_GRAY", "CYAN", "PURPLE", "BLUE", "BROWN", "GREEN", "RED", "BLACK",
-        )
-        val SUPPORTED_PATTERNS = setOf(
-            "SQUARE_BOTTOM_LEFT", "SQUARE_BOTTOM_RIGHT", "SQUARE_TOP_LEFT", "SQUARE_TOP_RIGHT",
-            "STRIPE_BOTTOM", "STRIPE_TOP", "STRIPE_LEFT", "STRIPE_RIGHT", "STRIPE_CENTER",
-            "STRIPE_MIDDLE", "STRIPE_DOWNRIGHT", "STRIPE_DOWNLEFT", "STRIPE_SMALL", "CROSS",
-            "STRAIGHT_CROSS", "TRIANGLE_BOTTOM", "TRIANGLE_TOP", "TRIANGLES_BOTTOM", "TRIANGLES_TOP",
-            "DIAGONAL_LEFT", "DIAGONAL_RIGHT", "DIAGONAL_LEFT_MIRROR", "DIAGONAL_RIGHT_MIRROR",
-            "CIRCLE", "RHOMBUS", "HALF_VERTICAL", "HALF_HORIZONTAL", "HALF_VERTICAL_MIRROR",
-            "HALF_HORIZONTAL_MIRROR", "BORDER", "CURLY_BORDER", "GRADIENT", "GRADIENT_UP",
-            "BRICKS", "GLOBE", "CREEPER", "SKULL", "FLOWER", "MOJANG", "PIGLIN", "FLOW", "GUSTER",
-        )
+        val SUPPORTED_COLORS =
+            setOf(
+                "WHITE", "ORANGE", "MAGENTA", "LIGHT_BLUE", "YELLOW", "LIME", "PINK", "GRAY",
+                "LIGHT_GRAY", "CYAN", "PURPLE", "BLUE", "BROWN", "GREEN", "RED", "BLACK",
+            )
+        val SUPPORTED_PATTERNS =
+            setOf(
+                "SQUARE_BOTTOM_LEFT", "SQUARE_BOTTOM_RIGHT", "SQUARE_TOP_LEFT", "SQUARE_TOP_RIGHT",
+                "STRIPE_BOTTOM", "STRIPE_TOP", "STRIPE_LEFT", "STRIPE_RIGHT", "STRIPE_CENTER",
+                "STRIPE_MIDDLE", "STRIPE_DOWNRIGHT", "STRIPE_DOWNLEFT", "STRIPE_SMALL", "CROSS",
+                "STRAIGHT_CROSS", "TRIANGLE_BOTTOM", "TRIANGLE_TOP", "TRIANGLES_BOTTOM", "TRIANGLES_TOP",
+                "DIAGONAL_LEFT", "DIAGONAL_RIGHT", "DIAGONAL_LEFT_MIRROR", "DIAGONAL_RIGHT_MIRROR",
+                "CIRCLE", "RHOMBUS", "HALF_VERTICAL", "HALF_HORIZONTAL", "HALF_VERTICAL_MIRROR",
+                "HALF_HORIZONTAL_MIRROR", "BORDER", "CURLY_BORDER", "GRADIENT", "GRADIENT_UP",
+                "BRICKS", "GLOBE", "CREEPER", "SKULL", "FLOWER", "MOJANG", "PIGLIN", "FLOW", "GUSTER",
+            )
     }
 }

--- a/src/main/kotlin/net/lumalyte/lg/api/GuildVisualLookupImpl.kt
+++ b/src/main/kotlin/net/lumalyte/lg/api/GuildVisualLookupImpl.kt
@@ -2,10 +2,11 @@
 
 package net.lumalyte.lg.api
 
-import net.lumalyte.lg.application.services.GuildBannerService
 import net.lumalyte.lg.application.services.GuildService
 import net.lumalyte.lg.application.services.MemberService
 import net.lumalyte.lg.application.services.RankService
+import net.lumalyte.lg.utils.deserializeToItemStack
+import org.bukkit.inventory.meta.BannerMeta
 import java.util.UUID
 
 /** LumaGuilds-owned implementation of the stable public visual lookup. */
@@ -13,29 +14,39 @@ class GuildVisualLookupImpl(
     private val guilds: GuildService,
     private val members: MemberService,
     private val ranks: RankService,
-    private val banners: GuildBannerService,
 ) : GuildVisualLookup {
     override fun getGuildVisual(guildId: UUID): GuildVisualSummary? {
-        guilds.getGuild(guildId) ?: return null
+        val guild = guilds.getGuild(guildId) ?: return null
         val leaderId = ranks.getHighestRank(guildId)
             ?.let { members.getMembersByRank(guildId, it.id) }
             ?.map { it.playerId }
             ?.minByOrNull(UUID::toString)
-        val banner = banners.getGuildBanner(guildId)?.designData
-            ?.takeIf { design -> design.patterns.size <= MAX_BANNER_PATTERNS && design.patterns.all { it.type in SUPPORTED_PATTERNS } }
-            ?.let { design ->
-            GuildBannerDesignSummary(
-                baseColor = design.baseColor.name,
-                patterns = design.patterns.take(MAX_BANNER_PATTERNS).map {
-                    GuildBannerPatternSummary(it.type, it.color.name)
-                },
+        val banner = guild.banner?.let(::projectBanner)
+        return GuildVisualSummary(leaderId, banner)
+    }
+
+    private fun projectBanner(serialized: String): GuildBannerDesignSummary? {
+        val item = serialized.deserializeToItemStack() ?: return null
+        val baseColor = item.type.name.removeSuffix("_BANNER")
+            .takeIf { item.type.name.endsWith("_BANNER") && it in SUPPORTED_COLORS }
+            ?: return null
+        val meta = item.itemMeta as? BannerMeta ?: return null
+        val patterns = meta.patterns.map { pattern ->
+            GuildBannerPatternSummary(
+                pattern.pattern.key.key.uppercase(),
+                pattern.color.name,
             )
         }
-        return GuildVisualSummary(leaderId, banner)
+        if (patterns.size > MAX_BANNER_PATTERNS || patterns.any { it.type !in SUPPORTED_PATTERNS }) return null
+        return GuildBannerDesignSummary(baseColor, patterns)
     }
 
     private companion object {
         const val MAX_BANNER_PATTERNS = 6
+        val SUPPORTED_COLORS = setOf(
+            "WHITE", "ORANGE", "MAGENTA", "LIGHT_BLUE", "YELLOW", "LIME", "PINK", "GRAY",
+            "LIGHT_GRAY", "CYAN", "PURPLE", "BLUE", "BROWN", "GREEN", "RED", "BLACK",
+        )
         val SUPPORTED_PATTERNS = setOf(
             "SQUARE_BOTTOM_LEFT", "SQUARE_BOTTOM_RIGHT", "SQUARE_TOP_LEFT", "SQUARE_TOP_RIGHT",
             "STRIPE_BOTTOM", "STRIPE_TOP", "STRIPE_LEFT", "STRIPE_RIGHT", "STRIPE_CENTER",

--- a/src/main/kotlin/net/lumalyte/lg/api/GuildVisualLookupImpl.kt
+++ b/src/main/kotlin/net/lumalyte/lg/api/GuildVisualLookupImpl.kt
@@ -1,0 +1,50 @@
+@file:Suppress("LibraryEntitiesShouldNotBePublic")
+
+package net.lumalyte.lg.api
+
+import net.lumalyte.lg.application.services.GuildBannerService
+import net.lumalyte.lg.application.services.GuildService
+import net.lumalyte.lg.application.services.MemberService
+import net.lumalyte.lg.application.services.RankService
+import java.util.UUID
+
+/** LumaGuilds-owned implementation of the stable public visual lookup. */
+class GuildVisualLookupImpl(
+    private val guilds: GuildService,
+    private val members: MemberService,
+    private val ranks: RankService,
+    private val banners: GuildBannerService,
+) : GuildVisualLookup {
+    override fun getGuildVisual(guildId: UUID): GuildVisualSummary? {
+        guilds.getGuild(guildId) ?: return null
+        val leaderId = ranks.getHighestRank(guildId)
+            ?.let { members.getMembersByRank(guildId, it.id) }
+            ?.map { it.playerId }
+            ?.minByOrNull(UUID::toString)
+        val banner = banners.getGuildBanner(guildId)?.designData
+            ?.takeIf { design -> design.patterns.size <= MAX_BANNER_PATTERNS && design.patterns.all { it.type in SUPPORTED_PATTERNS } }
+            ?.let { design ->
+            GuildBannerDesignSummary(
+                baseColor = design.baseColor.name,
+                patterns = design.patterns.take(MAX_BANNER_PATTERNS).map {
+                    GuildBannerPatternSummary(it.type, it.color.name)
+                },
+            )
+        }
+        return GuildVisualSummary(leaderId, banner)
+    }
+
+    private companion object {
+        const val MAX_BANNER_PATTERNS = 6
+        val SUPPORTED_PATTERNS = setOf(
+            "SQUARE_BOTTOM_LEFT", "SQUARE_BOTTOM_RIGHT", "SQUARE_TOP_LEFT", "SQUARE_TOP_RIGHT",
+            "STRIPE_BOTTOM", "STRIPE_TOP", "STRIPE_LEFT", "STRIPE_RIGHT", "STRIPE_CENTER",
+            "STRIPE_MIDDLE", "STRIPE_DOWNRIGHT", "STRIPE_DOWNLEFT", "STRIPE_SMALL", "CROSS",
+            "STRAIGHT_CROSS", "TRIANGLE_BOTTOM", "TRIANGLE_TOP", "TRIANGLES_BOTTOM", "TRIANGLES_TOP",
+            "DIAGONAL_LEFT", "DIAGONAL_RIGHT", "DIAGONAL_LEFT_MIRROR", "DIAGONAL_RIGHT_MIRROR",
+            "CIRCLE", "RHOMBUS", "HALF_VERTICAL", "HALF_HORIZONTAL", "HALF_VERTICAL_MIRROR",
+            "HALF_HORIZONTAL_MIRROR", "BORDER", "CURLY_BORDER", "GRADIENT", "GRADIENT_UP",
+            "BRICKS", "GLOBE", "CREEPER", "SKULL", "FLOWER", "MOJANG", "PIGLIN", "FLOW", "GUSTER",
+        )
+    }
+}

--- a/src/main/kotlin/net/lumalyte/lg/domain/events/GuildBannerChangedEvent.kt
+++ b/src/main/kotlin/net/lumalyte/lg/domain/events/GuildBannerChangedEvent.kt
@@ -5,17 +5,22 @@ import org.bukkit.event.HandlerList
 import java.util.UUID
 
 /** Fired after the active public banner for a guild is set or removed. */
+@Suppress("LibraryEntitiesShouldNotBePublic") // Cross-plugin listeners require a public Bukkit event type.
 class GuildBannerChangedEvent(
+    /** Guild whose active banner changed. */
     val guildId: UUID,
+    /** Whether the guild now has an active banner. */
     val hasActiveBanner: Boolean,
 ) : Event() {
-    override fun getHandlers(): HandlerList = Companion.handlers
+    override fun getHandlers(): HandlerList = HANDLERS
 
+    /** Bukkit handler-list holder for this event type. */
     companion object {
         @JvmStatic
-        private val handlers = HandlerList()
+        private val HANDLERS = HandlerList()
 
+        /** Returns the shared Bukkit handler list. */
         @JvmStatic
-        fun getHandlerList(): HandlerList = handlers
+        fun getHandlerList(): HandlerList = HANDLERS
     }
 }

--- a/src/main/kotlin/net/lumalyte/lg/domain/events/GuildBannerChangedEvent.kt
+++ b/src/main/kotlin/net/lumalyte/lg/domain/events/GuildBannerChangedEvent.kt
@@ -1,0 +1,21 @@
+package net.lumalyte.lg.domain.events
+
+import org.bukkit.event.Event
+import org.bukkit.event.HandlerList
+import java.util.UUID
+
+/** Fired after the active public banner for a guild is set or removed. */
+class GuildBannerChangedEvent(
+    val guildId: UUID,
+    val hasActiveBanner: Boolean,
+) : Event() {
+    override fun getHandlers(): HandlerList = Companion.handlers
+
+    companion object {
+        @JvmStatic
+        private val handlers = HandlerList()
+
+        @JvmStatic
+        fun getHandlerList(): HandlerList = handlers
+    }
+}

--- a/src/main/kotlin/net/lumalyte/lg/infrastructure/services/GuildBannerServiceBukkit.kt
+++ b/src/main/kotlin/net/lumalyte/lg/infrastructure/services/GuildBannerServiceBukkit.kt
@@ -4,6 +4,8 @@ import net.lumalyte.lg.application.services.*
 import net.lumalyte.lg.application.persistence.GuildBannerRepository
 import net.lumalyte.lg.application.persistence.GuildRepository
 import net.lumalyte.lg.domain.entities.GuildBanner
+import net.lumalyte.lg.domain.events.GuildBannerChangedEvent
+import org.bukkit.Bukkit
 import org.koin.core.component.KoinComponent
 import org.koin.core.component.inject
 import org.slf4j.LoggerFactory
@@ -63,6 +65,7 @@ class GuildBannerServiceBukkit : GuildBannerService, KoinComponent {
             val success = bannerRepository.save(banner)
             if (success) {
                 logger.info("Banner set for guild $guildId by player $submitterId")
+                emitBannerChanged(guildId, true)
             }
             return success
 
@@ -94,6 +97,7 @@ class GuildBannerServiceBukkit : GuildBannerService, KoinComponent {
             val success = bannerRepository.removeActiveBanner(guildId)
             if (success) {
                 logger.info("Banner removed for guild $guildId by player $actorId")
+                emitBannerChanged(guildId, false)
             }
             return success
 
@@ -126,6 +130,14 @@ class GuildBannerServiceBukkit : GuildBannerService, KoinComponent {
             // Service operation - catching all exceptions to prevent service failure
             logger.error("Error retrieving banners for guild $guildId", e)
             emptyList()
+        }
+    }
+
+    private fun emitBannerChanged(guildId: UUID, hasActiveBanner: Boolean) {
+        try {
+            Bukkit.getPluginManager().callEvent(GuildBannerChangedEvent(guildId, hasActiveBanner))
+        } catch (exception: Exception) {
+            logger.warn("A guild banner changed, but an integration listener failed for guild $guildId", exception)
         }
     }
 }

--- a/src/main/kotlin/net/lumalyte/lg/infrastructure/services/GuildBannerServiceBukkit.kt
+++ b/src/main/kotlin/net/lumalyte/lg/infrastructure/services/GuildBannerServiceBukkit.kt
@@ -134,10 +134,6 @@ class GuildBannerServiceBukkit : GuildBannerService, KoinComponent {
     }
 
     private fun emitBannerChanged(guildId: UUID, hasActiveBanner: Boolean) {
-        try {
-            Bukkit.getPluginManager().callEvent(GuildBannerChangedEvent(guildId, hasActiveBanner))
-        } catch (exception: Exception) {
-            logger.warn("A guild banner changed, but an integration listener failed for guild $guildId", exception)
-        }
+        Bukkit.getPluginManager().callEvent(GuildBannerChangedEvent(guildId, hasActiveBanner))
     }
 }

--- a/src/main/kotlin/net/lumalyte/lg/infrastructure/services/GuildServiceBukkit.kt
+++ b/src/main/kotlin/net/lumalyte/lg/infrastructure/services/GuildServiceBukkit.kt
@@ -15,6 +15,7 @@ import net.lumalyte.lg.domain.entities.GuildHomes
 import net.lumalyte.lg.domain.entities.GuildMode
 import net.lumalyte.lg.domain.entities.RankPermission
 import net.lumalyte.lg.domain.events.GuildBannerSetEvent
+import net.lumalyte.lg.domain.events.GuildBannerChangedEvent
 import net.lumalyte.lg.domain.events.GuildCreatedEvent
 import net.lumalyte.lg.domain.events.GuildDisbandedEvent
 import net.lumalyte.lg.domain.events.GuildHomeSetEvent
@@ -222,6 +223,7 @@ class GuildServiceBukkit(
             val bannerText = if (banner != null) "${banner.type.name} with patterns" else "cleared (default white banner)"
             logger.info("Guild $guildId banner set to '$bannerText' by $actorId")
             Bukkit.getPluginManager().callEvent(GuildBannerSetEvent(guildId, actorId))
+            Bukkit.getPluginManager().callEvent(GuildBannerChangedEvent(guildId, banner != null))
 
             bannermanListeners.onGuildBannerChanged(guildId)
         }

--- a/src/test/kotlin/net/lumalyte/lg/api/GuildVisualLookupImplTest.kt
+++ b/src/test/kotlin/net/lumalyte/lg/api/GuildVisualLookupImplTest.kt
@@ -63,7 +63,7 @@ internal class GuildVisualLookupImplTest {
     }
 
     @Test
-    fun `six banner layers stay ordered`() {
+    fun `six ordered banner layers`() {
         val patterns =
             listOf(
                 Pattern(DyeColor.WHITE, PatternType.STRIPE_TOP),
@@ -125,8 +125,7 @@ internal class GuildVisualLookupImplTest {
     }
 }
 
-private fun guild(guildId: UUID, banner: String? = null) =
-    Guild(
+private fun guild(guildId: UUID, banner: String? = null) = Guild(
         id = guildId,
         name = "Synthetic Guild",
         banner = banner,

--- a/src/test/kotlin/net/lumalyte/lg/api/GuildVisualLookupImplTest.kt
+++ b/src/test/kotlin/net/lumalyte/lg/api/GuildVisualLookupImplTest.kt
@@ -125,12 +125,14 @@ internal class GuildVisualLookupImplTest {
     }
 }
 
-private fun guild(guildId: UUID, banner: String? = null) = Guild(
+private fun guild(guildId: UUID, banner: String? = null): Guild {
+    return Guild(
         id = guildId,
         name = "Synthetic Guild",
         banner = banner,
         createdAt = Instant.EPOCH,
     )
+}
 
 private fun member(id: UUID, guildId: UUID, rankId: UUID) = Member(id, guildId, rankId, Instant.EPOCH)
 

--- a/src/test/kotlin/net/lumalyte/lg/api/GuildVisualLookupImplTest.kt
+++ b/src/test/kotlin/net/lumalyte/lg/api/GuildVisualLookupImplTest.kt
@@ -1,0 +1,124 @@
+@file:Suppress("FunctionNaming", "MagicNumber", "UndocumentedPublicClass", "UndocumentedPublicFunction")
+
+package net.lumalyte.lg.api
+
+import io.mockk.every
+import io.mockk.mockk
+import net.lumalyte.lg.application.services.BannerColor
+import net.lumalyte.lg.application.services.BannerDesignData
+import net.lumalyte.lg.application.services.BannerPattern
+import net.lumalyte.lg.application.services.GuildBannerService
+import net.lumalyte.lg.application.services.GuildService
+import net.lumalyte.lg.application.services.MemberService
+import net.lumalyte.lg.application.services.RankService
+import net.lumalyte.lg.domain.entities.Guild
+import net.lumalyte.lg.domain.entities.GuildBanner
+import net.lumalyte.lg.domain.entities.Member
+import net.lumalyte.lg.domain.entities.Rank
+import java.time.Instant
+import java.util.UUID
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNull
+
+class GuildVisualLookupImplTest {
+    private val guildId = UUID.randomUUID()
+    private val leaderId = UUID.randomUUID()
+    private val rankId = UUID.randomUUID()
+    private val guilds = mockk<GuildService>()
+    private val members = mockk<MemberService>()
+    private val ranks = mockk<RankService>()
+    private val banners = mockk<GuildBannerService>()
+    private val lookup = GuildVisualLookupImpl(guilds, members, ranks, banners)
+
+    @Test
+    fun `guild without banner exposes leader`() {
+        stubGuildAndLeader(leaderId)
+        every { banners.getGuildBanner(guildId) } returns null
+
+        assertEquals(GuildVisualSummary(leaderId, null), lookup.getGuildVisual(guildId))
+    }
+
+    @Test
+    fun `banner with zero patterns remains a valid ordered projection`() {
+        stubGuildAndLeader(leaderId)
+        every { banners.getGuildBanner(guildId) } returns banner(BannerDesignData(BannerColor.BLUE))
+
+        assertEquals(
+            GuildBannerDesignSummary("BLUE", emptyList()),
+            lookup.getGuildVisual(guildId)?.banner,
+        )
+    }
+
+    @Test
+    fun `banner preserves all six layers in order`() {
+        stubGuildAndLeader(leaderId)
+        val patterns = listOf(
+            BannerPattern("STRIPE_TOP", BannerColor.WHITE),
+            BannerPattern("CROSS", BannerColor.RED),
+            BannerPattern("BORDER", BannerColor.BLACK),
+            BannerPattern("TRIANGLE_TOP", BannerColor.YELLOW),
+            BannerPattern("CIRCLE", BannerColor.LIME),
+            BannerPattern("FLOWER", BannerColor.PURPLE),
+        )
+        every { banners.getGuildBanner(guildId) } returns banner(BannerDesignData(BannerColor.BLUE, patterns))
+
+        assertEquals(
+            patterns.map { GuildBannerPatternSummary(it.type, it.color.name) },
+            lookup.getGuildVisual(guildId)?.banner?.patterns,
+        )
+    }
+
+    @Test
+    fun `banner removal is visible on the next lookup`() {
+        stubGuildAndLeader(leaderId)
+        every { banners.getGuildBanner(guildId) } returnsMany listOf(
+            banner(BannerDesignData(BannerColor.RED)),
+            null,
+        )
+
+        assertEquals("RED", lookup.getGuildVisual(guildId)?.banner?.baseColor)
+        assertNull(lookup.getGuildVisual(guildId)?.banner)
+    }
+
+    @Test
+    fun `leadership transfer is visible on the next lookup`() {
+        val newLeaderId = UUID.randomUUID()
+        every { guilds.getGuild(guildId) } returns guild()
+        every { ranks.getHighestRank(guildId) } returns Rank(rankId, guildId, "Owner", 0)
+        every { members.getMembersByRank(guildId, rankId) } returnsMany listOf(
+            setOf(member(leaderId)),
+            setOf(member(newLeaderId)),
+        )
+        every { banners.getGuildBanner(guildId) } returns null
+
+        assertEquals(leaderId, lookup.getGuildVisual(guildId)?.leaderId)
+        assertEquals(newLeaderId, lookup.getGuildVisual(guildId)?.leaderId)
+    }
+
+    @Test
+    fun `missing guild has no public visual`() {
+        every { guilds.getGuild(guildId) } returns null
+        assertNull(lookup.getGuildVisual(guildId))
+    }
+
+    private fun stubGuildAndLeader(id: UUID) {
+        every { guilds.getGuild(guildId) } returns guild()
+        every { ranks.getHighestRank(guildId) } returns Rank(rankId, guildId, "Owner", 0)
+        every { members.getMembersByRank(guildId, rankId) } returns setOf(member(id))
+    }
+
+    private fun guild() = Guild(id = guildId, name = "Synthetic Guild", createdAt = Instant.EPOCH)
+
+    private fun member(id: UUID) = Member(id, guildId, rankId, Instant.EPOCH)
+
+    private fun banner(design: BannerDesignData) = GuildBanner(
+        id = UUID.randomUUID(),
+        guildId = guildId,
+        name = null,
+        designData = design,
+        submittedBy = UUID.randomUUID(),
+        createdAt = Instant.EPOCH,
+        isActive = true,
+    )
+}

--- a/src/test/kotlin/net/lumalyte/lg/api/GuildVisualLookupImplTest.kt
+++ b/src/test/kotlin/net/lumalyte/lg/api/GuildVisualLookupImplTest.kt
@@ -26,7 +26,7 @@ import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertNull
 
-class GuildVisualLookupImplTest {
+internal class GuildVisualLookupImplTest {
     private val guildId = UUID.randomUUID()
     private val leaderId = UUID.randomUUID()
     private val rankId = UUID.randomUUID()
@@ -46,14 +46,14 @@ class GuildVisualLookupImplTest {
     }
 
     @Test
-    fun `guild without banner exposes leader`() {
+    fun `leader fallback`() {
         stubGuildAndLeader(leaderId)
 
         assertEquals(GuildVisualSummary(leaderId, null), lookup.getGuildVisual(guildId))
     }
 
     @Test
-    fun `banner with zero patterns remains a valid ordered projection`() {
+    fun `zero pattern banner`() {
         stubGuildAndLeader(leaderId, banner(Material.BLUE_BANNER))
 
         assertEquals(
@@ -63,15 +63,16 @@ class GuildVisualLookupImplTest {
     }
 
     @Test
-    fun `banner preserves all six layers in order`() {
-        val patterns = listOf(
-            Pattern(DyeColor.WHITE, PatternType.STRIPE_TOP),
-            Pattern(DyeColor.RED, PatternType.CROSS),
-            Pattern(DyeColor.BLACK, PatternType.BORDER),
-            Pattern(DyeColor.YELLOW, PatternType.TRIANGLE_TOP),
-            Pattern(DyeColor.LIME, PatternType.CIRCLE),
-            Pattern(DyeColor.PURPLE, PatternType.FLOWER),
-        )
+    fun `six banner layers stay ordered`() {
+        val patterns =
+            listOf(
+                Pattern(DyeColor.WHITE, PatternType.STRIPE_TOP),
+                Pattern(DyeColor.RED, PatternType.CROSS),
+                Pattern(DyeColor.BLACK, PatternType.BORDER),
+                Pattern(DyeColor.YELLOW, PatternType.TRIANGLE_TOP),
+                Pattern(DyeColor.LIME, PatternType.CIRCLE),
+                Pattern(DyeColor.PURPLE, PatternType.FLOWER),
+            )
         stubGuildAndLeader(leaderId, banner(Material.BLUE_BANNER, patterns))
 
         assertEquals(
@@ -81,11 +82,12 @@ class GuildVisualLookupImplTest {
     }
 
     @Test
-    fun `banner removal is visible on the next lookup`() {
-        every { guilds.getGuild(guildId) } returnsMany listOf(
-            guild(banner(Material.RED_BANNER)),
-            guild(),
-        )
+    fun `banner removal`() {
+        every { guilds.getGuild(guildId) } returnsMany
+            listOf(
+                guild(guildId, banner(Material.RED_BANNER)),
+                guild(guildId),
+            )
         stubLeader(leaderId)
 
         assertEquals("RED", lookup.getGuildVisual(guildId)?.banner?.baseColor)
@@ -93,48 +95,50 @@ class GuildVisualLookupImplTest {
     }
 
     @Test
-    fun `leadership transfer is visible on the next lookup`() {
+    fun `leadership transfer`() {
         val newLeaderId = UUID.randomUUID()
-        every { guilds.getGuild(guildId) } returns guild()
+        every { guilds.getGuild(guildId) } returns guild(guildId)
         every { ranks.getHighestRank(guildId) } returns Rank(rankId, guildId, "Owner", 0)
-        every { members.getMembersByRank(guildId, rankId) } returnsMany listOf(
-            setOf(member(leaderId)),
-            setOf(member(newLeaderId)),
-        )
+        every { members.getMembersByRank(guildId, rankId) } returnsMany
+            listOf(
+                setOf(member(leaderId, guildId, rankId)),
+                setOf(member(newLeaderId, guildId, rankId)),
+            )
         assertEquals(leaderId, lookup.getGuildVisual(guildId)?.leaderId)
         assertEquals(newLeaderId, lookup.getGuildVisual(guildId)?.leaderId)
     }
 
     @Test
-    fun `missing guild has no public visual`() {
+    fun `missing guild`() {
         every { guilds.getGuild(guildId) } returns null
         assertNull(lookup.getGuildVisual(guildId))
     }
 
     private fun stubGuildAndLeader(id: UUID, banner: String? = null) {
-        every { guilds.getGuild(guildId) } returns guild(banner)
+        every { guilds.getGuild(guildId) } returns guild(guildId, banner)
         stubLeader(id)
     }
 
     private fun stubLeader(id: UUID) {
         every { ranks.getHighestRank(guildId) } returns Rank(rankId, guildId, "Owner", 0)
-        every { members.getMembersByRank(guildId, rankId) } returns setOf(member(id))
+        every { members.getMembersByRank(guildId, rankId) } returns setOf(member(id, guildId, rankId))
     }
+}
 
-    private fun guild(banner: String? = null) = Guild(
+private fun guild(guildId: UUID, banner: String? = null) =
+    Guild(
         id = guildId,
         name = "Synthetic Guild",
         banner = banner,
         createdAt = Instant.EPOCH,
     )
 
-    private fun member(id: UUID) = Member(id, guildId, rankId, Instant.EPOCH)
+private fun member(id: UUID, guildId: UUID, rankId: UUID) = Member(id, guildId, rankId, Instant.EPOCH)
 
-    private fun banner(material: Material, patterns: List<Pattern> = emptyList()): String {
-        val item = ItemStack(material)
-        val meta = item.itemMeta as BannerMeta
-        meta.patterns = patterns
-        item.itemMeta = meta
-        return item.serializeToString()
-    }
+private fun banner(material: Material, patterns: List<Pattern> = emptyList()): String {
+    val item = ItemStack(material)
+    val meta = item.itemMeta as BannerMeta
+    meta.patterns = patterns
+    item.itemMeta = meta
+    return item.serializeToString()
 }

--- a/src/test/kotlin/net/lumalyte/lg/api/GuildVisualLookupImplTest.kt
+++ b/src/test/kotlin/net/lumalyte/lg/api/GuildVisualLookupImplTest.kt
@@ -4,17 +4,22 @@ package net.lumalyte.lg.api
 
 import io.mockk.every
 import io.mockk.mockk
-import net.lumalyte.lg.application.services.BannerColor
-import net.lumalyte.lg.application.services.BannerDesignData
-import net.lumalyte.lg.application.services.BannerPattern
-import net.lumalyte.lg.application.services.GuildBannerService
 import net.lumalyte.lg.application.services.GuildService
 import net.lumalyte.lg.application.services.MemberService
 import net.lumalyte.lg.application.services.RankService
 import net.lumalyte.lg.domain.entities.Guild
-import net.lumalyte.lg.domain.entities.GuildBanner
 import net.lumalyte.lg.domain.entities.Member
 import net.lumalyte.lg.domain.entities.Rank
+import net.lumalyte.lg.utils.serializeToString
+import org.bukkit.DyeColor
+import org.bukkit.Material
+import org.bukkit.block.banner.Pattern
+import org.bukkit.block.banner.PatternType
+import org.bukkit.inventory.ItemStack
+import org.bukkit.inventory.meta.BannerMeta
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.BeforeEach
+import org.mockbukkit.mockbukkit.MockBukkit
 import java.time.Instant
 import java.util.UUID
 import kotlin.test.Test
@@ -28,21 +33,28 @@ class GuildVisualLookupImplTest {
     private val guilds = mockk<GuildService>()
     private val members = mockk<MemberService>()
     private val ranks = mockk<RankService>()
-    private val banners = mockk<GuildBannerService>()
-    private val lookup = GuildVisualLookupImpl(guilds, members, ranks, banners)
+    private val lookup = GuildVisualLookupImpl(guilds, members, ranks)
+
+    @BeforeEach
+    fun setUp() {
+        MockBukkit.mock()
+    }
+
+    @AfterEach
+    fun tearDown() {
+        MockBukkit.unmock()
+    }
 
     @Test
     fun `guild without banner exposes leader`() {
         stubGuildAndLeader(leaderId)
-        every { banners.getGuildBanner(guildId) } returns null
 
         assertEquals(GuildVisualSummary(leaderId, null), lookup.getGuildVisual(guildId))
     }
 
     @Test
     fun `banner with zero patterns remains a valid ordered projection`() {
-        stubGuildAndLeader(leaderId)
-        every { banners.getGuildBanner(guildId) } returns banner(BannerDesignData(BannerColor.BLUE))
+        stubGuildAndLeader(leaderId, banner(Material.BLUE_BANNER))
 
         assertEquals(
             GuildBannerDesignSummary("BLUE", emptyList()),
@@ -52,30 +64,29 @@ class GuildVisualLookupImplTest {
 
     @Test
     fun `banner preserves all six layers in order`() {
-        stubGuildAndLeader(leaderId)
         val patterns = listOf(
-            BannerPattern("STRIPE_TOP", BannerColor.WHITE),
-            BannerPattern("CROSS", BannerColor.RED),
-            BannerPattern("BORDER", BannerColor.BLACK),
-            BannerPattern("TRIANGLE_TOP", BannerColor.YELLOW),
-            BannerPattern("CIRCLE", BannerColor.LIME),
-            BannerPattern("FLOWER", BannerColor.PURPLE),
+            Pattern(DyeColor.WHITE, PatternType.STRIPE_TOP),
+            Pattern(DyeColor.RED, PatternType.CROSS),
+            Pattern(DyeColor.BLACK, PatternType.BORDER),
+            Pattern(DyeColor.YELLOW, PatternType.TRIANGLE_TOP),
+            Pattern(DyeColor.LIME, PatternType.CIRCLE),
+            Pattern(DyeColor.PURPLE, PatternType.FLOWER),
         )
-        every { banners.getGuildBanner(guildId) } returns banner(BannerDesignData(BannerColor.BLUE, patterns))
+        stubGuildAndLeader(leaderId, banner(Material.BLUE_BANNER, patterns))
 
         assertEquals(
-            patterns.map { GuildBannerPatternSummary(it.type, it.color.name) },
+            patterns.map { GuildBannerPatternSummary(it.pattern.key.key.uppercase(), it.color.name) },
             lookup.getGuildVisual(guildId)?.banner?.patterns,
         )
     }
 
     @Test
     fun `banner removal is visible on the next lookup`() {
-        stubGuildAndLeader(leaderId)
-        every { banners.getGuildBanner(guildId) } returnsMany listOf(
-            banner(BannerDesignData(BannerColor.RED)),
-            null,
+        every { guilds.getGuild(guildId) } returnsMany listOf(
+            guild(banner(Material.RED_BANNER)),
+            guild(),
         )
+        stubLeader(leaderId)
 
         assertEquals("RED", lookup.getGuildVisual(guildId)?.banner?.baseColor)
         assertNull(lookup.getGuildVisual(guildId)?.banner)
@@ -90,8 +101,6 @@ class GuildVisualLookupImplTest {
             setOf(member(leaderId)),
             setOf(member(newLeaderId)),
         )
-        every { banners.getGuildBanner(guildId) } returns null
-
         assertEquals(leaderId, lookup.getGuildVisual(guildId)?.leaderId)
         assertEquals(newLeaderId, lookup.getGuildVisual(guildId)?.leaderId)
     }
@@ -102,23 +111,30 @@ class GuildVisualLookupImplTest {
         assertNull(lookup.getGuildVisual(guildId))
     }
 
-    private fun stubGuildAndLeader(id: UUID) {
-        every { guilds.getGuild(guildId) } returns guild()
+    private fun stubGuildAndLeader(id: UUID, banner: String? = null) {
+        every { guilds.getGuild(guildId) } returns guild(banner)
+        stubLeader(id)
+    }
+
+    private fun stubLeader(id: UUID) {
         every { ranks.getHighestRank(guildId) } returns Rank(rankId, guildId, "Owner", 0)
         every { members.getMembersByRank(guildId, rankId) } returns setOf(member(id))
     }
 
-    private fun guild() = Guild(id = guildId, name = "Synthetic Guild", createdAt = Instant.EPOCH)
+    private fun guild(banner: String? = null) = Guild(
+        id = guildId,
+        name = "Synthetic Guild",
+        banner = banner,
+        createdAt = Instant.EPOCH,
+    )
 
     private fun member(id: UUID) = Member(id, guildId, rankId, Instant.EPOCH)
 
-    private fun banner(design: BannerDesignData) = GuildBanner(
-        id = UUID.randomUUID(),
-        guildId = guildId,
-        name = null,
-        designData = design,
-        submittedBy = UUID.randomUUID(),
-        createdAt = Instant.EPOCH,
-        isActive = true,
-    )
+    private fun banner(material: Material, patterns: List<Pattern> = emptyList()): String {
+        val item = ItemStack(material)
+        val meta = item.itemMeta as BannerMeta
+        meta.patterns = patterns
+        item.itemMeta = meta
+        return item.serializeToString()
+    }
 }


### PR DESCRIPTION
Adds a stable read-only guild visual API with leader UUID and bounded banner design data. The implementation reads the same serialized Guild.banner ItemStack used by the normal Java and Bedrock guild banner menus, projects only base color plus up to six ordered patterns, and emits a visual-change event after successful set or clear operations.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

### Features
- Expose a read-only `GuildVisualLookup` API with leader UUIDs and bounded banner designs.
- Emit `GuildBannerChangedEvent` after guild banners are set or cleared.
- Register the visual lookup API through Bukkit’s `ServicesManager`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->