### PR TITLE
feat: %lumaguilds_guild_emoji_minimessage% placeholder (Nexo glyph tags for Velocitab)

### DIFF
--- a/docs/placeholders.md
+++ b/docs/placeholders.md
@@ -17,7 +17,8 @@ Resolve to `""` (empty) if the player has no guild — except `has_guild`, which
 | `%lumaguilds_guild_tag%` | Formatted tag, falls back to `§6<name>` |
 | `%lumaguilds_guild_tag_minimessage%` | Tag normalized to MiniMessage (for MiniMessage-only formatters like Velocitab), falls back to `<gold><name>` |
 | `%lumaguilds_guild_tag_raw%` | Tag exactly as stored (may be legacy `&` codes or MiniMessage) |
-| `%lumaguilds_guild_emoji%` | Nexo placeholder (`%nexo_<name>%`) |
+| `%lumaguilds_guild_emoji%` | Nexo placeholder (`%nexo_<name>%`) — resolves only where Nexo's PAPI expansion runs (backend) |
+| `%lumaguilds_guild_emoji_minimessage%` | Nexo glyph tag (`<glyph:name>`) — for MiniMessage formatters like Velocitab (rendered proxy-side via NexoProxy) |
 | `%lumaguilds_guild_level%` | Current level |
 | `%lumaguilds_guild_balance%` | Bank balance |
 | `%lumaguilds_guild_mode%` | `Peaceful` / `Hostile` |
@@ -88,7 +89,8 @@ Cached for 30 seconds. Returns `""` if the slot is empty.
 | `balance` | Bank balance |
 | `activity` | Current week activity score |
 | `age_days` | Days since creation |
-| `emoji` | Nexo placeholder |
+| `emoji` | Nexo placeholder (`%nexo_<name>%`) |
+| `emoji_mm` | Nexo glyph tag (`<glyph:name>`) |
 
 ### Examples
 

--- a/docs/placeholders.md
+++ b/docs/placeholders.md
@@ -18,7 +18,7 @@ Resolve to `""` (empty) if the player has no guild — except `has_guild`, which
 | `%lumaguilds_guild_tag_minimessage%` | Tag normalized to MiniMessage (for MiniMessage-only formatters like Velocitab), falls back to `<gold><name>` |
 | `%lumaguilds_guild_tag_raw%` | Tag exactly as stored (may be legacy `&` codes or MiniMessage) |
 | `%lumaguilds_guild_emoji%` | Nexo placeholder (`%nexo_<name>%`) — resolves only where Nexo's PAPI expansion runs (backend) |
-| `%lumaguilds_guild_emoji_minimessage%` | Nexo glyph tag (`<glyph:name>`) — for MiniMessage formatters like Velocitab (rendered proxy-side via NexoProxy) |
+| `%lumaguilds_guild_emoji_minimessage%` | Nexo glyph tag for MiniMessage formatters like Velocitab (rendered proxy-side via NexoProxy). Matching `:name:` values become `<glyph:name>`; null/blank returns empty; other values pass through unchanged |
 | `%lumaguilds_guild_level%` | Current level |
 | `%lumaguilds_guild_balance%` | Bank balance |
 | `%lumaguilds_guild_mode%` | `Peaceful` / `Hostile` |
@@ -90,7 +90,7 @@ Cached for 30 seconds. Returns `""` if the slot is empty.
 | `activity` | Current week activity score |
 | `age_days` | Days since creation |
 | `emoji` | Nexo placeholder (`%nexo_<name>%`) |
-| `emoji_mm` | Nexo glyph tag (`<glyph:name>`) |
+| `emoji_mm` | Nexo glyph tag — `:name:` → `<glyph:name>`; null/blank → empty; other values pass through |
 
 ### Examples
 

--- a/src/main/kotlin/net/lumalyte/lg/infrastructure/placeholders/LumaGuildsExpansion.kt
+++ b/src/main/kotlin/net/lumalyte/lg/infrastructure/placeholders/LumaGuildsExpansion.kt
@@ -36,7 +36,8 @@ import java.util.concurrent.ConcurrentHashMap
  * - %lumaguilds_guild_tag_minimessage% - Player's guild tag normalized to MiniMessage (proxy/MiniMessage-safe, e.g. Velocitab)
  * - %lumaguilds_guild_tag_raw% - Raw tag string as stored (may contain MiniMessage tags)
  * - %lumaguilds_guild_tag_plain% - Tag with all formatting stripped
- * - %lumaguilds_guild_emoji% - Player's guild emoji (converted to %nexo_<emoji>% format for tab/scoreboard)
+ * - %lumaguilds_guild_emoji% - Player's guild emoji (converted to %nexo_<emoji>% format for backend tab/scoreboard/chat)
+ * - %lumaguilds_guild_emoji_minimessage% - Player's guild emoji as Nexo glyph tag (<glyph:emoji>) for MiniMessage formatters (Velocitab via NexoProxy)
  * - %lumaguilds_guild_level% - Player's guild level
  * - %lumaguilds_guild_balance% - Player's guild bank balance
  * - %lumaguilds_guild_members% - Player's guild member count
@@ -141,6 +142,7 @@ class LumaGuildsExpansion : PlaceholderExpansion(), KoinComponent {
             "guild_tag_raw" -> guild.tag ?: "§6${guild.name}"
             "guild_tag_plain" -> renderTagAsPlain(guild)
             "guild_emoji" -> convertEmojiToNexoPlaceholder(guild.emoji)
+            "guild_emoji_minimessage" -> ColorCodeUtils.emojiToGlyphTag(guild.emoji)
             "guild_level" -> guild.level.toString()
             // BankService.getBalance resolves to the unified guild balance (store B: vault gold),
             // the single source of truth shared by /g bal, /g baltop, /g menu -> Bank and the vault.
@@ -389,8 +391,8 @@ class LumaGuildsExpansion : PlaceholderExpansion(), KoinComponent {
     // Format: top_<category>_<rank>_<field>
     //   category: level | balance | activity | members | age
     //   rank: 1..N (1-based)
-    //   field: name | tag | tag_plain | id | value | level | members |
-    //          balance | activity | age_days | emoji
+    //   field: name | tag | tag_mm | tag_plain | id | value | level | members |
+    //          balance | activity | age_days | emoji | emoji_mm
     // Examples: top_balance_1_name, top_level_3_value, top_activity_2_members
     // -----------------------------------------------------------------
     private fun handleTopPlaceholder(ident: String): String {
@@ -423,6 +425,7 @@ class LumaGuildsExpansion : PlaceholderExpansion(), KoinComponent {
         "activity" -> safeWeeklyActivityScore(guild.id).toString()
         "age_days" -> Duration.between(guild.createdAt, Instant.now()).toDays().toString()
         "emoji" -> convertEmojiToNexoPlaceholder(guild.emoji)
+        "emoji_mm" -> ColorCodeUtils.emojiToGlyphTag(guild.emoji)
         else -> ""
     }
 

--- a/src/main/kotlin/net/lumalyte/lg/utils/ColorCodeUtils.kt
+++ b/src/main/kotlin/net/lumalyte/lg/utils/ColorCodeUtils.kt
@@ -10,6 +10,25 @@ import net.kyori.adventure.text.serializer.legacy.LegacyComponentSerializer
 object ColorCodeUtils {
 
     /**
+     * Converts a guild emoji (stored in Discord format, e.g. `:catsmileysmile:`) into
+     * the Nexo glyph MiniMessage tag (`<glyph:catsmileysmile>`).
+     *
+     * This is the proxy-safe counterpart to `%nexo_<name>%`: the PAPI placeholder only
+     * resolves where Nexo's expansion runs (backend Paper), while the `<glyph:name>` tag
+     * renders in MiniMessage formatters that have glyph support — e.g. Velocitab on the
+     * proxy via NexoProxy, and backend chat/scoreboards via Nexo's formatting engine.
+     *
+     * Non-`:name:` values pass through unchanged; null/empty return `""`.
+     */
+    fun emojiToGlyphTag(emoji: String?): String {
+        if (emoji.isNullOrEmpty()) return ""
+        if (emoji.startsWith(":") && emoji.endsWith(":") && emoji.length > 2) {
+            return "<glyph:${emoji.substring(1, emoji.length - 1)}>"
+        }
+        return emoji
+    }
+
+    /**
      * Converts legacy color codes (&c, &6, etc.) to MiniMessage format.
      * If the input is already MiniMessage, returns it unchanged.
      *

--- a/src/main/kotlin/net/lumalyte/lg/utils/ColorCodeUtils.kt
+++ b/src/main/kotlin/net/lumalyte/lg/utils/ColorCodeUtils.kt
@@ -18,10 +18,10 @@ object ColorCodeUtils {
      * renders in MiniMessage formatters that have glyph support — e.g. Velocitab on the
      * proxy via NexoProxy, and backend chat/scoreboards via Nexo's formatting engine.
      *
-     * Non-`:name:` values pass through unchanged; null/empty return `""`.
+     * Non-`:name:` values pass through unchanged; null or blank return `""`.
      */
     fun emojiToGlyphTag(emoji: String?): String {
-        if (emoji.isNullOrEmpty()) return ""
+        if (emoji.isNullOrBlank()) return ""
         if (emoji.startsWith(":") && emoji.endsWith(":") && emoji.length > 2) {
             return "<glyph:${emoji.substring(1, emoji.length - 1)}>"
         }

--- a/src/test/kotlin/net/lumalyte/lg/utils/ColorCodeUtilsEmojiGlyphTest.kt
+++ b/src/test/kotlin/net/lumalyte/lg/utils/ColorCodeUtilsEmojiGlyphTest.kt
@@ -1,0 +1,33 @@
+package net.lumalyte.lg.utils
+
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Test
+
+/**
+ * Pure-Kotlin tests for [ColorCodeUtils.emojiToGlyphTag], the guild-emoji →
+ * Nexo `<glyph:name>` converter used by %lumaguilds_guild_emoji_minimessage%
+ * (Velocitab/NexoProxy-safe) and the `emoji_mm` leaderboard field.
+ */
+class ColorCodeUtilsEmojiGlyphTest {
+
+    @Test
+    fun `converts discord emoji to nexo glyph tag`() {
+        assertEquals("<glyph:catsmileysmile>", ColorCodeUtils.emojiToGlyphTag(":catsmileysmile:"))
+        assertEquals("<glyph:clown>", ColorCodeUtils.emojiToGlyphTag(":clown:"))
+        assertEquals("<glyph:fire>", ColorCodeUtils.emojiToGlyphTag(":fire:"))
+    }
+
+    @Test
+    fun `passes non-discord values through unchanged`() {
+        assertEquals(":weird", ColorCodeUtils.emojiToGlyphTag(":weird"))
+        assertEquals("plain", ColorCodeUtils.emojiToGlyphTag("plain"))
+        // ":": length 1, doesn't match the :name: guard -> passthrough (same as the legacy converter)
+        assertEquals(":", ColorCodeUtils.emojiToGlyphTag(":"))
+    }
+
+    @Test
+    fun `returns empty for null or blank`() {
+        assertEquals("", ColorCodeUtils.emojiToGlyphTag(null))
+        assertEquals("", ColorCodeUtils.emojiToGlyphTag(""))
+    }
+}

--- a/src/test/kotlin/net/lumalyte/lg/utils/ColorCodeUtilsEmojiGlyphTest.kt
+++ b/src/test/kotlin/net/lumalyte/lg/utils/ColorCodeUtilsEmojiGlyphTest.kt
@@ -29,5 +29,7 @@ class ColorCodeUtilsEmojiGlyphTest {
     fun `returns empty for null or blank`() {
         assertEquals("", ColorCodeUtils.emojiToGlyphTag(null))
         assertEquals("", ColorCodeUtils.emojiToGlyphTag(""))
+        assertEquals("", ColorCodeUtils.emojiToGlyphTag("   "))
+        assertEquals("", ColorCodeUtils.emojiToGlyphTag("\t\n"))
     }
 }

--- a/wiki/docs/admins/placeholderapi.md
+++ b/wiki/docs/admins/placeholderapi.md
@@ -32,7 +32,8 @@ The same variants apply to `guild_display` and `guild_chat_format`.
 | `guild_tag_minimessage` | Text (MiniMessage) | Tag normalized to MiniMessage (`&`/`§` codes converted). For Velocitab / MiniMessage-only formatters |
 | `guild_tag_raw` | Text (raw) | Guild tag exactly as stored (may be legacy `&`/`§` codes or MiniMessage markup) |
 | `guild_tag_plain` | Text (plain) | Guild tag with formatting stripped |
-| `guild_emoji` | Text | Guild emoji, converted to Nexo PAPI format (`%nexo_<name>%`) |
+| `guild_emoji` | Text | Guild emoji, converted to Nexo PAPI format (`%nexo_<name>%`) — resolves only where Nexo's PAPI expansion runs (backend) |
+| `guild_emoji_minimessage` | Text | Guild emoji as Nexo glyph tag (`<glyph:name>`) — for MiniMessage formatters (Velocitab via NexoProxy) |
 | `guild_level` | Integer | Current guild level |
 | `guild_balance` | Integer | Virtual bank balance (coins) |
 | `guild_mode` | Text | `Peaceful` or `Hostile` |
@@ -83,6 +84,7 @@ Format: `%lumaguilds_top_<category>_<rank>_<field>%`
 - `activity` — Weekly activity score
 - `age_days` — Days since creation
 - `emoji` — Guild emoji (`%nexo_<name>%`)
+- `emoji_mm` — Guild emoji as Nexo glyph tag (`<glyph:name>`)
 
 **Examples:**
 
@@ -128,11 +130,11 @@ header:
   - "Rank: %lumaguilds_guild_rank% | Level: %lumaguilds_guild_level%"
 ```
 
-**Velocitab (Velocity proxy):** Velocitab's `MINIMESSAGE` formatter does not parse legacy `§`/`&` codes. Use `guild_tag_minimessage` (not `guild_tag`) so player-set legacy tags render correctly:
+**Velocitab (Velocity proxy):** Velocitab's `MINIMESSAGE` formatter does not parse legacy `§`/`&` codes. Use `guild_tag_minimessage` (not `guild_tag`) so player-set legacy tags render correctly, and `guild_emoji_minimessage` (not `guild_emoji`) so Nexo emojis render — `%nexo_<name>%` cannot resolve on the proxy, but `<glyph:name>` renders there via NexoProxy:
 
 ```yaml
-# tab_groups.yml (Velocitab)
-format: "<gray>[</gray>%lumaguilds_guild_tag_minimessage%<gray>]</gray> %username%"
+# tab_groups.yml (Velocitab) — needs NexoProxy on the Velocity proxy
+format: "<gray>[</gray>%lumaguilds_guild_emoji_minimessage%%lumaguilds_guild_tag_minimessage%<gray>]</gray> %username%"
 ```
 
 ### Chat format (RoseChat, EssentialsChat)

--- a/wiki/docs/admins/placeholderapi.md
+++ b/wiki/docs/admins/placeholderapi.md
@@ -33,7 +33,7 @@ The same variants apply to `guild_display` and `guild_chat_format`.
 | `guild_tag_raw` | Text (raw) | Guild tag exactly as stored (may be legacy `&`/`§` codes or MiniMessage markup) |
 | `guild_tag_plain` | Text (plain) | Guild tag with formatting stripped |
 | `guild_emoji` | Text | Guild emoji, converted to Nexo PAPI format (`%nexo_<name>%`) — resolves only where Nexo's PAPI expansion runs (backend) |
-| `guild_emoji_minimessage` | Text | Guild emoji as Nexo glyph tag (`<glyph:name>`) — for MiniMessage formatters (Velocitab via NexoProxy) |
+| `guild_emoji_minimessage` | Text | Guild emoji as Nexo glyph tag for MiniMessage formatters (Velocitab via NexoProxy). Matching `:name:` values become `<glyph:name>`; null/blank returns empty; other values pass through unchanged |
 | `guild_level` | Integer | Current guild level |
 | `guild_balance` | Integer | Virtual bank balance (coins) |
 | `guild_mode` | Text | `Peaceful` or `Hostile` |
@@ -84,7 +84,7 @@ Format: `%lumaguilds_top_<category>_<rank>_<field>%`
 - `activity` — Weekly activity score
 - `age_days` — Days since creation
 - `emoji` — Guild emoji (`%nexo_<name>%`)
-- `emoji_mm` — Guild emoji as Nexo glyph tag (`<glyph:name>`)
+- `emoji_mm` — Guild emoji as Nexo glyph tag (`:name:` → `<glyph:name>`; null/blank → empty; other values pass through)
 
 **Examples:**
 


### PR DESCRIPTION
## Problem
`%lumaguilds_guild_emoji%` returns `%nexo_<name>%` (PAPI), which only resolves where Nexo's expansion runs — the backend. Since the tab list moved to **Velocitab on the Velocity proxy**, placeholders resolve via PapiProxyBridge and the emoji came back as a literal `%nexo_<name>%` string (Nexo's expansion isn't loaded proxy-side).

## Fix
New **`%lumaguilds_guild_emoji_minimessage%`** placeholder returning the traditional Nexo glyph tag **`<glyph:name>`**, which NexoProxy renders in Velocitab's MINIMESSAGE formatter. Mirrors the `guild_tag_minimessage` pattern from #84.

- `ColorCodeUtils.emojiToGlyphTag` — pure converter (`:catsmileysmile:` → `<glyph:catsmileysmile>`), same format guard as the legacy converter; non-`:name:` values pass through
- `guild_emoji_minimessage` placeholder + `emoji_mm` leaderboard field (mirrors `tag_mm`)
- **Legacy placeholders untouched** — `guild_emoji`, `guild_display`, `guild_chat_format`, `top_*_emoji` keep `%nexo_<name>%` for backend consumers (TAB scoreboard, Discord playerlist via InteractiveChat)
- Docs: `docs/placeholders.md` + `wiki/docs/admins/placeholderapi.md` (Velocitab example: `%lumaguilds_guild_emoji_minimessage%%lumaguilds_guild_tag_minimessage%`)

## Deploy note
Requires **NexoProxy** on the Velocity proxy (already the plan for `<glyph:enthusia_logo>`). Velocitab `tab_groups.yml` format: `<gray>[</gray>%lumaguilds_guild_emoji_minimessage%%lumaguilds_guild_tag_minimessage%<gray>]</gray> %username%`.

Build + full test suite (354 tests) green.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

### Features
- Add `guild_emoji_minimessage` and `emoji_mm` placeholders that return Nexo glyph tags for MiniMessage rendering.
- Add `ColorCodeUtils.emojiToGlyphTag` with coverage for Discord emoji, passthrough values, and empty inputs.
- Document Velocitab configuration and NexoProxy requirements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->