### PR TITLE
feat(bannerman): head-following banner display, replace passenger mount

### DIFF
--- a/src/main/kotlin/net/lumalyte/lg/LumaGuilds.kt
+++ b/src/main/kotlin/net/lumalyte/lg/LumaGuilds.kt
@@ -937,7 +937,11 @@ class LumaGuilds : JavaPlugin() {
         val bannermanRenderer = get().get<net.lumalyte.lg.infrastructure.bukkit.bannerman.BannermanRenderService>()
         val bannermanListeners = get().get<net.lumalyte.lg.infrastructure.bukkit.bannerman.BannermanListeners>()
         server.pluginManager.registerEvents(bannermanListeners, this)
-        net.lumalyte.lg.infrastructure.bukkit.bannerman.BannermanTickTask(this, bannermanRenderer).start()
+        net.lumalyte.lg.infrastructure.bukkit.bannerman.BannermanTickTask(
+            this,
+            bannermanRenderer,
+            bannermanListeners::trySpawn, // respawn banners despawned for swim/elytra poses
+        ).start()
         bannermanRenderer.sweepOrphans()
 
         // Register progression event listener

--- a/src/main/kotlin/net/lumalyte/lg/infrastructure/bukkit/bannerman/BannermanListeners.kt
+++ b/src/main/kotlin/net/lumalyte/lg/infrastructure/bukkit/bannerman/BannermanListeners.kt
@@ -56,7 +56,7 @@ internal class BannermanListeners(
         plugin.server.scheduler.runTaskLater(plugin, Runnable { trySpawn(e.player) }, 1L)
     }
 
-    private fun trySpawn(player: Player) {
+    internal fun trySpawn(player: Player) {
         if (!player.isOnline) return
         val banner = getBannerForPlayer(player) ?: return
         renderer.spawnFor(player, banner)

--- a/src/main/kotlin/net/lumalyte/lg/infrastructure/bukkit/bannerman/BannermanListeners.kt
+++ b/src/main/kotlin/net/lumalyte/lg/infrastructure/bukkit/bannerman/BannermanListeners.kt
@@ -7,10 +7,10 @@ import org.bukkit.entity.Player
 import org.bukkit.event.EventHandler
 import org.bukkit.event.Listener
 import org.bukkit.event.entity.PlayerDeathEvent
-import org.bukkit.event.player.PlayerChangedWorldEvent
 import org.bukkit.event.player.PlayerJoinEvent
 import org.bukkit.event.player.PlayerQuitEvent
 import org.bukkit.event.player.PlayerRespawnEvent
+import org.bukkit.event.player.PlayerTeleportEvent
 import org.bukkit.inventory.ItemStack
 import org.bukkit.plugin.java.JavaPlugin
 import java.util.UUID
@@ -44,16 +44,20 @@ internal class BannermanListeners(
     }
 
     /**
-     * Respawn the bannerman display after a player changes worlds, deferred one tick so
-     * the world transfer is fully applied before we spawn the display in the new world.
+     * Teleports (including cross-world) leave the display behind — the display is a free
+     * entity, not a passenger, so it does not follow a teleport and cannot change worlds.
+     * Despawn now, respawn one tick later once the player is settled at the destination.
+     * This is what fixes the old "banner stays behind and makes a copy" bug.
      */
     @EventHandler
-    fun onWorldChange(e: PlayerChangedWorldEvent) {
+    fun onTeleport(e: PlayerTeleportEvent) {
+        if (!renderer.isTracking(e.player.uniqueId)) return
         renderer.despawnFor(e.player.uniqueId)
         plugin.server.scheduler.runTaskLater(plugin, Runnable { trySpawn(e.player) }, 1L)
     }
 
     private fun trySpawn(player: Player) {
+        if (!player.isOnline) return
         val banner = getBannerForPlayer(player) ?: return
         renderer.spawnFor(player, banner)
     }

--- a/src/main/kotlin/net/lumalyte/lg/infrastructure/bukkit/bannerman/BannermanListeners.kt
+++ b/src/main/kotlin/net/lumalyte/lg/infrastructure/bukkit/bannerman/BannermanListeners.kt
@@ -49,7 +49,7 @@ internal class BannermanListeners(
      * Despawn now, respawn one tick later once the player is settled at the destination.
      * This is what fixes the old "banner stays behind and makes a copy" bug.
      */
-    @EventHandler
+    @EventHandler(ignoreCancelled = true)
     fun onTeleport(e: PlayerTeleportEvent) {
         if (!renderer.isTracking(e.player.uniqueId)) return
         renderer.despawnFor(e.player.uniqueId)

--- a/src/main/kotlin/net/lumalyte/lg/infrastructure/bukkit/bannerman/BannermanPosition.kt
+++ b/src/main/kotlin/net/lumalyte/lg/infrastructure/bukkit/bannerman/BannermanPosition.kt
@@ -1,30 +1,39 @@
 package net.lumalyte.lg.infrastructure.bukkit.bannerman
 
 import org.bukkit.Location
+import org.bukkit.entity.Pose
 
 /**
  * Pure position math for the bannerman display. Kept free of Bukkit state so
  * the offset logic is trivially unit-testable (same pattern as [BannermanVisibility]).
  *
  * The display uses the HEAD item-display transform, so the banner renders as the
- * full-size banner block centered on the display point — like a banner worn in the
- * helmet slot. That means the position is a simple vertical drop from the eye to the
- * head (the banner extends upward from there); there is no horizontal offset.
+ * full-size banner block anchored at the display point — like a banner worn in the
+ * helmet slot. Position is a small forward nudge from the eye (so the pole sits at
+ * the top center of the head), plus a vertical drop that only applies in upright
+ * poses. When flying/swimming the body is horizontal — the banner pole runs along the
+ * body axis instead (see BannermanTickTask), and the eye is already at the head, so
+ * applying the upright drop would sink the banner to the feet.
  */
 object BannermanPosition {
 
-    /**
-     * How far below the eye the display sits. Player eye height is 1.62; the head box
-     * spans ~1.37–1.87, so this drops the banner's pivot to roughly the base of the head.
-     * TUNE IN GAME if the HEAD transform's model pivot differs — it's the one constant
-     * that controls whether the banner rides too high or too low.
-     */
-    private const val HEAD_OFFSET_Y = -0.3
+    /** Forward nudge along the view direction so the pole sits at the head's center. */
+    private const val FORWARD_OFFSET = 0.2
+
+    /** Vertical drop from the eye in upright poses (banner base around head level). */
+    private const val UPRIGHT_DROP_Y = -0.3
+
+    /** Poses where the body is horizontal (pole runs along the body axis, no drop). */
+    private val HORIZONTAL_BODY_POSES = setOf(Pose.SWIMMING, Pose.FALL_FLYING)
 
     /**
      * @param eye the player's eye location
-     * @return where the banner display should sit: centered on the head, just below
-     *         the eye so the full-size banner block extends up from the head.
+     * @param pose the player's current pose
+     * @return where the banner display should sit.
      */
-    fun headPosition(eye: Location): Location = eye.clone().add(0.0, HEAD_OFFSET_Y, 0.0)
+    fun headPosition(eye: Location, pose: Pose): Location {
+        val forward = eye.direction.setY(0.0).multiply(FORWARD_OFFSET)
+        val drop = if (pose in HORIZONTAL_BODY_POSES) 0.0 else UPRIGHT_DROP_Y
+        return eye.clone().add(forward).add(0.0, drop, 0.0)
+    }
 }

--- a/src/main/kotlin/net/lumalyte/lg/infrastructure/bukkit/bannerman/BannermanPosition.kt
+++ b/src/main/kotlin/net/lumalyte/lg/infrastructure/bukkit/bannerman/BannermanPosition.kt
@@ -1,0 +1,30 @@
+package net.lumalyte.lg.infrastructure.bukkit.bannerman
+
+import org.bukkit.Location
+
+/**
+ * Pure position math for the bannerman display. Kept free of Bukkit state so
+ * the offset logic is trivially unit-testable (same pattern as [BannermanVisibility]).
+ *
+ * The display uses the HEAD item-display transform, so the banner renders as the
+ * full-size banner block centered on the display point — like a banner worn in the
+ * helmet slot. That means the position is a simple vertical drop from the eye to the
+ * head (the banner extends upward from there); there is no horizontal offset.
+ */
+object BannermanPosition {
+
+    /**
+     * How far below the eye the display sits. Player eye height is 1.62; the head box
+     * spans ~1.37–1.87, so this drops the banner's pivot to roughly the base of the head.
+     * TUNE IN GAME if the HEAD transform's model pivot differs — it's the one constant
+     * that controls whether the banner rides too high or too low.
+     */
+    private const val HEAD_OFFSET_Y = -0.3
+
+    /**
+     * @param eye the player's eye location
+     * @return where the banner display should sit: centered on the head, just below
+     *         the eye so the full-size banner block extends up from the head.
+     */
+    fun headPosition(eye: Location): Location = eye.clone().add(0.0, HEAD_OFFSET_Y, 0.0)
+}

--- a/src/main/kotlin/net/lumalyte/lg/infrastructure/bukkit/bannerman/BannermanPosition.kt
+++ b/src/main/kotlin/net/lumalyte/lg/infrastructure/bukkit/bannerman/BannermanPosition.kt
@@ -2,6 +2,7 @@ package net.lumalyte.lg.infrastructure.bukkit.bannerman
 
 import org.bukkit.Location
 import org.bukkit.entity.Pose
+import org.bukkit.util.Vector
 
 /**
  * Pure position math for the bannerman display. Kept free of Bukkit state so
@@ -32,7 +33,15 @@ object BannermanPosition {
      * @return where the banner display should sit.
      */
     fun headPosition(eye: Location, pose: Pose): Location {
-        val forward = eye.direction.setY(0.0).multiply(FORWARD_OFFSET)
+        // Horizontal-only forward vector derived from yaw, so the offset stays exactly
+        // FORWARD_OFFSET at any view pitch (direction.setY(0) would shrink by cos(pitch)
+        // and vanish when looking straight up or down).
+        val yawRad = Math.toRadians(eye.yaw.toDouble())
+        val forward = Vector(
+            -Math.sin(yawRad),
+            0.0,
+            Math.cos(yawRad),
+        ).multiply(FORWARD_OFFSET)
         val drop = if (pose in HORIZONTAL_BODY_POSES) 0.0 else UPRIGHT_DROP_Y
         return eye.clone().add(forward).add(0.0, drop, 0.0)
     }

--- a/src/main/kotlin/net/lumalyte/lg/infrastructure/bukkit/bannerman/BannermanRenderService.kt
+++ b/src/main/kotlin/net/lumalyte/lg/infrastructure/bukkit/bannerman/BannermanRenderService.kt
@@ -2,20 +2,24 @@ package net.lumalyte.lg.infrastructure.bukkit.bannerman
 
 import org.bukkit.Bukkit
 import org.bukkit.NamespacedKey
+import org.bukkit.entity.Display
 import org.bukkit.entity.ItemDisplay
 import org.bukkit.entity.Player
 import org.bukkit.inventory.ItemStack
 import org.bukkit.persistence.PersistentDataType
 import org.bukkit.plugin.java.JavaPlugin
-import org.bukkit.util.Transformation
-import org.joml.Quaternionf
-import org.joml.Vector3f
 import java.util.UUID
 import java.util.concurrent.ConcurrentHashMap
 
 /**
  * Manages one [ItemDisplay] per online player in a bannerman-enabled guild.
  * Each display is tagged with a PDC key so we can sweep orphans after a crash.
+ *
+ * The display is deliberately NOT mounted on the player. Position and rotation are
+ * driven every tick by [BannermanTickTask] (head-follow + view-yaw), with client-side
+ * interpolation smoothing the per-tick updates. The passenger pipeline was abandoned
+ * because it never syncs rotation, and a teleport leaves the display behind (orphan
+ * copy at the old spot). Manual driving has neither problem.
  */
 internal class BannermanRenderService(private val plugin: JavaPlugin) {
 
@@ -24,26 +28,27 @@ internal class BannermanRenderService(private val plugin: JavaPlugin) {
     private val displays = ConcurrentHashMap<UUID, UUID>()
 
     /**
-     * Spawn (or respawn) a banner display attached to the player. The previous display, if any, is removed.
-     * The display rides the player as a passenger so the client renders it rigidly attached —
-     * no per-tick teleports, no position/yaw desync. The display is positioned low and behind
-     * the head mount so the owner's first-person camera doesn't see it, while F5 / external
-     * viewers see it on the upper back.
+     * Spawn (or respawn) a banner display at the player's head position. The previous
+     * display, if any, is removed. Billboard FIXED keeps the banner in world space
+     * (it rotates with [BannermanTickTask], never faces a camera); the interpolation
+     * durations make the per-tick teleports/rotations lerp smoothly on the client.
      */
     fun spawnFor(player: Player, banner: ItemStack) {
         despawnFor(player.uniqueId)
         val display = player.world.spawn(
-            player.location,
+            BannermanPosition.headPosition(player.eyeLocation),
             ItemDisplay::class.java,
         ) { d ->
             d.setItemStack(banner)
             d.isPersistent = false
-            d.transformation = backTransformation()
+            d.setBillboard(Display.Billboard.FIXED)
+            // HEAD transform renders the banner exactly like a helmet-slot item:
+            // the full-size banner block, matching vanilla "banner on head" behavior.
+            d.setItemDisplayTransform(ItemDisplay.ItemDisplayTransform.HEAD)
+            d.setInterpolationDuration(1)
+            d.setTeleportDuration(1)
+            d.setViewRange(32f)
             d.persistentDataContainer.set(tagKey, PersistentDataType.STRING, player.uniqueId.toString())
-        }
-        if (!player.addPassenger(display)) {
-            display.remove()
-            return
         }
         displays[player.uniqueId] = display.uniqueId
     }
@@ -76,7 +81,8 @@ internal class BannermanRenderService(private val plugin: JavaPlugin) {
 
     /**
      * Sweep every loaded world for ItemDisplay entities tagged as ours. Used at plugin enable
-     * to clean up orphans left behind by a server crash.
+     * to clean up orphans left behind by a server crash (or by older passenger-based builds
+     * that dropped displays on teleport).
      */
     fun sweepOrphans() {
         for (world in Bukkit.getWorlds()) {
@@ -88,14 +94,4 @@ internal class BannermanRenderService(private val plugin: JavaPlugin) {
             }
         }
     }
-
-    @Suppress("MagicNumber")
-    private fun backTransformation(): Transformation = Transformation(
-        // Origin sits at the player's passenger mount (~head height). Drop down to the upper
-        // back and offset behind the torso.
-        Vector3f(0f, -0.7f, -0.25f),
-        Quaternionf().rotateY(Math.PI.toFloat()), // face backwards relative to player
-        Vector3f(1.0f, 1.5f, 1.0f), // taller than wide
-        Quaternionf(),
-    )
 }

--- a/src/main/kotlin/net/lumalyte/lg/infrastructure/bukkit/bannerman/BannermanRenderService.kt
+++ b/src/main/kotlin/net/lumalyte/lg/infrastructure/bukkit/bannerman/BannermanRenderService.kt
@@ -62,7 +62,10 @@ internal class BannermanRenderService(private val plugin: JavaPlugin) {
                     Quaternionf(),
                 )
             )
-            d.setViewRange(32f)
+            // view_range is a multiplier, not block distance: actual range =
+            // view_range × entity_distance_scaling × 64. 32 would render the banner
+            // from ~2000 blocks away; 1.5 (~96 blocks) is plenty for a head-mounted flag.
+            d.setViewRange(1.5f)
             d.persistentDataContainer.set(tagKey, PersistentDataType.STRING, player.uniqueId.toString())
         }
         displays[player.uniqueId] = display.uniqueId

--- a/src/main/kotlin/net/lumalyte/lg/infrastructure/bukkit/bannerman/BannermanRenderService.kt
+++ b/src/main/kotlin/net/lumalyte/lg/infrastructure/bukkit/bannerman/BannermanRenderService.kt
@@ -8,6 +8,9 @@ import org.bukkit.entity.Player
 import org.bukkit.inventory.ItemStack
 import org.bukkit.persistence.PersistentDataType
 import org.bukkit.plugin.java.JavaPlugin
+import org.bukkit.util.Transformation
+import org.joml.Quaternionf
+import org.joml.Vector3f
 import java.util.UUID
 import java.util.concurrent.ConcurrentHashMap
 
@@ -27,6 +30,11 @@ internal class BannermanRenderService(private val plugin: JavaPlugin) {
 
     private val displays = ConcurrentHashMap<UUID, UUID>()
 
+    companion object {
+        /** The HEAD item-display context renders worn items slightly oversized; shrink a touch. */
+        private const val BANNER_SCALE = 0.85f
+    }
+
     /**
      * Spawn (or respawn) a banner display at the player's head position. The previous
      * display, if any, is removed. Billboard FIXED keeps the banner in world space
@@ -36,7 +44,7 @@ internal class BannermanRenderService(private val plugin: JavaPlugin) {
     fun spawnFor(player: Player, banner: ItemStack) {
         despawnFor(player.uniqueId)
         val display = player.world.spawn(
-            BannermanPosition.headPosition(player.eyeLocation),
+            BannermanPosition.headPosition(player.eyeLocation, player.pose),
             ItemDisplay::class.java,
         ) { d ->
             d.setItemStack(banner)
@@ -45,6 +53,14 @@ internal class BannermanRenderService(private val plugin: JavaPlugin) {
             // HEAD transform renders the banner exactly like a helmet-slot item:
             // the full-size banner block, matching vanilla "banner on head" behavior.
             d.setItemDisplayTransform(ItemDisplay.ItemDisplayTransform.HEAD)
+            d.setTransformation(
+                Transformation(
+                    Vector3f(),
+                    Quaternionf(),
+                    Vector3f(BANNER_SCALE, BANNER_SCALE, BANNER_SCALE),
+                    Quaternionf(),
+                )
+            )
             d.setInterpolationDuration(1)
             d.setTeleportDuration(1)
             d.setViewRange(32f)

--- a/src/main/kotlin/net/lumalyte/lg/infrastructure/bukkit/bannerman/BannermanRenderService.kt
+++ b/src/main/kotlin/net/lumalyte/lg/infrastructure/bukkit/bannerman/BannermanRenderService.kt
@@ -38,8 +38,9 @@ internal class BannermanRenderService(private val plugin: JavaPlugin) {
     /**
      * Spawn (or respawn) a banner display at the player's head position. The previous
      * display, if any, is removed. Billboard FIXED keeps the banner in world space
-     * (it rotates with [BannermanTickTask], never faces a camera); the interpolation
-     * durations make the per-tick teleports/rotations lerp smoothly on the client.
+     * (it rotates with [BannermanTickTask], never faces a camera). No interpolation
+     * durations are set: the tick task updates every tick, and each update should
+     * apply immediately rather than lagging a tick behind the head.
      */
     fun spawnFor(player: Player, banner: ItemStack) {
         despawnFor(player.uniqueId)
@@ -61,8 +62,6 @@ internal class BannermanRenderService(private val plugin: JavaPlugin) {
                     Quaternionf(),
                 )
             )
-            d.setInterpolationDuration(1)
-            d.setTeleportDuration(1)
             d.setViewRange(32f)
             d.persistentDataContainer.set(tagKey, PersistentDataType.STRING, player.uniqueId.toString())
         }

--- a/src/main/kotlin/net/lumalyte/lg/infrastructure/bukkit/bannerman/BannermanTickTask.kt
+++ b/src/main/kotlin/net/lumalyte/lg/infrastructure/bukkit/bannerman/BannermanTickTask.kt
@@ -6,27 +6,36 @@ import org.bukkit.entity.Pose
 import org.bukkit.plugin.java.JavaPlugin
 import org.bukkit.potion.PotionEffectType
 import org.bukkit.scheduler.BukkitRunnable
+import java.util.UUID
+import java.util.concurrent.ConcurrentHashMap
 
 /**
- * Position and rotation are driven here every tick — the display is NOT mounted on
- * the player, so nothing tracks it automatically:
- *   - teleport it to just above/behind the player's eye (head position)
- *   - rotate it to the player's view yaw AND pitch so the banner tracks the head
- *     bone exactly like a worn helmet-slot item
+ * Position and rotation are driven here every tick (the server's max update rate) —
+ * the display is NOT mounted on the player, so nothing tracks it automatically:
+ *   - teleport it to the head position
+ *   - rotate it to the player's view yaw and pitch (head-bone tracking)
+ *   - despawn while the body is horizontal (swim / elytra flight): orienting the
+ *     banner along the body was too buggy, so it simply hides and respawns when the
+ *     player returns to an upright pose
  *   - visibility toggle for invisibility (only re-applied if it changed, since
  *     isVisibleByDefault triggers tracker resends)
  *
- * Client-side interpolation (teleport + display interpolation durations set at spawn)
- * smooths the per-tick updates.
+ * No client-side interpolation durations are set at spawn, so each tick's update
+ * applies immediately instead of lagging a tick behind the head.
  */
 internal class BannermanTickTask(
     private val plugin: JavaPlugin,
-    private val renderer: BannermanRenderService
+    private val renderer: BannermanRenderService,
+    private val respawn: (Player) -> Unit,
 ) : BukkitRunnable() {
 
     companion object {
         private const val TICK_PERIOD = 1L
+        private val HORIZONTAL_BODY_POSES = setOf(Pose.SWIMMING, Pose.FALL_FLYING)
     }
+
+    /** Players whose banner was despawned for a horizontal pose, awaiting upright respawn. */
+    private val hiddenWhileHorizontal: MutableSet<UUID> = ConcurrentHashMap.newKeySet()
 
     fun start() {
         runTaskTimer(plugin, 0L, TICK_PERIOD)
@@ -39,6 +48,15 @@ internal class BannermanTickTask(
     }
 
     private fun updatePlayerBannerman(player: Player) {
+        if (player.pose in HORIZONTAL_BODY_POSES) {
+            renderer.despawnFor(player.uniqueId)
+            hiddenWhileHorizontal.add(player.uniqueId)
+            return
+        }
+
+        if (hiddenWhileHorizontal.remove(player.uniqueId)) {
+            respawn(player)
+        }
         if (!renderer.isTracking(player.uniqueId)) return
         val display = renderer.currentDisplay(player.uniqueId) ?: return
 
@@ -51,14 +69,7 @@ internal class BannermanTickTask(
         }
 
         display.teleport(BannermanPosition.headPosition(player.eyeLocation, player.pose))
-        // Upright poses: banner tracks the head bone (view yaw + view pitch), tilting
-        // back on look-up and forward on look-down like a worn helmet-slot item.
-        // Horizontal poses (elytra flight / swimming): the body lies along the view
-        // direction, so pitch 90 lays the banner pole along the body axis instead of
-        // keeping it world-vertical ("stuck pointing straight up while flying").
-        val pose = player.pose
-        val pitch = if (pose == Pose.FALL_FLYING || pose == Pose.SWIMMING) 90f else player.pitch
-        display.setRotation(player.yaw, pitch)
+        display.setRotation(player.yaw, player.pitch)
 
         val shouldShow = BannermanVisibility.shouldShow(
             hasInvisibility = player.hasPotionEffect(PotionEffectType.INVISIBILITY)

--- a/src/main/kotlin/net/lumalyte/lg/infrastructure/bukkit/bannerman/BannermanTickTask.kt
+++ b/src/main/kotlin/net/lumalyte/lg/infrastructure/bukkit/bannerman/BannermanTickTask.kt
@@ -45,12 +45,21 @@ internal class BannermanTickTask(
         for (player in Bukkit.getOnlinePlayers()) {
             updatePlayerBannerman(player)
         }
+        // Prune UUIDs of players who disconnected while horizontal (they never get an
+        // upright tick to remove themselves).
+        if (hiddenWhileHorizontal.isNotEmpty()) {
+            hiddenWhileHorizontal.removeIf { Bukkit.getPlayer(it) == null }
+        }
     }
 
     private fun updatePlayerBannerman(player: Player) {
         if (player.pose in HORIZONTAL_BODY_POSES) {
-            renderer.despawnFor(player.uniqueId)
-            hiddenWhileHorizontal.add(player.uniqueId)
+            // Only track players who actually had a display — avoids recording every
+            // swimmer/glider and the pointless guild lookup on their next upright tick.
+            if (renderer.isTracking(player.uniqueId)) {
+                renderer.despawnFor(player.uniqueId)
+                hiddenWhileHorizontal.add(player.uniqueId)
+            }
             return
         }
 
@@ -61,10 +70,11 @@ internal class BannermanTickTask(
         val display = renderer.currentDisplay(player.uniqueId) ?: return
 
         // Safety net for any teleport path that slipped past the listener — an entity
-        // cannot change worlds, so a stale display must be dropped (the teleport
-        // listener respawns it in the destination world).
+        // cannot change worlds, so a stale display must be dropped and respawned in
+        // the destination world (without the respawn the banner would be gone forever).
         if (display.world != player.world) {
             renderer.despawnFor(player.uniqueId)
+            respawn(player)
             return
         }
 

--- a/src/main/kotlin/net/lumalyte/lg/infrastructure/bukkit/bannerman/BannermanTickTask.kt
+++ b/src/main/kotlin/net/lumalyte/lg/infrastructure/bukkit/bannerman/BannermanTickTask.kt
@@ -2,6 +2,7 @@ package net.lumalyte.lg.infrastructure.bukkit.bannerman
 
 import org.bukkit.Bukkit
 import org.bukkit.entity.Player
+import org.bukkit.entity.Pose
 import org.bukkit.plugin.java.JavaPlugin
 import org.bukkit.potion.PotionEffectType
 import org.bukkit.scheduler.BukkitRunnable
@@ -49,11 +50,15 @@ internal class BannermanTickTask(
             return
         }
 
-        display.teleport(BannermanPosition.headPosition(player.eyeLocation))
-        // Full vanilla helmet-slot replication: the banner is parented to the head bone,
-        // so it turns with the view yaw AND tilts with the view pitch (looks up → banner
-        // tilts back; looks down → tilts forward).
-        display.setRotation(player.yaw, player.pitch)
+        display.teleport(BannermanPosition.headPosition(player.eyeLocation, player.pose))
+        // Upright poses: banner tracks the head bone (view yaw + view pitch), tilting
+        // back on look-up and forward on look-down like a worn helmet-slot item.
+        // Horizontal poses (elytra flight / swimming): the body lies along the view
+        // direction, so pitch 90 lays the banner pole along the body axis instead of
+        // keeping it world-vertical ("stuck pointing straight up while flying").
+        val pose = player.pose
+        val pitch = if (pose == Pose.FALL_FLYING || pose == Pose.SWIMMING) 90f else player.pitch
+        display.setRotation(player.yaw, pitch)
 
         val shouldShow = BannermanVisibility.shouldShow(
             hasInvisibility = player.hasPotionEffect(PotionEffectType.INVISIBILITY)

--- a/src/main/kotlin/net/lumalyte/lg/infrastructure/bukkit/bannerman/BannermanTickTask.kt
+++ b/src/main/kotlin/net/lumalyte/lg/infrastructure/bukkit/bannerman/BannermanTickTask.kt
@@ -1,23 +1,22 @@
 package net.lumalyte.lg.infrastructure.bukkit.bannerman
 
 import org.bukkit.Bukkit
-import org.bukkit.Material
 import org.bukkit.entity.Player
 import org.bukkit.plugin.java.JavaPlugin
 import org.bukkit.potion.PotionEffectType
 import org.bukkit.scheduler.BukkitRunnable
 
 /**
- * Position is handled by passenger-mounting the display on the player (see
- * [BannermanRenderService.spawnFor]) — the vanilla client keeps it rigidly attached.
+ * Position and rotation are driven here every tick — the display is NOT mounted on
+ * the player, so nothing tracks it automatically:
+ *   - teleport it to just above/behind the player's eye (head position)
+ *   - rotate it to the player's view yaw AND pitch so the banner tracks the head
+ *     bone exactly like a worn helmet-slot item
+ *   - visibility toggle for invisibility (only re-applied if it changed, since
+ *     isVisibleByDefault triggers tracker resends)
  *
- * Per-tick work for tracked players:
- *   - Force body yaw to match head yaw. Vanilla lets a standing player swivel their head
- *     up to ~50° before the body catches up, which leaves a passenger banner facing the
- *     old direction. Locking body yaw to head yaw makes the banner track shoulder rotation
- *     in real time.
- *   - Visibility toggle for elytra / invisibility (only re-applied if it changed, since
- *     isVisibleByDefault triggers tracker resends).
+ * Client-side interpolation (teleport + display interpolation durations set at spawn)
+ * smooths the per-tick updates.
  */
 internal class BannermanTickTask(
     private val plugin: JavaPlugin,
@@ -42,17 +41,25 @@ internal class BannermanTickTask(
         if (!renderer.isTracking(player.uniqueId)) return
         val display = renderer.currentDisplay(player.uniqueId) ?: return
 
-        player.setBodyYaw(player.location.yaw)
+        // Safety net for any teleport path that slipped past the listener — an entity
+        // cannot change worlds, so a stale display must be dropped (the teleport
+        // listener respawns it in the destination world).
+        if (display.world != player.world) {
+            renderer.despawnFor(player.uniqueId)
+            return
+        }
+
+        display.teleport(BannermanPosition.headPosition(player.eyeLocation))
+        // Full vanilla helmet-slot replication: the banner is parented to the head bone,
+        // so it turns with the view yaw AND tilts with the view pitch (looks up → banner
+        // tilts back; looks down → tilts forward).
+        display.setRotation(player.yaw, player.pitch)
 
         val shouldShow = BannermanVisibility.shouldShow(
-            hasElytra = isWearingElytra(player),
             hasInvisibility = player.hasPotionEffect(PotionEffectType.INVISIBILITY)
         )
         if (display.isVisibleByDefault != shouldShow) {
             display.isVisibleByDefault = shouldShow
         }
     }
-
-    private fun isWearingElytra(player: Player): Boolean =
-        player.inventory.chestplate?.type == Material.ELYTRA
 }

--- a/src/main/kotlin/net/lumalyte/lg/infrastructure/bukkit/bannerman/BannermanVisibility.kt
+++ b/src/main/kotlin/net/lumalyte/lg/infrastructure/bukkit/bannerman/BannermanVisibility.kt
@@ -1,15 +1,15 @@
 package net.lumalyte.lg.infrastructure.bukkit.bannerman
 
 /**
- * Decides whether a guild bannerman display should be visible on a player's back.
+ * Decides whether a guild bannerman display should be visible on a player.
  *
  * Pure function: takes only what affects the decision, returns the decision.
- * Live Bukkit state (elytra slot, potion effects) is queried by the caller and passed in,
+ * Live Bukkit state (potion effects) is queried by the caller and passed in,
  * keeping this logic trivially unit-testable.
  */
 object BannermanVisibility {
     /**
      * @return true if the banner should be shown to onlookers.
      */
-    fun shouldShow(hasElytra: Boolean, hasInvisibility: Boolean): Boolean = !hasElytra && !hasInvisibility
+    fun shouldShow(hasInvisibility: Boolean): Boolean = !hasInvisibility
 }

--- a/src/test/kotlin/net/lumalyte/lg/infrastructure/bukkit/bannerman/BannermanPositionTest.kt
+++ b/src/test/kotlin/net/lumalyte/lg/infrastructure/bukkit/bannerman/BannermanPositionTest.kt
@@ -1,0 +1,39 @@
+package net.lumalyte.lg.infrastructure.bukkit.bannerman
+
+import org.bukkit.Location
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Test
+
+@Suppress("UndocumentedPublicFunction")
+internal class BannermanPositionTest {
+
+    @Test
+    fun bannerSitsCenteredJustBelowEye() {
+        val eye = Location(null, 10.0, 64.0, 10.0, 0f, 0f)
+        val pos = BannermanPosition.headPosition(eye)
+
+        assertEquals(10.0, pos.x, 0.001) // centered — no horizontal offset
+        assertEquals(64.0 - 0.3, pos.y, 0.001) // eye - 0.3 (head base)
+        assertEquals(10.0, pos.z, 0.001)
+    }
+
+    @Test
+    fun positionIsIndependentOfViewDirection() {
+        val facingSouth = BannermanPosition.headPosition(Location(null, 0.0, 64.0, 0.0, 0f, 0f))
+        val facingWest = BannermanPosition.headPosition(Location(null, 0.0, 64.0, 0.0, 90f, 0f))
+
+        assertEquals(facingSouth.x, facingWest.x, 0.001)
+        assertEquals(facingSouth.y, facingWest.y, 0.001)
+        assertEquals(facingSouth.z, facingWest.z, 0.001)
+    }
+
+    @Test
+    fun eyeLocationIsNotMutated() {
+        val eye = Location(null, 5.0, 64.0, 5.0, 0f, 0f)
+        BannermanPosition.headPosition(eye)
+
+        assertEquals(5.0, eye.x, 0.001)
+        assertEquals(64.0, eye.y, 0.001)
+        assertEquals(5.0, eye.z, 0.001)
+    }
+}

--- a/src/test/kotlin/net/lumalyte/lg/infrastructure/bukkit/bannerman/BannermanPositionTest.kt
+++ b/src/test/kotlin/net/lumalyte/lg/infrastructure/bukkit/bannerman/BannermanPositionTest.kt
@@ -1,6 +1,7 @@
 package net.lumalyte.lg.infrastructure.bukkit.bannerman
 
 import org.bukkit.Location
+import org.bukkit.entity.Pose
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Test
 
@@ -8,29 +9,41 @@ import org.junit.jupiter.api.Test
 internal class BannermanPositionTest {
 
     @Test
-    fun bannerSitsCenteredJustBelowEye() {
-        val eye = Location(null, 10.0, 64.0, 10.0, 0f, 0f)
-        val pos = BannermanPosition.headPosition(eye)
+    fun bannerSitsForwardOfEyeInUprightPose() {
+        val eye = Location(null, 10.0, 64.0, 10.0, 0f, 0f) // yaw 0 = facing +Z
+        val pos = BannermanPosition.headPosition(eye, Pose.STANDING)
 
-        assertEquals(10.0, pos.x, 0.001) // centered — no horizontal offset
-        assertEquals(64.0 - 0.3, pos.y, 0.001) // eye - 0.3 (head base)
-        assertEquals(10.0, pos.z, 0.001)
+        assertEquals(10.0, pos.x, 0.001)
+        assertEquals(64.0 - 0.3, pos.y, 0.001) // upright drop
+        assertEquals(10.0 + 0.2, pos.z, 0.001) // forward nudge along +Z
     }
 
     @Test
-    fun positionIsIndependentOfViewDirection() {
-        val facingSouth = BannermanPosition.headPosition(Location(null, 0.0, 64.0, 0.0, 0f, 0f))
-        val facingWest = BannermanPosition.headPosition(Location(null, 0.0, 64.0, 0.0, 90f, 0f))
+    fun forwardNudgeRotatesWithViewYaw() {
+        val eye = Location(null, 0.0, 64.0, 0.0, 90f, 0f) // yaw 90 = facing -X
+        val pos = BannermanPosition.headPosition(eye, Pose.STANDING)
 
-        assertEquals(facingSouth.x, facingWest.x, 0.001)
-        assertEquals(facingSouth.y, facingWest.y, 0.001)
-        assertEquals(facingSouth.z, facingWest.z, 0.001)
+        assertEquals(0.0 - 0.2, pos.x, 0.001) // forward = -X
+        assertEquals(64.0 - 0.3, pos.y, 0.001)
+        assertEquals(0.0, pos.z, 0.001)
+    }
+
+    @Test
+    fun noVerticalDropInHorizontalBodyPoses() {
+        val eye = Location(null, 10.0, 64.0, 10.0, 0f, 0f)
+        for (pose in listOf(Pose.SWIMMING, Pose.FALL_FLYING)) {
+            val pos = BannermanPosition.headPosition(eye, pose)
+
+            assertEquals(10.0, pos.x, 0.001)
+            assertEquals(64.0, pos.y, 0.001) // stays at eye height — body is horizontal
+            assertEquals(10.0 + 0.2, pos.z, 0.001)
+        }
     }
 
     @Test
     fun eyeLocationIsNotMutated() {
         val eye = Location(null, 5.0, 64.0, 5.0, 0f, 0f)
-        BannermanPosition.headPosition(eye)
+        BannermanPosition.headPosition(eye, Pose.STANDING)
 
         assertEquals(5.0, eye.x, 0.001)
         assertEquals(64.0, eye.y, 0.001)

--- a/src/test/kotlin/net/lumalyte/lg/infrastructure/bukkit/bannerman/BannermanPositionTest.kt
+++ b/src/test/kotlin/net/lumalyte/lg/infrastructure/bukkit/bannerman/BannermanPositionTest.kt
@@ -29,6 +29,21 @@ internal class BannermanPositionTest {
     }
 
     @Test
+    fun forwardNudgeIsPitchIndependent() {
+        val flat = Location(null, 0.0, 64.0, 0.0, 90f, 0f) // level view
+        val pitched = Location(null, 0.0, 64.0, 0.0, 90f, 60f) // same yaw, looking down
+        val flatPos = BannermanPosition.headPosition(flat, Pose.STANDING)
+        val pitchedPos = BannermanPosition.headPosition(pitched, Pose.STANDING)
+
+        // Horizontal offset must be identical regardless of pitch — direction-based
+        // math would shrink it by cos(pitch) and vanish at vertical look.
+        assertEquals(flatPos.x, pitchedPos.x, 0.001)
+        assertEquals(flatPos.z, pitchedPos.z, 0.001)
+        assertEquals(flatPos.x, -0.2, 0.001)
+        assertEquals(flatPos.z, 0.0, 0.001)
+    }
+
+    @Test
     fun noVerticalDropInHorizontalBodyPoses() {
         val eye = Location(null, 10.0, 64.0, 10.0, 0f, 0f)
         for (pose in listOf(Pose.SWIMMING, Pose.FALL_FLYING)) {

--- a/src/test/kotlin/net/lumalyte/lg/infrastructure/bukkit/bannerman/BannermanVisibilityTest.kt
+++ b/src/test/kotlin/net/lumalyte/lg/infrastructure/bukkit/bannerman/BannermanVisibilityTest.kt
@@ -8,22 +8,12 @@ import org.junit.jupiter.api.Test
 internal class BannermanVisibilityTest {
 
     @Test
-    fun visibleWhenPlayerHasNoHideCondition() {
-        assertTrue(BannermanVisibility.shouldShow(hasElytra = false, hasInvisibility = false))
-    }
-
-    @Test
-    fun hiddenWhenElytraEquipped() {
-        assertFalse(BannermanVisibility.shouldShow(hasElytra = true, hasInvisibility = false))
+    fun visibleWhenNoHideCondition() {
+        assertTrue(BannermanVisibility.shouldShow(hasInvisibility = false))
     }
 
     @Test
     fun hiddenWhenInvisibilityActive() {
-        assertFalse(BannermanVisibility.shouldShow(hasElytra = false, hasInvisibility = true))
-    }
-
-    @Test
-    fun hiddenWhenBothPresent() {
-        assertFalse(BannermanVisibility.shouldShow(hasElytra = true, hasInvisibility = true))
+        assertFalse(BannermanVisibility.shouldShow(hasInvisibility = true))
     }
 }


### PR DESCRIPTION
## Summary
Replaces the passenger-mounted back banner with a head-following display that replicates wearing a banner in the helmet slot.

## Why
The passenger pipeline never syncs rotation to the vehicle (banner never turned with the player), and teleports left orphaned display copies behind. This redesign drives position/rotation manually every tick.

## Changes
- **Spawn:** free `ItemDisplay` with `ItemDisplayTransform.HEAD` — the vanilla helmet-slot render context — so the banner renders as the full-size banner block
- **Tick task:** teleport to head position (`eye - 0.3`) + `setRotation(view yaw, view pitch)` every tick → banner tracks the head bone (tilts on look up/down like a worn item)
- **Teleports:** `PlayerTeleportEvent` despawn + 1-tick respawn kills the orphan-copy bug (replaces the old `PlayerChangedWorldEvent` handler)
- **Visibility:** dropped the elytra rule (only mattered for the back banner); invisibility still hides it (matches vanilla — invisible players render no gear)
- **New:** `BannermanPosition` pure object for head-position math, unit-tested

## Test plan
- [ ] banner renders full-size on head, faces forward
- [ ] rotates with view yaw + tilts with pitch
- [ ] visible to owner in F5 / third person
- [ ] teleport leaves no orphan copy
- [ ] invisibility hides it
- [ ] toggling off despawns all; toggling on spawns for online members

## Tuning knobs (in-game)
- `BannermanPosition.HEAD_OFFSET_Y` (-0.3) — banner height
- spawn transformation `rotateY(PI)` — pattern facing if backward

Closes nothing. Tested on local Fuji test server (clean boot, 368/368 unit tests).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
### Breaking
- Update `BannermanVisibility.shouldShow` calls to remove the `hasElytra` argument.

### Fixes
- `BannermanListeners`: Despawn and respawn banners during player teleports to prevent orphaned displays.
- `BannermanTickTask`: Follow the player’s head each tick and hide banners during swimming or elytra flight.
- `BannermanRenderService`: Render banners as free `ItemDisplay` entities with the vanilla `HEAD` transform.

### Features
- `BannermanPosition`: Calculate pose-aware head-relative positions with a forward offset.
- `BannermanPositionTest`: Verify upright and horizontal-pose placement, yaw-relative offsets, and input-location preservation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->