### PR TITLE
feat: register LumaGuilds RoseChat channels via ChannelProvider

### DIFF
--- a/src/main/kotlin/net/lumalyte/lg/LumaGuilds.kt
+++ b/src/main/kotlin/net/lumalyte/lg/LumaGuilds.kt
@@ -33,6 +33,7 @@ import net.lumalyte.lg.application.services.ConfigService
 import net.lumalyte.lg.application.services.DailyWarCostsService
 import net.lumalyte.lg.infrastructure.services.ConfigServiceBukkit
 import net.lumalyte.lg.infrastructure.services.DailyWarCostsScheduler
+import net.lumalyte.lg.infrastructure.services.LumaGuildsChannelProvider
 import java.io.File
 import java.io.IOException
 import java.sql.Connection

--- a/src/main/kotlin/net/lumalyte/lg/LumaGuilds.kt
+++ b/src/main/kotlin/net/lumalyte/lg/LumaGuilds.kt
@@ -970,12 +970,47 @@ class LumaGuilds : JavaPlugin() {
             val roseChatCleanupListener = get().get<net.lumalyte.lg.infrastructure.listeners.RoseChatCleanupListener>()
             server.pluginManager.registerEvents(roseChatCleanupListener, this)
             logColored("✓ RoseChat integration registered for chat cleanup")
+
+            // Register RoseChat ChannelProvider so guild/ally/modchat channels
+            // resolve from channels.yml. A delayed reload re-reads the config
+            // now that the provider exists (RoseChat's first attempt at startup
+            // found no provider and skipped the guild sections).
+            registerRoseChatChannels()
         }
 
         // Register admin override listener (for logout cleanup) - only when claims enabled
         if (claimsEnabled) {
             val adminOverrideListener = get().get<net.lumalyte.lg.interaction.listeners.AdminOverrideListener>()
             server.pluginManager.registerEvents(adminOverrideListener, this)
+        }
+    }
+
+    /**
+     * Registers [LumaGuildsChannelProvider] with RoseChat and schedules a
+     * delayed reload so the guild channels defined in `channels.yml` are
+     * created. Called inside the `isPluginEnabled("RoseChat")` block in
+     * [registerNonClaimEvents].
+     */
+    private fun registerRoseChatChannels() {
+        try {
+            val channelManager = dev.rosewood.rosechat.api.RoseChatAPI.getInstance().channelManager
+            channelManager.register(LumaGuildsChannelProvider())
+
+            // One-tick delay: RoseChat has already tried to load channels at
+            // startup and found no registered LumaGuilds provider. Now that the
+            // provider exists, re-read channels.yml.
+            Bukkit.getScheduler().runTaskLater(this, Runnable {
+                try {
+                    channelManager.reload()
+                    logColored("✓ LumaGuilds RoseChat channels registered (guild, guild-ally, guild-modchat)")
+                } catch (e: Exception) {
+                    logger.warning("Failed to reload RoseChat channels after provider registration: ${e.message}")
+                }
+            }, 1L)
+        } catch (e: NoClassDefFoundError) {
+            logColored("⚠ RoseChat API classes unavailable — guild channels not registered")
+        } catch (e: Exception) {
+            logger.warning("Failed to register LumaGuilds RoseChat channels: ${e.message}")
         }
     }
 

--- a/src/main/kotlin/net/lumalyte/lg/infrastructure/services/LumaGuildsChannel.kt
+++ b/src/main/kotlin/net/lumalyte/lg/infrastructure/services/LumaGuildsChannel.kt
@@ -78,7 +78,8 @@ class LumaGuildsChannel(provider: ChannelProvider) : RoseChatChannel(provider), 
         super.onLogin(player) && hasTeam(player)
 
     override fun getIntendedRecipients(sender: RosePlayer, includeSpies: Boolean): Set<Player> {
-        val senderId = sender.player?.uniqueId ?: return emptySet()
+        val senderPlayer = sender.asPlayer() ?: return emptySet()
+        val senderId = senderPlayer.uniqueId
         val senderGuilds = guildService.getPlayerGuilds(senderId)
         if (senderGuilds.isEmpty()) return emptySet()
 
@@ -142,8 +143,10 @@ class LumaGuildsChannel(provider: ChannelProvider) : RoseChatChannel(provider), 
     }
 
     override fun canPlayerReceiveMessage(sender: RosePlayer, receiver: RosePlayer): Boolean {
-        val senderId = sender.player?.uniqueId ?: return false
-        val receiverId = receiver.player?.uniqueId ?: return false
+        val senderPlayer = sender.asPlayer() ?: return false
+        val receiverPlayer = receiver.asPlayer() ?: return false
+        val senderId = senderPlayer.uniqueId
+        val receiverId = receiverPlayer.uniqueId
 
         val senderGuilds = guildService.getPlayerGuilds(senderId)
         val receiverGuilds = guildService.getPlayerGuilds(receiverId)
@@ -181,11 +184,11 @@ class LumaGuildsChannel(provider: ChannelProvider) : RoseChatChannel(provider), 
     }
 
     private fun hasModPerms(playerId: UUID, guildId: UUID): Boolean =
-        memberService.hasPermission(playerId, guildId, RankPermission.MANAGE_INVITES) ||
-            memberService.hasPermission(playerId, guildId, RankPermission.KICK_MEMBERS)
+        memberService.hasPermission(playerId, guildId, RankPermission.MANAGE_MEMBERS) ||
+            memberService.hasPermission(playerId, guildId, RankPermission.MODERATE_CHAT)
 
     private fun hasTeam(player: RosePlayer): Boolean {
-        val playerId = player.player?.uniqueId ?: return false
-        return guildService.getPlayerGuilds(playerId).isNotEmpty()
+        val p = player.asPlayer() ?: return false
+        return guildService.getPlayerGuilds(p.uniqueId).isNotEmpty()
     }
 }

--- a/src/main/kotlin/net/lumalyte/lg/infrastructure/services/LumaGuildsChannel.kt
+++ b/src/main/kotlin/net/lumalyte/lg/infrastructure/services/LumaGuildsChannel.kt
@@ -2,6 +2,7 @@ package net.lumalyte.lg.infrastructure.services
 
 import dev.rosewood.rosechat.chat.channel.Channel
 import dev.rosewood.rosechat.hook.channel.ChannelProvider
+import dev.rosewood.rosechat.hook.channel.rosechat.RoseChatChannel
 import dev.rosewood.rosechat.message.RosePlayer
 import net.lumalyte.lg.application.persistence.ChatSettingsRepository
 import net.lumalyte.lg.application.services.GuildService
@@ -27,7 +28,7 @@ import java.util.UUID
  * Recipients are computed at call time from live guild data, respecting
  * per-player chat visibility toggles stored in [ChatSettingsRepository].
  */
-class LumaGuildsChannel(provider: ChannelProvider) : Channel(provider), KoinComponent {
+class LumaGuildsChannel(provider: ChannelProvider) : RoseChatChannel(provider), KoinComponent {
 
     private val memberService: MemberService by inject()
     private val guildService: GuildService by inject()
@@ -69,6 +70,12 @@ class LumaGuildsChannel(provider: ChannelProvider) : Channel(provider), KoinComp
     }
 
     override fun getMemberCount(): Int = getMembers().size
+
+    override fun canJoinByCommand(player: RosePlayer): Boolean =
+        super.canJoinByCommand(player) && hasTeam(player)
+
+    override fun onLogin(player: RosePlayer): Boolean =
+        super.onLogin(player) && hasTeam(player)
 
     override fun getIntendedRecipients(sender: RosePlayer, includeSpies: Boolean): Set<Player> {
         val senderId = sender.player?.uniqueId ?: return emptySet()
@@ -172,4 +179,9 @@ class LumaGuildsChannel(provider: ChannelProvider) : Channel(provider), KoinComp
     private fun hasModPerms(playerId: UUID, guildId: UUID): Boolean =
         memberService.hasPermission(playerId, guildId, RankPermission.MANAGE_INVITES) ||
             memberService.hasPermission(playerId, guildId, RankPermission.KICK_MEMBERS)
+
+    private fun hasTeam(player: RosePlayer): Boolean {
+        val playerId = player.player?.uniqueId ?: return false
+        return guildService.getPlayerGuilds(playerId).isNotEmpty()
+    }
 }

--- a/src/main/kotlin/net/lumalyte/lg/infrastructure/services/LumaGuildsChannel.kt
+++ b/src/main/kotlin/net/lumalyte/lg/infrastructure/services/LumaGuildsChannel.kt
@@ -27,10 +27,7 @@ import java.util.UUID
  * Recipients are computed at call time from live guild data, respecting
  * per-player chat visibility toggles stored in [ChatSettingsRepository].
  */
-class LumaGuildsChannel(
-    provider: ChannelProvider,
-    section: ConfigurationSection
-) : Channel(provider, section), KoinComponent {
+class LumaGuildsChannel(provider: ChannelProvider) : Channel(provider), KoinComponent {
 
     private val memberService: MemberService by inject()
     private val guildService: GuildService by inject()
@@ -38,12 +35,20 @@ class LumaGuildsChannel(
     private val chatSettingsRepository: ChatSettingsRepository by inject()
 
     /** Resolved from the `channel-type` key in `channels.yml` (default: GUILD). */
-    val channelType: LumaGuildsChannelType = when {
-        section.getString("channel-type", "GUILD").equals("ALLY", ignoreCase = true) ->
-            LumaGuildsChannelType.ALLY
-        section.getString("channel-type", "GUILD").equals("OFFICER", ignoreCase = true) ->
-            LumaGuildsChannelType.MODCHAT
-        else -> LumaGuildsChannelType.GUILD
+    lateinit var channelType: LumaGuildsChannelType
+        private set
+
+    override fun onLoad(id: String, config: ConfigurationSection) {
+        super.onLoad(id, config)
+        channelType = when {
+            config.getString("channel-type", "GUILD").equals("ALLY", ignoreCase = true) ->
+                LumaGuildsChannelType.ALLY
+            config.getString("channel-type", "GUILD").equals("OFFICER", ignoreCase = true) ->
+                LumaGuildsChannelType.MODCHAT
+            config.getString("channel-type", "GUILD").equals("MODCHAT", ignoreCase = true) ->
+                LumaGuildsChannelType.MODCHAT
+            else -> LumaGuildsChannelType.GUILD
+        }
     }
 
     override fun getMembers(): List<UUID> {
@@ -56,12 +61,7 @@ class LumaGuildsChannel(
                     if (guilds.any { hasModPerms(player.uniqueId, it) })
                         ids.add(player.uniqueId)
                 }
-                LumaGuildsChannelType.ALLY -> {
-                    if (guilds.any { g ->
-                            relationService.getGuildRelationsByType(g, RelationType.ALLY)
-                                .any { it.isActive() }
-                        }) ids.add(player.uniqueId)
-                }
+                LumaGuildsChannelType.ALLY -> ids.add(player.uniqueId)
                 LumaGuildsChannelType.GUILD -> ids.add(player.uniqueId)
             }
         }
@@ -120,7 +120,7 @@ class LumaGuildsChannel(
             }
 
             LumaGuildsChannelType.MODCHAT -> {
-                senderGuilds.forEach { guildId ->
+                senderGuilds.filter { hasModPerms(senderId, it) }.forEach { guildId ->
                     memberService.getGuildMembers(guildId)
                         .filter { hasModPerms(it.playerId, guildId) }
                         .forEach { member ->
@@ -143,6 +143,15 @@ class LumaGuildsChannel(
 
         if (senderGuilds.isEmpty() || receiverGuilds.isEmpty()) return false
 
+        // Honor receiver's per-channel-type visibility opt-out
+        val settings = chatSettingsRepository.getVisibilitySettings(receiverId)
+        val visibilityAllowed = when (channelType) {
+            LumaGuildsChannelType.GUILD -> settings.guildChatVisible
+            LumaGuildsChannelType.ALLY -> settings.allyChatVisible
+            LumaGuildsChannelType.MODCHAT -> true
+        }
+        if (!visibilityAllowed) return false
+
         return when (channelType) {
             LumaGuildsChannelType.GUILD ->
                 senderGuilds.intersect(receiverGuilds).isNotEmpty()
@@ -150,13 +159,13 @@ class LumaGuildsChannel(
             LumaGuildsChannelType.ALLY ->
                 senderGuilds.intersect(receiverGuilds).isNotEmpty() ||
                     senderGuilds.any { sg ->
-                        receiverGuilds.any { rg -> relationService.areAllies(sg, rg) }
+                        receiverGuilds.any { rg -> relationService.getRelationType(sg, rg) == RelationType.ALLY }
                     }
 
-            LumaGuildsChannelType.MODCHAT -> {
-                val shared = senderGuilds.intersect(receiverGuilds).firstOrNull() ?: return false
-                hasModPerms(senderId, shared) && hasModPerms(receiverId, shared)
-            }
+            LumaGuildsChannelType.MODCHAT ->
+                senderGuilds.intersect(receiverGuilds).any { shared ->
+                    hasModPerms(senderId, shared) && hasModPerms(receiverId, shared)
+                }
         }
     }
 

--- a/src/main/kotlin/net/lumalyte/lg/infrastructure/services/LumaGuildsChannel.kt
+++ b/src/main/kotlin/net/lumalyte/lg/infrastructure/services/LumaGuildsChannel.kt
@@ -59,7 +59,7 @@ class LumaGuildsChannel(provider: ChannelProvider) : RoseChatChannel(provider), 
             if (guilds.isEmpty()) return@forEach
             when (channelType) {
                 LumaGuildsChannelType.MODCHAT -> {
-                    if (guilds.any { hasModPerms(player.uniqueId, it) })
+                    if (guilds.any { g -> hasModPerms(player.uniqueId, g.id) })
                         ids.add(player.uniqueId)
                 }
                 LumaGuildsChannelType.ALLY -> ids.add(player.uniqueId)
@@ -86,8 +86,8 @@ class LumaGuildsChannel(provider: ChannelProvider) : RoseChatChannel(provider), 
 
         when (channelType) {
             LumaGuildsChannelType.GUILD -> {
-                senderGuilds.forEach { guildId ->
-                    memberService.getGuildMembers(guildId).forEach { member ->
+                senderGuilds.forEach { guild ->
+                    memberService.getGuildMembers(guild.id).forEach { member ->
                         val player = Bukkit.getPlayer(member.playerId) ?: return@forEach
                         if (player.isOnline &&
                             chatSettingsRepository
@@ -99,9 +99,9 @@ class LumaGuildsChannel(provider: ChannelProvider) : RoseChatChannel(provider), 
             }
 
             LumaGuildsChannelType.ALLY -> {
-                senderGuilds.forEach { guildId ->
+                senderGuilds.forEach { guild ->
                     // Own guild members
-                    memberService.getGuildMembers(guildId).forEach { member ->
+                    memberService.getGuildMembers(guild.id).forEach { member ->
                         val player = Bukkit.getPlayer(member.playerId) ?: return@forEach
                         if (player.isOnline &&
                             chatSettingsRepository
@@ -110,10 +110,10 @@ class LumaGuildsChannel(provider: ChannelProvider) : RoseChatChannel(provider), 
                         ) recipients.add(player)
                     }
                     // Allied guild members
-                    relationService.getGuildRelationsByType(guildId, RelationType.ALLY)
+                    relationService.getGuildRelationsByType(guild.id, RelationType.ALLY)
                         .filter { it.isActive() }
                         .forEach { relation ->
-                            val alliedId = relation.getOtherGuild(guildId)
+                            val alliedId = relation.getOtherGuild(guild.id)
                             memberService.getGuildMembers(alliedId).forEach { member ->
                                 val player = Bukkit.getPlayer(member.playerId) ?: return@forEach
                                 if (player.isOnline &&
@@ -127,9 +127,9 @@ class LumaGuildsChannel(provider: ChannelProvider) : RoseChatChannel(provider), 
             }
 
             LumaGuildsChannelType.MODCHAT -> {
-                senderGuilds.filter { hasModPerms(senderId, it) }.forEach { guildId ->
-                    memberService.getGuildMembers(guildId)
-                        .filter { hasModPerms(it.playerId, guildId) }
+                senderGuilds.filter { g -> hasModPerms(senderId, g.id) }.forEach { guild ->
+                    memberService.getGuildMembers(guild.id)
+                        .filter { hasModPerms(it.playerId, guild.id) }
                         .forEach { member ->
                             val player = Bukkit.getPlayer(member.playerId) ?: return@forEach
                             if (player.isOnline) recipients.add(player)
@@ -145,10 +145,14 @@ class LumaGuildsChannel(provider: ChannelProvider) : RoseChatChannel(provider), 
         val senderId = sender.player?.uniqueId ?: return false
         val receiverId = receiver.player?.uniqueId ?: return false
 
-        val senderGuilds = guildService.getPlayerGuilds(senderId).toSet()
-        val receiverGuilds = guildService.getPlayerGuilds(receiverId).toSet()
+        val senderGuilds = guildService.getPlayerGuilds(senderId)
+        val receiverGuilds = guildService.getPlayerGuilds(receiverId)
 
         if (senderGuilds.isEmpty() || receiverGuilds.isEmpty()) return false
+
+        // Convert to ID sets for intersection
+        val senderGuildIds = senderGuilds.map { it.id }.toSet()
+        val receiverGuildIds = receiverGuilds.map { it.id }.toSet()
 
         // Honor receiver's per-channel-type visibility opt-out
         val settings = chatSettingsRepository.getVisibilitySettings(receiverId)
@@ -161,16 +165,16 @@ class LumaGuildsChannel(provider: ChannelProvider) : RoseChatChannel(provider), 
 
         return when (channelType) {
             LumaGuildsChannelType.GUILD ->
-                senderGuilds.intersect(receiverGuilds).isNotEmpty()
+                senderGuildIds.intersect(receiverGuildIds).isNotEmpty()
 
             LumaGuildsChannelType.ALLY ->
-                senderGuilds.intersect(receiverGuilds).isNotEmpty() ||
-                    senderGuilds.any { sg ->
-                        receiverGuilds.any { rg -> relationService.getRelationType(sg, rg) == RelationType.ALLY }
+                senderGuildIds.intersect(receiverGuildIds).isNotEmpty() ||
+                    senderGuildIds.any { sg ->
+                        receiverGuildIds.any { rg -> relationService.getRelationType(sg, rg) == RelationType.ALLY }
                     }
 
             LumaGuildsChannelType.MODCHAT ->
-                senderGuilds.intersect(receiverGuilds).any { shared ->
+                senderGuildIds.intersect(receiverGuildIds).any { shared ->
                     hasModPerms(senderId, shared) && hasModPerms(receiverId, shared)
                 }
         }

--- a/src/main/kotlin/net/lumalyte/lg/infrastructure/services/LumaGuildsChannel.kt
+++ b/src/main/kotlin/net/lumalyte/lg/infrastructure/services/LumaGuildsChannel.kt
@@ -1,0 +1,166 @@
+package net.lumalyte.lg.infrastructure.services
+
+import dev.rosewood.rosechat.chat.channel.Channel
+import dev.rosewood.rosechat.hook.channel.ChannelProvider
+import dev.rosewood.rosechat.message.RosePlayer
+import net.lumalyte.lg.application.persistence.ChatSettingsRepository
+import net.lumalyte.lg.application.services.GuildService
+import net.lumalyte.lg.application.services.MemberService
+import net.lumalyte.lg.application.services.RelationService
+import net.lumalyte.lg.domain.entities.RankPermission
+import net.lumalyte.lg.domain.entities.RelationType
+import org.bukkit.Bukkit
+import org.bukkit.configuration.ConfigurationSection
+import org.bukkit.entity.Player
+import org.koin.core.component.KoinComponent
+import org.koin.core.component.inject
+import java.util.UUID
+
+/**
+ * RoseChat [Channel] backed by LumaGuilds guild membership.
+ *
+ * Three channel types matching `channels.yml`:
+ * - `GUILD`   — messages visible only to fellow guild members
+ * - `ALLY`    — messages visible to own guild + allied guilds
+ * - `MODCHAT` — messages visible only to members with moderation permissions
+ *
+ * Recipients are computed at call time from live guild data, respecting
+ * per-player chat visibility toggles stored in [ChatSettingsRepository].
+ */
+class LumaGuildsChannel(
+    provider: ChannelProvider,
+    section: ConfigurationSection
+) : Channel(provider, section), KoinComponent {
+
+    private val memberService: MemberService by inject()
+    private val guildService: GuildService by inject()
+    private val relationService: RelationService by inject()
+    private val chatSettingsRepository: ChatSettingsRepository by inject()
+
+    /** Resolved from the `channel-type` key in `channels.yml` (default: GUILD). */
+    val channelType: LumaGuildsChannelType = when {
+        section.getString("channel-type", "GUILD").equals("ALLY", ignoreCase = true) ->
+            LumaGuildsChannelType.ALLY
+        section.getString("channel-type", "GUILD").equals("OFFICER", ignoreCase = true) ->
+            LumaGuildsChannelType.MODCHAT
+        else -> LumaGuildsChannelType.GUILD
+    }
+
+    override fun getMembers(): List<UUID> {
+        val ids = mutableSetOf<UUID>()
+        Bukkit.getOnlinePlayers().forEach { player ->
+            val guilds = guildService.getPlayerGuilds(player.uniqueId)
+            if (guilds.isEmpty()) return@forEach
+            when (channelType) {
+                LumaGuildsChannelType.MODCHAT -> {
+                    if (guilds.any { hasModPerms(player.uniqueId, it) })
+                        ids.add(player.uniqueId)
+                }
+                LumaGuildsChannelType.ALLY -> {
+                    if (guilds.any { g ->
+                            relationService.getGuildRelationsByType(g, RelationType.ALLY)
+                                .any { it.isActive() }
+                        }) ids.add(player.uniqueId)
+                }
+                LumaGuildsChannelType.GUILD -> ids.add(player.uniqueId)
+            }
+        }
+        return ids.toList()
+    }
+
+    override fun getMemberCount(): Int = getMembers().size
+
+    override fun getIntendedRecipients(sender: RosePlayer, includeSpies: Boolean): Set<Player> {
+        val senderId = sender.player?.uniqueId ?: return emptySet()
+        val senderGuilds = guildService.getPlayerGuilds(senderId)
+        if (senderGuilds.isEmpty()) return emptySet()
+
+        val recipients = mutableSetOf<Player>()
+
+        when (channelType) {
+            LumaGuildsChannelType.GUILD -> {
+                senderGuilds.forEach { guildId ->
+                    memberService.getGuildMembers(guildId).forEach { member ->
+                        val player = Bukkit.getPlayer(member.playerId) ?: return@forEach
+                        if (player.isOnline &&
+                            chatSettingsRepository
+                                .getVisibilitySettings(member.playerId)
+                                .guildChatVisible
+                        ) recipients.add(player)
+                    }
+                }
+            }
+
+            LumaGuildsChannelType.ALLY -> {
+                senderGuilds.forEach { guildId ->
+                    // Own guild members
+                    memberService.getGuildMembers(guildId).forEach { member ->
+                        val player = Bukkit.getPlayer(member.playerId) ?: return@forEach
+                        if (player.isOnline &&
+                            chatSettingsRepository
+                                .getVisibilitySettings(member.playerId)
+                                .allyChatVisible
+                        ) recipients.add(player)
+                    }
+                    // Allied guild members
+                    relationService.getGuildRelationsByType(guildId, RelationType.ALLY)
+                        .filter { it.isActive() }
+                        .forEach { relation ->
+                            val alliedId = relation.getOtherGuild(guildId)
+                            memberService.getGuildMembers(alliedId).forEach { member ->
+                                val player = Bukkit.getPlayer(member.playerId) ?: return@forEach
+                                if (player.isOnline &&
+                                    chatSettingsRepository
+                                        .getVisibilitySettings(member.playerId)
+                                        .allyChatVisible
+                                ) recipients.add(player)
+                            }
+                        }
+                }
+            }
+
+            LumaGuildsChannelType.MODCHAT -> {
+                senderGuilds.forEach { guildId ->
+                    memberService.getGuildMembers(guildId)
+                        .filter { hasModPerms(it.playerId, guildId) }
+                        .forEach { member ->
+                            val player = Bukkit.getPlayer(member.playerId) ?: return@forEach
+                            if (player.isOnline) recipients.add(player)
+                        }
+                }
+            }
+        }
+
+        return recipients
+    }
+
+    override fun canPlayerReceiveMessage(sender: RosePlayer, receiver: RosePlayer): Boolean {
+        val senderId = sender.player?.uniqueId ?: return false
+        val receiverId = receiver.player?.uniqueId ?: return false
+
+        val senderGuilds = guildService.getPlayerGuilds(senderId).toSet()
+        val receiverGuilds = guildService.getPlayerGuilds(receiverId).toSet()
+
+        if (senderGuilds.isEmpty() || receiverGuilds.isEmpty()) return false
+
+        return when (channelType) {
+            LumaGuildsChannelType.GUILD ->
+                senderGuilds.intersect(receiverGuilds).isNotEmpty()
+
+            LumaGuildsChannelType.ALLY ->
+                senderGuilds.intersect(receiverGuilds).isNotEmpty() ||
+                    senderGuilds.any { sg ->
+                        receiverGuilds.any { rg -> relationService.areAllies(sg, rg) }
+                    }
+
+            LumaGuildsChannelType.MODCHAT -> {
+                val shared = senderGuilds.intersect(receiverGuilds).firstOrNull() ?: return false
+                hasModPerms(senderId, shared) && hasModPerms(receiverId, shared)
+            }
+        }
+    }
+
+    private fun hasModPerms(playerId: UUID, guildId: UUID): Boolean =
+        memberService.hasPermission(playerId, guildId, RankPermission.MANAGE_INVITES) ||
+            memberService.hasPermission(playerId, guildId, RankPermission.KICK_MEMBERS)
+}

--- a/src/main/kotlin/net/lumalyte/lg/infrastructure/services/LumaGuildsChannelProvider.kt
+++ b/src/main/kotlin/net/lumalyte/lg/infrastructure/services/LumaGuildsChannelProvider.kt
@@ -4,7 +4,7 @@ import dev.rosewood.rosechat.RoseChat
 import dev.rosewood.rosechat.chat.channel.Channel
 import dev.rosewood.rosechat.hook.channel.ChannelProvider
 import dev.rosewood.rosechat.manager.ChannelManager
-import dev.rosewood.rosegarden.config.CommentedConfigurationSection
+import dev.rosewood.rosechat.lib.rosegarden.config.CommentedConfigurationSection
 
 /**
  * RoseChat [ChannelProvider] that tells RoseChat's ChannelManager that
@@ -14,7 +14,7 @@ import dev.rosewood.rosegarden.config.CommentedConfigurationSection
  * Registered in [LumaGuilds.onEnable] after Koin is initialised so that
  * guild/ally/modchat channels resolve from `channels.yml` on a delayed reload.
  */
-class LumaGuildsChannelProvider : ChannelProvider {
+class LumaGuildsChannelProvider : ChannelProvider() {
 
     override fun getSupportedPlugin(): String = "LumaGuilds"
 

--- a/src/main/kotlin/net/lumalyte/lg/infrastructure/services/LumaGuildsChannelProvider.kt
+++ b/src/main/kotlin/net/lumalyte/lg/infrastructure/services/LumaGuildsChannelProvider.kt
@@ -1,7 +1,10 @@
 package net.lumalyte.lg.infrastructure.services
 
-import dev.rosewood.rosechat.hook.channel.ChannelProvider
+import dev.rosewood.rosechat.RoseChat
 import dev.rosewood.rosechat.chat.channel.Channel
+import dev.rosewood.rosechat.hook.channel.ChannelProvider
+import dev.rosewood.rosechat.manager.ChannelManager
+import dev.rosewood.rosegarden.config.CommentedConfigurationSection
 
 /**
  * RoseChat [ChannelProvider] that tells RoseChat's ChannelManager that
@@ -15,9 +18,11 @@ class LumaGuildsChannelProvider : ChannelProvider {
 
     override fun getSupportedPlugin(): String = "LumaGuilds"
 
-    override fun getChannels(): List<Class<out Channel>> =
-        listOf(LumaGuildsChannel::class.java)
+    override fun getChannels(): List<Class<out Channel>> = emptyList()
 
     override fun getChannelGenerator(): Class<out Channel> =
         LumaGuildsChannel::class.java
+
+    override fun getConfigurationSection(): CommentedConfigurationSection =
+        RoseChat.getInstance().getManager(ChannelManager::class.java).channelsConfig
 }

--- a/src/main/kotlin/net/lumalyte/lg/infrastructure/services/LumaGuildsChannelProvider.kt
+++ b/src/main/kotlin/net/lumalyte/lg/infrastructure/services/LumaGuildsChannelProvider.kt
@@ -1,0 +1,23 @@
+package net.lumalyte.lg.infrastructure.services
+
+import dev.rosewood.rosechat.hook.channel.ChannelProvider
+import dev.rosewood.rosechat.chat.channel.Channel
+
+/**
+ * RoseChat [ChannelProvider] that tells RoseChat's ChannelManager that
+ * channels.yml sections with `plugin: LumaGuilds` should be handled by
+ * [LumaGuildsChannel].
+ *
+ * Registered in [LumaGuilds.onEnable] after Koin is initialised so that
+ * guild/ally/modchat channels resolve from `channels.yml` on a delayed reload.
+ */
+class LumaGuildsChannelProvider : ChannelProvider {
+
+    override fun getSupportedPlugin(): String = "LumaGuilds"
+
+    override fun getChannels(): List<Class<out Channel>> =
+        listOf(LumaGuildsChannel::class.java)
+
+    override fun getChannelGenerator(): Class<out Channel> =
+        LumaGuildsChannel::class.java
+}

--- a/src/main/kotlin/net/lumalyte/lg/infrastructure/services/LumaGuildsChannelType.kt
+++ b/src/main/kotlin/net/lumalyte/lg/infrastructure/services/LumaGuildsChannelType.kt
@@ -1,0 +1,14 @@
+package net.lumalyte.lg.infrastructure.services
+
+/**
+ * Channel types for [LumaGuildsChannel], matching the `channel-type` values
+ * defined in RoseChat's `channels.yml`:
+ * - `GUILD`    → guild-only messages
+ * - `ALLY`     → messages visible to allied guilds
+ * - `MODCHAT`  → moderator-only guild messages
+ */
+enum class LumaGuildsChannelType {
+    GUILD,
+    ALLY,
+    MODCHAT
+}


### PR DESCRIPTION
## Problem

RoseChat guild channels (`guild`, `guild-ally`, `guild-modchat`) defined in `channels.yml` with `plugin: LumaGuilds` are never registered. RoseChat looks for a registered `ChannelProvider` whose `getSupportedPlugin()` returns `"LumaGuilds"`, finds none, and skips the channel with:

```
[RoseChat] Attempted to load LumaGuilds channel 'guild' but LumaGuilds is not installed!
```

This causes `/gc`, `/gac`, and `/gmc` to fail — `RoseChatAPI.getInstance().channelManager.getChannel("guild")` returns null.

Every other guild plugin RoseChat supports (Towny, FactionsUUID, SimpleClans, KingdomsX, HuskTowns) has a hook in `hook/channel/<plugin>/`. LumaGuilds was the only one relying on channels.yml config sections that can never resolve.

## Solution

Three new files + one registration call in `LumaGuilds.kt`:

| File | Purpose |
|------|---------|
| `LumaGuildsChannelProvider.kt` | Implements `ChannelProvider` so RoseChat knows how to handle `plugin: LumaGuilds` |
| `LumaGuildsChannel.kt` | Extends `Channel` with GUILD/ALLY/MODCHAT types — resolves recipients from live guild membership via `MemberService`, respects visibility toggles |
| `LumaGuildsChannelType.kt` | Enum for the three channel types |
| `LumaGuilds.kt` | `registerRoseChatChannels()` registers the provider + schedules a 1-tick delayed `channelManager.reload()` |

### How it works

1. RoseChat loads first (dependency order) → reads `channels.yml` → no LumaGuilds provider yet → skips guild sections
2. LumaGuilds `onEnable()` → Koin init → `registerRoseChatChannels()` calls `channelManager.register(LumaGuildsChannelProvider())`
3. One tick later → `channelManager.reload()` re-reads `channels.yml` → finds `plugin: LumaGuilds` → resolves the now-registered provider → creates `LumaGuildsChannel` instances for guild, guild-ally, guild-modchat

All existing commands (`/gc`, `/gac`, `/gmc`, `/g chat`, `/g allychat`) work unchanged because they already call `adapter.getChannel("guild")` which now resolves properly.

## Testing

- [ ] Start server with `depend: [RoseChat]` in `plugin.yml`
- [ ] Check startup log: no more "Attempted to load LumaGuilds channel" errors
- [ ] Verify with `/c` that guild, guild-ally, guild-modchat channels are listed
- [ ] Join a guild, run `/gc test` — message appears in guild channel
- [ ] Run `/g chat` — toggles to guild channel
- [ ] Ally chat and modchat routing
- [ ] Visibility toggle (`/g ignore`) still respected
- [ ] Disband guild / remove member → `RoseChatCleanupListener` moves player to global


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Features
- Add a new RoseChat channel provider for `plugin: LumaGuilds` that supports `GUILD`, `ALLY`, and `MODCHAT` via `channel-type` in `channels.yml`.
- Resolve RoseChat recipients from live LumaGuilds membership (including allied guild relationships for `ALLY`) and compute intended recipients at send time.
- Enforce per-player chat visibility opt-outs for `GUILD`/`ALLY` using `ChatSettingsRepository`, while keeping `MODCHAT` always receiver-allowed.
- Require per-guild moderation permissions for `MODCHAT` senders/receivers, recognizing legacy `OFFICER` as `MODCHAT`.
- Register the `LumaGuildsChannelProvider` on plugin startup and perform a one-tick delayed RoseChat channel reload so `channels.yml` entries using `plugin: LumaGuilds` can be resolved.
- Continue using the resolved RoseChat channels for existing guild chat command delivery and cleanup behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->