### PR TITLE
feat: Guild Strikes — LiteBans punishment tracking, public /g strikes view, admin penalty GUI

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -77,6 +77,11 @@ dependencies {
     compileOnly(files("libs/RoseChat-RC-2.jar"))
     testImplementation(files("libs/RoseChat-RC-2.jar"))
 
+    // LiteBans API (litebans.api.* — Events/Entry/Database) for Guild Strikes.
+    // Drop the prod jar into libs/ (libs/ is gitignored); the API package is stable
+    // across 2.x builds and the jar is only needed at compile time.
+    compileOnly(files("libs/LiteBans.jar"))
+
     // EnthusiaMarket public API (net.badgersmc.em.api.ShopGuildLookup) for guild-shop
     // integration. Slim api-only jar (one interface, depends only on Bukkit) — NOT the
     // full EM jar, to avoid a circular build dependency (EM builds against LumaGuilds).

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -78,9 +78,11 @@ dependencies {
     testImplementation(files("libs/RoseChat-RC-2.jar"))
 
     // LiteBans API (litebans.api.* — Events/Entry/Database) for Guild Strikes.
-    // Drop the prod jar into libs/ (libs/ is gitignored); the API package is stable
-    // across 2.x builds and the jar is only needed at compile time.
-    compileOnly(files("libs/LiteBans.jar"))
+    // Resolved from JitPack (official API repo: gitlab.com/ruany/LiteBansAPI),
+    // so CI needs no local jar — see the API wiki's Gradle setup. Must stay
+    // compileOnly: LiteBans bundles the API at runtime, shading it would cause
+    // a version conflict. jitpack.io is declared in repositories above.
+    compileOnly("com.gitlab.ruany:LiteBansAPI:0.6.1")
 
     // EnthusiaMarket public API (net.badgersmc.em.api.ShopGuildLookup) for guild-shop
     // integration. Slim api-only jar (one interface, depends only on Bukkit) — NOT the

--- a/src/main/kotlin/net/lumalyte/lg/LumaGuilds.kt
+++ b/src/main/kotlin/net/lumalyte/lg/LumaGuilds.kt
@@ -985,30 +985,51 @@ class LumaGuilds : JavaPlugin() {
             server.pluginManager.registerEvents(adminOverrideListener, this)
         }
 
-        // Guild Strikes — LiteBans hook (softdepend; only registers when LiteBans is present)
-        if (server.pluginManager.getPlugin("LiteBans") != null) {
-            try {
-                litebans.api.Events.get().register(get().get<net.lumalyte.lg.infrastructure.litebans.LiteBansStrikeListener>())
-                logColored("✓ Guild Strikes hooked into LiteBans (punishments tracked per guild)")
-
-                // One-shot backfill of pre-existing LiteBans punishments
-                // (async, idempotent — deduped by LiteBans entry id).
-                Bukkit.getScheduler().runTaskAsynchronously(this, Runnable {
-                    try {
-                        val result = get().get<net.lumalyte.lg.infrastructure.litebans.StrikeBackfillService>().run()
-                        logColored(
-                            "✓ Guild Strikes backfill: ${result.recorded} recorded, " +
-                                "${result.attributed} attributed, ${result.skippedUnattributable} skipped (unattributable)",
-                        )
-                    } catch (e: Exception) {
-                        logger.warning("Guild Strikes backfill failed: ${e.message}")
-                    }
-                })
-            } catch (e: Exception) {
-                logger.warning("Failed to register LiteBans strike listener: ${e.message}")
-            }
+        // Guild Strikes — LiteBans hook (softdepend; only registers when LiteBans is present).
+        // LumaGuilds can enable BEFORE LiteBans (observed on Fuji: +22s), so we also
+        // listen for LiteBans' PluginEnableEvent and wire the hook when it arrives.
+        val liteBansHook = net.lumalyte.lg.infrastructure.litebans.LiteBansEnableListener {
+            registerLiteBansStrikeHook()
+        }
+        server.pluginManager.registerEvents(liteBansHook, this)
+        if (net.lumalyte.lg.infrastructure.litebans.LiteBansEnableListener.liteBansPresent(server) &&
+            server.pluginManager.getPlugin("LiteBans")?.isEnabled == true
+        ) {
+            // LiteBans already enabled (reverse load order) — wire immediately;
+            // the enable listener covers the case where it enables later.
+            registerLiteBansStrikeHook()
         } else {
-            logger.info("LiteBans not detected - Guild Strikes disabled (punishments will not be tracked)")
+            logger.info("LiteBans not yet enabled - Guild Strikes hook will wire when it enables")
+        }
+    }
+
+    /**
+     * Wires the Guild Strikes listener into LiteBans and kicks off the one-shot
+     * backfill. Safe to call multiple times: Events.register with the same
+     * listener is idempotent in practice (and the backfill is deduped by
+     * LiteBans entry id). Wrapped in try/catch so a LiteBans API hiccup can
+     * never take down LumaGuilds.
+     */
+    private fun registerLiteBansStrikeHook() {
+        try {
+            litebans.api.Events.get().register(get().get<net.lumalyte.lg.infrastructure.litebans.LiteBansStrikeListener>())
+            logColored("✓ Guild Strikes hooked into LiteBans (punishments tracked per guild)")
+
+            // One-shot backfill of pre-existing LiteBans punishments
+            // (async, idempotent — deduped by LiteBans entry id).
+            Bukkit.getScheduler().runTaskAsynchronously(this, Runnable {
+                try {
+                    val result = get().get<net.lumalyte.lg.infrastructure.litebans.StrikeBackfillService>().run()
+                    logColored(
+                        "✓ Guild Strikes backfill: ${result.recorded} recorded, " +
+                            "${result.attributed} attributed, ${result.skippedUnattributable} skipped (unattributable)",
+                    )
+                } catch (e: Exception) {
+                    logger.warning("Guild Strikes backfill failed: ${e.message}")
+                }
+            })
+        } catch (e: Exception) {
+            logger.warning("Failed to register LiteBans strike listener: ${e.message}")
         }
     }
 

--- a/src/main/kotlin/net/lumalyte/lg/LumaGuilds.kt
+++ b/src/main/kotlin/net/lumalyte/lg/LumaGuilds.kt
@@ -972,6 +972,11 @@ class LumaGuilds : JavaPlugin() {
             server.pluginManager.registerEvents(roseChatCleanupListener, this)
             logColored("✓ RoseChat integration registered for chat cleanup")
 
+            // Enforce guild mutes on the live RoseChat message path (players
+            // already seated in a guild channel when a mute lands).
+            val guildMuteChatListener = get().get<net.lumalyte.lg.infrastructure.listeners.GuildMuteChatListener>()
+            server.pluginManager.registerEvents(guildMuteChatListener, this)
+
             // Register RoseChat ChannelProvider so guild/ally/modchat channels
             // resolve from channels.yml. A delayed reload re-reads the config
             // now that the provider exists (RoseChat's first attempt at startup
@@ -993,7 +998,7 @@ class LumaGuilds : JavaPlugin() {
         }
         server.pluginManager.registerEvents(liteBansHook, this)
         if (net.lumalyte.lg.infrastructure.litebans.LiteBansEnableListener.liteBansPresent(server) &&
-            server.pluginManager.getPlugin("LiteBans")?.isEnabled == true
+            server.pluginManager.isPluginEnabled("LiteBans")
         ) {
             // LiteBans already enabled (reverse load order) — wire immediately;
             // the enable listener covers the case where it enables later.
@@ -1007,8 +1012,9 @@ class LumaGuilds : JavaPlugin() {
      * Wires the Guild Strikes listener into LiteBans and kicks off the one-shot
      * backfill. Safe to call multiple times: Events.register with the same
      * listener is idempotent in practice (and the backfill is deduped by
-     * LiteBans entry id). Wrapped in try/catch so a LiteBans API hiccup can
-     * never take down LumaGuilds.
+     * LiteBans entry id). Wrapped in try/catch (including LinkageError, which
+     * Bukkit can throw on class-load of a plugin dependency) so a LiteBans API
+     * hiccup can never take down LumaGuilds.
      */
     private fun registerLiteBansStrikeHook() {
         try {
@@ -1028,6 +1034,10 @@ class LumaGuilds : JavaPlugin() {
                     logger.warning("Guild Strikes backfill failed: ${e.message}")
                 }
             })
+        } catch (e: LinkageError) {
+            // Class-load failure of a LiteBans API class (e.g. NoClassDefFoundError) —
+            // not an Exception, so it needs its own catch to keep the plugin alive.
+            logger.warning("Failed to register LiteBans strike listener (LiteBans API incompatible): ${e.message}")
         } catch (e: Exception) {
             logger.warning("Failed to register LiteBans strike listener: ${e.message}")
         }

--- a/src/main/kotlin/net/lumalyte/lg/LumaGuilds.kt
+++ b/src/main/kotlin/net/lumalyte/lg/LumaGuilds.kt
@@ -984,6 +984,32 @@ class LumaGuilds : JavaPlugin() {
             val adminOverrideListener = get().get<net.lumalyte.lg.interaction.listeners.AdminOverrideListener>()
             server.pluginManager.registerEvents(adminOverrideListener, this)
         }
+
+        // Guild Strikes — LiteBans hook (softdepend; only registers when LiteBans is present)
+        if (server.pluginManager.getPlugin("LiteBans") != null) {
+            try {
+                litebans.api.Events.get().register(get().get<net.lumalyte.lg.infrastructure.litebans.LiteBansStrikeListener>())
+                logColored("✓ Guild Strikes hooked into LiteBans (punishments tracked per guild)")
+
+                // One-shot backfill of pre-existing LiteBans punishments
+                // (async, idempotent — deduped by LiteBans entry id).
+                Bukkit.getScheduler().runTaskAsynchronously(this, Runnable {
+                    try {
+                        val result = get().get<net.lumalyte.lg.infrastructure.litebans.StrikeBackfillService>().run()
+                        logColored(
+                            "✓ Guild Strikes backfill: ${result.recorded} recorded, " +
+                                "${result.attributed} attributed, ${result.skippedUnattributable} skipped (unattributable)",
+                        )
+                    } catch (e: Exception) {
+                        logger.warning("Guild Strikes backfill failed: ${e.message}")
+                    }
+                })
+            } catch (e: Exception) {
+                logger.warning("Failed to register LiteBans strike listener: ${e.message}")
+            }
+        } else {
+            logger.info("LiteBans not detected - Guild Strikes disabled (punishments will not be tracked)")
+        }
     }
 
     /**

--- a/src/main/kotlin/net/lumalyte/lg/application/persistence/PenaltyRepository.kt
+++ b/src/main/kotlin/net/lumalyte/lg/application/persistence/PenaltyRepository.kt
@@ -1,0 +1,24 @@
+package net.lumalyte.lg.application.persistence
+
+import net.lumalyte.lg.domain.entities.GuildPenalty
+import net.lumalyte.lg.domain.entities.PenaltyType
+import java.util.UUID
+
+/**
+ * Persistence for admin-applied guild penalties (level reduction, EXP
+ * reduction, guild mute, disband) — the audit trail behind the strike system.
+ */
+interface PenaltyRepository {
+
+    /** Records an applied penalty. Returns true on success. */
+    fun recordPenalty(penalty: GuildPenalty): Boolean
+
+    /** All penalties applied to a guild, newest first. */
+    fun getByGuild(guildId: UUID): List<GuildPenalty>
+
+    /** True when the guild has an in-force GUILD_MUTE penalty at [now]. */
+    fun hasActiveMute(guildId: UUID, now: java.time.Instant): Boolean
+
+    /** Most recent penalty applied to a guild, or null. */
+    fun getLatest(guildId: UUID): GuildPenalty?
+}

--- a/src/main/kotlin/net/lumalyte/lg/application/persistence/StrikeRepository.kt
+++ b/src/main/kotlin/net/lumalyte/lg/application/persistence/StrikeRepository.kt
@@ -9,25 +9,33 @@ import java.util.UUID
 interface StrikeRepository {
 
     /**
-     * Records a strike if one with the same [GuildStrike.litebansEntryId] does
-     * not already exist (dedupe). Returns true if a new row was inserted.
+     * Records a strike if one with the same [GuildStrike.punishmentType] +
+     * [GuildStrike.litebansEntryId] does not already exist (dedupe). Returns
+     * true if a new row was inserted. LiteBans ids are per-table sequences, so
+     * the type is part of the dedupe key.
      */
     fun recordStrike(strike: GuildStrike): Boolean
 
     /**
      * Marks a strike inactive (punishment removed/expired). Returns true if a row
-     * was updated.
+     * was updated. [punishmentType] disambiguates LiteBans' per-table id sequences.
      */
-    fun deactivateStrike(litebansEntryId: Long): Boolean
+    fun deactivateStrike(punishmentType: String, litebansEntryId: Long): Boolean
 
     /** Total strikes (active + inactive) recorded against a guild. */
     fun countByGuild(guildId: UUID): Int
+
+    /** Strikes currently in force (active = 1) against a guild. */
+    fun countActiveByGuild(guildId: UUID): Int
 
     /** All strikes for a guild, newest first. */
     fun getByGuild(guildId: UUID): List<GuildStrike>
 
     /** Total strikes per guild, guild id -> count. Only guilds with >= 1 strike. */
     fun getAllCounts(): Map<UUID, Int>
+
+    /** Active (in-force) strikes per guild, guild id -> count. Only guilds with >= 1. */
+    fun getAllActiveCounts(): Map<UUID, Int>
 
     /** Overall number of recorded strikes. */
     fun countAll(): Int

--- a/src/main/kotlin/net/lumalyte/lg/application/persistence/StrikeRepository.kt
+++ b/src/main/kotlin/net/lumalyte/lg/application/persistence/StrikeRepository.kt
@@ -1,0 +1,34 @@
+package net.lumalyte.lg.application.persistence
+
+import net.lumalyte.lg.domain.entities.GuildStrike
+import java.util.UUID
+
+/**
+ * Persistence for Guild Strikes — LiteBans punishments attributed to guilds.
+ */
+interface StrikeRepository {
+
+    /**
+     * Records a strike if one with the same [GuildStrike.litebansEntryId] does
+     * not already exist (dedupe). Returns true if a new row was inserted.
+     */
+    fun recordStrike(strike: GuildStrike): Boolean
+
+    /**
+     * Marks a strike inactive (punishment removed/expired). Returns true if a row
+     * was updated.
+     */
+    fun deactivateStrike(litebansEntryId: Long): Boolean
+
+    /** Total strikes (active + inactive) recorded against a guild. */
+    fun countByGuild(guildId: UUID): Int
+
+    /** All strikes for a guild, newest first. */
+    fun getByGuild(guildId: UUID): List<GuildStrike>
+
+    /** Total strikes per guild, guild id -> count. Only guilds with >= 1 strike. */
+    fun getAllCounts(): Map<UUID, Int>
+
+    /** Overall number of recorded strikes. */
+    fun countAll(): Int
+}

--- a/src/main/kotlin/net/lumalyte/lg/application/services/PenaltyService.kt
+++ b/src/main/kotlin/net/lumalyte/lg/application/services/PenaltyService.kt
@@ -78,11 +78,20 @@ class PenaltyService(
         )
         penaltyRepository.recordPenalty(penalty)
         val hours = durationMs / 3_600_000.0
-        logger.info("Guild mute penalty applied to guild {} ({}h) by {}", guild.name, hours, actorName)
-        return PenaltyResult.Success(penalty, "§a${guild.name} §7is now muted for §e$hours§7 hour(s).")
+        logger.info("Guild mute penalty applied to guild {} ({}h) by {}", guild.name, formatHours(hours), actorName)
+        return PenaltyResult.Success(penalty, "§a${guild.name} §7is now muted for §e${formatHours(hours)}§7 hour(s).")
     }
 
     fun applyDisband(guild: Guild, actorUuid: UUID, actorName: String): PenaltyResult {
+        // Admin-triggered disband: use the system UUID so the permission check in
+        // GuildService.disbandGuild (which requires MANAGE_RANKS in the target guild)
+        // doesn't reject the admin who is opening the penalty menu.
+        val systemUuid = UUID.fromString("00000000-0000-0000-0000-000000000000")
+        val success = guildService.disbandGuild(guild.id, systemUuid)
+        if (!success) return PenaltyResult.Failure("§cFailed to disband ${guild.name}.")
+
+        // Only record the penalty AFTER the disband actually succeeded — otherwise the
+        // audit trail would show a disband that never happened.
         val penalty = GuildPenalty(
             guildId = guild.id,
             type = PenaltyType.DISBAND,
@@ -93,11 +102,11 @@ class PenaltyService(
             createdAt = Instant.now()
         )
         penaltyRepository.recordPenalty(penalty)
-        val success = guildService.disbandGuild(guild.id, actorUuid)
-        if (!success) return PenaltyResult.Failure("§cFailed to disband ${guild.name}.")
         logger.info("Disband penalty applied to guild {} by {}", guild.name, actorName)
         return PenaltyResult.Success(penalty, "§c${guild.name} §7has been disbanded.")
     }
+
+    private fun formatHours(hours: Double): String = "%.1f".format(hours)
 
     /** True while the guild has an in-force guild-mute penalty. */
     fun isGuildMuted(guildId: UUID): Boolean = penaltyRepository.hasActiveMute(guildId, Instant.now())

--- a/src/main/kotlin/net/lumalyte/lg/application/services/PenaltyService.kt
+++ b/src/main/kotlin/net/lumalyte/lg/application/services/PenaltyService.kt
@@ -1,0 +1,108 @@
+package net.lumalyte.lg.application.services
+
+import net.lumalyte.lg.application.persistence.PenaltyRepository
+import net.lumalyte.lg.config.StrikesConfig
+import net.lumalyte.lg.domain.entities.Guild
+import net.lumalyte.lg.domain.entities.GuildPenalty
+import net.lumalyte.lg.domain.entities.PenaltyType
+import org.slf4j.LoggerFactory
+import java.time.Instant
+import java.util.UUID
+
+/**
+ * Applies and records admin-triggered guild penalties (Level Reduction, EXP
+ * reduction, Guild Mute, Disband) once a guild reaches the strike threshold.
+ */
+class PenaltyService(
+    private val penaltyRepository: PenaltyRepository,
+    private val progressionService: ProgressionService,
+    private val guildService: GuildService,
+    private val configProvider: () -> StrikesConfig,
+) {
+
+    private val logger = LoggerFactory.getLogger(javaClass)
+
+    /** Outcome of applying a penalty. */
+    sealed interface PenaltyResult {
+        data class Success(val penalty: GuildPenalty, val message: String) : PenaltyResult
+        data class Failure(val message: String) : PenaltyResult
+    }
+
+    fun applyLevelReduction(guild: Guild, actorUuid: UUID, actorName: String): PenaltyResult {
+        val levels = configProvider().penalties.levelReductionLevels
+        if (levels <= 0) return PenaltyResult.Failure("Level reduction is disabled in config (levels = 0).")
+        val newLevel = progressionService.reduceLevel(guild.id, levels, ExperienceSource.ADMIN_BONUS)
+        val penalty = GuildPenalty(
+            guildId = guild.id,
+            type = PenaltyType.LEVEL_REDUCTION,
+            amount = levels.toLong(),
+            reason = "Strike penalty",
+            actorUuid = actorUuid,
+            actorName = actorName,
+            createdAt = Instant.now()
+        )
+        penaltyRepository.recordPenalty(penalty)
+        logger.info("Level reduction penalty applied to guild {} ({} -> level {}) by {}", guild.name, guild.level, newLevel, actorName)
+        return PenaltyResult.Success(penalty, "§aLevel reduced to §e$newLevel§a for ${guild.name}.")
+    }
+
+    fun applyExpReduction(guild: Guild, actorUuid: UUID, actorName: String): PenaltyResult {
+        val amount = configProvider().penalties.expReductionAmount
+        if (amount <= 0) return PenaltyResult.Failure("EXP reduction is disabled in config (amount = 0).")
+        val newLevel = progressionService.removeExperience(guild.id, amount, ExperienceSource.ADMIN_BONUS)
+        val penalty = GuildPenalty(
+            guildId = guild.id,
+            type = PenaltyType.EXP_REDUCTION,
+            amount = amount.toLong(),
+            reason = "Strike penalty",
+            actorUuid = actorUuid,
+            actorName = actorName,
+            createdAt = Instant.now()
+        )
+        penaltyRepository.recordPenalty(penalty)
+        logger.info("EXP reduction penalty applied to guild {} (removed {}, now level {}) by {}", guild.name, amount, newLevel, actorName)
+        return PenaltyResult.Success(penalty, "§aRemoved §e$amount XP§a from ${guild.name}.")
+    }
+
+    fun applyGuildMute(guild: Guild, actorUuid: UUID, actorName: String): PenaltyResult {
+        val durationMs = configProvider().penalties.guildMuteDurationMillis
+        if (durationMs <= 0) return PenaltyResult.Failure("Guild mute is disabled in config (duration = 0).")
+        val penalty = GuildPenalty(
+            guildId = guild.id,
+            type = PenaltyType.GUILD_MUTE,
+            amount = durationMs,
+            reason = "Strike penalty",
+            actorUuid = actorUuid,
+            actorName = actorName,
+            createdAt = Instant.now()
+        )
+        penaltyRepository.recordPenalty(penalty)
+        val hours = durationMs / 3_600_000.0
+        logger.info("Guild mute penalty applied to guild {} ({}h) by {}", guild.name, hours, actorName)
+        return PenaltyResult.Success(penalty, "§a${guild.name} §7is now muted for §e$hours§7 hour(s).")
+    }
+
+    fun applyDisband(guild: Guild, actorUuid: UUID, actorName: String): PenaltyResult {
+        val penalty = GuildPenalty(
+            guildId = guild.id,
+            type = PenaltyType.DISBAND,
+            amount = null,
+            reason = "Strike penalty",
+            actorUuid = actorUuid,
+            actorName = actorName,
+            createdAt = Instant.now()
+        )
+        penaltyRepository.recordPenalty(penalty)
+        val success = guildService.disbandGuild(guild.id, actorUuid)
+        if (!success) return PenaltyResult.Failure("§cFailed to disband ${guild.name}.")
+        logger.info("Disband penalty applied to guild {} by {}", guild.name, actorName)
+        return PenaltyResult.Success(penalty, "§c${guild.name} §7has been disbanded.")
+    }
+
+    /** True while the guild has an in-force guild-mute penalty. */
+    fun isGuildMuted(guildId: UUID): Boolean = penaltyRepository.hasActiveMute(guildId, Instant.now())
+
+    fun getByGuild(guildId: UUID): List<GuildPenalty> = penaltyRepository.getByGuild(guildId)
+
+    fun getLatest(guildId: UUID): GuildPenalty? = penaltyRepository.getLatest(guildId)
+}

--- a/src/main/kotlin/net/lumalyte/lg/application/services/ProgressionService.kt
+++ b/src/main/kotlin/net/lumalyte/lg/application/services/ProgressionService.kt
@@ -9,7 +9,7 @@ import java.util.UUID
 interface ProgressionService {
 
     /**
-     * Awards experience points to a guild.
+     * Awards experience to a guild.
      *
      * @param guildId The ID of the guild.
      * @param experience The amount of experience to award.
@@ -17,6 +17,24 @@ interface ProgressionService {
      * @return The new guild level if leveled up, null otherwise.
      */
     fun awardExperience(guildId: UUID, experience: Int, source: ExperienceSource): Int?
+
+    /**
+     * Removes experience from a guild (used by Guild Strikes EXP penalties).
+     * Never drops total XP below 0. Recalculates level and syncs the guild's
+     * level field.
+     *
+     * @return The new guild level.
+     */
+    fun removeExperience(guildId: UUID, amount: Int, source: ExperienceSource): Int
+
+    /**
+     * Reduces a guild's level by the given number of levels (used by Guild
+     * Strikes Level Reduction penalties). Total XP is set to the threshold of
+     * the target level; level never drops below 1.
+     *
+     * @return The new guild level.
+     */
+    fun reduceLevel(guildId: UUID, levels: Int, source: ExperienceSource): Int
 
     /**
      * Calculates the experience required for the next level.

--- a/src/main/kotlin/net/lumalyte/lg/application/services/StrikeService.kt
+++ b/src/main/kotlin/net/lumalyte/lg/application/services/StrikeService.kt
@@ -17,7 +17,8 @@ class StrikeService(
     private val configProvider: () -> StrikesConfig,
 ) {
 
-    /** Records a strike for a guild member's punishment. No-op if disabled or dedupe-hit. */
+    /** Records a strike for a guild member's punishment. Returns true if a new row
+     *  was inserted, false if disabled or a dedupe hit. */
     fun recordStrike(
         guildId: UUID,
         playerUuid: UUID,
@@ -27,9 +28,10 @@ class StrikeService(
         executorName: String?,
         issuedAt: Instant,
         litebansEntryId: Long?,
-    ) {
-        if (!configProvider().enabled) return
-        repository.recordStrike(
+        active: Boolean = true,
+    ): Boolean {
+        if (!configProvider().enabled) return false
+        return repository.recordStrike(
             GuildStrike(
                 guildId = guildId,
                 playerUuid = playerUuid,
@@ -39,28 +41,32 @@ class StrikeService(
                 executorName = executorName,
                 issuedAt = issuedAt,
                 litebansEntryId = litebansEntryId,
-                active = true
+                active = active
             )
         )
     }
 
     /** Marks a strike inactive when its LiteBans punishment is removed/expired. */
-    fun deactivateStrike(litebansEntryId: Long) {
+    fun deactivateStrike(punishmentType: String, litebansEntryId: Long) {
         if (!configProvider().enabled) return
-        repository.deactivateStrike(litebansEntryId)
+        repository.deactivateStrike(punishmentType, litebansEntryId)
     }
 
     fun countByGuild(guildId: UUID): Int = repository.countByGuild(guildId)
+
+    fun countActiveByGuild(guildId: UUID): Int = repository.countActiveByGuild(guildId)
 
     fun getByGuild(guildId: UUID): List<GuildStrike> = repository.getByGuild(guildId)
 
     fun getAllCounts(): Map<UUID, Int> = repository.getAllCounts()
 
+    fun getAllActiveCounts(): Map<UUID, Int> = repository.getAllActiveCounts()
+
     fun countAll(): Int = repository.countAll()
 
-    /** True when a guild has reached (or passed) the strike threshold. */
+    /** True when a guild's ACTIVE strikes have reached (or passed) the threshold. */
     fun isUpForPenalty(guildId: UUID): Boolean {
         val threshold = configProvider().threshold
-        return threshold > 0 && repository.countByGuild(guildId) >= threshold
+        return threshold > 0 && repository.countActiveByGuild(guildId) >= threshold
     }
 }

--- a/src/main/kotlin/net/lumalyte/lg/application/services/StrikeService.kt
+++ b/src/main/kotlin/net/lumalyte/lg/application/services/StrikeService.kt
@@ -1,0 +1,66 @@
+package net.lumalyte.lg.application.services
+
+import net.lumalyte.lg.application.persistence.StrikeRepository
+import net.lumalyte.lg.config.StrikesConfig
+import net.lumalyte.lg.domain.entities.GuildStrike
+import java.time.Instant
+import java.util.UUID
+
+/**
+ * Application-layer service for Guild Strikes.
+ *
+ * Bridges LiteBans punishment events and the persistence layer, and answers
+ * the queries the public command + admin GUI need.
+ */
+class StrikeService(
+    private val repository: StrikeRepository,
+    private val configProvider: () -> StrikesConfig,
+) {
+
+    /** Records a strike for a guild member's punishment. No-op if disabled or dedupe-hit. */
+    fun recordStrike(
+        guildId: UUID,
+        playerUuid: UUID,
+        playerName: String?,
+        punishmentType: String,
+        reason: String?,
+        executorName: String?,
+        issuedAt: Instant,
+        litebansEntryId: Long?,
+    ) {
+        if (!configProvider().enabled) return
+        repository.recordStrike(
+            GuildStrike(
+                guildId = guildId,
+                playerUuid = playerUuid,
+                playerName = playerName,
+                punishmentType = punishmentType,
+                reason = reason,
+                executorName = executorName,
+                issuedAt = issuedAt,
+                litebansEntryId = litebansEntryId,
+                active = true
+            )
+        )
+    }
+
+    /** Marks a strike inactive when its LiteBans punishment is removed/expired. */
+    fun deactivateStrike(litebansEntryId: Long) {
+        if (!configProvider().enabled) return
+        repository.deactivateStrike(litebansEntryId)
+    }
+
+    fun countByGuild(guildId: UUID): Int = repository.countByGuild(guildId)
+
+    fun getByGuild(guildId: UUID): List<GuildStrike> = repository.getByGuild(guildId)
+
+    fun getAllCounts(): Map<UUID, Int> = repository.getAllCounts()
+
+    fun countAll(): Int = repository.countAll()
+
+    /** True when a guild has reached (or passed) the strike threshold. */
+    fun isUpForPenalty(guildId: UUID): Boolean {
+        val threshold = configProvider().threshold
+        return threshold > 0 && repository.countByGuild(guildId) >= threshold
+    }
+}

--- a/src/main/kotlin/net/lumalyte/lg/config/MainConfig.kt
+++ b/src/main/kotlin/net/lumalyte/lg/config/MainConfig.kt
@@ -34,7 +34,55 @@ data class MainConfig(
     var discord: DiscordConfig = DiscordConfig(),
     var party: PartyConfig = PartyConfig(),
     var bedrock: BedrockConfig = BedrockConfig(),
-    var webApi: WebApiConfig = WebApiConfig()
+    var webApi: WebApiConfig = WebApiConfig(),
+    var strikes: StrikesConfig = StrikesConfig()
+)
+
+/**
+ * Guild Strikes — LiteBans punishments attributed to guilds.
+ */
+data class StrikesConfig(
+    /** Master switch: if false, no punishments are recorded and /g strikes is disabled. */
+    var enabled: Boolean = true,
+    /** Punishments before a guild is "up for a penalty" (admin-triggered action). */
+    var threshold: Int = 5,
+    /**
+     * Which LiteBans punishment types count as strikes. LiteBans types:
+     * WARN, KICK, MUTE, BAN (matching litebans.api.Entry#getType()).
+     */
+    var countedTypes: List<String> = listOf("WARN", "KICK", "MUTE", "BAN"),
+    /** Admin penalty actions available once a guild crosses the threshold. */
+    var penalties: StrikesPenaltiesConfig = StrikesPenaltiesConfig(),
+    /** One-shot backfill of pre-existing LiteBans punishments on startup. */
+    var backfill: StrikesBackfillConfig = StrikesBackfillConfig()
+)
+
+/**
+ * Backfill settings — imports historical LiteBans punishments into the strike
+ * ledger on startup so existing guilds get credit for past behaviour.
+ */
+data class StrikesBackfillConfig(
+    /** Run the backfill on startup (idempotent — deduped by LiteBans entry id). */
+    var enabled: Boolean = true,
+    /**
+     * When membership history cannot prove which guild the player was in at the
+     * punishment time (history tracking predates the punishment), fall back to
+     * the player's current guild. False = skip unattributable punishments.
+     */
+    var fallbackToCurrentGuild: Boolean = true
+)
+
+/**
+ * Admin penalty parameters — what each action does when triggered from the
+ * penalty GUI.
+ */
+data class StrikesPenaltiesConfig(
+    /** How many levels a Level Reduction removes (0 = disabled). */
+    var levelReductionLevels: Int = 1,
+    /** How much XP an EXP Reduction removes (0 = disabled). */
+    var expReductionAmount: Int = 1000,
+    /** Guild mute duration in milliseconds (0 = disabled). */
+    var guildMuteDurationMillis: Long = 24 * 3_600_000L
 )
 
 data class WebApiConfig(

--- a/src/main/kotlin/net/lumalyte/lg/di/Modules.kt
+++ b/src/main/kotlin/net/lumalyte/lg/di/Modules.kt
@@ -421,6 +421,44 @@ fun guildsModule() = module {
     single<net.lumalyte.lg.infrastructure.bukkit.bannerman.BannermanListeners> {
         net.lumalyte.lg.infrastructure.bukkit.bannerman.BannermanListeners(get<LumaGuilds>(), get(), get(), get())
     }
+
+    // Guild Strikes (LiteBans integration)
+    single<net.lumalyte.lg.application.persistence.StrikeRepository> {
+        net.lumalyte.lg.infrastructure.persistence.guilds.StrikeRepositorySQLite(get())
+    }
+    single<net.lumalyte.lg.application.persistence.PenaltyRepository> {
+        net.lumalyte.lg.infrastructure.persistence.guilds.PenaltyRepositorySQLite(get())
+    }
+    single<net.lumalyte.lg.application.services.StrikeService> {
+        net.lumalyte.lg.application.services.StrikeService(
+            repository = get(),
+            configProvider = { get<ConfigService>().loadConfig().strikes }
+        )
+    }
+    single<net.lumalyte.lg.application.services.PenaltyService> {
+        net.lumalyte.lg.application.services.PenaltyService(
+            penaltyRepository = get(),
+            progressionService = get(),
+            guildService = get(),
+            configProvider = { get<ConfigService>().loadConfig().strikes }
+        )
+    }
+    single<net.lumalyte.lg.infrastructure.litebans.LiteBansStrikeListener> {
+        net.lumalyte.lg.infrastructure.litebans.LiteBansStrikeListener(
+            plugin = get<LumaGuilds>(),
+            guildService = get(),
+            strikeService = get(),
+            configProvider = { get<ConfigService>().loadConfig().strikes }
+        )
+    }
+    single<net.lumalyte.lg.infrastructure.litebans.StrikeBackfillService> {
+        net.lumalyte.lg.infrastructure.litebans.StrikeBackfillService(
+            strikeService = get(),
+            membershipHistoryRepository = get(),
+            guildService = get(),
+            configProvider = { get<ConfigService>().loadConfig().strikes }
+        )
+    }
 }
 
 /**

--- a/src/main/kotlin/net/lumalyte/lg/di/Modules.kt
+++ b/src/main/kotlin/net/lumalyte/lg/di/Modules.kt
@@ -429,10 +429,16 @@ fun guildsModule() = module {
     single<net.lumalyte.lg.application.persistence.PenaltyRepository> {
         net.lumalyte.lg.infrastructure.persistence.guilds.PenaltyRepositorySQLite(get())
     }
+    // StrikesConfig is captured ONCE per Koin graph. ConfigService.loadConfig()
+    // rebuilds the whole config tree on every call, and StrikeService.recordStrike
+    // runs per backfill row — a lambda would rebuild it hundreds of times per run.
+    single<net.lumalyte.lg.config.StrikesConfig> {
+        get<ConfigService>().loadConfig().strikes
+    }
     single<net.lumalyte.lg.application.services.StrikeService> {
         net.lumalyte.lg.application.services.StrikeService(
             repository = get(),
-            configProvider = { get<ConfigService>().loadConfig().strikes }
+            configProvider = { get<net.lumalyte.lg.config.StrikesConfig>() }
         )
     }
     single<net.lumalyte.lg.application.services.PenaltyService> {
@@ -440,7 +446,7 @@ fun guildsModule() = module {
             penaltyRepository = get(),
             progressionService = get(),
             guildService = get(),
-            configProvider = { get<ConfigService>().loadConfig().strikes }
+            configProvider = { get<net.lumalyte.lg.config.StrikesConfig>() }
         )
     }
     single<net.lumalyte.lg.infrastructure.litebans.LiteBansStrikeListener> {
@@ -448,7 +454,8 @@ fun guildsModule() = module {
             plugin = get<LumaGuilds>(),
             guildService = get(),
             strikeService = get(),
-            configProvider = { get<ConfigService>().loadConfig().strikes }
+            membershipHistoryRepository = get(),
+            configProvider = { get<net.lumalyte.lg.config.StrikesConfig>() }
         )
     }
     single<net.lumalyte.lg.infrastructure.litebans.StrikeBackfillService> {
@@ -456,7 +463,7 @@ fun guildsModule() = module {
             strikeService = get(),
             membershipHistoryRepository = get(),
             guildService = get(),
-            configProvider = { get<ConfigService>().loadConfig().strikes }
+            configProvider = { get<net.lumalyte.lg.config.StrikesConfig>() }
         )
     }
 }
@@ -496,6 +503,9 @@ fun socialModule() = module {
     }
     single<net.lumalyte.lg.infrastructure.listeners.RoseChatCleanupListener> {
         net.lumalyte.lg.infrastructure.listeners.RoseChatCleanupListener(get(), get(), get(), get())
+    }
+    single<net.lumalyte.lg.infrastructure.listeners.GuildMuteChatListener> {
+        net.lumalyte.lg.infrastructure.listeners.GuildMuteChatListener(get(), get())
     }
 }
 

--- a/src/main/kotlin/net/lumalyte/lg/domain/entities/GuildPenalty.kt
+++ b/src/main/kotlin/net/lumalyte/lg/domain/entities/GuildPenalty.kt
@@ -1,0 +1,33 @@
+package net.lumalyte.lg.domain.entities
+
+import java.time.Instant
+import java.util.UUID
+
+/** The admin-applied penalties a guild can receive once it reaches the strike threshold. */
+enum class PenaltyType {
+    LEVEL_REDUCTION,
+    EXP_REDUCTION,
+    GUILD_MUTE,
+    DISBAND
+}
+
+/**
+ * A penalty applied to a guild by staff, recorded for audit and public display.
+ *
+ * [amount] is interpreted per type: levels removed for LEVEL_REDUCTION, XP
+ * removed for EXP_REDUCTION, mute duration in milliseconds for GUILD_MUTE.
+ */
+data class GuildPenalty(
+    val id: Long = 0,
+    val guildId: UUID,
+    val type: PenaltyType,
+    val amount: Long? = null,
+    val reason: String? = null,
+    val actorUuid: UUID,
+    val actorName: String,
+    val createdAt: Instant
+) {
+    /** True while a GUILD_MUTE penalty is still in force. */
+    val isMuteActive: Boolean
+        get() = type == PenaltyType.GUILD_MUTE && amount != null && amount > 0 && createdAt.plusMillis(amount).isAfter(Instant.now())
+}

--- a/src/main/kotlin/net/lumalyte/lg/domain/entities/GuildStrike.kt
+++ b/src/main/kotlin/net/lumalyte/lg/domain/entities/GuildStrike.kt
@@ -1,0 +1,27 @@
+package net.lumalyte.lg.domain.entities
+
+import java.time.Instant
+import java.util.UUID
+
+/**
+ * A single recorded strike against a guild, derived from a LiteBans punishment
+ * that was issued to one of the guild's members at the time of the punishment.
+ *
+ * The strike is attributed to the guild the player belonged to when the
+ * punishment was issued — not the guild they may belong to now — so members
+ * cannot dodge strikes by leaving the guild.
+ */
+data class GuildStrike(
+    val id: Long = 0,
+    val guildId: UUID,
+    val playerUuid: UUID,
+    val playerName: String? = null,
+    val punishmentType: String,
+    val reason: String? = null,
+    val executorName: String? = null,
+    val issuedAt: Instant,
+    /** LiteBans punishment id — used to dedupe sync/re-fire events. */
+    val litebansEntryId: Long? = null,
+    /** False once the punishment is removed/expired (appealed, unmuted, pardoned...). */
+    val active: Boolean = true
+)

--- a/src/main/kotlin/net/lumalyte/lg/infrastructure/listeners/GuildMuteChatListener.kt
+++ b/src/main/kotlin/net/lumalyte/lg/infrastructure/listeners/GuildMuteChatListener.kt
@@ -1,0 +1,46 @@
+package net.lumalyte.lg.infrastructure.listeners
+
+import dev.rosewood.rosechat.api.event.message.PreParseMessageEvent
+import net.lumalyte.lg.application.services.GuildService
+import net.lumalyte.lg.application.services.PenaltyService
+import net.lumalyte.lg.infrastructure.services.LumaGuildsChannel
+import org.bukkit.event.EventHandler
+import org.bukkit.event.EventPriority
+import org.bukkit.event.Listener
+
+/**
+ * Enforces guild mutes on the RoseChat message path.
+ *
+ * The mute checks in [net.lumalyte.lg.interaction.commands.QuickGuildChatCommand]
+ * and [GuildChatListener] only cover channel entry and the `/gc` command — a
+ * player who is ALREADY seated in the guild channel when the mute lands could
+ * keep chatting. RoseChat fires a cancellable [PreParseMessageEvent] for every
+ * recipient of a channel message, so cancelling it here (whenever the sender's
+ * guild is muted) blocks delivery to every recipient.
+ *
+ * Registered only when RoseChat is present (softdepend), same as the channel
+ * provider. Async-safe: PreParseMessageEvent is fired off the main thread.
+ */
+class GuildMuteChatListener(
+    private val guildService: GuildService,
+    private val penaltyService: PenaltyService,
+) : Listener {
+
+    @EventHandler(priority = EventPriority.LOW, ignoreCancelled = true)
+    fun onPreParseMessage(event: PreParseMessageEvent) {
+        val channel = event.message.channel
+        if (channel !is LumaGuildsChannel) return
+
+        val sender = event.message.sender.asPlayer() ?: return
+        val senderGuilds = guildService.getPlayerGuilds(sender.uniqueId)
+        if (senderGuilds.isEmpty()) return
+
+        // A guild-wide mute silences everyone in that guild, on every channel
+        // type (GUILD / ALLY / MODCHAT) — same rule as the /gc and /g chat checks.
+        val muted = senderGuilds.any { penaltyService.isGuildMuted(it.id) }
+        if (!muted) return
+
+        event.isCancelled = true
+        sender.sendMessage("§c❌ Your guild is muted — guild chat is disabled until the mute expires.")
+    }
+}

--- a/src/main/kotlin/net/lumalyte/lg/infrastructure/litebans/LiteBansEnableListener.kt
+++ b/src/main/kotlin/net/lumalyte/lg/infrastructure/litebans/LiteBansEnableListener.kt
@@ -1,0 +1,44 @@
+package net.lumalyte.lg.infrastructure.litebans
+
+import org.bukkit.event.EventHandler
+import org.bukkit.event.EventPriority
+import org.bukkit.event.Listener
+import org.bukkit.event.server.PluginEnableEvent
+import org.bukkit.plugin.Plugin
+import org.slf4j.LoggerFactory
+
+/**
+ * Waits for LiteBans to finish enabling before wiring the Guild Strikes hook.
+ *
+ * LumaGuilds' own onEnable can run BEFORE LiteBans' onEnable (plugin load order
+ * is not guaranteed for softdependencies), and `litebans.api.Events.get()`
+ * returns null until LiteBans has enabled. Registering the hook too early
+ * silently fails — observed on the Fuji test server: LumaGuilds enabled at
+ * T+0, LiteBans at T+22s, hook never wired.
+ *
+ * This listener fires on PluginEnableEvent for LiteBans and calls
+ * [onLiteBansEnabled]. The caller should also attempt registration once
+ * immediately, covering the reverse load order (LiteBans already enabled).
+ */
+class LiteBansEnableListener(
+    private val onLiteBansEnabled: () -> Unit,
+) : Listener {
+
+    private val logger = LoggerFactory.getLogger(javaClass)
+
+    @EventHandler(priority = EventPriority.MONITOR, ignoreCancelled = true)
+    fun onPluginEnable(event: PluginEnableEvent) {
+        if (event.plugin.name != "LiteBans") return
+        logger.info("LiteBans enabled — wiring Guild Strikes hook now.")
+        onLiteBansEnabled()
+    }
+
+    /** Convenience: only wire when the plugin actually exists in the server. */
+    companion object {
+        fun liteBansPresent(server: org.bukkit.Server): Boolean =
+            server.pluginManager.getPlugin("LiteBans") != null
+
+        /** Null-safe LiteBans presence check for a plugin reference. */
+        fun isLiteBans(plugin: Plugin): Boolean = plugin.name == "LiteBans"
+    }
+}

--- a/src/main/kotlin/net/lumalyte/lg/infrastructure/litebans/LiteBansStrikeListener.kt
+++ b/src/main/kotlin/net/lumalyte/lg/infrastructure/litebans/LiteBansStrikeListener.kt
@@ -1,8 +1,10 @@
 package net.lumalyte.lg.infrastructure.litebans
 
+import litebans.api.Database
 import litebans.api.Entry
 import litebans.api.Events
 import litebans.api.`Events$Listener`
+import net.lumalyte.lg.application.persistence.MembershipHistoryRepository
 import net.lumalyte.lg.application.services.GuildService
 import net.lumalyte.lg.application.services.StrikeService
 import net.lumalyte.lg.config.StrikesConfig
@@ -29,6 +31,7 @@ class LiteBansStrikeListener(
     private val plugin: JavaPlugin,
     private val guildService: GuildService,
     private val strikeService: StrikeService,
+    private val membershipHistoryRepository: MembershipHistoryRepository,
     private val configProvider: () -> StrikesConfig,
 ) : `Events$Listener`() {
 
@@ -37,41 +40,64 @@ class LiteBansStrikeListener(
 
     override fun entryAdded(entry: Entry) {
         if (!configProvider().enabled) return
+        // Resolve the player's name here on LiteBans' own thread via LiteBans'
+        // DB — never Bukkit.getOfflinePlayer(), which can block on a Mojang
+        // lookup if the profile isn't cached (and would run on the tick thread).
+        val playerUuid = runCatching { UUID.fromString(entry.uuid) }.getOrNull()
+        val playerName = playerUuid?.let { runCatching { Database.get().getPlayerName(it) }.getOrNull() }
         // LiteBans can fire this on its own threads; hop to the main thread
         // before touching Bukkit/GuildService state.
         Bukkit.getScheduler().runTask(plugin, Runnable {
-            handleEntryAdded(entry)
+            handleEntryAdded(entry, playerUuid, playerName)
         })
     }
 
     override fun entryRemoved(entry: Entry) {
         if (!configProvider().enabled) return
+        val type = entry.type?.uppercase() ?: return
         val entryId = entry.id
         if (entryId <= 0) return
         // Same thread policy as entryAdded: LiteBans may fire on its own threads.
         Bukkit.getScheduler().runTask(plugin, Runnable {
-            strikeService.deactivateStrike(entryId)
+            strikeService.deactivateStrike(type, entryId)
         })
     }
 
-    private fun handleEntryAdded(entry: Entry) {
+    private fun handleEntryAdded(entry: Entry, playerUuid: UUID?, playerName: String?) {
         val type = entry.type?.uppercase() ?: return
         if (type !in countedTypes) return
+        if (playerUuid == null) return
 
-        val playerUuid = runCatching { UUID.fromString(entry.uuid) }.getOrNull() ?: return
-
-        // Resolve the guild the player belonged to at punishment time.
-        val guild = guildService.getPlayerGuilds(playerUuid).firstOrNull() ?: return
+        // Resolve the guild the player belonged to at punishment time. For a
+        // live event that's "now" — resolve via membership-history stints first
+        // (deterministic, matches the backfill), falling back to current guilds.
+        val guildId = resolveGuildAtTime(playerUuid, Instant.ofEpochMilli(entry.dateStart))
+            ?: return
 
         strikeService.recordStrike(
-            guildId = guild.id,
+            guildId = guildId,
             playerUuid = playerUuid,
-            playerName = Bukkit.getOfflinePlayer(playerUuid).name,
+            playerName = playerName,
             punishmentType = type,
             reason = entry.reason,
             executorName = entry.executorName,
             issuedAt = Instant.ofEpochMilli(entry.dateStart),
             litebansEntryId = entry.id.takeIf { it > 0 }
         )
+    }
+
+    /**
+     * The guild the player belonged to at [at]: the membership-history stint
+     * covering that moment (same resolution the backfill uses), falling back to
+     * the player's current guild — sorted by id for determinism if a player is
+     * somehow in several.
+     */
+    private fun resolveGuildAtTime(playerUuid: UUID, at: Instant): UUID? {
+        val stints = runCatching { membershipHistoryRepository.getByPlayer(playerUuid) }
+            .getOrElse { emptyList() }
+        stints.firstOrNull { stint ->
+            !stint.joinedAt.isAfter(at) && (stint.departedAt == null || stint.departedAt!!.isAfter(at))
+        }?.let { return it.guildId }
+        return guildService.getPlayerGuilds(playerUuid).sortedBy { it.id }.firstOrNull()?.id
     }
 }

--- a/src/main/kotlin/net/lumalyte/lg/infrastructure/litebans/LiteBansStrikeListener.kt
+++ b/src/main/kotlin/net/lumalyte/lg/infrastructure/litebans/LiteBansStrikeListener.kt
@@ -3,7 +3,7 @@ package net.lumalyte.lg.infrastructure.litebans
 import litebans.api.Database
 import litebans.api.Entry
 import litebans.api.Events
-import litebans.api.`Events$Listener`
+import litebans.api.Events.Listener
 import net.lumalyte.lg.application.persistence.MembershipHistoryRepository
 import net.lumalyte.lg.application.services.GuildService
 import net.lumalyte.lg.application.services.StrikeService
@@ -22,10 +22,6 @@ import java.util.UUID
  * public view keeps showing it but flagged as lifted.
  *
  * Only registered when the LiteBans plugin is present at runtime (softdepend).
- *
- * Note: the LiteBans 2.x `Events$Listener` class file ships without an
- * InnerClasses attribute, so Kotlin sees it as a top-level class and it must
- * be referenced with the backtick-quoted name.
  */
 class LiteBansStrikeListener(
     private val plugin: JavaPlugin,
@@ -33,7 +29,7 @@ class LiteBansStrikeListener(
     private val strikeService: StrikeService,
     private val membershipHistoryRepository: MembershipHistoryRepository,
     private val configProvider: () -> StrikesConfig,
-) : `Events$Listener`() {
+) : Listener() {
 
     private val countedTypes: Set<String>
         get() = configProvider().countedTypes.map { it.uppercase() }.toSet()

--- a/src/main/kotlin/net/lumalyte/lg/infrastructure/litebans/LiteBansStrikeListener.kt
+++ b/src/main/kotlin/net/lumalyte/lg/infrastructure/litebans/LiteBansStrikeListener.kt
@@ -1,0 +1,77 @@
+package net.lumalyte.lg.infrastructure.litebans
+
+import litebans.api.Entry
+import litebans.api.Events
+import litebans.api.`Events$Listener`
+import net.lumalyte.lg.application.services.GuildService
+import net.lumalyte.lg.application.services.StrikeService
+import net.lumalyte.lg.config.StrikesConfig
+import org.bukkit.Bukkit
+import org.bukkit.plugin.java.JavaPlugin
+import java.time.Instant
+import java.util.UUID
+
+/**
+ * Bridges LiteBans punishment events into Guild Strikes.
+ *
+ * When a punishment is issued ([entryAdded]) the punished player's guild at
+ * that moment is resolved and a strike is recorded against it. When a
+ * punishment is removed ([entryRemoved]) the strike is marked inactive — the
+ * public view keeps showing it but flagged as lifted.
+ *
+ * Only registered when the LiteBans plugin is present at runtime (softdepend).
+ *
+ * Note: the LiteBans 2.x `Events$Listener` class file ships without an
+ * InnerClasses attribute, so Kotlin sees it as a top-level class and it must
+ * be referenced with the backtick-quoted name.
+ */
+class LiteBansStrikeListener(
+    private val plugin: JavaPlugin,
+    private val guildService: GuildService,
+    private val strikeService: StrikeService,
+    private val configProvider: () -> StrikesConfig,
+) : `Events$Listener`() {
+
+    private val countedTypes: Set<String>
+        get() = configProvider().countedTypes.map { it.uppercase() }.toSet()
+
+    override fun entryAdded(entry: Entry) {
+        if (!configProvider().enabled) return
+        // LiteBans can fire this on its own threads; hop to the main thread
+        // before touching Bukkit/GuildService state.
+        Bukkit.getScheduler().runTask(plugin, Runnable {
+            handleEntryAdded(entry)
+        })
+    }
+
+    override fun entryRemoved(entry: Entry) {
+        if (!configProvider().enabled) return
+        val entryId = entry.id
+        if (entryId <= 0) return
+        // Same thread policy as entryAdded: LiteBans may fire on its own threads.
+        Bukkit.getScheduler().runTask(plugin, Runnable {
+            strikeService.deactivateStrike(entryId)
+        })
+    }
+
+    private fun handleEntryAdded(entry: Entry) {
+        val type = entry.type?.uppercase() ?: return
+        if (type !in countedTypes) return
+
+        val playerUuid = runCatching { UUID.fromString(entry.uuid) }.getOrNull() ?: return
+
+        // Resolve the guild the player belonged to at punishment time.
+        val guild = guildService.getPlayerGuilds(playerUuid).firstOrNull() ?: return
+
+        strikeService.recordStrike(
+            guildId = guild.id,
+            playerUuid = playerUuid,
+            playerName = Bukkit.getOfflinePlayer(playerUuid).name,
+            punishmentType = type,
+            reason = entry.reason,
+            executorName = entry.executorName,
+            issuedAt = Instant.ofEpochMilli(entry.dateStart),
+            litebansEntryId = entry.id.takeIf { it > 0 }
+        )
+    }
+}

--- a/src/main/kotlin/net/lumalyte/lg/infrastructure/litebans/StrikeBackfillService.kt
+++ b/src/main/kotlin/net/lumalyte/lg/infrastructure/litebans/StrikeBackfillService.kt
@@ -48,8 +48,9 @@ class StrikeBackfillService(
      */
     fun run(): BackfillResult {
         val config = configProvider()
-        if (!config.enabled || !config.countedTypes.any { it in BACKFILL_QUERIES }) {
-            logger.info("Strike backfill skipped (disabled or no counted types).")
+        val countedTypes = config.countedTypes.map { it.uppercase() }
+        if (!config.enabled || !config.backfill.enabled || countedTypes.none { it in BACKFILL_QUERIES }) {
+            logger.info("Strike backfill skipped (disabled, backfill off, or no counted types).")
             return BackfillResult(0, 0, 0, 0)
         }
 
@@ -64,19 +65,27 @@ class StrikeBackfillService(
         val historyCache = mutableMapOf<UUID, List<net.lumalyte.lg.domain.entities.MembershipHistory>>()
 
         for ((type, table) in BACKFILL_QUERIES) {
-            if (type !in config.countedTypes) continue
+            if (type !in countedTypes) continue
 
             try {
-                Database.get().prepareStatement("SELECT id, uuid, reason, banned_by_name, time, until FROM $table").use { stmt ->
+                // `until` + `removed_by_date` let us express already-lifted
+                // punishments as inactive strikes from the moment of insertion.
+                // NB: litebans_kicks has no removed_by_date column (kicks are
+                // instantaneous and never "removed"), so the column list is
+                // per-table.
+                val removedByDateColumn = if (tableHasRemovedByDate(table)) ", removed_by_date" else ""
+                Database.get().prepareStatement(
+                    "SELECT id, uuid, reason, banned_by_name, time, until$removedByDateColumn FROM $table"
+                ).use { stmt ->
                     stmt.executeQuery().use { rs ->
                         while (rs.next()) {
+                            scanned++
                             val playerUuid = rs.getUuid("uuid")
                             val entryId = rs.getLong("id")
                             if (playerUuid == null || entryId <= 0) {
                                 continue
                             }
 
-                            scanned++
                             val punishmentTime = Instant.ofEpochMilli(rs.getLong("time"))
 
                             val guildId = resolveGuildAtTime(
@@ -95,7 +104,19 @@ class StrikeBackfillService(
                                 Database.get().getPlayerName(playerUuid)
                             }
 
-                            strikeService.recordStrike(
+                            val now = System.currentTimeMillis()
+                            val until = rs.getLong("until")
+                            val removedByDate = if (tableHasRemovedByDate(table)) {
+                                rs.getTimestamp("removed_by_date")
+                            } else {
+                                null
+                            }
+                            // A punishment is still in force when it hasn't been removed
+                            // and (permanent OR its expiry hasn't passed).
+                            val active = removedByDate == null &&
+                                (until <= 0 || until > now)
+
+                            val inserted = strikeService.recordStrike(
                                 guildId = guildId,
                                 playerUuid = playerUuid,
                                 playerName = playerName,
@@ -104,8 +125,9 @@ class StrikeBackfillService(
                                 executorName = rs.getString("banned_by_name"),
                                 issuedAt = punishmentTime,
                                 litebansEntryId = entryId,
+                                active = active,
                             )
-                            recorded++
+                            if (inserted) recorded++
                         }
                     }
                 }
@@ -162,5 +184,15 @@ class StrikeBackfillService(
             "MUTE" to "litebans_mutes",
             "BAN" to "litebans_bans",
         )
+
+        /** Tables carrying a `removed_by_date` column (kicks don't). */
+        private val TABLES_WITH_REMOVED_BY_DATE = setOf(
+            "litebans_warnings",
+            "litebans_mutes",
+            "litebans_bans",
+        )
+
+        private fun tableHasRemovedByDate(table: String): Boolean =
+            table in TABLES_WITH_REMOVED_BY_DATE
     }
 }

--- a/src/main/kotlin/net/lumalyte/lg/infrastructure/litebans/StrikeBackfillService.kt
+++ b/src/main/kotlin/net/lumalyte/lg/infrastructure/litebans/StrikeBackfillService.kt
@@ -1,0 +1,166 @@
+package net.lumalyte.lg.infrastructure.litebans
+
+import litebans.api.Database
+import net.lumalyte.lg.application.persistence.MembershipHistoryRepository
+import net.lumalyte.lg.application.services.GuildService
+import net.lumalyte.lg.application.services.StrikeService
+import net.lumalyte.lg.config.StrikesConfig
+import org.slf4j.LoggerFactory
+import java.sql.ResultSet
+import java.time.Instant
+import java.util.UUID
+
+/**
+ * One-shot backfill: imports pre-existing LiteBans punishments into the
+ * strike ledger on startup.
+ *
+ * Attribution rule (matches the live listener): a punishment is attributed to
+ * the guild the player was a member of AT THE TIME of the punishment, proven
+ * via membership history stints. When no stint covers the punishment time
+ * (history tracking predates the punishment), optionally falls back to the
+ * player's current guild so old data still contributes to the "most
+ * troublesome guild" ranking.
+ *
+ * Idempotent: every insert is deduped by LiteBans entry id, so re-runs (or a
+ * backfill racing the live listener) cannot double-count.
+ */
+class StrikeBackfillService(
+    private val strikeService: StrikeService,
+    private val membershipHistoryRepository: MembershipHistoryRepository,
+    private val guildService: GuildService,
+    private val configProvider: () -> StrikesConfig,
+) {
+
+    private val logger = LoggerFactory.getLogger(javaClass)
+
+    /** Result summary of a backfill run. */
+    data class BackfillResult(
+        val scanned: Int,
+        val attributed: Int,
+        val skippedUnattributable: Int,
+        val recorded: Int,
+    )
+
+    /**
+     * Runs the backfill synchronously (caller decides threading). Reads from
+     * LiteBans' own connection via [Database.prepareStatement] — no external
+     * DB credentials required.
+     */
+    fun run(): BackfillResult {
+        val config = configProvider()
+        if (!config.enabled || !config.countedTypes.any { it in BACKFILL_QUERIES }) {
+            logger.info("Strike backfill skipped (disabled or no counted types).")
+            return BackfillResult(0, 0, 0, 0)
+        }
+
+        var scanned = 0
+        var attributed = 0
+        var skippedUnattributable = 0
+        var recorded = 0
+
+        // Player-name cache to avoid hammering LiteBans per row.
+        val nameCache = mutableMapOf<UUID, String?>()
+        // Per-player history cache (stints are stable during a backfill run).
+        val historyCache = mutableMapOf<UUID, List<net.lumalyte.lg.domain.entities.MembershipHistory>>()
+
+        for ((type, table) in BACKFILL_QUERIES) {
+            if (type !in config.countedTypes) continue
+
+            try {
+                Database.get().prepareStatement("SELECT id, uuid, reason, banned_by_name, time, until FROM $table").use { stmt ->
+                    stmt.executeQuery().use { rs ->
+                        while (rs.next()) {
+                            val playerUuid = rs.getUuid("uuid")
+                            val entryId = rs.getLong("id")
+                            if (playerUuid == null || entryId <= 0) {
+                                continue
+                            }
+
+                            scanned++
+                            val punishmentTime = Instant.ofEpochMilli(rs.getLong("time"))
+
+                            val guildId = resolveGuildAtTime(
+                                playerUuid,
+                                punishmentTime,
+                                config,
+                                historyCache,
+                            )
+                            if (guildId == null) {
+                                skippedUnattributable++
+                                continue
+                            }
+
+                            attributed++
+                            val playerName = nameCache.getOrPut(playerUuid) {
+                                Database.get().getPlayerName(playerUuid)
+                            }
+
+                            strikeService.recordStrike(
+                                guildId = guildId,
+                                playerUuid = playerUuid,
+                                playerName = playerName,
+                                punishmentType = type,
+                                reason = rs.getString("reason"),
+                                executorName = rs.getString("banned_by_name"),
+                                issuedAt = punishmentTime,
+                                litebansEntryId = entryId,
+                            )
+                            recorded++
+                        }
+                    }
+                }
+            } catch (e: Exception) {
+                // One table failing (e.g. renamed table) shouldn't kill the whole backfill.
+                logger.warn("Strike backfill: failed reading $table: {}", e.message)
+            }
+        }
+
+        logger.info(
+            "Strike backfill complete: scanned={}, attributed={}, unattributable={}, recorded={}",
+            scanned, attributed, skippedUnattributable, recorded,
+        )
+        return BackfillResult(scanned, attributed, skippedUnattributable, recorded)
+    }
+
+    /**
+     * Resolves the guild the player belonged to at [at], using membership
+     * history stints. Falls back to the player's current guild if configured
+     * and no stint proves membership.
+     */
+    private fun resolveGuildAtTime(
+        playerUuid: UUID,
+        at: Instant,
+        config: StrikesConfig,
+        historyCache: MutableMap<UUID, List<net.lumalyte.lg.domain.entities.MembershipHistory>>,
+    ): UUID? {
+        val stints = historyCache.getOrPut(playerUuid) {
+            runCatching { membershipHistoryRepository.getByPlayer(playerUuid) }.getOrElse { emptyList() }
+        }
+        // A stint covers `at` when joinedAt <= at AND (departedAt == null OR departedAt > at).
+        val stintGuild = stints.firstOrNull { stint ->
+            !stint.joinedAt.isAfter(at) && (stint.departedAt == null || stint.departedAt!!.isAfter(at))
+        }?.guildId
+
+        if (stintGuild != null) return stintGuild
+        if (!config.backfill.fallbackToCurrentGuild) return null
+
+        // Fallback: the player's current guild (best effort for old data).
+        return runCatching {
+            guildService.getPlayerGuilds(playerUuid).firstOrNull()?.id
+        }.getOrNull()
+    }
+
+    private fun ResultSet.getUuid(column: String): UUID? {
+        return runCatching { UUID.fromString(getString(column)) }.getOrNull()
+    }
+
+    companion object {
+        /** Punishment type -> LiteBans table name. Keys must match countedTypes values. */
+        val BACKFILL_QUERIES: Map<String, String> = linkedMapOf(
+            "WARN" to "litebans_warnings",
+            "KICK" to "litebans_kicks",
+            "MUTE" to "litebans_mutes",
+            "BAN" to "litebans_bans",
+        )
+    }
+}

--- a/src/main/kotlin/net/lumalyte/lg/infrastructure/persistence/guilds/PenaltyRepositorySQLite.kt
+++ b/src/main/kotlin/net/lumalyte/lg/infrastructure/persistence/guilds/PenaltyRepositorySQLite.kt
@@ -119,11 +119,13 @@ class PenaltyRepositorySQLite(
 
     private fun co.aikar.idb.DbRow.toPenalty(): GuildPenalty? {
         return runCatching {
+            val typeName = getString("penalty_type") ?: return@runCatching null
+            val type = PenaltyType.entries.firstOrNull { it.name == typeName }
+                ?: return@runCatching null
             GuildPenalty(
                 id = getLong("id") ?: 0L,
                 guildId = UUID.fromString(getString("guild_id")),
-                type = PenaltyType.entries.firstOrNull { it.name == getString("penalty_type") }
-                    ?: PenaltyType.DISBAND,
+                type = type,
                 amount = getLong("amount"),
                 reason = getString("reason"),
                 actorUuid = UUID.fromString(getString("actor_uuid")),

--- a/src/main/kotlin/net/lumalyte/lg/infrastructure/persistence/guilds/PenaltyRepositorySQLite.kt
+++ b/src/main/kotlin/net/lumalyte/lg/infrastructure/persistence/guilds/PenaltyRepositorySQLite.kt
@@ -1,0 +1,138 @@
+package net.lumalyte.lg.infrastructure.persistence.guilds
+
+import co.aikar.idb.Database
+import net.lumalyte.lg.application.persistence.PenaltyRepository
+import net.lumalyte.lg.domain.entities.GuildPenalty
+import net.lumalyte.lg.domain.entities.PenaltyType
+import net.lumalyte.lg.infrastructure.persistence.storage.Storage
+import org.slf4j.LoggerFactory
+import java.sql.SQLException
+import java.time.Instant
+import java.util.UUID
+
+/**
+ * SQLite/MariaDB implementation of [PenaltyRepository]. Portable SQL only —
+ * works on both backends.
+ */
+class PenaltyRepositorySQLite(
+    private val storage: Storage<Database>
+) : PenaltyRepository {
+
+    private val logger = LoggerFactory.getLogger(javaClass)
+
+    init {
+        createTable()
+    }
+
+    private fun createTable() {
+        val sql = """
+            CREATE TABLE IF NOT EXISTS guild_penalties (
+                id INTEGER PRIMARY KEY AUTOINCREMENT,
+                guild_id TEXT NOT NULL,
+                penalty_type TEXT NOT NULL,
+                amount INTEGER,
+                reason TEXT,
+                actor_uuid TEXT NOT NULL,
+                actor_name TEXT,
+                created_at INTEGER NOT NULL
+            )
+        """.trimIndent()
+
+        val guildIndexSql = "CREATE INDEX IF NOT EXISTS idx_guild_penalties_guild ON guild_penalties(guild_id)"
+
+        try {
+            storage.connection.executeUpdate(sql)
+            storage.connection.executeUpdate(guildIndexSql)
+        } catch (e: SQLException) {
+            logger.error("Failed to create guild_penalties table", e)
+        }
+    }
+
+    override fun recordPenalty(penalty: GuildPenalty): Boolean {
+        val sql = """
+            INSERT INTO guild_penalties (guild_id, penalty_type, amount, reason, actor_uuid, actor_name, created_at)
+            VALUES (?, ?, ?, ?, ?, ?, ?)
+        """.trimIndent()
+        return try {
+            storage.connection.executeUpdate(
+                sql,
+                penalty.guildId.toString(),
+                penalty.type.name,
+                penalty.amount,
+                penalty.reason,
+                penalty.actorUuid.toString(),
+                penalty.actorName,
+                penalty.createdAt.toEpochMilli()
+            ) > 0
+        } catch (e: SQLException) {
+            logger.error("Failed to record penalty for guild {}", penalty.guildId, e)
+            false
+        }
+    }
+
+    override fun getByGuild(guildId: UUID): List<GuildPenalty> {
+        val sql = """
+            SELECT id, guild_id, penalty_type, amount, reason, actor_uuid, actor_name, created_at
+            FROM guild_penalties
+            WHERE guild_id = ?
+            ORDER BY created_at DESC
+        """.trimIndent()
+        return try {
+            storage.connection.getResults(sql, guildId.toString()).mapNotNull { it.toPenalty() }
+        } catch (e: SQLException) {
+            logger.error("Failed to load penalties for guild {}", guildId, e)
+            emptyList()
+        }
+    }
+
+    override fun hasActiveMute(guildId: UUID, now: Instant): Boolean {
+        val sql = """
+            SELECT 1 AS found FROM guild_penalties
+            WHERE guild_id = ? AND penalty_type = 'GUILD_MUTE'
+              AND amount IS NOT NULL AND amount > 0
+              AND (created_at + amount) > ?
+            LIMIT 1
+        """.trimIndent()
+        return try {
+            storage.connection.getResults(sql, guildId.toString(), now.toEpochMilli()).isNotEmpty()
+        } catch (e: SQLException) {
+            logger.error("Failed to check active mute for guild {}", guildId, e)
+            false
+        }
+    }
+
+    override fun getLatest(guildId: UUID): GuildPenalty? {
+        val sql = """
+            SELECT id, guild_id, penalty_type, amount, reason, actor_uuid, actor_name, created_at
+            FROM guild_penalties
+            WHERE guild_id = ?
+            ORDER BY created_at DESC
+            LIMIT 1
+        """.trimIndent()
+        return try {
+            storage.connection.getResults(sql, guildId.toString()).firstOrNull()?.toPenalty()
+        } catch (e: SQLException) {
+            logger.error("Failed to load latest penalty for guild {}", guildId, e)
+            null
+        }
+    }
+
+    private fun co.aikar.idb.DbRow.toPenalty(): GuildPenalty? {
+        return runCatching {
+            GuildPenalty(
+                id = getLong("id") ?: 0L,
+                guildId = UUID.fromString(getString("guild_id")),
+                type = PenaltyType.entries.firstOrNull { it.name == getString("penalty_type") }
+                    ?: PenaltyType.DISBAND,
+                amount = getLong("amount"),
+                reason = getString("reason"),
+                actorUuid = UUID.fromString(getString("actor_uuid")),
+                actorName = getString("actor_name") ?: "Unknown",
+                createdAt = Instant.ofEpochMilli(getLong("created_at") ?: 0L)
+            )
+        }.getOrElse { e ->
+            logger.warn("Skipping malformed penalty row: {}", e.message)
+            null
+        }
+    }
+}

--- a/src/main/kotlin/net/lumalyte/lg/infrastructure/persistence/guilds/StrikeRepositorySQLite.kt
+++ b/src/main/kotlin/net/lumalyte/lg/infrastructure/persistence/guilds/StrikeRepositorySQLite.kt
@@ -1,0 +1,186 @@
+package net.lumalyte.lg.infrastructure.persistence.guilds
+
+import co.aikar.idb.Database
+import net.lumalyte.lg.application.errors.DatabaseOperationException
+import net.lumalyte.lg.application.persistence.StrikeRepository
+import net.lumalyte.lg.domain.entities.GuildStrike
+import net.lumalyte.lg.infrastructure.persistence.storage.Storage
+import org.slf4j.LoggerFactory
+import java.sql.SQLException
+import java.time.Instant
+import java.util.UUID
+
+/**
+ * SQLite/MariaDB implementation of [StrikeRepository].
+ *
+ * Works against both backends — the SQL used here is portable (no SQLite-only
+ * syntax like INSERT OR IGNORE / ON CONFLICT). Dedupe is done by checking the
+ * LiteBans entry id before inserting.
+ */
+class StrikeRepositorySQLite(
+    private val storage: Storage<Database>
+) : StrikeRepository {
+
+    private val logger = LoggerFactory.getLogger(javaClass)
+
+    init {
+        createTable()
+    }
+
+    private fun createTable() {
+        val sql = """
+            CREATE TABLE IF NOT EXISTS guild_strikes (
+                id INTEGER PRIMARY KEY AUTOINCREMENT,
+                guild_id TEXT NOT NULL,
+                player_uuid TEXT NOT NULL,
+                player_name TEXT,
+                punishment_type TEXT NOT NULL,
+                reason TEXT,
+                executor_name TEXT,
+                issued_at INTEGER NOT NULL,
+                litebans_entry_id INTEGER,
+                active INTEGER NOT NULL DEFAULT 1
+            )
+        """.trimIndent()
+
+        val guildIndexSql = "CREATE INDEX IF NOT EXISTS idx_guild_strikes_guild ON guild_strikes(guild_id)"
+        val entryIndexSql = "CREATE INDEX IF NOT EXISTS idx_guild_strikes_entry ON guild_strikes(litebans_entry_id)"
+
+        try {
+            storage.connection.executeUpdate(sql)
+            storage.connection.executeUpdate(guildIndexSql)
+            storage.connection.executeUpdate(entryIndexSql)
+        } catch (e: SQLException) {
+            logger.error("Failed to create guild_strikes table", e)
+        }
+    }
+
+    override fun recordStrike(strike: GuildStrike): Boolean {
+        // Dedupe: LiteBans can re-fire entryAdded for the same punishment
+        // (cross-server sync, reloads). Only insert if not already recorded.
+        val entryId = strike.litebansEntryId
+        if (entryId != null && existsByEntryId(entryId)) {
+            return false
+        }
+
+        val sql = """
+            INSERT INTO guild_strikes (guild_id, player_uuid, player_name, punishment_type,
+                                       reason, executor_name, issued_at, litebans_entry_id, active)
+            VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
+        """.trimIndent()
+
+        return try {
+            val rows = storage.connection.executeUpdate(
+                sql,
+                strike.guildId.toString(),
+                strike.playerUuid.toString(),
+                strike.playerName,
+                strike.punishmentType,
+                strike.reason,
+                strike.executorName,
+                strike.issuedAt.toEpochMilli(),
+                entryId,
+                if (strike.active) 1 else 0
+            )
+            rows > 0
+        } catch (e: SQLException) {
+            logger.error("Failed to record strike for guild {}", strike.guildId, e)
+            false
+        }
+    }
+
+    override fun deactivateStrike(litebansEntryId: Long): Boolean {
+        val sql = "UPDATE guild_strikes SET active = 0 WHERE litebans_entry_id = ?"
+        return try {
+            storage.connection.executeUpdate(sql, litebansEntryId) > 0
+        } catch (e: SQLException) {
+            logger.error("Failed to deactivate strike entry {}", litebansEntryId, e)
+            false
+        }
+    }
+
+    override fun countByGuild(guildId: UUID): Int {
+        val sql = "SELECT COUNT(*) AS cnt FROM guild_strikes WHERE guild_id = ?"
+        return try {
+            val results = storage.connection.getResults(sql, guildId.toString())
+            results.firstOrNull()?.getInt("cnt") ?: 0
+        } catch (e: SQLException) {
+            logger.error("Failed to count strikes for guild {}", guildId, e)
+            0
+        }
+    }
+
+    override fun getByGuild(guildId: UUID): List<GuildStrike> {
+        val sql = """
+            SELECT id, guild_id, player_uuid, player_name, punishment_type, reason,
+                   executor_name, issued_at, litebans_entry_id, active
+            FROM guild_strikes
+            WHERE guild_id = ?
+            ORDER BY issued_at DESC
+        """.trimIndent()
+        return try {
+            storage.connection.getResults(sql, guildId.toString()).mapNotNull { it.toStrike() }
+        } catch (e: SQLException) {
+            logger.error("Failed to load strikes for guild {}", guildId, e)
+            emptyList()
+        }
+    }
+
+    override fun getAllCounts(): Map<UUID, Int> {
+        val sql = """
+            SELECT guild_id, COUNT(*) AS cnt
+            FROM guild_strikes
+            GROUP BY guild_id
+            ORDER BY cnt DESC
+        """.trimIndent()
+        return try {
+            storage.connection.getResults(sql).mapNotNull { row ->
+                val guildId = runCatching { UUID.fromString(row.getString("guild_id")) }.getOrNull() ?: return@mapNotNull null
+                guildId to row.getInt("cnt")
+            }.toMap()
+        } catch (e: SQLException) {
+            logger.error("Failed to load all strike counts", e)
+            emptyMap()
+        }
+    }
+
+    override fun countAll(): Int {
+        val sql = "SELECT COUNT(*) AS cnt FROM guild_strikes"
+        return try {
+            storage.connection.getResults(sql).firstOrNull()?.getInt("cnt") ?: 0
+        } catch (e: SQLException) {
+            logger.error("Failed to count all strikes", e)
+            0
+        }
+    }
+
+    private fun existsByEntryId(entryId: Long): Boolean {
+        val sql = "SELECT 1 AS found FROM guild_strikes WHERE litebans_entry_id = ? LIMIT 1"
+        return try {
+            storage.connection.getResults(sql, entryId).isNotEmpty()
+        } catch (e: SQLException) {
+            logger.error("Failed to check strike entry {}", entryId, e)
+            false
+        }
+    }
+
+    private fun co.aikar.idb.DbRow.toStrike(): GuildStrike? {
+        return runCatching {
+            GuildStrike(
+                id = getLong("id") ?: 0L,
+                guildId = UUID.fromString(getString("guild_id")),
+                playerUuid = UUID.fromString(getString("player_uuid")),
+                playerName = getString("player_name"),
+                punishmentType = getString("punishment_type"),
+                reason = getString("reason"),
+                executorName = getString("executor_name"),
+                issuedAt = Instant.ofEpochMilli(getLong("issued_at") ?: 0L),
+                litebansEntryId = getLong("litebans_entry_id"),
+                active = (getInt("active") ?: 1) == 1
+            )
+        }.getOrElse { e ->
+            logger.warn("Skipping malformed strike row: {}", e.message)
+            null
+        }
+    }
+}

--- a/src/main/kotlin/net/lumalyte/lg/infrastructure/persistence/guilds/StrikeRepositorySQLite.kt
+++ b/src/main/kotlin/net/lumalyte/lg/infrastructure/persistence/guilds/StrikeRepositorySQLite.kt
@@ -14,8 +14,14 @@ import java.util.UUID
  * SQLite/MariaDB implementation of [StrikeRepository].
  *
  * Works against both backends — the SQL used here is portable (no SQLite-only
- * syntax like INSERT OR IGNORE / ON CONFLICT). Dedupe is done by checking the
- * LiteBans entry id before inserting.
+ * syntax like INSERT OR IGNORE / ON CONFLICT). Dedupe is enforced by the
+ * UNIQUE index on `litebans_entry_id` (created by migration v24) plus a
+ * pre-insert existence check, so a race between the backfill and the live
+ * listener can never double-record the same punishment.
+ *
+ * The table itself is owned by migration v24 (both backends) — this class no
+ * longer creates it at construction, because the old SQLite-only `AUTOINCREMENT`
+ * DDL broke MariaDB startup.
  */
 class StrikeRepositorySQLite(
     private val storage: Storage<Database>
@@ -23,43 +29,13 @@ class StrikeRepositorySQLite(
 
     private val logger = LoggerFactory.getLogger(javaClass)
 
-    init {
-        createTable()
-    }
-
-    private fun createTable() {
-        val sql = """
-            CREATE TABLE IF NOT EXISTS guild_strikes (
-                id INTEGER PRIMARY KEY AUTOINCREMENT,
-                guild_id TEXT NOT NULL,
-                player_uuid TEXT NOT NULL,
-                player_name TEXT,
-                punishment_type TEXT NOT NULL,
-                reason TEXT,
-                executor_name TEXT,
-                issued_at INTEGER NOT NULL,
-                litebans_entry_id INTEGER,
-                active INTEGER NOT NULL DEFAULT 1
-            )
-        """.trimIndent()
-
-        val guildIndexSql = "CREATE INDEX IF NOT EXISTS idx_guild_strikes_guild ON guild_strikes(guild_id)"
-        val entryIndexSql = "CREATE INDEX IF NOT EXISTS idx_guild_strikes_entry ON guild_strikes(litebans_entry_id)"
-
-        try {
-            storage.connection.executeUpdate(sql)
-            storage.connection.executeUpdate(guildIndexSql)
-            storage.connection.executeUpdate(entryIndexSql)
-        } catch (e: SQLException) {
-            logger.error("Failed to create guild_strikes table", e)
-        }
-    }
-
     override fun recordStrike(strike: GuildStrike): Boolean {
         // Dedupe: LiteBans can re-fire entryAdded for the same punishment
         // (cross-server sync, reloads). Only insert if not already recorded.
+        // Keyed on (type, entryId) — LiteBans ids are per-table sequences, so
+        // the type disambiguates rows from different punishment tables.
         val entryId = strike.litebansEntryId
-        if (entryId != null && existsByEntryId(entryId)) {
+        if (entryId != null && existsByTypeAndEntryId(strike.punishmentType, entryId)) {
             return false
         }
 
@@ -84,17 +60,25 @@ class StrikeRepositorySQLite(
             )
             rows > 0
         } catch (e: SQLException) {
+            // UNIQUE constraint on litebans_entry_id — a concurrent insert won
+            // the race. Treat as a dedupe hit, not an error.
+            if (e.message.orEmpty().contains("UNIQUE", ignoreCase = true) ||
+                e.message.orEmpty().contains("duplicate", ignoreCase = true)
+            ) {
+                logger.debug("Strike for entry {} already recorded (dedupe hit)", entryId)
+                return false
+            }
             logger.error("Failed to record strike for guild {}", strike.guildId, e)
             false
         }
     }
 
-    override fun deactivateStrike(litebansEntryId: Long): Boolean {
-        val sql = "UPDATE guild_strikes SET active = 0 WHERE litebans_entry_id = ?"
+    override fun deactivateStrike(punishmentType: String, litebansEntryId: Long): Boolean {
+        val sql = "UPDATE guild_strikes SET active = 0 WHERE punishment_type = ? AND litebans_entry_id = ?"
         return try {
-            storage.connection.executeUpdate(sql, litebansEntryId) > 0
+            storage.connection.executeUpdate(sql, punishmentType, litebansEntryId) > 0
         } catch (e: SQLException) {
-            logger.error("Failed to deactivate strike entry {}", litebansEntryId, e)
+            logger.error("Failed to deactivate strike {} entry {}", punishmentType, litebansEntryId, e)
             false
         }
     }
@@ -106,6 +90,17 @@ class StrikeRepositorySQLite(
             results.firstOrNull()?.getInt("cnt") ?: 0
         } catch (e: SQLException) {
             logger.error("Failed to count strikes for guild {}", guildId, e)
+            0
+        }
+    }
+
+    override fun countActiveByGuild(guildId: UUID): Int {
+        val sql = "SELECT COUNT(*) AS cnt FROM guild_strikes WHERE guild_id = ? AND active = 1"
+        return try {
+            val results = storage.connection.getResults(sql, guildId.toString())
+            results.firstOrNull()?.getInt("cnt") ?: 0
+        } catch (e: SQLException) {
+            logger.error("Failed to count active strikes for guild {}", guildId, e)
             0
         }
     }
@@ -144,6 +139,25 @@ class StrikeRepositorySQLite(
         }
     }
 
+    override fun getAllActiveCounts(): Map<UUID, Int> {
+        val sql = """
+            SELECT guild_id, COUNT(*) AS cnt
+            FROM guild_strikes
+            WHERE active = 1
+            GROUP BY guild_id
+            ORDER BY cnt DESC
+        """.trimIndent()
+        return try {
+            storage.connection.getResults(sql).mapNotNull { row ->
+                val guildId = runCatching { UUID.fromString(row.getString("guild_id")) }.getOrNull() ?: return@mapNotNull null
+                guildId to row.getInt("cnt")
+            }.toMap()
+        } catch (e: SQLException) {
+            logger.error("Failed to load all active strike counts", e)
+            emptyMap()
+        }
+    }
+
     override fun countAll(): Int {
         val sql = "SELECT COUNT(*) AS cnt FROM guild_strikes"
         return try {
@@ -154,12 +168,12 @@ class StrikeRepositorySQLite(
         }
     }
 
-    private fun existsByEntryId(entryId: Long): Boolean {
-        val sql = "SELECT 1 AS found FROM guild_strikes WHERE litebans_entry_id = ? LIMIT 1"
+    private fun existsByTypeAndEntryId(punishmentType: String, entryId: Long): Boolean {
+        val sql = "SELECT 1 AS found FROM guild_strikes WHERE punishment_type = ? AND litebans_entry_id = ? LIMIT 1"
         return try {
-            storage.connection.getResults(sql, entryId).isNotEmpty()
+            storage.connection.getResults(sql, punishmentType, entryId).isNotEmpty()
         } catch (e: SQLException) {
-            logger.error("Failed to check strike entry {}", entryId, e)
+            logger.error("Failed to check strike {} entry {}", punishmentType, entryId, e)
             false
         }
     }

--- a/src/main/kotlin/net/lumalyte/lg/infrastructure/persistence/migrations/MariaDBMigrations.kt
+++ b/src/main/kotlin/net/lumalyte/lg/infrastructure/persistence/migrations/MariaDBMigrations.kt
@@ -41,6 +41,13 @@ class MariaDBMigrations(private val plugin: JavaPlugin, private val connection: 
                 updateDatabaseVersion(19)
                 currentDbVersion = 19
             }
+            // v20 (per-home access perms) was historically missing from the MariaDB
+            // chain — run it here so a v19/v22 MariaDB DB can't skip straight past it.
+            if (currentDbVersion < 20) {
+                migrateToVersion20()
+                updateDatabaseVersion(20)
+                currentDbVersion = 20
+            }
             if (currentDbVersion < 21) {
                 migrateToVersion21()
                 updateDatabaseVersion(21)
@@ -50,6 +57,13 @@ class MariaDBMigrations(private val plugin: JavaPlugin, private val connection: 
                 migrateToVersion22()
                 updateDatabaseVersion(BANNERMAN_MIGRATION_VERSION)
                 currentDbVersion = BANNERMAN_MIGRATION_VERSION
+            }
+            // v23 (unify guild balances into vault gold) was historically missing from
+            // the MariaDB chain — run it here so it can't be permanently skipped.
+            if (currentDbVersion < 23) {
+                migrateToVersion23()
+                updateDatabaseVersion(23)
+                currentDbVersion = 23
             }
             if (currentDbVersion < 24) {
                 migrateToVersion24()
@@ -624,6 +638,187 @@ class MariaDBMigrations(private val plugin: JavaPlugin, private val connection: 
     }
 
     /**
+     * Migration to version 20.
+     * Per-home access perms: adds `allowed_ranks` to guild_homes and
+     * `ally_home_allowed_guilds` to guilds, backfills both from existing data,
+     * and grants USE_ALLY_HOMES to all ranks. Ported from SQLiteMigrations v20
+     * (was historically missing from the MariaDB chain).
+     */
+    private fun migrateToVersion20() {
+        componentLogger.info(Component.text("Migrating to version 20: per-home access perms..."))
+
+        connection.createStatement().use { stmt ->
+            if (!columnExists("guild_homes", "allowed_ranks")) {
+                stmt.execute("ALTER TABLE guild_homes ADD COLUMN allowed_ranks TEXT")
+            }
+            if (!columnExists("guilds", "ally_home_allowed_guilds")) {
+                stmt.execute("ALTER TABLE guilds ADD COLUMN ally_home_allowed_guilds TEXT")
+            }
+        }
+
+        // Backfill allowed_ranks from the ranks table (GROUP_CONCAT is portable).
+        connection.prepareStatement(
+            "UPDATE guild_homes SET allowed_ranks = ? WHERE guild_id = ? AND allowed_ranks IS NULL",
+        ).use { ps ->
+            connection.createStatement().use { stmt ->
+                stmt.executeQuery(
+                    "SELECT r.guild_id, GROUP_CONCAT(r.id, ',') AS rank_csv " +
+                        "FROM ranks r " +
+                        "WHERE r.guild_id IN (SELECT DISTINCT guild_id FROM guild_homes WHERE allowed_ranks IS NULL) " +
+                        "GROUP BY r.guild_id",
+                ).use { rs ->
+                    while (rs.next()) {
+                        ps.setString(1, rs.getString("rank_csv") ?: "")
+                        ps.setString(2, rs.getString("guild_id"))
+                        ps.addBatch()
+                    }
+                }
+            }
+            ps.executeBatch()
+        }
+
+        // Backfill ally_home_allowed_guilds from active alliances. Guarded: an old
+        // MariaDB relations schema used guild_id/target_guild_id/relation_type
+        // instead of the runtime repo's guild_a/guild_b/type/status — skip the
+        // backfill (not schema-critical) rather than crash on a missing column.
+        val alliesByGuild = mutableMapOf<String, MutableSet<String>>()
+        if (columnExists("relations", "guild_a")) {
+            connection.createStatement().use { stmt ->
+                stmt.executeQuery(
+                    "SELECT guild_a, guild_b FROM relations WHERE type = 'ALLY' AND status = 'ACTIVE'",
+                ).use { rs ->
+                    while (rs.next()) {
+                        val a = rs.getString("guild_a")
+                        val b = rs.getString("guild_b")
+                        alliesByGuild.getOrPut(a) { mutableSetOf() }.add(b)
+                        alliesByGuild.getOrPut(b) { mutableSetOf() }.add(a)
+                    }
+                }
+            }
+        }
+        connection.prepareStatement(
+            "UPDATE guilds SET ally_home_allowed_guilds = ? WHERE id = ?",
+        ).use { ps ->
+            for ((gid, allies) in alliesByGuild) {
+                ps.setString(1, allies.joinToString(","))
+                ps.setString(2, gid)
+                ps.addBatch()
+            }
+            ps.executeBatch()
+        }
+
+        // Grant USE_ALLY_HOMES to every rank that doesn't have it yet.
+        connection.prepareStatement("UPDATE ranks SET permissions = ? WHERE id = ?").use { ps ->
+            connection.createStatement().use { stmt ->
+                stmt.executeQuery("SELECT id, permissions FROM ranks").use { rs ->
+                    while (rs.next()) {
+                        val id = rs.getString("id")
+                        val perms = rs.getString("permissions").orEmpty()
+                        val parts = perms.split(",").filter { it.isNotBlank() }.toMutableSet()
+                        if (parts.add("USE_ALLY_HOMES")) {
+                            ps.setString(1, parts.joinToString(","))
+                            ps.setString(2, id)
+                            ps.addBatch()
+                        }
+                    }
+                }
+            }
+            ps.executeBatch()
+        }
+        componentLogger.info(Component.text("✓ Migration v20 complete: per-home access perms"))
+    }
+
+    /**
+     * Migration to version 23.
+     * Unifies the three historical guild-balance stores into vault_gold as the
+     * single source of truth. MariaDB port of GuildBalanceConsolidator
+     * (which is SQLite-only due to `ON CONFLICT`/sqlite_master).
+     */
+    private fun migrateToVersion23() {
+        componentLogger.info(
+            Component.text("Migrating to version 23: consolidating guild balances into unified vault gold..."),
+        )
+
+        if (!tableExists("vault_gold") || !tableExists("guilds")) {
+            componentLogger.info(Component.text("  Skipping balance consolidation (required tables not present yet)"))
+            return
+        }
+
+        val now = System.currentTimeMillis()
+
+        // Store A: ledger sum per guild.
+        val ledger = HashMap<String, Int>()
+        if (tableExists("bank_transactions")) {
+            connection.createStatement().use { stmt ->
+                stmt.executeQuery(
+                    "SELECT guild_id, COALESCE(SUM(CASE WHEN type='DEPOSIT' THEN amount ELSE -amount - fee END), 0) AS bal " +
+                        "FROM bank_transactions GROUP BY guild_id",
+                ).use { rs ->
+                    while (rs.next()) ledger[rs.getString("guild_id")] = rs.getInt("bal")
+                }
+            }
+        }
+
+        // Store B: existing vault gold balances.
+        val vaultB = HashMap<String, Int>()
+        connection.createStatement().use { stmt ->
+            stmt.executeQuery("SELECT guild_id, balance FROM vault_gold").use { rs ->
+                while (rs.next()) vaultB[rs.getString("guild_id")] = rs.getInt("balance")
+            }
+        }
+
+        val folds = ArrayList<Triple<String, Int, Int>>() // (guildId, oldVault, newVault)
+        connection.createStatement().use { stmt ->
+            stmt.executeQuery("SELECT id, bank_balance FROM guilds").use { rs ->
+                while (rs.next()) {
+                    val id = rs.getString("id")
+                    val legacy = rs.getInt("bank_balance")
+                    val a = ledger[id] ?: 0
+                    val oldVault = vaultB[id] ?: 0
+                    val newVault = maxOf(0, oldVault + a + legacy)
+                    if (a != 0 || legacy != 0) folds.add(Triple(id, oldVault, newVault))
+                }
+            }
+        }
+
+        if (folds.isNotEmpty()) {
+            val upsert = "INSERT INTO vault_gold (guild_id, balance, last_modified) VALUES (?, ?, ?) " +
+                "ON DUPLICATE KEY UPDATE balance = VALUES(balance), last_modified = VALUES(last_modified)"
+            connection.prepareStatement(upsert).use { ps ->
+                for ((gid, _, newVault) in folds) {
+                    ps.setString(1, gid)
+                    ps.setInt(2, newVault)
+                    ps.setLong(3, now)
+                    ps.addBatch()
+                }
+                ps.executeBatch()
+            }
+        }
+
+        // Zero the legacy column so it can't be mistaken for a live balance.
+        val zeroed = connection.createStatement().use { st ->
+            st.executeUpdate("UPDATE guilds SET bank_balance = 0 WHERE bank_balance <> 0")
+        }
+        componentLogger.info(
+            Component.text("✓ Migration v23 complete: folded ${folds.size} guild balance(s), zeroed $zeroed legacy row(s)"),
+        )
+    }
+
+    private fun columnExists(table: String, column: String): Boolean {
+        return connection.prepareStatement(
+            """
+                SELECT COUNT(*)
+                FROM information_schema.columns
+                WHERE table_schema = DATABASE()
+                  AND table_name = '$table'
+                  AND column_name = '$column'
+            """.trimIndent(),
+        ).use { ps ->
+            ps.executeQuery().use { rs -> rs.next() && rs.getInt(1) > 0 }
+        }
+    }
+
+    /**
      * Migration to version 24.
      * Adds the guild_strikes table for the Guild Strikes feature (LiteBans
      * punishments attributed to guilds).
@@ -640,7 +835,7 @@ class MariaDBMigrations(private val plugin: JavaPlugin, private val connection: 
                     id BIGINT AUTO_INCREMENT PRIMARY KEY,
                     guild_id VARCHAR(36) NOT NULL,
                     player_uuid VARCHAR(36) NOT NULL,
-                    player_name VARCHAR(16),
+                    player_name VARCHAR(64),
                     punishment_type VARCHAR(16) NOT NULL,
                     reason VARCHAR(2048),
                     executor_name VARCHAR(128),
@@ -648,7 +843,7 @@ class MariaDBMigrations(private val plugin: JavaPlugin, private val connection: 
                     litebans_entry_id BIGINT,
                     active TINYINT(1) NOT NULL DEFAULT 1,
                     INDEX idx_guild_strikes_guild (guild_id),
-                    INDEX idx_guild_strikes_entry (litebans_entry_id)
+                    UNIQUE INDEX idx_guild_strikes_entry (punishment_type, litebans_entry_id)
                 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci
                 """.trimIndent(),
             )

--- a/src/main/kotlin/net/lumalyte/lg/infrastructure/persistence/migrations/MariaDBMigrations.kt
+++ b/src/main/kotlin/net/lumalyte/lg/infrastructure/persistence/migrations/MariaDBMigrations.kt
@@ -51,6 +51,16 @@ class MariaDBMigrations(private val plugin: JavaPlugin, private val connection: 
                 updateDatabaseVersion(BANNERMAN_MIGRATION_VERSION)
                 currentDbVersion = BANNERMAN_MIGRATION_VERSION
             }
+            if (currentDbVersion < 24) {
+                migrateToVersion24()
+                updateDatabaseVersion(24)
+                currentDbVersion = 24
+            }
+            if (currentDbVersion < 25) {
+                migrateToVersion25()
+                updateDatabaseVersion(25)
+                currentDbVersion = 25
+            }
 
             connection.commit()
 
@@ -611,5 +621,72 @@ class MariaDBMigrations(private val plugin: JavaPlugin, private val connection: 
                 ),
             )
         }
+    }
+
+    /**
+     * Migration to version 24.
+     * Adds the guild_strikes table for the Guild Strikes feature (LiteBans
+     * punishments attributed to guilds).
+     */
+    private fun migrateToVersion24() {
+        componentLogger.info(
+            Component.text("Migrating to version 24: adding guild_strikes table..."),
+        )
+
+        connection.createStatement().use { stmt ->
+            stmt.execute(
+                """
+                CREATE TABLE IF NOT EXISTS guild_strikes (
+                    id BIGINT AUTO_INCREMENT PRIMARY KEY,
+                    guild_id VARCHAR(36) NOT NULL,
+                    player_uuid VARCHAR(36) NOT NULL,
+                    player_name VARCHAR(16),
+                    punishment_type VARCHAR(16) NOT NULL,
+                    reason VARCHAR(2048),
+                    executor_name VARCHAR(128),
+                    issued_at BIGINT NOT NULL,
+                    litebans_entry_id BIGINT,
+                    active TINYINT(1) NOT NULL DEFAULT 1,
+                    INDEX idx_guild_strikes_guild (guild_id),
+                    INDEX idx_guild_strikes_entry (litebans_entry_id)
+                ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci
+                """.trimIndent(),
+            )
+        }
+        componentLogger.info(
+            Component.text("✓ Added guild_strikes table (migration v24)"),
+        )
+    }
+
+    /**
+     * Migration to version 25.
+     * Adds the guild_penalties table — the audit trail of admin-applied
+     * penalties (level reduction, EXP reduction, guild mute, disband).
+     */
+    private fun migrateToVersion25() {
+        componentLogger.info(
+            Component.text("Migrating to version 25: adding guild_penalties table..."),
+        )
+
+        connection.createStatement().use { stmt ->
+            stmt.execute(
+                """
+                CREATE TABLE IF NOT EXISTS guild_penalties (
+                    id BIGINT AUTO_INCREMENT PRIMARY KEY,
+                    guild_id VARCHAR(36) NOT NULL,
+                    penalty_type VARCHAR(32) NOT NULL,
+                    amount BIGINT,
+                    reason VARCHAR(2048),
+                    actor_uuid VARCHAR(36) NOT NULL,
+                    actor_name VARCHAR(128),
+                    created_at BIGINT NOT NULL,
+                    INDEX idx_guild_penalties_guild (guild_id)
+                ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci
+                """.trimIndent(),
+            )
+        }
+        componentLogger.info(
+            Component.text("✓ Added guild_penalties table (migration v25)"),
+        )
     }
 }

--- a/src/main/kotlin/net/lumalyte/lg/infrastructure/persistence/migrations/SQLiteMigrations.kt
+++ b/src/main/kotlin/net/lumalyte/lg/infrastructure/persistence/migrations/SQLiteMigrations.kt
@@ -1626,7 +1626,7 @@ class SQLiteMigrations(private val plugin: JavaPlugin, private val connection: C
             )
             """.trimIndent(),
             "CREATE INDEX IF NOT EXISTS idx_guild_strikes_guild ON guild_strikes(guild_id);",
-            "CREATE INDEX IF NOT EXISTS idx_guild_strikes_entry ON guild_strikes(litebans_entry_id);"
+            "CREATE UNIQUE INDEX IF NOT EXISTS idx_guild_strikes_entry ON guild_strikes(punishment_type, litebans_entry_id);"
         )
         executeMigrationCommands(sqlCommands)
         componentLogger.info(Component.text("✓ Migration v24 complete: guild_strikes table added"))

--- a/src/main/kotlin/net/lumalyte/lg/infrastructure/persistence/migrations/SQLiteMigrations.kt
+++ b/src/main/kotlin/net/lumalyte/lg/infrastructure/persistence/migrations/SQLiteMigrations.kt
@@ -134,6 +134,16 @@ class SQLiteMigrations(private val plugin: JavaPlugin, private val connection: C
                 updateDatabaseVersion(23)
                 dbVersion = 23
             }
+            if (dbVersion < 24) {
+                migrateToVersion24()
+                updateDatabaseVersion(24)
+                dbVersion = 24
+            }
+            if (dbVersion < 25) {
+                migrateToVersion25()
+                updateDatabaseVersion(25)
+                dbVersion = 25
+            }
 
             // Validate that all required tables exist, recreate if missing
             validateAndRepairSchema()
@@ -1309,7 +1319,8 @@ class SQLiteMigrations(private val plugin: JavaPlugin, private val connection: C
             "guilds", "guild_homes", "members", "relations", "parties", "party_requests",
             "player_party_preferences", "bank_tx", "kills",
             "audits", "wars", "leaderboards", "guild_invitations",
-            "vault_slots", "vault_gold", "vault_transaction_log"
+            "vault_slots", "vault_gold", "vault_transaction_log",
+            "guild_strikes", "guild_penalties"
         )
 
         // Add claim tables to required list if claims are enabled
@@ -1588,5 +1599,62 @@ class SQLiteMigrations(private val plugin: JavaPlugin, private val connection: C
     private fun migrateToVersion23() {
         componentLogger.info(Component.text("Migrating to version 23: consolidating guild balances into unified vault gold (store B)..."))
         GuildBalanceConsolidator.consolidate(connection, componentLogger)
+    }
+
+    /**
+     * Migration from version 23 to version 24.
+     * Adds the guild_strikes table for the Guild Strikes feature (LiteBans
+     * punishments attributed to guilds). The table is also self-created by
+     * StrikeRepositorySQLite on first use; this migration makes it explicit
+     * in the schema history for both SQLite and MariaDB deployments.
+     */
+    private fun migrateToVersion24() {
+        componentLogger.info(Component.text("Migrating to version 24: adding guild_strikes table..."))
+        val sqlCommands = mutableListOf(
+            """
+            CREATE TABLE IF NOT EXISTS guild_strikes (
+                id INTEGER PRIMARY KEY AUTOINCREMENT,
+                guild_id TEXT NOT NULL,
+                player_uuid TEXT NOT NULL,
+                player_name TEXT,
+                punishment_type TEXT NOT NULL,
+                reason TEXT,
+                executor_name TEXT,
+                issued_at INTEGER NOT NULL,
+                litebans_entry_id INTEGER,
+                active INTEGER NOT NULL DEFAULT 1
+            )
+            """.trimIndent(),
+            "CREATE INDEX IF NOT EXISTS idx_guild_strikes_guild ON guild_strikes(guild_id);",
+            "CREATE INDEX IF NOT EXISTS idx_guild_strikes_entry ON guild_strikes(litebans_entry_id);"
+        )
+        executeMigrationCommands(sqlCommands)
+        componentLogger.info(Component.text("✓ Migration v24 complete: guild_strikes table added"))
+    }
+
+    /**
+     * Migration from version 24 to version 25.
+     * Adds the guild_penalties table — the audit trail of admin-applied
+     * penalties (level reduction, EXP reduction, guild mute, disband).
+     */
+    private fun migrateToVersion25() {
+        componentLogger.info(Component.text("Migrating to version 25: adding guild_penalties table..."))
+        val sqlCommands = mutableListOf(
+            """
+            CREATE TABLE IF NOT EXISTS guild_penalties (
+                id INTEGER PRIMARY KEY AUTOINCREMENT,
+                guild_id TEXT NOT NULL,
+                penalty_type TEXT NOT NULL,
+                amount INTEGER,
+                reason TEXT,
+                actor_uuid TEXT NOT NULL,
+                actor_name TEXT,
+                created_at INTEGER NOT NULL
+            )
+            """.trimIndent(),
+            "CREATE INDEX IF NOT EXISTS idx_guild_penalties_guild ON guild_penalties(guild_id);"
+        )
+        executeMigrationCommands(sqlCommands)
+        componentLogger.info(Component.text("✓ Migration v25 complete: guild_penalties table added"))
     }
 }

--- a/src/main/kotlin/net/lumalyte/lg/infrastructure/persistence/migrations/SQLiteMigrations.kt
+++ b/src/main/kotlin/net/lumalyte/lg/infrastructure/persistence/migrations/SQLiteMigrations.kt
@@ -1360,6 +1360,14 @@ class SQLiteMigrations(private val plugin: JavaPlugin, private val connection: C
                 migrateToVersion19()
                 componentLogger.info(Component.text("✓ Recreated guild_homes table"))
             }
+            if ("guild_strikes" in missingTables) {
+                migrateToVersion24()
+                componentLogger.info(Component.text("✓ Recreated guild_strikes table"))
+            }
+            if ("guild_penalties" in missingTables) {
+                migrateToVersion25()
+                componentLogger.info(Component.text("✓ Recreated guild_penalties table"))
+            }
             // Recreate claim tables if missing (only checked when claims enabled)
             if (claimsEnabled && missingTables.any { it in listOf("claims", "claim_partitions", "claim_flags", "claim_permissions", "player_access") }) {
                 migrateToVersion2()

--- a/src/main/kotlin/net/lumalyte/lg/infrastructure/services/ConfigServiceBukkit.kt
+++ b/src/main/kotlin/net/lumalyte/lg/infrastructure/services/ConfigServiceBukkit.kt
@@ -31,7 +31,27 @@ class ConfigServiceBukkit(private val config: FileConfiguration): ConfigService 
             ui = loadUIConfig(),
             discord = loadDiscordConfig(),
             party = loadPartyConfig(),
-            webApi = loadWebApiConfig()
+            webApi = loadWebApiConfig(),
+            strikes = loadStrikesConfig()
+        )
+    }
+
+    private fun loadStrikesConfig(): StrikesConfig {
+        return StrikesConfig(
+            enabled = config.getBoolean("strikes.enabled", true),
+            threshold = config.getInt("strikes.threshold", 5),
+            countedTypes = config.getStringList("strikes.counted_types").ifEmpty {
+                listOf("WARN", "KICK", "MUTE", "BAN")
+            },
+            penalties = StrikesPenaltiesConfig(
+                levelReductionLevels = config.getInt("strikes.penalties.level_reduction.levels", 1),
+                expReductionAmount = config.getInt("strikes.penalties.exp_reduction.amount", 1000),
+                guildMuteDurationMillis = config.getLong("strikes.penalties.guild_mute.duration_ms", 24 * 3_600_000L)
+            ),
+            backfill = StrikesBackfillConfig(
+                enabled = config.getBoolean("strikes.backfill.enabled", true),
+                fallbackToCurrentGuild = config.getBoolean("strikes.backfill.fallback_to_current_guild", true)
+            )
         )
     }
 

--- a/src/main/kotlin/net/lumalyte/lg/infrastructure/services/ProgressionServiceBukkit.kt
+++ b/src/main/kotlin/net/lumalyte/lg/infrastructure/services/ProgressionServiceBukkit.kt
@@ -112,63 +112,81 @@ class ProgressionServiceBukkit(
     }
 
     override fun removeExperience(guildId: UUID, amount: Int, source: ExperienceSource): Int {
-        if (amount <= 0) return getLevelFromExperience(progressionRepository.getGuildProgression(guildId)?.totalExperience ?: 0)
-        val progression = progressionRepository.getGuildProgression(guildId)
-            ?: GuildProgression.create(guildId)
+        try {
+            if (amount <= 0) return getLevelFromExperience(progressionRepository.getGuildProgression(guildId)?.totalExperience ?: 0)
+            val progression = progressionRepository.getGuildProgression(guildId)
+                ?: GuildProgression.create(guildId)
 
-        val newTotalExperience = (progression.totalExperience - amount).coerceAtLeast(0)
-        val newLevel = getLevelFromExperience(newTotalExperience)
+            val newTotalExperience = (progression.totalExperience - amount).coerceAtLeast(0)
+            val newLevel = getLevelFromExperience(newTotalExperience)
 
-        val updatedProgression = progression.copy(
-            totalExperience = newTotalExperience,
-            currentLevel = newLevel,
-            experienceThisLevel = getExperienceInCurrentLevel(newTotalExperience),
-            experienceForNextLevel = getExperienceForNextLevel(newLevel),
-            lastUpdated = Instant.now()
-        )
-        progressionRepository.saveGuildProgression(updatedProgression)
-        progressionRepository.recordExperienceTransaction(
-            ExperienceTransaction(
-                guildId = guildId,
-                source = source,
-                amount = -amount,
-                description = "Strike penalty: removed $amount XP"
+            val updatedProgression = progression.copy(
+                totalExperience = newTotalExperience,
+                currentLevel = newLevel,
+                experienceThisLevel = getExperienceInCurrentLevel(newTotalExperience),
+                experienceForNextLevel = getExperienceForNextLevel(newLevel),
+                lastUpdated = Instant.now()
             )
-        )
-        syncGuildLevelField(guildId, newLevel)
-        logger.info("Guild $guildId XP reduced by $amount -> level $newLevel (strike penalty)")
-        return newLevel
+            val saved = progressionRepository.saveGuildProgression(updatedProgression)
+            if (!saved) {
+                logger.error("Failed to save guild progression for guild $guildId (strike XP penalty)")
+                return progression.currentLevel
+            }
+            progressionRepository.recordExperienceTransaction(
+                ExperienceTransaction(
+                    guildId = guildId,
+                    source = source,
+                    amount = -amount,
+                    description = "Strike penalty: removed $amount XP"
+                )
+            )
+            syncGuildLevelField(guildId, newLevel)
+            logger.info("Guild $guildId XP reduced by $amount -> level $newLevel (strike penalty)")
+            return newLevel
+        } catch (e: Exception) {
+            logger.error("Error reducing experience for guild $guildId (strike penalty)", e)
+            return progressionRepository.getGuildProgression(guildId)?.currentLevel ?: 1
+        }
     }
 
     override fun reduceLevel(guildId: UUID, levels: Int, source: ExperienceSource): Int {
-        val progression = progressionRepository.getGuildProgression(guildId)
-            ?: GuildProgression.create(guildId)
+        try {
+            val progression = progressionRepository.getGuildProgression(guildId)
+                ?: GuildProgression.create(guildId)
 
-        val currentLevel = progression.currentLevel
-        val targetLevel = (currentLevel - levels).coerceAtLeast(1)
-        if (targetLevel == currentLevel) return currentLevel
+            val currentLevel = progression.currentLevel
+            val targetLevel = (currentLevel - levels).coerceAtLeast(1)
+            if (targetLevel == currentLevel) return currentLevel
 
-        // Set total XP to the threshold of the target level (start of that level).
-        val newTotalExperience = getTotalExperienceForLevel(targetLevel)
-        val updatedProgression = progression.copy(
-            totalExperience = newTotalExperience,
-            currentLevel = targetLevel,
-            experienceThisLevel = getExperienceInCurrentLevel(newTotalExperience),
-            experienceForNextLevel = getExperienceForNextLevel(targetLevel),
-            lastUpdated = Instant.now()
-        )
-        progressionRepository.saveGuildProgression(updatedProgression)
-        progressionRepository.recordExperienceTransaction(
-            ExperienceTransaction(
-                guildId = guildId,
-                source = source,
-                amount = -(progression.totalExperience - newTotalExperience),
-                description = "Strike penalty: reduced level $currentLevel -> $targetLevel"
+            // Set total XP to the threshold of the target level (start of that level).
+            val newTotalExperience = getTotalExperienceForLevel(targetLevel)
+            val updatedProgression = progression.copy(
+                totalExperience = newTotalExperience,
+                currentLevel = targetLevel,
+                experienceThisLevel = getExperienceInCurrentLevel(newTotalExperience),
+                experienceForNextLevel = getExperienceForNextLevel(targetLevel),
+                lastUpdated = Instant.now()
             )
-        )
-        syncGuildLevelField(guildId, targetLevel)
-        logger.info("Guild $guildId level reduced $currentLevel -> $targetLevel (strike penalty)")
-        return targetLevel
+            val saved = progressionRepository.saveGuildProgression(updatedProgression)
+            if (!saved) {
+                logger.error("Failed to save guild progression for guild $guildId (strike level penalty)")
+                return currentLevel
+            }
+            progressionRepository.recordExperienceTransaction(
+                ExperienceTransaction(
+                    guildId = guildId,
+                    source = source,
+                    amount = -(progression.totalExperience - newTotalExperience),
+                    description = "Strike penalty: reduced level $currentLevel -> $targetLevel"
+                )
+            )
+            syncGuildLevelField(guildId, targetLevel)
+            logger.info("Guild $guildId level reduced $currentLevel -> $targetLevel (strike penalty)")
+            return targetLevel
+        } catch (e: Exception) {
+            logger.error("Error reducing level for guild $guildId (strike penalty)", e)
+            return progressionRepository.getGuildProgression(guildId)?.currentLevel ?: 1
+        }
     }
 
     override fun getTotalExperienceForLevel(targetLevel: Int): Int {

--- a/src/main/kotlin/net/lumalyte/lg/infrastructure/services/ProgressionServiceBukkit.kt
+++ b/src/main/kotlin/net/lumalyte/lg/infrastructure/services/ProgressionServiceBukkit.kt
@@ -111,6 +111,66 @@ class ProgressionServiceBukkit(
         return (baseXp * nextLevel.toDouble().pow(exponent) + (nextLevel * linearBonus)).toInt()
     }
 
+    override fun removeExperience(guildId: UUID, amount: Int, source: ExperienceSource): Int {
+        if (amount <= 0) return getLevelFromExperience(progressionRepository.getGuildProgression(guildId)?.totalExperience ?: 0)
+        val progression = progressionRepository.getGuildProgression(guildId)
+            ?: GuildProgression.create(guildId)
+
+        val newTotalExperience = (progression.totalExperience - amount).coerceAtLeast(0)
+        val newLevel = getLevelFromExperience(newTotalExperience)
+
+        val updatedProgression = progression.copy(
+            totalExperience = newTotalExperience,
+            currentLevel = newLevel,
+            experienceThisLevel = getExperienceInCurrentLevel(newTotalExperience),
+            experienceForNextLevel = getExperienceForNextLevel(newLevel),
+            lastUpdated = Instant.now()
+        )
+        progressionRepository.saveGuildProgression(updatedProgression)
+        progressionRepository.recordExperienceTransaction(
+            ExperienceTransaction(
+                guildId = guildId,
+                source = source,
+                amount = -amount,
+                description = "Strike penalty: removed $amount XP"
+            )
+        )
+        syncGuildLevelField(guildId, newLevel)
+        logger.info("Guild $guildId XP reduced by $amount -> level $newLevel (strike penalty)")
+        return newLevel
+    }
+
+    override fun reduceLevel(guildId: UUID, levels: Int, source: ExperienceSource): Int {
+        val progression = progressionRepository.getGuildProgression(guildId)
+            ?: GuildProgression.create(guildId)
+
+        val currentLevel = progression.currentLevel
+        val targetLevel = (currentLevel - levels).coerceAtLeast(1)
+        if (targetLevel == currentLevel) return currentLevel
+
+        // Set total XP to the threshold of the target level (start of that level).
+        val newTotalExperience = getTotalExperienceForLevel(targetLevel)
+        val updatedProgression = progression.copy(
+            totalExperience = newTotalExperience,
+            currentLevel = targetLevel,
+            experienceThisLevel = getExperienceInCurrentLevel(newTotalExperience),
+            experienceForNextLevel = getExperienceForNextLevel(targetLevel),
+            lastUpdated = Instant.now()
+        )
+        progressionRepository.saveGuildProgression(updatedProgression)
+        progressionRepository.recordExperienceTransaction(
+            ExperienceTransaction(
+                guildId = guildId,
+                source = source,
+                amount = -(progression.totalExperience - newTotalExperience),
+                description = "Strike penalty: reduced level $currentLevel -> $targetLevel"
+            )
+        )
+        syncGuildLevelField(guildId, targetLevel)
+        logger.info("Guild $guildId level reduced $currentLevel -> $targetLevel (strike penalty)")
+        return targetLevel
+    }
+
     override fun getTotalExperienceForLevel(targetLevel: Int): Int {
         if (targetLevel <= 1) return 0
         

--- a/src/main/kotlin/net/lumalyte/lg/interaction/commands/GuildCommand.kt
+++ b/src/main/kotlin/net/lumalyte/lg/interaction/commands/GuildCommand.kt
@@ -1064,18 +1064,21 @@ class GuildCommand : BaseCommand(), KoinComponent {
         val total = strikeService.countAll()
         player.sendMessage("§8[§bLumaGuilds§8] §fGuild Strikes §8(§7$total total§8)")
         if (threshold > 0) {
-            player.sendMessage("§8» §7Guilds at §c$threshold§7+ strikes are up for a penalty")
+            player.sendMessage("§8» §7Guilds at §c$threshold§7+ §7active strikes are up for a penalty")
         }
 
+        // Penalty eligibility is based on ACTIVE strikes only (lifted punishments
+        // don't count toward the threshold) — same rule as /g strikes <guild>.
+        val activeCounts = strikeService.getAllActiveCounts()
         val nameById = guildServiceRef.getAllGuilds().associateBy { it.id }
         var index = 0
         for ((guildId, count) in counts.entries.sortedByDescending { it.value }) {
             val guild = nameById[guildId]
             val label = guild?.let { GuildResolver.displayName(it) } ?: guildId.toString().take(8)
-            val flag = if (threshold > 0 && count >= threshold) " §c⚠ UP FOR PENALTY" else ""
+            val flag = if (threshold > 0 && (activeCounts[guildId] ?: 0) >= threshold) " §c⚠ UP FOR PENALTY" else ""
             player.sendMessage("§7${++index}. §f$label §8— §e$count §7strike(s)$flag")
         }
-        player.sendMessage("§8» §7Click a guild in the list above for details: §f/g strikes <guild>")
+        player.sendMessage("§8» §7Run §f/g strikes <guild>§7 for the punishments behind a guild's strikes")
     }
 
     /**
@@ -1123,10 +1126,13 @@ class GuildCommand : BaseCommand(), KoinComponent {
         }
         player.sendMessage("§8[§bLumaGuilds§8] §f$name §7— §e${strikes.size} §7strike(s)$status")
         if (threshold > 0) {
-            player.sendMessage("§8» §7Penalty threshold: §f$threshold")
+            player.sendMessage("§8» §7Penalty threshold: §f$threshold§7 (active strikes)")
         }
 
-        strikes.forEach { strike ->
+        // Cap the per-guild detail list — a guild with hundreds of punishments
+        // would otherwise flood the player's chat.
+        val maxShown = 15
+        strikes.take(maxShown).forEach { strike ->
             val typeColor = when (strike.punishmentType.uppercase()) {
                 "BAN" -> "§c"
                 "MUTE" -> "§6"
@@ -1140,6 +1146,10 @@ class GuildCommand : BaseCommand(), KoinComponent {
                 "$typeColor${strike.punishmentType.uppercase()}§8 §f${strike.playerName ?: strike.playerUuid.toString().take(8)}" +
                     "$reason$by §8${formatStrikeDate(strike.issuedAt)}$lifted"
             )
+        }
+        val hidden = strikes.size - maxShown
+        if (hidden > 0) {
+            player.sendMessage("§8… §7and §f$hidden§7 more (showing newest $maxShown)")
         }
     }
 

--- a/src/main/kotlin/net/lumalyte/lg/interaction/commands/GuildCommand.kt
+++ b/src/main/kotlin/net/lumalyte/lg/interaction/commands/GuildCommand.kt
@@ -25,6 +25,7 @@ import net.lumalyte.lg.interaction.menus.guild.*
 import net.lumalyte.lg.utils.deserializeToItemStack
 import net.lumalyte.lg.utils.GuildHomeSafety
 import net.lumalyte.lg.utils.GuildNameFilter
+import net.lumalyte.lg.utils.GuildResolver
 import org.bukkit.Bukkit
 import org.bukkit.Location
 import org.bukkit.command.Command
@@ -52,6 +53,7 @@ class GuildCommand : BaseCommand(), KoinComponent {
     private val adminOverrideService: net.lumalyte.lg.application.services.AdminOverrideService by inject()
     private val teleportationService: net.lumalyte.lg.infrastructure.services.TeleportationService by inject()
     private val bannermanListeners: net.lumalyte.lg.infrastructure.bukkit.bannerman.BannermanListeners by inject()
+    private val strikeService: net.lumalyte.lg.application.services.StrikeService by inject()
 
     private val lastHomeTeleport = mutableMapOf<java.util.UUID, Long>()
 
@@ -1022,6 +1024,128 @@ class GuildCommand : BaseCommand(), KoinComponent {
             val guild = guilds.first()
             menuNavigator.openMenu(menuFactory.createGuildInfoMenu(menuNavigator, player, guild))
         }
+    }
+
+    /**
+     * Public Guild Strikes view — lists every guild's strikes and, with a guild
+     * argument, the individual punishments behind them.
+     *
+     * No permission required: the strike ledger is public by design.
+     */
+    @Subcommand("strikes")
+    @CommandCompletion("@guilds")
+    fun onStrikes(player: Player, @Optional target: String?) {
+        val strikesConfig = configService.loadConfig().strikes
+        if (!strikesConfig.enabled) {
+            player.sendMessage("§cGuild strikes are currently disabled.")
+            return
+        }
+
+        val threshold = strikesConfig.threshold
+        val guildServiceRef = guildService
+
+        if (target != null) {
+            val guild = GuildResolver.resolve(target, guildServiceRef)
+            if (guild == null) {
+                player.sendMessage("§cNo guild or player named '$target' found.")
+                return
+            }
+            showGuildStrikeDetails(player, guild, threshold)
+            return
+        }
+
+        // Global public view: every guild that has at least one strike.
+        val counts = strikeService.getAllCounts()
+        if (counts.isEmpty()) {
+            player.sendMessage("§8[§bLumaGuilds§8] §7No guild has any strikes yet.")
+            return
+        }
+
+        val total = strikeService.countAll()
+        player.sendMessage("§8[§bLumaGuilds§8] §fGuild Strikes §8(§7$total total§8)")
+        if (threshold > 0) {
+            player.sendMessage("§8» §7Guilds at §c$threshold§7+ strikes are up for a penalty")
+        }
+
+        val nameById = guildServiceRef.getAllGuilds().associateBy { it.id }
+        var index = 0
+        for ((guildId, count) in counts.entries.sortedByDescending { it.value }) {
+            val guild = nameById[guildId]
+            val label = guild?.let { GuildResolver.displayName(it) } ?: guildId.toString().take(8)
+            val flag = if (threshold > 0 && count >= threshold) " §c⚠ UP FOR PENALTY" else ""
+            player.sendMessage("§7${++index}. §f$label §8— §e$count §7strike(s)$flag")
+        }
+        player.sendMessage("§8» §7Click a guild in the list above for details: §f/g strikes <guild>")
+    }
+
+    /**
+     * Admin penalty GUI — opens the penalty menu for a guild. Requires
+     * `lumaguilds.admin.strikes`.
+     */
+    @Subcommand("strikes punish")
+    @CommandPermission("lumaguilds.admin.strikes")
+    @CommandCompletion("@guilds")
+    fun onStrikesPunish(player: Player, target: String) {
+        val strikesConfig = configService.loadConfig().strikes
+        if (!strikesConfig.enabled) {
+            player.sendMessage("§cGuild strikes are currently disabled.")
+            return
+        }
+
+        val guild = GuildResolver.resolve(target, guildService)
+        if (guild == null) {
+            player.sendMessage("§cNo guild or player named '$target' found.")
+            return
+        }
+
+        val menuNavigator = MenuNavigator(player)
+        menuNavigator.openMenu(
+            net.lumalyte.lg.interaction.menus.guild.GuildStrikePenaltyMenu(
+                menuNavigator, player, guild, strikesConfig
+            )
+        )
+    }
+
+    private fun showGuildStrikeDetails(player: Player, guild: net.lumalyte.lg.domain.entities.Guild, threshold: Int) {
+        val strikes = strikeService.getByGuild(guild.id)
+        val name = GuildResolver.displayName(guild)
+
+        if (strikes.isEmpty()) {
+            player.sendMessage("§8[§bLumaGuilds§8] §f$name §7has no strikes.")
+            return
+        }
+
+        val activeCount = strikes.count { it.active }
+        val status = if (threshold > 0 && activeCount >= threshold) {
+            " §c⚠ UP FOR PENALTY"
+        } else {
+            ""
+        }
+        player.sendMessage("§8[§bLumaGuilds§8] §f$name §7— §e${strikes.size} §7strike(s)$status")
+        if (threshold > 0) {
+            player.sendMessage("§8» §7Penalty threshold: §f$threshold")
+        }
+
+        strikes.forEach { strike ->
+            val typeColor = when (strike.punishmentType.uppercase()) {
+                "BAN" -> "§c"
+                "MUTE" -> "§6"
+                "KICK" -> "§e"
+                else -> "§7"
+            }
+            val lifted = if (strike.active) "" else " §8(lifted)"
+            val reason = strike.reason?.takeIf { it.isNotBlank() }?.let { " §7— §f${it.take(80)}" } ?: ""
+            val by = strike.executorName?.let { " §8by $it" } ?: ""
+            player.sendMessage(
+                "$typeColor${strike.punishmentType.uppercase()}§8 §f${strike.playerName ?: strike.playerUuid.toString().take(8)}" +
+                    "$reason$by §8${formatStrikeDate(strike.issuedAt)}$lifted"
+            )
+        }
+    }
+
+    private fun formatStrikeDate(instant: java.time.Instant): String {
+        val formatter = java.time.format.DateTimeFormatter.ofPattern("yyyy-MM-dd")
+        return formatter.format(instant.atZone(java.time.ZoneId.systemDefault()))
     }
     
     @Subcommand("disband")

--- a/src/main/kotlin/net/lumalyte/lg/interaction/commands/QuickGuildChatCommand.kt
+++ b/src/main/kotlin/net/lumalyte/lg/interaction/commands/QuickGuildChatCommand.kt
@@ -5,6 +5,7 @@ import co.aikar.commands.annotation.CommandAlias
 import co.aikar.commands.annotation.CommandPermission
 import co.aikar.commands.annotation.Default
 import net.lumalyte.lg.application.services.GuildService
+import net.lumalyte.lg.application.services.PenaltyService
 import net.lumalyte.lg.domain.values.ChatChannelIds
 import net.lumalyte.lg.infrastructure.services.RoseChatQuickChat
 import org.bukkit.entity.Player
@@ -21,6 +22,7 @@ import org.koin.core.component.inject
 @CommandAlias("gc")
 internal class QuickGuildChatCommand : BaseCommand(), KoinComponent {
     private val guildService: GuildService by inject()
+    private val penaltyService: PenaltyService by inject()
 
     /** Shows usage help when `/gc` is typed without arguments. */
     @Default
@@ -38,6 +40,12 @@ internal class QuickGuildChatCommand : BaseCommand(), KoinComponent {
     @CommandPermission("lumaguilds.guild.chat")
     fun onMessage(player: Player, vararg message: String) {
         if (!player.requireGuildMembership(guildService)) return
+
+        val guildId = guildService.getPlayerGuilds(player.uniqueId).firstOrNull()?.id
+        if (guildId != null && penaltyService.isGuildMuted(guildId)) {
+            player.sendMessage("§c❌ Your guild is muted — guild chat is disabled until the mute expires.")
+            return
+        }
 
         val text = message.joinToString(" ")
         when (RoseChatQuickChat.send(player, ChatChannelIds.GUILD, text)) {

--- a/src/main/kotlin/net/lumalyte/lg/interaction/listeners/GuildChatListener.kt
+++ b/src/main/kotlin/net/lumalyte/lg/interaction/listeners/GuildChatListener.kt
@@ -3,6 +3,7 @@ package net.lumalyte.lg.interaction.listeners
 import dev.rosewood.rosechat.chat.channel.Channel
 import net.lumalyte.lg.application.services.GuildService
 import net.lumalyte.lg.application.services.MemberService
+import net.lumalyte.lg.application.services.PenaltyService
 import net.lumalyte.lg.domain.entities.Guild
 import net.lumalyte.lg.domain.entities.RankPermission
 import net.lumalyte.lg.domain.values.ChatChannelIds
@@ -30,6 +31,7 @@ class GuildChatListener : Listener, KoinComponent {
 
     private val guildService: GuildService by inject()
     private val memberService: MemberService by inject()
+    private val penaltyService: PenaltyService by inject()
 
     private val logger = LoggerFactory.getLogger(GuildChatListener::class.java)
 
@@ -67,6 +69,13 @@ class GuildChatListener : Listener, KoinComponent {
         // Toggle ON — must be in a guild.
         if (guildService.getPlayerGuilds(player.uniqueId).isEmpty()) {
             player.sendMessage("§c❌ You are not in a guild!")
+            return false
+        }
+
+        // Guild mute blocks joining guild chat (and /gc is blocked separately).
+        val guildId = guildService.getPlayerGuilds(player.uniqueId).firstOrNull()?.id
+        if (guildId != null && penaltyService.isGuildMuted(guildId)) {
+            player.sendMessage("§c❌ Your guild is muted — guild chat is disabled until the mute expires.")
             return false
         }
 

--- a/src/main/kotlin/net/lumalyte/lg/interaction/menus/guild/GuildStrikePenaltyConfirmMenu.kt
+++ b/src/main/kotlin/net/lumalyte/lg/interaction/menus/guild/GuildStrikePenaltyConfirmMenu.kt
@@ -3,7 +3,6 @@ package net.lumalyte.lg.interaction.menus.guild
 import com.github.stefvanschie.inventoryframework.gui.GuiItem
 import com.github.stefvanschie.inventoryframework.gui.type.ChestGui
 import com.github.stefvanschie.inventoryframework.pane.StaticPane
-import net.lumalyte.lg.application.services.GuildService
 import net.lumalyte.lg.application.services.PenaltyService
 import net.lumalyte.lg.config.StrikesConfig
 import net.lumalyte.lg.domain.entities.Guild
@@ -34,7 +33,7 @@ class GuildStrikePenaltyConfirmMenu(
 ) : Menu, KoinComponent {
 
     private val penaltyService: PenaltyService by inject()
-    private val guildService: GuildService by inject()
+    private val memberService: net.lumalyte.lg.application.services.MemberService by inject()
     private val menuFactory: net.lumalyte.lg.interaction.menus.MenuFactory by inject()
 
     override fun open() {
@@ -79,7 +78,7 @@ class GuildStrikePenaltyConfirmMenu(
         return when (penaltyType) {
             PenaltyType.LEVEL_REDUCTION -> "Remove ${p.levelReductionLevels} level(s)"
             PenaltyType.EXP_REDUCTION -> "Remove ${p.expReductionAmount} XP"
-            PenaltyType.GUILD_MUTE -> "Mute guild chat for ${p.guildMuteDurationMillis / 3_600_000} hour(s)"
+            PenaltyType.GUILD_MUTE -> "Mute guild chat for ${"%.1f".format(p.guildMuteDurationMillis / 3_600_000.0)} hour(s)"
             PenaltyType.DISBAND -> "FULLY DISBAND the guild"
         }
     }
@@ -99,9 +98,11 @@ class GuildStrikePenaltyConfirmMenu(
                 player.sendMessage("§8[§bLumaGuilds§8] ${result.message}")
                 // Notify online members of their guild being penalized.
                 if (penaltyType != PenaltyType.DISBAND) {
-                    // Notify every online player whose guild is the penalized guild
+                    // One member lookup for the whole guild, then filter online —
+                    // avoids N guildService.getPlayerGuilds() calls on the tick thread.
+                    val memberUuids = memberService.getGuildMembers(guild.id).map { it.playerId }
                     Bukkit.getOnlinePlayers()
-                        .filter { online -> guild.id in guildService.getPlayerGuilds(online.uniqueId).map { it.id } }
+                        .filter { online -> online.uniqueId in memberUuids }
                         .forEach { member ->
                             member.sendMessage("§8[§bLumaGuilds§8] §c⚠ Your guild has received a penalty: ${penaltyType.name.replace('_', ' ')}")
                         }

--- a/src/main/kotlin/net/lumalyte/lg/interaction/menus/guild/GuildStrikePenaltyConfirmMenu.kt
+++ b/src/main/kotlin/net/lumalyte/lg/interaction/menus/guild/GuildStrikePenaltyConfirmMenu.kt
@@ -1,0 +1,116 @@
+package net.lumalyte.lg.interaction.menus.guild
+
+import com.github.stefvanschie.inventoryframework.gui.GuiItem
+import com.github.stefvanschie.inventoryframework.gui.type.ChestGui
+import com.github.stefvanschie.inventoryframework.pane.StaticPane
+import net.lumalyte.lg.application.services.GuildService
+import net.lumalyte.lg.application.services.PenaltyService
+import net.lumalyte.lg.config.StrikesConfig
+import net.lumalyte.lg.domain.entities.Guild
+import net.lumalyte.lg.domain.entities.PenaltyType
+import net.lumalyte.lg.interaction.menus.Menu
+import net.lumalyte.lg.interaction.menus.MenuNavigator
+import net.lumalyte.lg.utils.GuildResolver
+import net.lumalyte.lg.utils.lore
+import net.lumalyte.lg.utils.name
+import org.bukkit.Bukkit
+import org.bukkit.Material
+import org.bukkit.entity.Player
+import org.bukkit.inventory.ItemStack
+import org.koin.core.component.KoinComponent
+import org.koin.core.component.inject
+
+/**
+ * Confirmation step for a single penalty action. Clicking confirm applies the
+ * penalty through [PenaltyService]; the strike ledger is intentionally left
+ * intact so the public /g strikes view keeps its full history.
+ */
+class GuildStrikePenaltyConfirmMenu(
+    private val menuNavigator: MenuNavigator,
+    private val player: Player,
+    private val guild: Guild,
+    private val penaltyType: PenaltyType,
+    private val strikesConfig: StrikesConfig,
+) : Menu, KoinComponent {
+
+    private val penaltyService: PenaltyService by inject()
+    private val guildService: GuildService by inject()
+    private val menuFactory: net.lumalyte.lg.interaction.menus.MenuFactory by inject()
+
+    override fun open() {
+        val gui = ChestGui(3, "§4§lConfirm - ${penaltyType.name.replace('_', ' ')}")
+        val pane = StaticPane(0, 0, 9, 3)
+        gui.setOnTopClick { event -> event.isCancelled = true }
+        gui.setOnBottomClick { event ->
+            if (event.click == org.bukkit.event.inventory.ClickType.SHIFT_LEFT ||
+                event.click == org.bukkit.event.inventory.ClickType.SHIFT_RIGHT
+            ) {
+                event.isCancelled = true
+            }
+        }
+
+        val warning = ItemStack.of(Material.BARRIER)
+            .name("§c⚠ CONFIRMATION")
+            .lore("§cThis action cannot be undone!")
+            .lore("§7")
+            .lore("§7Guild: §f${GuildResolver.displayName(guild)}")
+            .lore("§7Penalty: §f${describePenalty()}")
+        pane.addItem(GuiItem(warning), 0, 0)
+
+        val confirmItem = ItemStack.of(Material.RED_WOOL)
+            .name("§c✅ CONFIRM ${penaltyType.name.replace('_', ' ').uppercase()}")
+            .lore("§7Click to apply the penalty")
+        pane.addItem(GuiItem(confirmItem) { applyPenalty() }, 4, 1)
+
+        val cancelItem = ItemStack.of(Material.GREEN_WOOL)
+            .name("§a❌ CANCEL")
+            .lore("§7Return to penalty menu")
+            .lore("§7No changes will be made")
+        pane.addItem(GuiItem(cancelItem) {
+            menuNavigator.openMenu(GuildStrikePenaltyMenu(menuNavigator, player, guild, strikesConfig))
+        }, 6, 1)
+
+        gui.addPane(pane)
+        gui.show(player)
+    }
+
+    private fun describePenalty(): String {
+        val p = strikesConfig.penalties
+        return when (penaltyType) {
+            PenaltyType.LEVEL_REDUCTION -> "Remove ${p.levelReductionLevels} level(s)"
+            PenaltyType.EXP_REDUCTION -> "Remove ${p.expReductionAmount} XP"
+            PenaltyType.GUILD_MUTE -> "Mute guild chat for ${p.guildMuteDurationMillis / 3_600_000} hour(s)"
+            PenaltyType.DISBAND -> "FULLY DISBAND the guild"
+        }
+    }
+
+    private fun applyPenalty() {
+        val result = when (penaltyType) {
+            PenaltyType.LEVEL_REDUCTION -> penaltyService.applyLevelReduction(guild, player.uniqueId, player.name)
+            PenaltyType.EXP_REDUCTION -> penaltyService.applyExpReduction(guild, player.uniqueId, player.name)
+            PenaltyType.GUILD_MUTE -> penaltyService.applyGuildMute(guild, player.uniqueId, player.name)
+            PenaltyType.DISBAND -> penaltyService.applyDisband(guild, player.uniqueId, player.name)
+        }
+
+        player.closeInventory()
+
+        when (result) {
+            is PenaltyService.PenaltyResult.Success -> {
+                player.sendMessage("§8[§bLumaGuilds§8] ${result.message}")
+                // Notify online members of their guild being penalized.
+                if (penaltyType != PenaltyType.DISBAND) {
+                    // Notify every online player whose guild is the penalized guild
+                    Bukkit.getOnlinePlayers()
+                        .filter { online -> guild.id in guildService.getPlayerGuilds(online.uniqueId).map { it.id } }
+                        .forEach { member ->
+                            member.sendMessage("§8[§bLumaGuilds§8] §c⚠ Your guild has received a penalty: ${penaltyType.name.replace('_', ' ')}")
+                        }
+                }
+            }
+            is PenaltyService.PenaltyResult.Failure -> {
+                player.sendMessage("§8[§bLumaGuilds§8] ${result.message}")
+                menuNavigator.openMenu(GuildStrikePenaltyMenu(menuNavigator, player, guild, strikesConfig))
+            }
+        }
+    }
+}

--- a/src/main/kotlin/net/lumalyte/lg/interaction/menus/guild/GuildStrikePenaltyMenu.kt
+++ b/src/main/kotlin/net/lumalyte/lg/interaction/menus/guild/GuildStrikePenaltyMenu.kt
@@ -82,7 +82,7 @@ class GuildStrikePenaltyMenu(
             "§7Remove §e${strikesConfig.penalties.expReductionAmount}§7 XP",
             PenaltyType.EXP_REDUCTION)
         addPenaltyButton(pane, 5, 3, Material.NAME_TAG, "§d🔇 Guild Mute",
-            "§7Mute guild chat for §e${strikesConfig.penalties.guildMuteDurationMillis / 3_600_000}h§7",
+            "§7Mute guild chat for §e${formatHours(strikesConfig.penalties.guildMuteDurationMillis)}§7",
             PenaltyType.GUILD_MUTE)
         addPenaltyButton(pane, 7, 3, Material.TNT, "§c💥 Disband Guild",
             "§cPermanently disbands the guild",
@@ -101,13 +101,15 @@ class GuildStrikePenaltyMenu(
 
         // Back / close
         val backItem = ItemStack.of(Material.ARROW)
-            .name("§a← Back to strikes")
+            .name("§a← Close")
             .lore("§7Close this menu")
         pane.addItem(GuiItem(backItem) { player.closeInventory() }, 7, 5)
 
         gui.addPane(pane)
         gui.show(player)
     }
+
+    private fun formatHours(millis: Long): String = "%.1f".format(millis / 3_600_000.0)
 
     private fun addPenaltyButton(
         pane: StaticPane,

--- a/src/main/kotlin/net/lumalyte/lg/interaction/menus/guild/GuildStrikePenaltyMenu.kt
+++ b/src/main/kotlin/net/lumalyte/lg/interaction/menus/guild/GuildStrikePenaltyMenu.kt
@@ -1,0 +1,137 @@
+package net.lumalyte.lg.interaction.menus.guild
+
+import com.github.stefvanschie.inventoryframework.gui.GuiItem
+import com.github.stefvanschie.inventoryframework.gui.type.ChestGui
+import com.github.stefvanschie.inventoryframework.pane.StaticPane
+import net.lumalyte.lg.application.services.PenaltyService
+import net.lumalyte.lg.application.services.StrikeService
+import net.lumalyte.lg.config.StrikesConfig
+import net.lumalyte.lg.domain.entities.Guild
+import net.lumalyte.lg.domain.entities.PenaltyType
+import net.lumalyte.lg.interaction.menus.Menu
+import net.lumalyte.lg.interaction.menus.MenuNavigator
+import net.lumalyte.lg.utils.GuildResolver
+import net.lumalyte.lg.utils.lore
+import net.lumalyte.lg.utils.name
+import org.bukkit.Material
+import org.bukkit.entity.Player
+import org.bukkit.inventory.ItemStack
+import org.koin.core.component.KoinComponent
+import org.koin.core.component.inject
+
+/**
+ * Admin penalty GUI — shows a guild's strike ledger and offers the four
+ * penalty actions (Level Reduction, EXP Reduction, Guild Mute, Disband),
+ * each gated behind a confirmation menu.
+ *
+ * Permission: lumaguilds.admin.strikes (checked by the command).
+ */
+class GuildStrikePenaltyMenu(
+    private val menuNavigator: MenuNavigator,
+    private val player: Player,
+    private val guild: Guild,
+    private val strikesConfig: StrikesConfig,
+) : Menu, KoinComponent {
+
+    private val strikeService: StrikeService by inject()
+    private val penaltyService: PenaltyService by inject()
+
+    override fun open() {
+        val gui = ChestGui(6, "§4§lPenalties - ${GuildResolver.displayName(guild)}")
+        val pane = StaticPane(0, 0, 9, 6)
+        gui.setOnTopClick { event -> event.isCancelled = true }
+        gui.setOnBottomClick { event ->
+            if (event.click == org.bukkit.event.inventory.ClickType.SHIFT_LEFT ||
+                event.click == org.bukkit.event.inventory.ClickType.SHIFT_RIGHT
+            ) {
+                event.isCancelled = true
+            }
+        }
+
+        // Guild info header (row 0)
+        val infoItem = ItemStack.of(Material.NAME_TAG)
+            .name("§f${GuildResolver.displayName(guild)}")
+            .lore("§7Level: §f${guild.level}")
+            .lore("§7Strikes: §e${strikeService.countByGuild(guild.id)}")
+            .lore("§7Threshold: §f${strikesConfig.threshold}")
+        pane.addItem(GuiItem(infoItem), 0, 0)
+
+        // Strike ledger (rows 0-2, slots 1-7). Newest strikes on the left.
+        val strikes = strikeService.getByGuild(guild.id).take(7)
+        strikes.forEachIndexed { index, strike ->
+            val material = when (strike.punishmentType.uppercase()) {
+                "BAN" -> Material.BARRIER
+                "MUTE" -> Material.WHITE_WOOL
+                "KICK" -> Material.LEATHER_BOOTS
+                else -> Material.PAPER
+            }
+            val lifted = if (strike.active) "" else " §8(lifted)"
+            val item = ItemStack.of(material)
+                .name("§c${strike.punishmentType.uppercase()}$lifted")
+                .lore("§7Player: §f${strike.playerName ?: strike.playerUuid.toString().take(8)}")
+                .lore("§7Reason: §f${strike.reason?.take(60) ?: "—"}")
+                .lore("§7By: §f${strike.executorName ?: "?"} §8• §7${formatDate(strike.issuedAt)}")
+            pane.addItem(GuiItem(item), 1 + index, 0)
+        }
+
+        // Penalty action buttons (rows 3-4)
+        addPenaltyButton(pane, 1, 3, Material.GOLD_INGOT, "§6⬇ Level Reduction",
+            "§7Remove §e${strikesConfig.penalties.levelReductionLevels}§7 level(s)",
+            PenaltyType.LEVEL_REDUCTION)
+        addPenaltyButton(pane, 3, 3, Material.EXPERIENCE_BOTTLE, "§b⬇ EXP Reduction",
+            "§7Remove §e${strikesConfig.penalties.expReductionAmount}§7 XP",
+            PenaltyType.EXP_REDUCTION)
+        addPenaltyButton(pane, 5, 3, Material.NAME_TAG, "§d🔇 Guild Mute",
+            "§7Mute guild chat for §e${strikesConfig.penalties.guildMuteDurationMillis / 3_600_000}h§7",
+            PenaltyType.GUILD_MUTE)
+        addPenaltyButton(pane, 7, 3, Material.TNT, "§c💥 Disband Guild",
+            "§cPermanently disbands the guild",
+            PenaltyType.DISBAND)
+
+        // Recent penalties (row 5)
+        val recentPenalties = penaltyService.getByGuild(guild.id).take(3)
+        if (recentPenalties.isNotEmpty()) {
+            val penItem = ItemStack.of(Material.BOOK)
+                .name("§7Recent penalties")
+            recentPenalties.forEach { p ->
+                penItem.lore("§7- §f${p.type.name.replace('_', ' ')} §8by ${p.actorName} §8(${formatDate(p.createdAt)})")
+            }
+            pane.addItem(GuiItem(penItem), 1, 5)
+        }
+
+        // Back / close
+        val backItem = ItemStack.of(Material.ARROW)
+            .name("§a← Back to strikes")
+            .lore("§7Close this menu")
+        pane.addItem(GuiItem(backItem) { player.closeInventory() }, 7, 5)
+
+        gui.addPane(pane)
+        gui.show(player)
+    }
+
+    private fun addPenaltyButton(
+        pane: StaticPane,
+        x: Int,
+        y: Int,
+        material: Material,
+        title: String,
+        description: String,
+        type: PenaltyType,
+    ) {
+        val item = ItemStack.of(material)
+            .name(title)
+            .lore(description)
+            .lore("§7")
+            .lore("§eClick to confirm")
+        pane.addItem(GuiItem(item) {
+            menuNavigator.openMenu(
+                GuildStrikePenaltyConfirmMenu(menuNavigator, player, guild, type, strikesConfig)
+            )
+        }, x, y)
+    }
+
+    private fun formatDate(instant: java.time.Instant): String {
+        return java.time.format.DateTimeFormatter.ofPattern("yyyy-MM-dd")
+            .format(instant.atZone(java.time.ZoneId.systemDefault()))
+    }
+}

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -836,3 +836,43 @@ apollo:
     # Example: "Playing Guild: MyGuild [TAG] - 5/50 members online"
     # Server IP shown in rich presence (empty = don't show)
     server_ip: "play.enthusia.info"
+# =====================================
+# Guild Strikes
+# LiteBans punishments attributed to guilds. When a guild member is punished
+# (warn/kick/mute/ban) while in the guild, the guild receives a strike.
+# =====================================
+strikes:
+  # Master switch: if false, no punishments are recorded and /g strikes is disabled.
+  enabled: true
+  # Punishments before a guild is "up for a penalty" (admin-triggered action).
+  threshold: 5
+  # Which LiteBans punishment types count as strikes.
+  # Valid: WARN, KICK, MUTE, BAN
+  counted_types:
+    - WARN
+    - KICK
+    - MUTE
+    - BAN
+
+  # Admin penalty actions (triggered from the /g strikes punish GUI).
+  penalties:
+    level_reduction:
+      # How many levels a Level Reduction removes (0 = disabled).
+      levels: 1
+    exp_reduction:
+      # How much XP an EXP Reduction removes (0 = disabled).
+      amount: 1000
+    guild_mute:
+      # Guild mute duration in milliseconds (0 = disabled). 24h default.
+      duration_ms: 86400000
+
+  # One-shot backfill of pre-existing LiteBans punishments on startup, so
+  # existing guilds get credit for past behaviour. Idempotent (deduped by
+  # LiteBans entry id) — safe to leave enabled.
+  backfill:
+    # Run the backfill on startup.
+    enabled: true
+    # When membership history cannot prove which guild the player was in at
+    # punishment time, attribute to the player's current guild instead
+    # (maximizes coverage of the "most troublesome guild" ranking).
+    fallback_to_current_guild: true

--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -3,7 +3,7 @@ version: ${version}
 api-version: '1.21.11'
 load: STARTUP
 main: net.lumalyte.lg.LumaGuilds
-softdepend: [Vault, PlaceholderAPI, AxKoth]
+softdepend: [Vault, PlaceholderAPI, AxKoth, LiteBans]
 depend: [RoseChat]
 
 commands:
@@ -244,6 +244,11 @@ permissions:
 
   bellclaims.admin:
     description: Allows access to admin commands including guild override mode
+    default: op
+
+  # Guild Strikes Admin Permissions
+  lumaguilds.admin.strikes:
+    description: Open the guild penalty GUI (/g strikes punish)
     default: op
 
   # Bedrock Cache Permissions

--- a/src/test/kotlin/net/lumalyte/lg/application/services/PenaltyServiceTest.kt
+++ b/src/test/kotlin/net/lumalyte/lg/application/services/PenaltyServiceTest.kt
@@ -1,0 +1,109 @@
+package net.lumalyte.lg.application.services
+
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.verify
+import net.lumalyte.lg.application.persistence.PenaltyRepository
+import net.lumalyte.lg.config.StrikesConfig
+import net.lumalyte.lg.config.StrikesPenaltiesConfig
+import net.lumalyte.lg.domain.entities.Guild
+import net.lumalyte.lg.domain.entities.PenaltyType
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+import java.time.Instant
+import java.util.UUID
+
+class PenaltyServiceTest {
+
+    private val penaltyRepository = mockk<PenaltyRepository>(relaxed = true)
+    private val progressionService = mockk<ProgressionService>()
+    private val guildService = mockk<GuildService>(relaxed = true)
+
+    private fun config(block: StrikesPenaltiesConfig.() -> Unit = {}): StrikesConfig {
+        val penalties = StrikesPenaltiesConfig().apply(block)
+        return StrikesConfig(enabled = true, threshold = 5, penalties = penalties)
+    }
+
+    private val guild = Guild(
+        id = UUID.randomUUID(),
+        name = "Testers",
+        tag = "TEST",
+        level = 7,
+        createdAt = Instant.now(),
+    )
+
+    @Test
+    fun `level reduction delegates to progression and records penalty`() {
+        every { progressionService.reduceLevel(guild.id, 1, ExperienceSource.ADMIN_BONUS) } returns 6
+        val service = PenaltyService(penaltyRepository, progressionService, guildService) { config() }
+
+        val result = service.applyLevelReduction(guild, UUID.randomUUID(), "Admin")
+
+        assertTrue(result is PenaltyService.PenaltyResult.Success)
+        val penalty = (result as PenaltyService.PenaltyResult.Success).penalty
+        assertEquals(PenaltyType.LEVEL_REDUCTION, penalty.type)
+        assertEquals(1L, penalty.amount)
+        verify { penaltyRepository.recordPenalty(penalty) }
+    }
+
+    @Test
+    fun `level reduction disabled when levels is zero`() {
+        val service = PenaltyService(penaltyRepository, progressionService, guildService) {
+            config { levelReductionLevels = 0 }
+        }
+
+        val result = service.applyLevelReduction(guild, UUID.randomUUID(), "Admin")
+
+        assertTrue(result is PenaltyService.PenaltyResult.Failure)
+        verify(exactly = 0) { penaltyRepository.recordPenalty(any()) }
+    }
+
+    @Test
+    fun `exp reduction delegates to progression and records penalty`() {
+        every { progressionService.removeExperience(guild.id, 1000, ExperienceSource.ADMIN_BONUS) } returns 5
+        val service = PenaltyService(penaltyRepository, progressionService, guildService) { config() }
+
+        val result = service.applyExpReduction(guild, UUID.randomUUID(), "Admin")
+
+        assertTrue(result is PenaltyService.PenaltyResult.Success)
+        assertEquals(PenaltyType.EXP_REDUCTION, (result as PenaltyService.PenaltyResult.Success).penalty.type)
+        verify { penaltyRepository.recordPenalty(any()) }
+    }
+
+    @Test
+    fun `guild mute records duration and is reported as active`() {
+        every { penaltyRepository.hasActiveMute(guild.id, any()) } returns true
+        val service = PenaltyService(penaltyRepository, progressionService, guildService) { config() }
+
+        val result = service.applyGuildMute(guild, UUID.randomUUID(), "Admin")
+
+        assertTrue(result is PenaltyService.PenaltyResult.Success)
+        assertEquals(PenaltyType.GUILD_MUTE, (result as PenaltyService.PenaltyResult.Success).penalty.type)
+        assertEquals(24L * 3_600_000L, (result as PenaltyService.PenaltyResult.Success).penalty.amount)
+        assertTrue(service.isGuildMuted(guild.id))
+    }
+
+    @Test
+    fun `disband records penalty and disbands guild`() {
+        every { guildService.disbandGuild(guild.id, any()) } returns true
+        val service = PenaltyService(penaltyRepository, progressionService, guildService) { config() }
+
+        val result = service.applyDisband(guild, UUID.randomUUID(), "Admin")
+
+        assertTrue(result is PenaltyService.PenaltyResult.Success)
+        assertEquals(PenaltyType.DISBAND, (result as PenaltyService.PenaltyResult.Success).penalty.type)
+        verify { guildService.disbandGuild(guild.id, any()) }
+        verify { penaltyRepository.recordPenalty(any()) }
+    }
+
+    @Test
+    fun `disband failure surfaces as failure result`() {
+        every { guildService.disbandGuild(guild.id, any()) } returns false
+        val service = PenaltyService(penaltyRepository, progressionService, guildService) { config() }
+
+        val result = service.applyDisband(guild, UUID.randomUUID(), "Admin")
+
+        assertTrue(result is PenaltyService.PenaltyResult.Failure)
+    }
+}

--- a/src/test/kotlin/net/lumalyte/lg/application/services/PenaltyServiceTest.kt
+++ b/src/test/kotlin/net/lumalyte/lg/application/services/PenaltyServiceTest.kt
@@ -93,17 +93,23 @@ class PenaltyServiceTest {
 
         assertTrue(result is PenaltyService.PenaltyResult.Success)
         assertEquals(PenaltyType.DISBAND, (result as PenaltyService.PenaltyResult.Success).penalty.type)
-        verify { guildService.disbandGuild(guild.id, any()) }
+        // The disband must run as the system UUID so the guild's own permission
+        // check (MANAGE_RANKS in the target guild) can't reject an admin penalty.
+        verify {
+            guildService.disbandGuild(guild.id, UUID.fromString("00000000-0000-0000-0000-000000000000"))
+        }
         verify { penaltyRepository.recordPenalty(any()) }
     }
 
     @Test
-    fun `disband failure surfaces as failure result`() {
+    fun `disband failure surfaces as failure result and records no penalty`() {
         every { guildService.disbandGuild(guild.id, any()) } returns false
         val service = PenaltyService(penaltyRepository, progressionService, guildService) { config() }
 
         val result = service.applyDisband(guild, UUID.randomUUID(), "Admin")
 
         assertTrue(result is PenaltyService.PenaltyResult.Failure)
+        // The audit trail must NOT show a disband that never happened.
+        verify(exactly = 0) { penaltyRepository.recordPenalty(any()) }
     }
 }

--- a/src/test/kotlin/net/lumalyte/lg/application/services/StrikeServiceTest.kt
+++ b/src/test/kotlin/net/lumalyte/lg/application/services/StrikeServiceTest.kt
@@ -1,0 +1,112 @@
+package net.lumalyte.lg.application.services
+
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.verify
+import net.lumalyte.lg.application.persistence.StrikeRepository
+import net.lumalyte.lg.config.StrikesConfig
+import net.lumalyte.lg.domain.entities.GuildStrike
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertFalse
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+import java.time.Instant
+import java.util.UUID
+
+class StrikeServiceTest {
+
+    private val guildId = UUID.randomUUID()
+    private val playerUuid = UUID.randomUUID()
+    private val now = Instant.parse("2026-08-04T12:00:00Z")
+
+    private fun serviceWith(config: StrikesConfig, repo: StrikeRepository = mockk(relaxed = true)) =
+        StrikeService(repository = repo, configProvider = { config })
+
+    @Test
+    fun `recordStrike delegates to repository when enabled`() {
+        val repo = mockk<StrikeRepository>(relaxed = true)
+        val service = serviceWith(StrikesConfig(enabled = true), repo)
+
+        service.recordStrike(guildId, playerUuid, "Steve", "BAN", "griefing", "Mod", now, 42L)
+
+        verify(exactly = 1) {
+            repo.recordStrike(
+                match {
+                    it.guildId == guildId &&
+                        it.playerUuid == playerUuid &&
+                        it.punishmentType == "BAN" &&
+                        it.reason == "griefing" &&
+                        it.executorName == "Mod" &&
+                        it.litebansEntryId == 42L &&
+                        it.active
+                }
+            )
+        }
+    }
+
+    @Test
+    fun `recordStrike is a no-op when disabled`() {
+        val repo = mockk<StrikeRepository>(relaxed = true)
+        val service = serviceWith(StrikesConfig(enabled = false), repo)
+
+        service.recordStrike(guildId, playerUuid, "Steve", "WARN", "spam", null, now, 1L)
+
+        verify(exactly = 0) { repo.recordStrike(any()) }
+    }
+
+    @Test
+    fun `isUpForPenalty respects threshold`() {
+        val repo = mockk<StrikeRepository>()
+        every { repo.countByGuild(guildId) } returns 5
+
+        val service = serviceWith(StrikesConfig(enabled = true, threshold = 5), repo)
+        assertTrue(service.isUpForPenalty(guildId))
+
+        every { repo.countByGuild(guildId) } returns 4
+        assertFalse(service.isUpForPenalty(guildId))
+    }
+
+    @Test
+    fun `threshold of zero never flags a guild`() {
+        val repo = mockk<StrikeRepository>()
+        every { repo.countByGuild(guildId) } returns 99
+
+        val service = serviceWith(StrikesConfig(enabled = true, threshold = 0), repo)
+        assertFalse(service.isUpForPenalty(guildId))
+    }
+
+    @Test
+    fun `deactivateStrike delegates and respects enabled flag`() {
+        val repo = mockk<StrikeRepository>(relaxed = true)
+        val service = serviceWith(StrikesConfig(enabled = true), repo)
+
+        service.deactivateStrike(77L)
+        verify(exactly = 1) { repo.deactivateStrike(77L) }
+
+        val disabled = serviceWith(StrikesConfig(enabled = false), repo)
+        disabled.deactivateStrike(77L)
+        verify(exactly = 1) { repo.deactivateStrike(77L) } // unchanged — disabled = no-op
+    }
+
+    @Test
+    fun `getAllCounts and countAll delegate to repository`() {
+        val repo = mockk<StrikeRepository>()
+        every { repo.getAllCounts() } returns mapOf(guildId to 3)
+        every { repo.countAll() } returns 3
+
+        val service = serviceWith(StrikesConfig(enabled = true), repo)
+        assertEquals(mapOf(guildId to 3), service.getAllCounts())
+        assertEquals(3, service.countAll())
+    }
+
+    @Test
+    fun `GuildStrike defaults active to true`() {
+        val strike = GuildStrike(
+            guildId = guildId,
+            playerUuid = playerUuid,
+            punishmentType = "KICK",
+            issuedAt = now
+        )
+        assertTrue(strike.active)
+    }
+}

--- a/src/test/kotlin/net/lumalyte/lg/application/services/StrikeServiceTest.kt
+++ b/src/test/kotlin/net/lumalyte/lg/application/services/StrikeServiceTest.kt
@@ -55,37 +55,37 @@ class StrikeServiceTest {
     }
 
     @Test
-    fun `isUpForPenalty respects threshold`() {
+    fun `isUpForPenalty respects threshold on ACTIVE strikes only`() {
         val repo = mockk<StrikeRepository>()
-        every { repo.countByGuild(guildId) } returns 5
+        every { repo.countActiveByGuild(guildId) } returns 5
 
         val service = serviceWith(StrikesConfig(enabled = true, threshold = 5), repo)
         assertTrue(service.isUpForPenalty(guildId))
 
-        every { repo.countByGuild(guildId) } returns 4
+        every { repo.countActiveByGuild(guildId) } returns 4
         assertFalse(service.isUpForPenalty(guildId))
     }
 
     @Test
     fun `threshold of zero never flags a guild`() {
         val repo = mockk<StrikeRepository>()
-        every { repo.countByGuild(guildId) } returns 99
+        every { repo.countActiveByGuild(guildId) } returns 99
 
         val service = serviceWith(StrikesConfig(enabled = true, threshold = 0), repo)
         assertFalse(service.isUpForPenalty(guildId))
     }
 
     @Test
-    fun `deactivateStrike delegates and respects enabled flag`() {
+    fun `deactivateStrike delegates with type and respects enabled flag`() {
         val repo = mockk<StrikeRepository>(relaxed = true)
         val service = serviceWith(StrikesConfig(enabled = true), repo)
 
-        service.deactivateStrike(77L)
-        verify(exactly = 1) { repo.deactivateStrike(77L) }
+        service.deactivateStrike("BAN", 77L)
+        verify(exactly = 1) { repo.deactivateStrike("BAN", 77L) }
 
         val disabled = serviceWith(StrikesConfig(enabled = false), repo)
-        disabled.deactivateStrike(77L)
-        verify(exactly = 1) { repo.deactivateStrike(77L) } // unchanged — disabled = no-op
+        disabled.deactivateStrike("BAN", 77L)
+        verify(exactly = 1) { repo.deactivateStrike("BAN", 77L) } // unchanged — disabled = no-op
     }
 
     @Test
@@ -97,6 +97,17 @@ class StrikeServiceTest {
         val service = serviceWith(StrikesConfig(enabled = true), repo)
         assertEquals(mapOf(guildId to 3), service.getAllCounts())
         assertEquals(3, service.countAll())
+    }
+
+    @Test
+    fun `getAllActiveCounts and countActiveByGuild delegate to repository`() {
+        val repo = mockk<StrikeRepository>()
+        every { repo.getAllActiveCounts() } returns mapOf(guildId to 2)
+        every { repo.countActiveByGuild(guildId) } returns 2
+
+        val service = serviceWith(StrikesConfig(enabled = true), repo)
+        assertEquals(mapOf(guildId to 2), service.getAllActiveCounts())
+        assertEquals(2, service.countActiveByGuild(guildId))
     }
 
     @Test


### PR DESCRIPTION
## Summary
Adds **Guild Strikes** to LumaGuilds: LiteBans punishments are counted against the guild the player belonged to *at punishment time*, viewable publicly, with an admin-triggered penalty GUI.

## Features
- **Strike capture**: `LiteBansStrikeListener` hooks `litebans.api.Events` (2.x prod API). On `entryAdded`, resolves the punished player's guild at that moment via `GuildService.getPlayerGuilds()` — guild-less players get no strike; leaving a guild does not dodge accrued strikes. Punishment removal marks the strike inactive (still visible, flagged).
- **Public command**: `/g strikes` (no permission) — global ledger of all guilds sorted by strike count with `⚠ UP FOR PENALTY` at threshold; `/g strikes <guild>` — per-punishment detail (type, player, reason, issuer, date, lifted flag). Tab-completion via existing `@guilds`.
- **Admin penalty GUI**: `/g strikes punish <guild>` (permission `lumaguilds.admin.strikes`, op default) — penalty panel with 4 actions, each confirm-gated: Level Reduction, EXP Reduction, Guild Mute, Disband. Applies through `PenaltyService` (progression hooks `removeExperience`/`reduceLevel` added), records audit trail in `guild_penalties`, notifies online members.
- **Guild mute**: enforced at both chat entry points (`/gc` and `/g chat` toggle) while a GUILD_MUTE penalty is in force.
- **Startup backfill**: one-shot, idempotent (deduped by LiteBans entry id) import of pre-existing punishments. Attribution uses membership-history stints (`joinedAt` ≤ time < `departedAt`); config `strikes.backfill.fallback_to_current_guild` (default true) covers punishments predating history tracking.
- **Storage**: migrations v24 (`guild_strikes`) + v25 (`guild_penalties`) for both SQLite and MariaDB; portable SQL repositories; schema-verifier updated.
- **Config**: `strikes.{enabled, threshold, counted_types, penalties.*, backfill.*}`.
- **Tests**: StrikeService (7) + PenaltyService (6) unit tests. Full suite 366 tests, 0 failures.

## Notes
- LiteBans is a softdepend; the feature activates only when the plugin is present. The prod jar (2.x API) is added as `compileOnly(files("libs/LiteBans.jar"))` (gitignored).
- `Events$Listener` in the prod jar lacks an InnerClasses attribute, so it is referenced via backtick-quoted `` `Events$Listener` `` with an explanatory comment.
- No live-penalty auto-application: the GUI is admin-triggered by design.

## Migration
Existing DBs auto-upgrade via migration runner (v24 → v25).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
### Fixes
- Enforce guild mutes in command and RoseChat message paths.
- Handle LiteBans load order, disabled plugins, and linkage failures safely.
- Attribute live and backfilled strikes through membership history.
- Deduplicate strikes by punishment type and LiteBans entry ID.

### Features
- Add configurable LiteBans strike capture, removal tracking, and startup backfill.
- Add `/g strikes` global and guild views.
- Add `/g strikes punish <guild>` with level, EXP, mute, and disband penalties.
- Persist strikes and penalties through SQLite and MariaDB migrations v24 and v25.
- Repair missing strike and penalty tables during schema validation.
- Add unit coverage for strike, penalty, repository, backfill, and disband behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->