### PR TITLE
feat: add getGuildMemberIds() to GuildLookup public API

### DIFF
--- a/src/main/kotlin/net/lumalyte/lg/api/GuildLookup.kt
+++ b/src/main/kotlin/net/lumalyte/lg/api/GuildLookup.kt
@@ -52,6 +52,9 @@ interface GuildLookup {
      */
     fun hasRankAtLeast(playerId: UUID, guildId: UUID, rankName: String): Boolean
 
+    /** UUIDs of every player who is a member of the guild (online or offline). */
+    fun getGuildMemberIds(guildId: UUID): Set<UUID>
+
     /** Guild bank balance for [guildId], or 0 if unknown. */
     fun getBankBalance(guildId: UUID): Long
 

--- a/src/main/kotlin/net/lumalyte/lg/api/GuildLookupImpl.kt
+++ b/src/main/kotlin/net/lumalyte/lg/api/GuildLookupImpl.kt
@@ -56,6 +56,9 @@ class GuildLookupImpl(
         return playerRank.priority <= targetRank.priority
     }
 
+    override fun getGuildMemberIds(guildId: UUID): Set<UUID> =
+        members.getGuildMembers(guildId).map { it.playerId }.toSet()
+
     override fun getBankBalance(guildId: UUID): Long = banks.getBalance(guildId).toLong()
 
     override fun bankWithdraw(guildId: UUID, actorId: UUID, amount: Long, reason: String): Boolean {

--- a/src/test/kotlin/net/lumalyte/lg/api/GuildLookupImplTest.kt
+++ b/src/test/kotlin/net/lumalyte/lg/api/GuildLookupImplTest.kt
@@ -137,6 +137,26 @@ class GuildLookupImplTest {
     }
 
     @Test
+    fun `getGuildMemberIds maps member entities to playerId set`() {
+        val member1 = Member(
+            playerId = UUID.randomUUID(), guildId = guildId,
+            rankId = UUID.randomUUID(), joinedAt = Instant.now(),
+        )
+        val member2 = Member(
+            playerId = UUID.randomUUID(), guildId = guildId,
+            rankId = UUID.randomUUID(), joinedAt = Instant.now(),
+        )
+        every { members.getGuildMembers(guildId) } returns setOf(member1, member2)
+        assertEquals(setOf(member1.playerId, member2.playerId), lookup.getGuildMemberIds(guildId))
+    }
+
+    @Test
+    fun `getGuildMemberIds empty when guild has no members`() {
+        every { members.getGuildMembers(guildId) } returns emptySet()
+        assertTrue(lookup.getGuildMemberIds(guildId).isEmpty())
+    }
+
+    @Test
     fun `getBankBalance delegates and widens to Long`() {
         every { banks.getBalance(guildId) } returns 4200
         assertEquals(4200L, lookup.getBankBalance(guildId))


### PR DESCRIPTION
Exposes `MemberService.getGuildMembers()` through the public `GuildLookup` interface so consumers like EnthusiaMarket can sync ALL guild members to WorldGuard regions — not just online players.

**Problem:** `LumaGuildsGuildProvider.memberIds()` was forced to filter `Bukkit.getOnlinePlayers()` because `GuildLookup` had no method returning all member UUIDs. On server restart, WG runtime state is wiped, and the resync misses offline members — leaving guild stalls with empty `members {}` while flags require `-group: MEMBERS`.

**Changes:**
- `GuildLookup.kt`: Added `getGuildMemberIds(guildId: UUID): Set<UUID>`
- `GuildLookupImpl.kt`: Implemented via `members.getGuildMembers(guildId).map { it.playerId }.toSet()`

**Required by:** BadgersMC/EnthusiaMarket#fix/guild-stall-all-members

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
### Features
- GuildLookup API: Add `getGuildMemberIds(guildId: UUID): Set<UUID>` to return UUIDs for all guild members, including offline members.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->