### PR TITLE
feat: add %lumaguilds_guild_tag_minimessage% placeholder for MiniMessage-only formatters

### DIFF
--- a/docs/placeholders.md
+++ b/docs/placeholders.md
@@ -15,6 +15,8 @@ Resolve to `""` (empty) if the player has no guild — except `has_guild`, which
 | `%lumaguilds_has_guild%` | `true` / `false` |
 | `%lumaguilds_guild_name%` | Guild name |
 | `%lumaguilds_guild_tag%` | Formatted tag, falls back to `§6<name>` |
+| `%lumaguilds_guild_tag_minimessage%` | Tag normalized to MiniMessage (for MiniMessage-only formatters like Velocitab), falls back to `<gold><name>` |
+| `%lumaguilds_guild_tag_raw%` | Tag exactly as stored (may be legacy `&` codes or MiniMessage) |
 | `%lumaguilds_guild_emoji%` | Nexo placeholder (`%nexo_<name>%`) |
 | `%lumaguilds_guild_level%` | Current level |
 | `%lumaguilds_guild_balance%` | Bank balance |
@@ -77,6 +79,7 @@ Cached for 30 seconds. Returns `""` if the slot is empty.
 |---|---|
 | `name` | Guild name |
 | `tag` | Formatted tag |
+| `tag_mm` | Tag normalized to MiniMessage |
 | `tag_plain` | Tag with formatting stripped |
 | `id` | Guild UUID |
 | `value` | The metric being ranked on (level / balance / activity score / members / epoch second for age) |

--- a/src/main/kotlin/net/lumalyte/lg/infrastructure/placeholders/LumaGuildsExpansion.kt
+++ b/src/main/kotlin/net/lumalyte/lg/infrastructure/placeholders/LumaGuildsExpansion.kt
@@ -4,6 +4,9 @@ import net.lumalyte.lg.application.persistence.LeaderboardRepository
 import net.lumalyte.lg.application.persistence.ProgressionRepository
 import net.lumalyte.lg.application.services.*
 import net.lumalyte.lg.domain.entities.Guild
+import net.lumalyte.lg.utils.ColorCodeUtils
+import net.kyori.adventure.text.Component
+import net.kyori.adventure.text.format.NamedTextColor
 import net.kyori.adventure.text.minimessage.MiniMessage
 import net.kyori.adventure.text.serializer.legacy.LegacyComponentSerializer
 import net.kyori.adventure.text.serializer.plain.PlainTextComponentSerializer
@@ -30,6 +33,7 @@ import java.util.concurrent.ConcurrentHashMap
  * Available placeholders:
  * - %lumaguilds_guild_name% - Player's guild name
  * - %lumaguilds_guild_tag% - Player's guild tag, MiniMessage rendered to legacy §-codes (chat-safe)
+ * - %lumaguilds_guild_tag_minimessage% - Player's guild tag normalized to MiniMessage (proxy/MiniMessage-safe, e.g. Velocitab)
  * - %lumaguilds_guild_tag_raw% - Raw tag string as stored (may contain MiniMessage tags)
  * - %lumaguilds_guild_tag_plain% - Tag with all formatting stripped
  * - %lumaguilds_guild_emoji% - Player's guild emoji (converted to %nexo_<emoji>% format for tab/scoreboard)
@@ -67,7 +71,7 @@ import java.util.concurrent.ConcurrentHashMap
  *   Format: %lumaguilds_top_<category>_<rank>_<field>%
  *   category = level | balance | activity | members | age
  *   rank     = 1..25 (1-based)
- *   field    = name | tag | tag_plain | id | value | level | members |
+ *   field    = name | tag | tag_mm | tag_plain | id | value | level | members |
  *              balance | activity | age_days | emoji
  *   Examples:
  *     %lumaguilds_top_balance_1_name%
@@ -133,6 +137,7 @@ class LumaGuildsExpansion : PlaceholderExpansion(), KoinComponent {
             // Basic guild info
             "guild_name" -> guild.name
             "guild_tag" -> renderTagAsLegacy(guild)
+            "guild_tag_minimessage" -> renderTagAsMiniMessage(guild)
             "guild_tag_raw" -> guild.tag ?: "§6${guild.name}"
             "guild_tag_plain" -> renderTagAsPlain(guild)
             "guild_emoji" -> convertEmojiToNexoPlaceholder(guild.emoji)
@@ -408,6 +413,7 @@ class LumaGuildsExpansion : PlaceholderExpansion(), KoinComponent {
     private fun formatTopField(guild: Guild, row: TopRow, field: String): String = when (field) {
         "name" -> guild.name
         "tag" -> guild.tag ?: "§6${guild.name}"
+        "tag_mm" -> renderTagAsMiniMessage(guild)
         "tag_plain" -> guild.tag?.let { stripFormatting(it) } ?: guild.name
         "id" -> guild.id.toString()
         "value" -> formatScore(row.value)
@@ -519,6 +525,21 @@ class LumaGuildsExpansion : PlaceholderExpansion(), KoinComponent {
         } catch (_: Exception) {
             raw
         }
+    }
+
+    /**
+     * Converts a guild's tag (stored as MiniMessage or legacy `&`/`§` codes) into
+     * MiniMessage syntax for consumers whose formatter only parses MiniMessage —
+     * e.g. Velocitab's MINIMESSAGE formatter on the proxy (resolved via PapiProxyBridge).
+     * Falls back to a `<gold>`-colored guild name when the guild has no custom tag.
+     * The name is serialized as literal text so any `<`/`>` inside it is escaped,
+     * never parsed as MiniMessage markup.
+     */
+    private fun renderTagAsMiniMessage(guild: Guild): String {
+        val raw = guild.tag ?: return miniMessage.serialize(
+            Component.text(guild.name).color(NamedTextColor.GOLD),
+        )
+        return ColorCodeUtils.toMiniMessage(raw)
     }
 
     private fun currentWeekStart(): Instant =

--- a/src/main/kotlin/net/lumalyte/lg/utils/ColorCodeUtils.kt
+++ b/src/main/kotlin/net/lumalyte/lg/utils/ColorCodeUtils.kt
@@ -42,6 +42,37 @@ object ColorCodeUtils {
     }
 
     /**
+     * Normalizes any supported tag format to canonical MiniMessage syntax.
+     *
+     * Accepts MiniMessage tags (kept, round-tripped to canonical form), legacy
+     * `&` codes, legacy `§` codes, or plain text. This is the read-side
+     * counterpart to [convertLegacyToMiniMessage], for consumers whose formatter
+     * only parses MiniMessage (e.g. Velocitab's MINIMESSAGE formatter on the proxy).
+     *
+     * Examples (canonical MiniMessage — redundant closing tags are dropped,
+     * hex is uppercase):
+     * - "&cRed" -> "<red>Red"
+     * - "§6&lGold" -> "<bold><gold>Gold"
+     * - "<red>Red</red>" -> "<red>Red"
+     * - "Plain" -> "Plain"
+     */
+    fun toMiniMessage(input: String): String {
+        return try {
+            val normalized = input.replace('§', '&')
+            val miniMessage = MiniMessage.miniMessage()
+            if (normalized.contains(Regex("<[^>]+>"))) {
+                miniMessage.serialize(miniMessage.deserialize(normalized))
+            } else {
+                miniMessage.serialize(LegacyComponentSerializer.legacyAmpersand().deserialize(normalized))
+            }
+        } catch (e: Exception) {
+    // Color code parsing - catching format errors
+            // If conversion fails, return original input
+            input
+        }
+    }
+
+    /**
      * Renders a tag with proper formatting for display in messages.
      * Accepts both legacy (&-style) and MiniMessage formats.
      * Returns legacy §-style format for Bukkit message display.

--- a/src/test/kotlin/net/lumalyte/lg/utils/ColorCodeUtilsToMiniMessageTest.kt
+++ b/src/test/kotlin/net/lumalyte/lg/utils/ColorCodeUtilsToMiniMessageTest.kt
@@ -1,0 +1,54 @@
+package net.lumalyte.lg.utils
+
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Test
+
+/**
+ * Pure-Kotlin tests for [ColorCodeUtils.toMiniMessage], the read-side tag
+ * normalizer used by %lumaguilds_guild_tag_minimessage% (Velocitab/proxy-safe).
+ *
+ * Expected values are the canonical MiniMessage form produced by the bundled
+ * Adventure MiniMessage serializer: redundant closing tags are dropped
+ * (`<red>Red`, not `<red>Red</red>`), hex colors are uppercase (`<#FF5733>`),
+ * and literal `<` is escaped as `\<`. All outputs re-parse as valid MiniMessage.
+ */
+class ColorCodeUtilsToMiniMessageTest {
+
+    @Test
+    fun `converts legacy ampersand codes to minimessage`() {
+        assertEquals("<red>Red", ColorCodeUtils.toMiniMessage("&cRed"))
+        assertEquals("<bold><gold>Gold", ColorCodeUtils.toMiniMessage("&6&lGold"))
+    }
+
+    @Test
+    fun `converts section codes to minimessage`() {
+        assertEquals("<red>Red", ColorCodeUtils.toMiniMessage("§cRed"))
+        assertEquals("<bold><gold>Gold", ColorCodeUtils.toMiniMessage("§6§lGold"))
+    }
+
+    @Test
+    fun `converts legacy hex codes to minimessage`() {
+        assertEquals("<#FF5733>Hex", ColorCodeUtils.toMiniMessage("&x&f&f&5&7&3&3Hex"))
+        assertEquals("<#FF5733>Hex", ColorCodeUtils.toMiniMessage("§x§f§f§5§7§3§3Hex"))
+    }
+
+    @Test
+    fun `keeps existing minimessage tags`() {
+        assertEquals("<red>Red", ColorCodeUtils.toMiniMessage("<red>Red</red>"))
+        assertEquals(
+            "<gradient:#FF0000:#00FF00>G",
+            ColorCodeUtils.toMiniMessage("<gradient:#ff0000:#00ff00>G</gradient>"),
+        )
+    }
+
+    @Test
+    fun `passes plain text through unchanged`() {
+        assertEquals("Elite", ColorCodeUtils.toMiniMessage("Elite"))
+        assertEquals("R\\<3", ColorCodeUtils.toMiniMessage("R<3"))
+    }
+
+    @Test
+    fun `handles empty input`() {
+        assertEquals("", ColorCodeUtils.toMiniMessage(""))
+    }
+}

--- a/wiki/docs/admins/placeholderapi.md
+++ b/wiki/docs/admins/placeholderapi.md
@@ -17,7 +17,8 @@ LumaGuilds integrates with PlaceholderAPI to expose guild information in chat, t
 LumaGuilds registers a PlaceholderAPI expansion with identifier `lumaguilds`. Placeholders take the form `%lumaguilds_<key>%` and resolve in player context. The expansion provides multiple rendering variants for tag-based placeholders:
 
 - **`%lumaguilds_guild_tag%`** — MiniMessage tags converted to legacy `§`-style color codes (safe for chat plugins that don't parse MiniMessage)
-- **`%lumaguilds_guild_tag_raw%`** — Raw MiniMessage string as stored (for plugins that parse MiniMessage themselves)
+- **`%lumaguilds_guild_tag_minimessage%`** — Tag normalized to MiniMessage: legacy `&`/`§` codes (e.g. from `/g tag`) are converted, MiniMessage tags are kept. Use this in MiniMessage-only formatters such as Velocitab on the proxy.
+- **`%lumaguilds_guild_tag_raw%`** — Raw tag string exactly as stored — may be MiniMessage markup or legacy `&`/`§` codes (for plugins that parse formatting themselves)
 - **`%lumaguilds_guild_tag_plain%`** — All formatting stripped (plain text only)
 
 The same variants apply to `guild_display` and `guild_chat_format`.
@@ -28,7 +29,8 @@ The same variants apply to `guild_display` and `guild_chat_format`.
 |-------------|---------|-------|
 | `guild_name` | Text | Player's guild name |
 | `guild_tag` | Text (MiniMessage→legacy) | Guild tag rendered to `§`-codes |
-| `guild_tag_raw` | Text (MiniMessage) | Guild tag as stored (may contain `<color>`, `<bold>`, etc.) |
+| `guild_tag_minimessage` | Text (MiniMessage) | Tag normalized to MiniMessage (`&`/`§` codes converted). For Velocitab / MiniMessage-only formatters |
+| `guild_tag_raw` | Text (raw) | Guild tag exactly as stored (may be legacy `&`/`§` codes or MiniMessage markup) |
 | `guild_tag_plain` | Text (plain) | Guild tag with formatting stripped |
 | `guild_emoji` | Text | Guild emoji, converted to Nexo PAPI format (`%nexo_<name>%`) |
 | `guild_level` | Integer | Current guild level |
@@ -71,6 +73,7 @@ Format: `%lumaguilds_top_<category>_<rank>_<field>%`
 
 - `name` — Guild name
 - `tag` — Guild tag (MiniMessage→legacy `§`-codes)
+- `tag_mm` — Guild tag normalized to MiniMessage (`&`/`§` codes converted)
 - `tag_plain` — Guild tag (plain text, no formatting)
 - `id` — Guild UUID
 - `value` — Numeric score (level, balance, activity score, member count, or age in days)
@@ -125,6 +128,13 @@ header:
   - "Rank: %lumaguilds_guild_rank% | Level: %lumaguilds_guild_level%"
 ```
 
+**Velocitab (Velocity proxy):** Velocitab's `MINIMESSAGE` formatter does not parse legacy `§`/`&` codes. Use `guild_tag_minimessage` (not `guild_tag`) so player-set legacy tags render correctly:
+
+```yaml
+# tab_groups.yml (Velocitab)
+format: "<gray>[</gray>%lumaguilds_guild_tag_minimessage%<gray>]</gray> %username%"
+```
+
 ### Chat format (RoseChat, EssentialsChat)
 
 Use `guild_tag`, `guild_chat_format`, `guild_emoji`:
@@ -170,6 +180,8 @@ format: "%player_name% %lumaguilds_rel_%player_name%_status%"
 ## Gotchas
 
 **MiniMessage tags leak in non-MiniMessage plugins:** If you use `%lumaguilds_guild_tag_raw%` in a plugin that doesn't parse MiniMessage (like vanilla TAB), you'll see raw tags like `<color:#FF5733>Elite</color>` in chat. Use `%lumaguilds_guild_tag%` (the legacy variant) instead—it converts MiniMessage to `§`-codes automatically.
+
+**Legacy codes leak in MiniMessage-only formatters:** The inverse problem — `%lumaguilds_guild_tag%` returns `§`-codes, which Velocitab's MiniMessage formatter renders literally. Use `%lumaguilds_guild_tag_minimessage%` there: it converts `&`/`§` codes (e.g. tags set via `/g tag`) to MiniMessage and keeps existing MiniMessage tags.
 
 **Relation indicator returns empty, not a space:** Neutral relations return a completely blank string (not a space). If you're using this in a player list and want consistent spacing, add a space yourself: `%player_name% %lumaguilds_rel_%player_name%_status%` (trailing space).
 


### PR DESCRIPTION
## Summary

Velocitab's `MINIMESSAGE` formatter (proxy-side, resolved via PapiProxyBridge) does not parse legacy `§`/`&` codes. Guild tags set via `/g tag` with legacy codes therefore leaked raw into the proxy tab list — `guild_tag` renders to legacy by design (chat-safe).

## Changes

- **New placeholder `%lumaguilds_guild_tag_minimessage%`** — normalizes the stored tag (MiniMessage, legacy `&`, legacy `§`, or plain text) to canonical MiniMessage via `ColorCodeUtils.toMiniMessage()`. Falls back to `<gold><name>` when no tag is set.
- **New leaderboard field `top_*_tag_mm`** — mirrors the per-guild tag variant.
- **Unit tests** for `toMiniMessage` (`ColorCodeUtilsToMiniMessageTest`): `&` codes, `§` codes, legacy hex (`&x…`/`§x…`), existing MiniMessage tags, plain text, empty input.
- **Docs** — `docs/placeholders.md` and `wiki/docs/admins/placeholderapi.md` (Velocitab usage example + legacy-leak gotcha).

Existing `%lumaguilds_guild_tag%` behavior (legacy `§`, chat-safe) is unchanged.

## Testing

`./gradlew build` — full suite green.

## Usage (Velocitab `tab_groups.yml`)

```yaml
format: "<gray>[</gray>%lumaguilds_guild_tag_minimessage%<gray>]</gray> %username%"
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Fixes
- Preserve `%lumaguilds_guild_tag%` as legacy `§` formatting while supporting MiniMessage-specific formatting.

## Features
- Add MiniMessage-normalized guild tag placeholders and `tag_mm` leaderboard fields.
- Add RoseChat channels for guild, ally, and moderator chat.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->