### PR TITLE
chore(spear): SPEAR bootstrap — docs, Konsist layer guard, domain purity (PR-0)

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -48,6 +48,7 @@ dependencies {
     }
     testImplementation("org.junit.jupiter:junit-jupiter:5.8.1")
     testImplementation("org.xerial:sqlite-jdbc:3.45.1.0")
+    testImplementation("com.lemonappdev:konsist:0.17.3")
 
     compileOnly("io.papermc.paper:paper-api:1.21.11-R0.1-SNAPSHOT")
     shadow("org.jetbrains.kotlin:kotlin-stdlib")

--- a/docs/implementation.md
+++ b/docs/implementation.md
@@ -1,0 +1,27 @@
+# LumaGuilds — Implementation Guide
+
+## Layer Dependency Rules
+
+Layers, from most stable to most volatile:
+
+- **domain** — pure guild/claim/bank/war/rank models, invariants, and ports. Depends on nothing outside `net.lumalyte.lg.domain` and the Kotlin stdlib.
+- **application** — use cases / application services orchestrating domain objects. Depends on `domain` only.
+- **infrastructure** — Bukkit adapters, persistence (MariaDB/IDB), external integrations (Nexo, RoseChat, LiteBans, Geyser/Floodgate, PlaceholderAPI, Vault, CombatLogX). Depends on `application` and `domain`.
+
+Precedence: **domain <- application <- infrastructure**. Never the reverse. Enforcement: `src/test/kotlin/net/lumalyte/lg/architecture/LayerRulesTest.kt` (Konsist).
+
+Packages outside the three layers (`api/`, `common/`, `config/`, `di/`, `integrations/`, `interaction/`, `utils/`) are not asserted by LayerRulesTest; `interaction/` (commands + menus) may depend on any of the three layers plus `common/`/`utils/`.
+
+## Forbidden Domain Annotations
+
+```yaml
+forbidden: []
+```
+
+The `domain/**` package must stay free of framework and server annotations (no Bukkit/Spigot imports, no Koin annotations, no ACF annotations, no Adventure types). When a domain model needs a port to the server, define it in `domain` and implement it in `infrastructure`.
+
+## Authoring Conventions
+
+- EARS requirements live in `docs/requirements.md`; tasks in `docs/tasks.md`; SPEAR state in `.claude/spear-state.json` (gitignored).
+- Every task carries exactly one tag (`TDD`/`DOC`/`INFRA`), a `References:` line, and an `Evidence:` block filled with real source citations during execution.
+- TDD tasks run the full cycle: spec → prove (failing test) → engine (min impl) → arch (layer check) → refine (green + close).

--- a/docs/implementation.md
+++ b/docs/implementation.md
@@ -18,6 +18,8 @@ Packages outside the three layers (`api/`, `common/`, `config/`, `di/`, `integra
 forbidden: []
 ```
 
+> **Status: target-state contract, not yet fully enforced.** `LayerRulesTest` enforces layer dependencies (domain ← application ← infrastructure), but Konsist's `dependsOnNothing()` only checks other *declared layers* — external packages (`org.bukkit`, `org.koin`, `co.aikar`, `net.kyori`) are not flagged. The domain currently imports `org.bukkit.event.Event` in 21 files (38 imports, mostly `domain/events/*`). Decoupling is tracked as REQ-045 / LG-1001; once merged, the forbidden list becomes executable and LayerRulesTest gains an external-package assertion.
+
 The `domain/**` package must stay free of framework and server annotations (no Bukkit/Spigot imports, no Koin annotations, no ACF annotations, no Adventure types). When a domain model needs a port to the server, define it in `domain` and implement it in `infrastructure`.
 
 ## Authoring Conventions

--- a/docs/requirements.md
+++ b/docs/requirements.md
@@ -1,0 +1,244 @@
+# LumaGuilds — Requirements (SPEAR)
+
+Scope: the 2026-08-09 unwired/incomplete-feature audit (`docs/audit/MASS-AUDIT-2026-06-08.md` is the earlier, separate June batch — not in scope). Audit doc: `lumaguilds-audit-2026-08-09.md` (repo root, Aug 9). Each finding becomes one EARS requirement; tasks are derived in `docs/tasks.md` and grouped into PRs.
+
+Legend: **Ubiquitous.** / **Event-driven.** / **State-driven.** / **Unwanted.**
+
+---
+
+## Section A — Critical: permissions
+
+### REQ-001
+**Unwanted.** IF a player holds the declared `lumaguilds.bedrock.cache.stats` or `lumaguilds.bedrock.cache.clear` permission THEN THE SYSTEM SHALL NOT deny them via the stale `lumalyte.*` prefix in `BedrockCacheStatsCommand`.
+
+> Audit C1: `interaction/commands/BedrockCacheStatsCommand.kt:21,55,74,80` checks `lumalyte.bedrock.cache.*`; `plugin.yml:255,258` declares `lumaguilds.bedrock.cache.*`. Align code and plugin.yml to the same prefix.
+
+### REQ-002
+**Event-driven.** WHEN a player executes one of the guild subcommands `join`, `list`, `lfg`, `decline`, `invites`, `leave`, `transfer`, `getvault`, `vault`, `help`, `ally`, `enemy`, `truce`, `neutral` THEN THE SYSTEM SHALL authorize it via the corresponding `lumaguilds.guild.<sub>` node declared in plugin.yml with a sane default.
+
+> Audit C2: `GuildCommand.kt:1283,1399,1439,1449,1477,1569,1652,1995,2108,2174,2201,2274,2342,2410` — nodes used but never declared; ACF defaults them to false and silently blocks execution.
+
+### REQ-003
+**Ubiquitous.** THE SYSTEM SHALL grant `lumaguilds.claim.partitions`, `lumaguilds.claim.trustlist`, `lumaguilds.claimmenu`, and `lumaguilds.claimoverride` to every holder of the `lumaguilds.command.*` wildcard.
+
+> Audit C2 (wildcard gap): these four nodes are missing from the wildcard's children set, so inheriting `lumaguilds.command.*` does not grant them.
+
+---
+
+## Section B — High: dead config, dead services, dead UI
+
+### REQ-004
+**Event-driven.** WHEN the plugin loads THEN THE SYSTEM SHALL load the entire `vault:` config section (config.yml:165-299: bank_mode, physical_currency, compressable_blocks, and all other vault keys) into the config model and apply it at runtime.
+
+> Audit H1: no `loadVaultConfig()` exists in `infrastructure/services/ConfigServiceBukkit.kt`; admin edits have zero effect.
+
+### REQ-005
+**Event-driven.** WHEN the plugin loads THEN THE SYSTEM SHALL load the `bedrock:` config section (config.yml:673-735: icon URLs, cache settings, menu toggles) and apply it, AND SHALL ship production-usable icon defaults instead of `https://via.placeholder.com/...`.
+
+> Audit H2: no `loadBedrockConfig()`; shipped icon defaults are placeholder-hosted images.
+
+### REQ-006
+**Event-driven.** WHEN chat settings are loaded THEN THE SYSTEM SHALL consume `chat.default_channel_visibility` and `chat.colored_chat_enabled` in the chat pipeline.
+
+> Audit H3 (chat): both keys parsed into MainConfig, never read by any service/listener.
+
+### REQ-007
+**State-driven.** WHILE a guild is in peaceful mode THEN THE SYSTEM SHALL enforce `guild.peaceful_mode_claim_pvp_disabled` (no PVP inside its claims) and `guild.peaceful_mode_prevent_wars` (war declarations blocked).
+
+> Audit H3 (guild): both flags parsed, never consumed. Also REQ-027 (M11) for the related opt-in field.
+
+### REQ-008
+**Ubiquitous.** THE SYSTEM SHALL enforce the combat configuration — `anti_griefing_enabled`, `war_duration_hours`, `war_end_grace_period_minutes`, `max_simultaneous_wars`, `kill_experience`, `war_win_experience`, `war_lose_experience`, `kill_cooldown_minutes`, `same_player_kill_limit`.
+
+> Audit H3 (combat): 9 knobs parsed, never consumed. No war cap/duration enforcement in `WarServiceBukkit`; no anti-grief listener.
+
+### REQ-009
+**Ubiquitous.** THE SYSTEM SHALL enforce the bank configuration — interest accrual per `bank.interest_rate_percent` and `bank.interest_compound_period_hours`, `bank.max_bank_balance`, `bank.audit_log_retention_days`, `bank.suspicious_transaction_threshold`, and `bank.auto_lock_suspicious_accounts`.
+
+> Audit H3 (bank): 6 knobs parsed, never consumed. No interest-accrual task exists in `BankServiceBukkit`.
+
+### REQ-010
+**Event-driven.** WHEN a player opens the guild bank automation menu THEN THE SYSTEM SHALL display persisted automation settings (not the hardcoded `interestRate=0.02` fakes), persist changes through the save action, and render the real next-run time and status.
+
+> Audit H4: `GuildBankAutomationMenu.kt` — `loadAutomationSettings()` returns fakes, save is a no-op message, next-run = now+1h, "Status: Healthy" hardcoded, 4 "coming soon" buttons (294, 319, 336, 353).
+
+### REQ-011
+**Event-driven.** WHEN a player opens the guild bank budget menu THEN THE SYSTEM SHALL display the guild's real persisted budget (`monthly`/`weekly`/`daily`) and persist changes through the save action.
+
+> Audit H5: `GuildBankBudgetMenu.kt` — hardcoded `monthly=10000/weekly=2500/daily=500`, no save, 3 "coming soon" buttons (222, 239, 256).
+
+### REQ-012
+**Event-driven.** WHEN a player opens the guild bank transaction history menu THEN THE SYSTEM SHALL render the guild's actual transactions and make the search, type, member, and date filters functional.
+
+> Audit H6: `GuildBankTransactionHistoryMenu.kt` — transaction items never added ("when API resolved"), filters are "coming soon" no-ops (219, 265, 443, 451, 459).
+
+### REQ-013
+**Event-driven.** WHEN the statistics menu requests a map render THEN THE SYSTEM SHALL produce real rendered maps for overview, trend, comparison, and proportion views, AND SHALL run the declared TTL cache cleanup.
+
+> Audit H7: `MapRendererServiceBukkit.kt` — all 4 render methods return blank maps, renderer services commented out, `isAvailable()` hardcodes true, cache cleanup never scheduled.
+
+### REQ-014
+**Ubiquitous.** THE SYSTEM SHALL implement `CombatServiceBukkit.getPlayerGuilds()` and `getRelationType()` against the guild/relation domain instead of returning `emptySet()` and hardcoded `NEUTRAL`.
+
+> Audit H8: `CombatServiceBukkit.kt:119-129` — inert placeholders; any combat/relation logic sees nothing.
+
+### REQ-015
+**Event-driven.** WHEN a player places a guild vault THEN THE SYSTEM SHALL validate the placement against claims whenever claims are enabled.
+
+> Audit H9: `GuildVaultServiceBukkit.kt:273-276` — `// TODO: Add claim validation when claims are enabled`; vaults place anywhere.
+
+### REQ-016
+**Ubiquitous.** THE SYSTEM SHALL render guild, bank, war, and admin command messages through the localization system (`lang/defaults/*.properties`), replacing hardcoded `§`-strings, and SHALL leave no lang keys unreferenced.
+
+> Audit H10: ~200 guild/bank/war/progression/command/error/menu keys have zero `translate()` calls; only the claims UI + Bedrock forms use the lang system.
+> Decision flag: audit offers "migrate commands to lang OR delete dead keys". Approved direction (finish features): migrate; delete nothing.
+
+---
+
+## Section C — Medium
+
+### REQ-017
+**Event-driven.** WHEN the plugin starts THEN THE SYSTEM SHALL either register `ShopIntegrationService` in DI with real consumers or remove it.
+
+> Audit M1: dead class, never registered in DI, no consumers.
+> Decision flag: default = remove (no consumers); flip to wire if a shop integration is planned.
+
+### REQ-018
+**Event-driven.** WHEN the plugin loads THEN THE SYSTEM SHALL load `brewingXp` (default 3) from config so operators can tune it.
+
+> Audit M2: `MainConfig.kt:398` — field exists, no yml key/loader.
+
+### REQ-019
+**Event-driven.** WHEN the plugin loads THEN THE SYSTEM SHALL load `modeSwitchingEnabled` (default true) from config so it can be disabled.
+
+> Audit M3: `MainConfig.kt:111` — field exists, no loader.
+
+### REQ-020
+**Event-driven.** WHEN the plugin loads THEN THE SYSTEM SHALL load `nameFilter` / `NameFilterConfig` (50+ regex patterns) from config.
+
+> Audit M4: `MainConfig.kt:107` — field exists, no loader.
+
+### REQ-021
+**Event-driven.** WHEN the plugin loads THEN THE SYSTEM SHALL load `guild.banner_copy_physical_cost` (config.yml:143) and apply it to banner-copy operations.
+
+> Audit M5: `loadGuildConfig()` never reads the key.
+
+### REQ-022
+**Ubiquitous.** THE SYSTEM SHALL apply the `ui.*.enchanted` menu-item setting so configured items render with the enchantment glow.
+
+> Audit M6: `MenuItemConfig.kt:338` parses it; menu builders never apply it.
+
+### REQ-023
+**Event-driven.** WHEN `discord_csv_delivery` is disabled THEN THE SYSTEM SHALL NOT run CSV delivery even when a webhook URL is configured.
+
+> Audit M7: `ConfigServiceBukkit.kt:276` loads the flag, nothing ever reads it.
+
+### REQ-024
+**Event-driven.** WHEN a war is declared THEN THE SYSTEM SHALL run the accept/decline declaration flow instead of auto-accepting immediately.
+
+> Audit M8: `WarServiceBukkit.kt:80` — `TODO`; wars auto-accept.
+
+### REQ-025
+**Ubiquitous.** THE SYSTEM SHALL resolve Nexo emoji glyphs through the public API without reflection into FontManager.
+
+> Audit M9: `NexoEmojiService.kt:198` — reflection hack, TODO to use API directly.
+> Decision flag: if Nexo has no public API for glyph resolution, keep the reflection isolated behind the service interface and document why.
+
+### REQ-026
+**Event-driven.** WHEN the plugin loads THEN THE SYSTEM SHALL load `combat.war_farming_cooldown_hours` (config.yml:408) and enforce it.
+
+> Audit M10: key never loaded; always 1h default.
+
+### REQ-027
+**Event-driven.** WHEN peaceful mode is toggled THEN THE SYSTEM SHALL load and consume `peacefulGuildPvpOptIn` per guild.
+
+> Audit M11: dead field in GuildConfig, never loaded nor consumed. Related to REQ-007.
+
+### REQ-028
+**Ubiquitous.** THE SYSTEM SHALL NOT hardcode the Discord CSV avatar URL — it SHALL be configurable.
+
+> Audit M12: `DiscordCsvService.kt:255` hardcodes `https://i.imgur.com/placeholder.png`.
+
+### REQ-029
+**Ubiquitous.** THE SYSTEM SHALL ship `parties_enabled` in the shipped `config.yml` defaults.
+
+> Audit M13: feature reads with default true but the key is absent from the defaults file, so it can't be disabled from defaults.
+
+---
+
+## Section D — Low: player-facing "coming soon" stubs
+
+### REQ-030
+**Event-driven.** WHEN a player opens the disband, leave, rank-list, or promotion confirmation menus THEN THE SYSTEM SHALL run the real operation instead of sending "coming soon!" and navigating back.
+
+> Audit: `GuildDisbandConfirmationMenu.kt:17`, `GuildLeaveConfirmationMenu.kt:17`, `GuildRankListMenu.kt:12`, `GuildPromotionMenu.kt:17` — whole Java menus are stubs (Bedrock equivalents exist).
+
+### REQ-031
+**Event-driven.** WHEN a player opens the bank security menu THEN THE SYSTEM SHALL implement the dual-auth threshold setting instead of showing "coming soon".
+
+> Audit: bank security ×1 (dual-auth threshold) click handler.
+
+### REQ-032
+**Event-driven.** WHEN a player opens a statistics detail view THEN THE SYSTEM SHALL render the 14 currently-stubbed drill-downs (kill stats, contributions, etc.) in addition to the implemented charts.
+
+> Audit: 14/17 statistics detail views stubbed; charts implemented.
+
+### REQ-033
+**Event-driven.** WHEN a player opens war management THEN THE SYSTEM SHALL implement the 7 stub buttons (details, list, incoming, outgoing, stats, history, detailed).
+
+> Audit: 7 war-management buttons are "coming soon" no-ops.
+
+### REQ-034
+**Event-driven.** WHEN a player opens party management THEN THE SYSTEM SHALL implement the 5 stub buttons (details, list, send request, create, access settings).
+
+> Audit: 5 party buttons are "coming soon" no-ops.
+
+### REQ-035
+**Event-driven.** WHEN a player opens rank creation or rank edit THEN THE SYSTEM SHALL implement permission-category selection (RankCreationMenu:388) and rank reset (RankEditMenu:385).
+
+> Audit: both handlers stubbed.
+
+### REQ-036
+**Event-driven.** WHEN a player interacts with guild settings, relations, or statistics menus THEN THE SYSTEM SHALL implement the remaining stub items: settings name-edit lore (GuildSettingsMenu.kt:77), enemies list (EnemiesListMenu.kt:232), peace agreement (PeaceAgreementMenu.kt:375,379), bank statistics tax system (GuildBankStatisticsMenu.kt:410,417), and statistics online tracking (GuildStatisticsMenu.kt:158).
+
+> Audit: misc menu stubs; tax system text says "coming in a future update".
+
+### REQ-037
+**Ubiquitous.** THE SYSTEM SHALL ship no `.coming.soon` lang keys in the Bedrock forms properties.
+
+> Audit: 11 keys in `lang/bedrock/forms.properties` (bank automation/budget/security, claim player/wide permissions, claim edit tool, party management ×2, war detailed stats, relation details, member list invite).
+
+### REQ-038
+**Event-driven.** WHEN a Bedrock player opens the bank budget, bank automation, bank security, claim player-permissions, claim wide-permissions, or edit-tool forms THEN THE SYSTEM SHALL present functional forms instead of read-only "coming soon" info forms.
+
+> Audit: `BedrockGuildBankBudgetMenu`, `BedrockGuildBankAutomationMenu`, `BedrockGuildBankSecurityMenu`, `BedrockClaimPlayerPermissionsMenu`, `BedrockClaimWidePermissionsMenu`, `BedrockEditToolMenu` — read-only placeholders.
+
+### REQ-039
+**Event-driven.** WHEN a war declaration's escrow is withdrawn THEN THE SYSTEM SHALL complete the withdraw in the war service.
+
+> Audit: `GuildWarDeclarationMenu.kt:527` — "will be implemented in the war service" (never).
+
+### REQ-040
+**Event-driven.** WHEN a player selects "return to LFG" in the join-requirements menu THEN THE SYSTEM SHALL reopen the LFG menu instead of closing the inventory.
+
+> Audit: `JoinRequirementsMenu.kt:157`.
+
+### REQ-041
+**Event-driven.** WHEN a Bedrock player opens a localized form THEN THE SYSTEM SHALL detect the Floodgate locale instead of always falling back to the Minecraft locale.
+
+> Audit: `BedrockLocalizationServiceFloodgate.kt:52`.
+
+### REQ-042
+**Ubiquitous.** THE SYSTEM SHALL construct `BaseBedrockMenu` via DI rather than the service-locator hack.
+
+> Audit: `BaseBedrockMenu.kt:576`.
+
+### REQ-043
+**Event-driven.** WHEN a Bedrock player opens the join-requirements flow THEN THE SYSTEM SHALL use the Bedrock flow rather than the Java menu fallback.
+
+> Audit: `MenuFactory.kt:1065`.
+
+### REQ-044
+**Event-driven.** WHEN a Bedrock player toggles auto-deposit in the guild bank menu THEN THE SYSTEM SHALL persist and apply the real setting.
+
+> Audit: `BedrockGuildBankMenu.kt:77,301` — toggle hardcoded false; no-op fakes success.

--- a/docs/requirements.md
+++ b/docs/requirements.md
@@ -9,19 +9,19 @@ Legend: **Ubiquitous.** / **Event-driven.** / **State-driven.** / **Unwanted.**
 ## Section A — Critical: permissions
 
 ### REQ-001
-**Unwanted.** IF a player holds the declared `lumaguilds.bedrock.cache.stats` or `lumaguilds.bedrock.cache.clear` permission THEN THE SYSTEM SHALL NOT deny them via the stale `lumalyte.*` prefix in `BedrockCacheStatsCommand`.
+**Unwanted.** IF a player holds the declared `lumaguilds.bedrock.cache.stats` or `lumaguilds.bedrock.cache.clear` permission THEN THE SYSTEM SHALL NOT deny them via the stale `lumalyte.*` prefix in `BedrockCacheStatsCommand`, AND the command SHALL authorize via the exact declared nodes `lumaguilds.bedrock.cache.stats` / `lumaguilds.bedrock.cache.clear` only.
 
 > Audit C1: `interaction/commands/BedrockCacheStatsCommand.kt:21,55,74,80` checks `lumalyte.bedrock.cache.*`; `plugin.yml:255,258` declares `lumaguilds.bedrock.cache.*`. Align code and plugin.yml to the same prefix.
 
 ### REQ-002
-**Event-driven.** WHEN a player executes one of the guild subcommands `join`, `list`, `lfg`, `decline`, `invites`, `leave`, `transfer`, `getvault`, `vault`, `help`, `ally`, `enemy`, `truce`, `neutral` THEN THE SYSTEM SHALL authorize it via the corresponding `lumaguilds.guild.<sub>` node declared in plugin.yml with a sane default.
+**Event-driven.** WHEN a player executes one of the guild subcommands `join`, `list`, `lfg`, `decline`, `invites`, `leave`, `transfer`, `getvault`, `vault`, `help`, `ally`, `enemy`, `truce`, `neutral` THEN THE SYSTEM SHALL authorize it via the corresponding `lumaguilds.guild.<sub>` node, declared with `default: true` both as a child of the `lumaguilds.guild.*` wildcard and as an individual plugin.yml node.
 
 > Audit C2: `GuildCommand.kt:1283,1399,1439,1449,1477,1569,1652,1995,2108,2174,2201,2274,2342,2410` — nodes used but never declared; ACF defaults them to false and silently blocks execution.
 
 ### REQ-003
-**Ubiquitous.** THE SYSTEM SHALL grant `lumaguilds.claim.partitions`, `lumaguilds.claim.trustlist`, `lumaguilds.claimmenu`, and `lumaguilds.claimoverride` to every holder of the `lumaguilds.command.*` wildcard.
+**Ubiquitous.** THE SYSTEM SHALL grant `lumaguilds.claim.partitions`, `lumaguilds.claim.trustlist`, `lumaguilds.claimmenu`, and `lumaguilds.claimoverride` to every holder of the `lumaguilds.command.*` wildcard, and SHALL keep each of the four nodes declared both individually (`default: op`) and as children of that wildcard.
 
-> Audit C2 (wildcard gap): these four nodes are missing from the wildcard's children set, so inheriting `lumaguilds.command.*` does not grant them.
+> Audit C2 (wildcard gap): the audit claimed these four nodes were missing from the wildcard's children set — re-verified against code + plugin.yml: they ARE declared (plugin.yml:165,170,175,176 + individual blocks). REQ-003 now locks both declaration forms.
 
 ---
 
@@ -242,3 +242,12 @@ Legend: **Ubiquitous.** / **Event-driven.** / **State-driven.** / **Unwanted.**
 **Event-driven.** WHEN a Bedrock player toggles auto-deposit in the guild bank menu THEN THE SYSTEM SHALL persist and apply the real setting.
 
 > Audit: `BedrockGuildBankMenu.kt:77,301` — toggle hardcoded false; no-op fakes success.
+
+---
+
+## Section E — Domain purity (deferred)
+
+### REQ-045
+**Ubiquitous.** THE SYSTEM SHALL keep the `domain/**` layer free of framework/server imports (`org.bukkit`, `org.koin`, `co.aikar`, `net.kyori`), decoupling the 21 domain files (38 imports — mostly `domain/events/*` extending `org.bukkit.event.Event`) from Bukkit so the `forbidden:` contract in `docs/implementation.md` becomes enforceable.
+
+> Origin: CodeRabbit PR #89 comment on `docs/implementation.md:21` — `forbidden: []` is not consumed, and Konsist's `dependsOnNothing()` only checks declared layers, so domain→org.bukkit imports pass the guard. Deferred to PR-10 (LG-1001); when merged, LayerRulesTest gains an external-package assertion and the forbidden list is populated.

--- a/docs/tasks.md
+++ b/docs/tasks.md
@@ -8,10 +8,10 @@ PR grouping: tasks under each `## PR-n` header ship together in one pull request
 
 ## PR-0 — SPEAR bootstrap (foundation, no code review)
 
-- [ ] **LG-000** Bootstrap SPEAR docs + Konsist architecture guard
+- [x] **LG-000** Bootstrap SPEAR docs + Konsist architecture guard
   - Tag: `INFRA`
   - References: all REQ-001..REQ-044; `docs/implementation.md` §Layer Dependency Rules
-  - Evidence:
+  - Evidence: 44 EARS REQs + 45 PR-grouped tasks authored (Aug 10); Konsist 0.17.3 wired; LayerRulesTest 3/3 green; 370/370 tests green after domain-purity relocation
   - Files: `docs/*` (tech-stack, requirements, implementation, tasks), `src/test/kotlin/net/lumalyte/lg/architecture/LayerRulesTest.kt`, `build.gradle.kts` (add Konsist 0.17.3)
 
 ---

--- a/docs/tasks.md
+++ b/docs/tasks.md
@@ -1,0 +1,288 @@
+# LumaGuilds — Tasks (SPEAR)
+
+Every task carries exactly one tag (`TDD` / `DOC` / `INFRA`), a `References:` line, and an `Evidence:` block that MUST be filled with real source citations before any downstream SPEAR phase runs on it.
+
+PR grouping: tasks under each `## PR-n` header ship together in one pull request. PR order is dependency-driven — permissions first (commands must be executable before any feature is testable), then config plumbing (features consume the knobs), then feature domains, with the cross-cutting lang migration and UI completion last.
+
+---
+
+## PR-0 — SPEAR bootstrap (foundation, no code review)
+
+- [ ] **LG-000** Bootstrap SPEAR docs + Konsist architecture guard
+  - Tag: `INFRA`
+  - References: all REQ-001..REQ-044; `docs/implementation.md` §Layer Dependency Rules
+  - Evidence:
+  - Files: `docs/*` (tech-stack, requirements, implementation, tasks), `src/test/kotlin/net/lumalyte/lg/architecture/LayerRulesTest.kt`, `build.gradle.kts` (add Konsist 0.17.3)
+
+---
+
+## PR-1 — Permission alignment (Section A)
+
+- [ ] **LG-101** Bedrock cache commands authorize via `lumaguilds.bedrock.cache.*` — no stale `lumalyte.*` prefix
+  - Tag: `TDD`
+  - References: REQ-001
+  - Evidence:
+  - Files: `interaction/commands/BedrockCacheStatsCommand.kt`, `src/main/resources/plugin.yml`, test asserting code prefix == plugin.yml prefix
+- [ ] **LG-102** Declare the 14 `lumaguilds.guild.*` command nodes (join, list, lfg, decline, invites, leave, transfer, getvault, vault, help, ally, enemy, truce, neutral) in plugin.yml with sane defaults
+  - Tag: `TDD`
+  - References: REQ-002
+  - Evidence:
+  - Files: `src/main/resources/plugin.yml`, test scanning `@CommandPermission` vs plugin.yml declarations
+- [ ] **LG-103** Add `claim.partitions`, `claim.trustlist`, `claimmenu`, `claimoverride` to the `lumaguilds.command.*` wildcard children
+  - Tag: `TDD`
+  - References: REQ-003
+  - Evidence:
+  - Files: `src/main/resources/plugin.yml`, wildcard children test
+
+---
+
+## PR-2 — Config plumbing (dead sections + orphan keys)
+
+- [ ] **LG-201** Load the full `vault:` config section (config.yml:165-299) and apply it at runtime
+  - Tag: `TDD`
+  - References: REQ-004
+  - Evidence:
+  - Files: `infrastructure/services/ConfigServiceBukkit.kt`, `config/MainConfig.kt`, loader tests
+- [ ] **LG-202** Load the `bedrock:` config section (config.yml:673-735) and replace placeholder icon defaults
+  - Tag: `TDD`
+  - References: REQ-005
+  - Evidence:
+  - Files: `infrastructure/services/ConfigServiceBukkit.kt`, `config/MainConfig.kt`, bedrock defaults in `config.yml`
+- [ ] **LG-203** Consume `chat.default_channel_visibility` and `chat.colored_chat_enabled` in the chat pipeline
+  - Tag: `TDD`
+  - References: REQ-006
+  - Evidence:
+  - Files: chat services/listeners, config model
+- [ ] **LG-204** Load `brewingXp` from config (operator-tunable)
+  - Tag: `TDD`
+  - References: REQ-018
+  - Evidence:
+  - Files: `config/MainConfig.kt`, `config.yml`, loader
+- [ ] **LG-205** Load `modeSwitchingEnabled` from config (can be disabled)
+  - Tag: `TDD`
+  - References: REQ-019
+  - Evidence:
+  - Files: `config/MainConfig.kt`, `config.yml`, loader
+- [ ] **LG-206** Load `nameFilter` / `NameFilterConfig` from config
+  - Tag: `TDD`
+  - References: REQ-020
+  - Evidence:
+  - Files: `config/MainConfig.kt`, `config.yml`, loader
+- [ ] **LG-207** Load `guild.banner_copy_physical_cost` and apply it to banner-copy operations
+  - Tag: `TDD`
+  - References: REQ-021
+  - Evidence:
+  - Files: `loadGuildConfig()`, banner-copy service
+- [ ] **LG-208** Gate CSV delivery on `discord_csv_delivery` (no delivery when disabled even with webhook set)
+  - Tag: `TDD`
+  - References: REQ-023
+  - Evidence:
+  - Files: `ConfigServiceBukkit.kt:276`, `DiscordCsvService.kt`
+- [ ] **LG-209** Ship `parties_enabled` in the config.yml defaults
+  - Tag: `TDD`
+  - References: REQ-029
+  - Evidence:
+  - Files: `src/main/resources/config.yml`, DI parties module
+
+---
+
+## PR-3 — Bank features (knobs + real menus)
+
+- [ ] **LG-301** Enforce bank config: interest accrual task, max balance, audit retention, suspicious-transaction detection + auto-lock
+  - Tag: `TDD`
+  - References: REQ-009
+  - Evidence:
+  - Files: `infrastructure/services/BankServiceBukkit.kt`, bank config model
+- [ ] **LG-302** Bank automation menu: persisted settings, real save, real next-run time + status
+  - Tag: `TDD`
+  - References: REQ-010
+  - Evidence:
+  - Files: `interaction/menus/GuildBankAutomationMenu.kt`, automation persistence
+- [ ] **LG-303** Bank budget menu: real persisted budget + save
+  - Tag: `TDD`
+  - References: REQ-011
+  - Evidence:
+  - Files: `interaction/menus/GuildBankBudgetMenu.kt`, budget persistence
+- [ ] **LG-304** Bank transaction history: renders actual transactions; search/type/member/date filters functional
+  - Tag: `TDD`
+  - References: REQ-012
+  - Evidence:
+  - Files: `interaction/menus/GuildBankTransactionHistoryMenu.kt`, transaction repository
+- [ ] **LG-305** Bank security menu: dual-auth threshold setting implemented
+  - Tag: `TDD`
+  - References: REQ-031
+  - Evidence:
+  - Files: bank security menu, dual-auth config
+
+---
+
+## PR-4 — Combat & wars (knobs + real services)
+
+- [ ] **LG-401** Enforce combat config: war duration, grace period, max simultaneous wars, kill/win/lose XP, kill cooldown, same-player kill limit, anti-griefing
+  - Tag: `TDD`
+  - References: REQ-008
+  - Evidence:
+  - Files: `infrastructure/services/WarServiceBukkit.kt`, combat listener
+- [ ] **LG-402** Implement `CombatServiceBukkit.getPlayerGuilds()` and `getRelationType()` against the guild/relation domain
+  - Tag: `TDD`
+  - References: REQ-014
+  - Evidence:
+  - Files: `infrastructure/services/CombatServiceBukkit.kt:119-129`
+- [ ] **LG-403** War declaration accept/decline flow (no instant auto-accept)
+  - Tag: `TDD`
+  - References: REQ-024
+  - Evidence:
+  - Files: `WarServiceBukkit.kt:80`, declaration menu
+- [ ] **LG-404** Load and enforce `combat.war_farming_cooldown_hours`
+  - Tag: `TDD`
+  - References: REQ-026
+  - Evidence:
+  - Files: `config.yml:408`, war service
+- [ ] **LG-405** War declaration escrow withdraw completed in the war service
+  - Tag: `TDD`
+  - References: REQ-039
+  - Evidence:
+  - Files: `GuildWarDeclarationMenu.kt:527`, war escrow service
+
+---
+
+## PR-5 — Claims, peaceful mode & vault (Section B residuals)
+
+- [ ] **LG-501** Enforce peaceful-mode flags: claim PVP disabled, war declarations blocked
+  - Tag: `TDD`
+  - References: REQ-007
+  - Evidence:
+  - Files: claim PVP listener, war service
+- [ ] **LG-502** Vault placement validates against claims when claims are enabled
+  - Tag: `TDD`
+  - References: REQ-015
+  - Evidence:
+  - Files: `GuildVaultServiceBukkit.kt:273-276`, claim domain
+- [ ] **LG-503** Load and consume `peacefulGuildPvpOptIn` per guild
+  - Tag: `TDD`
+  - References: REQ-027
+  - Evidence:
+  - Files: GuildConfig, peaceful-mode service
+
+---
+
+## PR-6 — Statistics & maps
+
+- [ ] **LG-601** MapRendererServiceBukkit produces real overview/trend/comparison/proportion renders; TTL cache cleanup scheduled; `isAvailable()` honest
+  - Tag: `TDD`
+  - References: REQ-013
+  - Evidence:
+  - Files: `infrastructure/services/MapRendererServiceBukkit.kt`, renderer services
+- [ ] **LG-602** Implement the 14 stubbed statistics drill-downs (kill stats, contributions, etc.)
+  - Tag: `TDD`
+  - References: REQ-032
+  - Evidence:
+  - Files: `interaction/menus/GuildStatisticsMenu.kt` + detail views
+
+---
+
+## PR-7 — Localization migration (cross-cutting)
+
+- [ ] **LG-701** Migrate guild/bank/war/admin command messages off hardcoded `§`-strings onto `lang/defaults/*.properties`; zero unreferenced lang keys remain
+  - Tag: `TDD`
+  - References: REQ-016
+  - Evidence:
+  - Files: `interaction/commands/*`, `lang/defaults/*.properties`, `LocalizationProviderProperties`
+  - Note: large — decompose into per-command sub-tasks during spec if the briefing exceeds ~1500 tokens.
+
+---
+
+## PR-8a — Java UI completion
+
+- [ ] **LG-801** Apply `ui.*.enchanted` menu-item glow
+  - Tag: `TDD`
+  - References: REQ-022
+  - Evidence:
+  - Files: `MenuItemConfig.kt:338`, menu builders
+- [ ] **LG-802** Real disband/leave/rank-list/promotion menus (replace "coming soon!" stubs)
+  - Tag: `TDD`
+  - References: REQ-030
+  - Evidence:
+  - Files: `GuildDisbandConfirmationMenu.kt:17`, `GuildLeaveConfirmationMenu.kt:17`, `GuildRankListMenu.kt:12`, `GuildPromotionMenu.kt:17`
+- [ ] **LG-803** War management buttons ×7 (details/list/incoming/outgoing/stats/history/detailed) implemented
+  - Tag: `TDD`
+  - References: REQ-033
+  - Evidence:
+  - Files: war management menus
+  - Note: needs PR-4 war data.
+- [ ] **LG-804** Party management buttons ×5 (details/list/send request/create/access settings) implemented
+  - Tag: `TDD`
+  - References: REQ-034
+  - Evidence:
+  - Files: party menus
+- [ ] **LG-805** Rank permission-category selection (RankCreationMenu:388) + rank reset (RankEditMenu:385) implemented
+  - Tag: `TDD`
+  - References: REQ-035
+  - Evidence:
+  - Files: `RankCreationMenu.kt`, `RankEditMenu.kt`
+- [ ] **LG-806** Misc menu stubs: settings name-edit lore, enemies list, peace agreement, bank statistics tax, statistics online tracking
+  - Tag: `TDD`
+  - References: REQ-036
+  - Evidence:
+  - Files: `GuildSettingsMenu.kt:77`, `EnemiesListMenu.kt:232`, `PeaceAgreementMenu.kt:375,379`, `GuildBankStatisticsMenu.kt:410,417`, `GuildStatisticsMenu.kt:158`
+
+---
+
+## PR-8b — Bedrock & misc UX
+
+- [ ] **LG-811** Remove all `.coming.soon` lang keys from `lang/bedrock/forms.properties`
+  - Tag: `TDD`
+  - References: REQ-037
+  - Evidence:
+  - Files: `lang/bedrock/forms.properties`
+- [ ] **LG-812** Functional Bedrock forms for bank budget/automation/security, claim player/wide permissions, and edit tool
+  - Tag: `TDD`
+  - References: REQ-038
+  - Evidence:
+  - Files: `BedrockGuildBankBudgetMenu`, `BedrockGuildBankAutomationMenu`, `BedrockGuildBankSecurityMenu`, `BedrockClaimPlayerPermissionsMenu`, `BedrockClaimWidePermissionsMenu`, `BedrockEditToolMenu`
+  - Note: bank forms need PR-3 persistence; claim forms need PR-5.
+- [ ] **LG-813** Floodgate locale detection in `BedrockLocalizationServiceFloodgate`
+  - Tag: `TDD`
+  - References: REQ-041
+  - Evidence:
+  - Files: `BedrockLocalizationServiceFloodgate.kt:52`
+- [ ] **LG-814** `BaseBedrockMenu` constructed via DI, not service-locator
+  - Tag: `INFRA`
+  - References: REQ-042
+  - Evidence:
+  - Files: `BaseBedrockMenu.kt:576`, Koin modules
+- [ ] **LG-815** Bedrock join-requirements flow — no Java menu fallback
+  - Tag: `TDD`
+  - References: REQ-043
+  - Evidence:
+  - Files: `MenuFactory.kt:1065`
+- [ ] **LG-816** Bedrock guild bank auto-deposit toggle persisted and applied
+  - Tag: `TDD`
+  - References: REQ-044
+  - Evidence:
+  - Files: `BedrockGuildBankMenu.kt:77,301`
+- [ ] **LG-817** "Return to LFG" in join-requirements menu reopens LFG
+  - Tag: `TDD`
+  - References: REQ-040
+  - Evidence:
+  - Files: `JoinRequirementsMenu.kt:157`
+
+---
+
+## PR-9 — Tech debt sweep
+
+- [ ] **LG-901** Remove `ShopIntegrationService` (dead class, no DI registration, no consumers)
+  - Tag: `INFRA`
+  - References: REQ-017
+  - Evidence:
+  - Files: `infrastructure/services/ShopIntegrationService.kt`
+- [ ] **LG-902** NexoEmojiService resolves glyphs without reflection into FontManager
+  - Tag: `TDD`
+  - References: REQ-025
+  - Evidence:
+  - Files: `NexoEmojiService.kt:198`
+- [ ] **LG-903** Discord CSV avatar URL configurable (no hardcoded placeholder)
+  - Tag: `TDD`
+  - References: REQ-028
+  - Evidence:
+  - Files: `DiscordCsvService.kt:255`, discord config section

--- a/docs/tasks.md
+++ b/docs/tasks.md
@@ -286,3 +286,13 @@ PR grouping: tasks under each `## PR-n` header ship together in one pull request
   - References: REQ-028
   - Evidence:
   - Files: `DiscordCsvService.kt:255`, discord config section
+
+---
+
+## PR-10 — Domain purity II (Bukkit-free domain)
+
+- [ ] **LG-1001** Decouple domain events from `org.bukkit.event.Event`; remove `org.bukkit`/`org.koin`/`co.aikar`/`net.kyori` imports from `domain/**`; make the `forbidden:` contract executable (LayerRulesTest external-package assertion + populated list)
+  - Tag: `TDD`
+  - References: REQ-045
+  - Evidence:
+  - Files: `domain/events/*` (21 files, 38 Bukkit imports), `domain/entities/{VaultInventory,ViewerSession,WriteBuffer}.kt`, `LayerRulesTest`, `docs/implementation.md`

--- a/docs/tech-stack.md
+++ b/docs/tech-stack.md
@@ -1,0 +1,22 @@
+# LumaGuilds — Tech Stack
+
+| Concern | Choice |
+|---|---|
+| Language | Kotlin 2.0.0 (JVM), JDK 21 toolchain |
+| Build | Gradle + Shadow 8.3.6 — archive `LumaGuilds.jar`; relocates `com.zaxxer.hikari`, `co.aikar.commands`, `co.aikar.idb` to `net.lumalyte.lg.shaded.*` |
+| Server API | Paper 1.21.11 `paper-api:1.21.11-R0.1-SNAPSHOT` (compileOnly + testImplementation) |
+| Commands | ACF `acf-paper:0.5.1-SNAPSHOT` + `idb-core:1.0.0-SNAPSHOT` (`interaction/commands/`, `@CommandPermission` nodes) |
+| DI | Koin `koin-core:4.0.2` (`di/Modules.kt`: coreModule, claimsModule, guildsModule, socialModule, progressionModule) |
+| GUIs | InventoryFramework `0.11.6` (`interaction/menus/`) |
+| Persistence | MariaDB `mariadb-java-client:3.3.2` + HikariCP `5.1.0` (shaded); sqlite-jdbc 3.45.1.0 on test classpath |
+| Async | kotlinx-coroutines-core/jdk8 `1.10.2` |
+| Bedrock | Geyser api `2.9.4-SNAPSHOT`, Floodgate api `2.2.5-SNAPSHOT`, Cumulus `2.0.0-SNAPSHOT` (forms in `interaction/menus/bedrock/` + `BedrockLocalizationServiceFloodgate`) |
+| Chat/display | Adventure api + MiniMessage `4.17.0`; PlaceholderAPI `2.11.6` (compileOnly); Vault `1.7` (compileOnly) |
+| Integrations | RoseChat RC-2 (local jar `libs/`, compileOnly — GuildChatListener channel switch), LiteBansAPI `0.6.1` (compileOnly, JitPack), EnthusiaMarket api jar (`libs/enthusiamarket-api.jar`), CombatLogX api, LunarClient Apollo `1.2.3`, AxKothAPI `4` |
+| i18n | `lang/defaults/*.properties` — actually serves claims UI + Bedrock forms only; guild/bank/war/admin commands hardcode `§`-strings (REQ-016 migrates them) |
+| Tests | kotlin-test, JUnit Jupiter 5.8.1, MockK 1.13.11, MockBukkit 4.107.0, sqlite-jdbc; Konsist `0.17.3` added in PR-0 |
+| Out of stack | Nexus framework, Flyway / DB migration frameworks, external web servers |
+
+## CI
+
+`.github/workflows/` — Gradle build + shadowJar artifact on push/PR. Konsist runs as part of `./gradlew test` (LayerRulesTest under `src/test/kotlin/net/lumalyte/lg/architecture/`).

--- a/src/main/kotlin/net/lumalyte/lg/application/persistence/ProgressionRepository.kt
+++ b/src/main/kotlin/net/lumalyte/lg/application/persistence/ProgressionRepository.kt
@@ -1,7 +1,7 @@
 package net.lumalyte.lg.application.persistence
 
 import net.lumalyte.lg.domain.entities.*
-import net.lumalyte.lg.application.services.ExperienceSource
+import net.lumalyte.lg.domain.values.ExperienceSource
 import java.time.Instant
 import java.util.UUID
 

--- a/src/main/kotlin/net/lumalyte/lg/application/services/GuildBannerService.kt
+++ b/src/main/kotlin/net/lumalyte/lg/application/services/GuildBannerService.kt
@@ -1,6 +1,7 @@
 package net.lumalyte.lg.application.services
 
 import net.lumalyte.lg.domain.entities.GuildBanner
+import net.lumalyte.lg.domain.values.BannerDesignData
 import java.util.UUID
 
 /**
@@ -62,54 +63,4 @@ interface GuildBannerService {
      * @return List of saved banner designs.
      */
     fun getGuildBanners(guildId: UUID): List<GuildBanner>
-}
-
-/**
- * Represents banner design data submitted by a guild.
- */
-data class BannerDesignData(
-    val baseColor: BannerColor,
-    val patterns: List<BannerPattern> = emptyList()
-) {
-    /**
-     * Validates the banner design data.
-     */
-    fun isValid(): Boolean {
-        return patterns.size <= 6 && // Minecraft banner limit
-               patterns.all { it.isValid() }
-    }
-}
-
-/**
- * Represents a banner pattern.
- */
-data class BannerPattern(
-    val type: String, // e.g., "STRIPE_TOP", "CROSS", "BORDER"
-    val color: BannerColor
-) {
-    fun isValid(): Boolean = color.isValid()
-}
-
-/**
- * Represents a banner color.
- */
-enum class BannerColor(val displayName: String, val hexCode: String, val materialName: String) {
-    WHITE("White", "#FFFFFF", "WHITE"),
-    ORANGE("Orange", "#FF8F00", "ORANGE"),
-    MAGENTA("Magenta", "#C74EBD", "MAGENTA"),
-    LIGHT_BLUE("Light Blue", "#3AAFD9", "LIGHT_BLUE"),
-    YELLOW("Yellow", "#FED83D", "YELLOW"),
-    LIME("Lime", "#80C71F", "LIME"),
-    PINK("Pink", "#F38BAA", "PINK"),
-    GRAY("Gray", "#474F52", "GRAY"),
-    LIGHT_GRAY("Light Gray", "#9D9D97", "LIGHT_GRAY"),
-    CYAN("Cyan", "#169C9C", "CYAN"),
-    PURPLE("Purple", "#9932CC", "PURPLE"),
-    BLUE("Blue", "#3C44AA", "BLUE"),
-    BROWN("Brown", "#825432", "BROWN"),
-    GREEN("Green", "#5E7C16", "GREEN"),
-    RED("Red", "#B02E26", "RED"),
-    BLACK("Black", "#1D1C21", "BLACK");
-
-    fun isValid(): Boolean = true
 }

--- a/src/main/kotlin/net/lumalyte/lg/application/services/PenaltyService.kt
+++ b/src/main/kotlin/net/lumalyte/lg/application/services/PenaltyService.kt
@@ -1,6 +1,7 @@
 package net.lumalyte.lg.application.services
 
 import net.lumalyte.lg.application.persistence.PenaltyRepository
+import net.lumalyte.lg.domain.values.ExperienceSource
 import net.lumalyte.lg.config.StrikesConfig
 import net.lumalyte.lg.domain.entities.Guild
 import net.lumalyte.lg.domain.entities.GuildPenalty

--- a/src/main/kotlin/net/lumalyte/lg/application/services/ProgressionService.kt
+++ b/src/main/kotlin/net/lumalyte/lg/application/services/ProgressionService.kt
@@ -1,5 +1,7 @@
 package net.lumalyte.lg.application.services
 
+import net.lumalyte.lg.domain.values.ExperienceSource
+import net.lumalyte.lg.domain.values.PerkType
 import java.time.Instant
 import java.util.UUID
 
@@ -215,68 +217,6 @@ interface ProgressionService {
      * GuildProgression.currentLevel. Returns the number of guild rows updated.
      */
     fun syncGuildLevels(): Int
-}
-
-/**
- * Sources of experience for guilds.
- */
-enum class ExperienceSource {
-    // Guild Activities
-    BANK_DEPOSIT,
-    MEMBER_JOINED,
-    WAR_WON,
-    WAR_LOST,
-    
-    // Player Activities
-    PLAYER_KILL,
-    MOB_KILL,
-    CROP_BREAK,
-    BLOCK_BREAK,
-    BLOCK_PLACE,
-    CRAFTING,
-    SMELTING,
-    FISHING,
-    ENCHANTING,
-    
-    // Claims (if enabled)
-    CLAIM_CREATED,
-    CLAIM_DESTROYED,
-    
-    // System
-    WEEKLY_ACTIVITY,
-    ADMIN_BONUS
-}
-
-/**
- * Types of perks that can be unlocked.
- */
-enum class PerkType {
-    // Claim perks (if claims enabled)
-    INCREASED_CLAIM_BLOCKS,
-    INCREASED_CLAIM_COUNT,
-    FASTER_CLAIM_REGEN,
-
-    // Bank perks
-    HIGHER_BANK_BALANCE,
-    BANK_INTEREST,
-    INCREASED_BANK_LIMIT,
-    REDUCED_WITHDRAWAL_FEES,
-
-    // Home perks
-    ADDITIONAL_HOMES,
-    TELEPORT_COOLDOWN_REDUCTION,
-    HOME_TELEPORT_SOUND_EFFECTS,
-    ALLY_HOME_ACCESS,
-
-    // Audio/Visual perks (always unlocked)
-    CUSTOM_BANNER_COLORS,
-    ANIMATED_EMOJIS,
-    SPECIAL_PARTICLES,
-    ANNOUNCEMENT_SOUND_EFFECTS,
-    WAR_DECLARATION_SOUND_EFFECTS,
-
-    // System perks
-    // (No system perks currently defined)
 }
 
 /**

--- a/src/main/kotlin/net/lumalyte/lg/application/services/scheduling/SchedulerService.kt
+++ b/src/main/kotlin/net/lumalyte/lg/application/services/scheduling/SchedulerService.kt
@@ -1,5 +1,7 @@
 package net.lumalyte.lg.application.services.scheduling
 
+import net.lumalyte.lg.domain.services.Task
+
 /**
  * Schedules an event to run after an X amount of time
  */

--- a/src/main/kotlin/net/lumalyte/lg/config/ProgressionConfig.kt
+++ b/src/main/kotlin/net/lumalyte/lg/config/ProgressionConfig.kt
@@ -1,6 +1,6 @@
 package net.lumalyte.lg.config
 
-import net.lumalyte.lg.application.services.PerkType
+import net.lumalyte.lg.domain.values.PerkType
 import org.bukkit.Material
 
 /**

--- a/src/main/kotlin/net/lumalyte/lg/domain/entities/GuildBanner.kt
+++ b/src/main/kotlin/net/lumalyte/lg/domain/entities/GuildBanner.kt
@@ -1,6 +1,6 @@
 package net.lumalyte.lg.domain.entities
 
-import net.lumalyte.lg.application.services.BannerDesignData
+import net.lumalyte.lg.domain.values.BannerDesignData
 import java.time.Instant
 import java.util.UUID
 

--- a/src/main/kotlin/net/lumalyte/lg/domain/entities/PlayerState.kt
+++ b/src/main/kotlin/net/lumalyte/lg/domain/entities/PlayerState.kt
@@ -1,6 +1,6 @@
 package net.lumalyte.lg.domain.entities
 
-import net.lumalyte.lg.application.services.scheduling.Task
+import net.lumalyte.lg.domain.services.Task
 import net.lumalyte.lg.domain.values.Position3D
 import java.time.Instant
 import java.util.UUID

--- a/src/main/kotlin/net/lumalyte/lg/domain/entities/Progression.kt
+++ b/src/main/kotlin/net/lumalyte/lg/domain/entities/Progression.kt
@@ -1,7 +1,7 @@
 package net.lumalyte.lg.domain.entities
 
-import net.lumalyte.lg.application.services.ExperienceSource
-import net.lumalyte.lg.application.services.PerkType
+import net.lumalyte.lg.domain.values.ExperienceSource
+import net.lumalyte.lg.domain.values.PerkType
 import java.time.Instant
 import java.util.UUID
 

--- a/src/main/kotlin/net/lumalyte/lg/domain/services/Task.kt
+++ b/src/main/kotlin/net/lumalyte/lg/domain/services/Task.kt
@@ -1,4 +1,4 @@
-package net.lumalyte.lg.application.services.scheduling
+package net.lumalyte.lg.domain.services
 
 /**
  * Represents a task that is to be performed

--- a/src/main/kotlin/net/lumalyte/lg/domain/values/BannerDesign.kt
+++ b/src/main/kotlin/net/lumalyte/lg/domain/values/BannerDesign.kt
@@ -1,0 +1,51 @@
+package net.lumalyte.lg.domain.values
+
+/**
+ * Represents banner design data submitted by a guild.
+ */
+data class BannerDesignData(
+    val baseColor: BannerColor,
+    val patterns: List<BannerPattern> = emptyList()
+) {
+    /**
+     * Validates the banner design data.
+     */
+    fun isValid(): Boolean {
+        return patterns.size <= 6 && // Minecraft banner limit
+               patterns.all { it.isValid() }
+    }
+}
+
+/**
+ * Represents a banner pattern.
+ */
+data class BannerPattern(
+    val type: String, // e.g., "STRIPE_TOP", "CROSS", "BORDER"
+    val color: BannerColor
+) {
+    fun isValid(): Boolean = color.isValid()
+}
+
+/**
+ * Represents a banner color.
+ */
+enum class BannerColor(val displayName: String, val hexCode: String, val materialName: String) {
+    WHITE("White", "#FFFFFF", "WHITE"),
+    ORANGE("Orange", "#FF8F00", "ORANGE"),
+    MAGENTA("Magenta", "#C74EBD", "MAGENTA"),
+    LIGHT_BLUE("Light Blue", "#3AAFD9", "LIGHT_BLUE"),
+    YELLOW("Yellow", "#FED83D", "YELLOW"),
+    LIME("Lime", "#80C71F", "LIME"),
+    PINK("Pink", "#F38BAA", "PINK"),
+    GRAY("Gray", "#474F52", "GRAY"),
+    LIGHT_GRAY("Light Gray", "#9D9D97", "LIGHT_GRAY"),
+    CYAN("Cyan", "#169C9C", "CYAN"),
+    PURPLE("Purple", "#9932CC", "PURPLE"),
+    BLUE("Blue", "#3C44AA", "BLUE"),
+    BROWN("Brown", "#825432", "BROWN"),
+    GREEN("Green", "#5E7C16", "GREEN"),
+    RED("Red", "#B02E26", "RED"),
+    BLACK("Black", "#1D1C21", "BLACK");
+
+    fun isValid(): Boolean = true
+}

--- a/src/main/kotlin/net/lumalyte/lg/domain/values/BannerDesign.kt
+++ b/src/main/kotlin/net/lumalyte/lg/domain/values/BannerDesign.kt
@@ -23,7 +23,7 @@ data class BannerPattern(
     val type: String, // e.g., "STRIPE_TOP", "CROSS", "BORDER"
     val color: BannerColor
 ) {
-    fun isValid(): Boolean = color.isValid()
+    fun isValid(): Boolean = type.isNotBlank() && color.isValid()
 }
 
 /**

--- a/src/main/kotlin/net/lumalyte/lg/domain/values/ExperienceSource.kt
+++ b/src/main/kotlin/net/lumalyte/lg/domain/values/ExperienceSource.kt
@@ -1,0 +1,31 @@
+package net.lumalyte.lg.domain.values
+
+/**
+ * Sources of experience for guilds.
+ */
+enum class ExperienceSource {
+    // Guild Activities
+    BANK_DEPOSIT,
+    MEMBER_JOINED,
+    WAR_WON,
+    WAR_LOST,
+    
+    // Player Activities
+    PLAYER_KILL,
+    MOB_KILL,
+    CROP_BREAK,
+    BLOCK_BREAK,
+    BLOCK_PLACE,
+    CRAFTING,
+    SMELTING,
+    FISHING,
+    ENCHANTING,
+    
+    // Claims (if enabled)
+    CLAIM_CREATED,
+    CLAIM_DESTROYED,
+    
+    // System
+    WEEKLY_ACTIVITY,
+    ADMIN_BONUS
+}

--- a/src/main/kotlin/net/lumalyte/lg/domain/values/PerkType.kt
+++ b/src/main/kotlin/net/lumalyte/lg/domain/values/PerkType.kt
@@ -1,0 +1,33 @@
+package net.lumalyte.lg.domain.values
+
+/**
+ * Types of perks that can be unlocked.
+ */
+enum class PerkType {
+    // Claim perks (if claims enabled)
+    INCREASED_CLAIM_BLOCKS,
+    INCREASED_CLAIM_COUNT,
+    FASTER_CLAIM_REGEN,
+
+    // Bank perks
+    HIGHER_BANK_BALANCE,
+    BANK_INTEREST,
+    INCREASED_BANK_LIMIT,
+    REDUCED_WITHDRAWAL_FEES,
+
+    // Home perks
+    ADDITIONAL_HOMES,
+    TELEPORT_COOLDOWN_REDUCTION,
+    HOME_TELEPORT_SOUND_EFFECTS,
+    ALLY_HOME_ACCESS,
+
+    // Audio/Visual perks (always unlocked)
+    CUSTOM_BANNER_COLORS,
+    ANIMATED_EMOJIS,
+    SPECIAL_PARTICLES,
+    ANNOUNCEMENT_SOUND_EFFECTS,
+    WAR_DECLARATION_SOUND_EFFECTS,
+
+    // System perks
+    // (No system perks currently defined)
+}

--- a/src/main/kotlin/net/lumalyte/lg/infrastructure/listeners/ProgressionEventListener.kt
+++ b/src/main/kotlin/net/lumalyte/lg/infrastructure/listeners/ProgressionEventListener.kt
@@ -13,7 +13,7 @@ import kotlinx.coroutines.launch
 import kotlinx.coroutines.runBlocking
 import net.lumalyte.lg.application.services.ActivityType
 import net.lumalyte.lg.application.services.ConfigService
-import net.lumalyte.lg.application.services.ExperienceSource
+import net.lumalyte.lg.domain.values.ExperienceSource
 import net.lumalyte.lg.application.services.LeaderboardService
 import net.lumalyte.lg.application.services.MemberService
 import net.lumalyte.lg.application.services.ProgressionService

--- a/src/main/kotlin/net/lumalyte/lg/infrastructure/persistence/guilds/GuildBannerRepositorySQLite.kt
+++ b/src/main/kotlin/net/lumalyte/lg/infrastructure/persistence/guilds/GuildBannerRepositorySQLite.kt
@@ -3,9 +3,9 @@ package net.lumalyte.lg.infrastructure.persistence.guilds
 import co.aikar.idb.Database
 
 import net.lumalyte.lg.application.persistence.GuildBannerRepository
-import net.lumalyte.lg.application.services.BannerDesignData
-import net.lumalyte.lg.application.services.BannerColor
-import net.lumalyte.lg.application.services.BannerPattern
+import net.lumalyte.lg.domain.values.BannerColor
+import net.lumalyte.lg.domain.values.BannerDesignData
+import net.lumalyte.lg.domain.values.BannerPattern
 import net.lumalyte.lg.domain.entities.GuildBanner
 import net.lumalyte.lg.infrastructure.persistence.storage.Storage
 import org.slf4j.LoggerFactory

--- a/src/main/kotlin/net/lumalyte/lg/infrastructure/persistence/guilds/ProgressionRepositorySQLite.kt
+++ b/src/main/kotlin/net/lumalyte/lg/infrastructure/persistence/guilds/ProgressionRepositorySQLite.kt
@@ -217,16 +217,15 @@ class ProgressionRepositorySQLite(private val storage: Storage<Database>) : Prog
     private fun parseUnlockedPerks(json: String): Set<net.lumalyte.lg.domain.values.PerkType> {
         if (json.isBlank() || json == "[]") return emptySet()
 
-        return try {
-            json.trim('[', ']')
-                .split(',')
-                .map { it.trim().trim('"') }
-                .filter { it.isNotEmpty() }
-                .map { net.lumalyte.lg.domain.values.PerkType.valueOf(it) }
-                .toSet()
-        } catch (e: SQLException) {
-            emptySet()
-        }
+        // Resilient against renamed/removed perk entries: PerkType.valueOf throws
+        // IllegalArgumentException (not SQLException), so unknown names are skipped
+        // instead of crashing preload with a stale DB.
+        return json.trim('[', ']')
+            .split(',')
+            .map { it.trim().trim('"') }
+            .filter { it.isNotEmpty() }
+            .mapNotNull { runCatching { net.lumalyte.lg.domain.values.PerkType.valueOf(it) }.getOrNull() }
+            .toSet()
     }
 
     private fun serializeUnlockedPerks(perks: Set<net.lumalyte.lg.domain.values.PerkType>): String {

--- a/src/main/kotlin/net/lumalyte/lg/infrastructure/persistence/guilds/ProgressionRepositorySQLite.kt
+++ b/src/main/kotlin/net/lumalyte/lg/infrastructure/persistence/guilds/ProgressionRepositorySQLite.kt
@@ -7,8 +7,8 @@ import net.lumalyte.lg.application.persistence.ProgressionRepository
 import net.lumalyte.lg.application.persistence.ActivityMetricType
 import net.lumalyte.lg.application.persistence.ProgressionStats
 import net.lumalyte.lg.domain.entities.*
-import net.lumalyte.lg.application.services.ExperienceSource
-import net.lumalyte.lg.application.services.PerkType
+import net.lumalyte.lg.domain.values.ExperienceSource
+import net.lumalyte.lg.domain.values.PerkType
 import net.lumalyte.lg.infrastructure.persistence.storage.Storage
 import org.slf4j.LoggerFactory
 import java.sql.SQLException
@@ -214,7 +214,7 @@ class ProgressionRepositorySQLite(private val storage: Storage<Database>) : Prog
         )
     }
 
-    private fun parseUnlockedPerks(json: String): Set<net.lumalyte.lg.application.services.PerkType> {
+    private fun parseUnlockedPerks(json: String): Set<net.lumalyte.lg.domain.values.PerkType> {
         if (json.isBlank() || json == "[]") return emptySet()
 
         return try {
@@ -222,14 +222,14 @@ class ProgressionRepositorySQLite(private val storage: Storage<Database>) : Prog
                 .split(',')
                 .map { it.trim().trim('"') }
                 .filter { it.isNotEmpty() }
-                .map { net.lumalyte.lg.application.services.PerkType.valueOf(it) }
+                .map { net.lumalyte.lg.domain.values.PerkType.valueOf(it) }
                 .toSet()
         } catch (e: SQLException) {
             emptySet()
         }
     }
 
-    private fun serializeUnlockedPerks(perks: Set<net.lumalyte.lg.application.services.PerkType>): String {
+    private fun serializeUnlockedPerks(perks: Set<net.lumalyte.lg.domain.values.PerkType>): String {
         if (perks.isEmpty()) return "[]"
 
         return perks.joinToString(",", "[", "]") { "\"$it\"" }

--- a/src/main/kotlin/net/lumalyte/lg/infrastructure/services/GuildBannerServiceBukkit.kt
+++ b/src/main/kotlin/net/lumalyte/lg/infrastructure/services/GuildBannerServiceBukkit.kt
@@ -1,6 +1,7 @@
 package net.lumalyte.lg.infrastructure.services
 
 import net.lumalyte.lg.application.services.*
+import net.lumalyte.lg.domain.values.BannerDesignData
 import net.lumalyte.lg.application.persistence.GuildBannerRepository
 import net.lumalyte.lg.application.persistence.GuildRepository
 import net.lumalyte.lg.domain.entities.GuildBanner

--- a/src/main/kotlin/net/lumalyte/lg/infrastructure/services/GuildBannerServiceBukkit.kt
+++ b/src/main/kotlin/net/lumalyte/lg/infrastructure/services/GuildBannerServiceBukkit.kt
@@ -7,6 +7,7 @@ import net.lumalyte.lg.application.persistence.GuildRepository
 import net.lumalyte.lg.domain.entities.GuildBanner
 import net.lumalyte.lg.domain.events.GuildBannerChangedEvent
 import org.bukkit.Bukkit
+import org.bukkit.block.banner.PatternType
 import org.koin.core.component.KoinComponent
 import org.koin.core.component.inject
 import org.slf4j.LoggerFactory
@@ -36,6 +37,16 @@ class GuildBannerServiceBukkit : GuildBannerService, KoinComponent {
             // Validate banner data
             if (!bannerData.isValid()) {
                 logger.warn("Invalid banner data submitted by player $submitterId for guild $guildId")
+                return false
+            }
+
+            // Authoritative pattern-type check against Bukkit's PatternType enum —
+            // domain's isValid() only rejects blank types to stay Bukkit-free.
+            val unknownType = bannerData.patterns.firstOrNull { p ->
+                runCatching { PatternType.valueOf(p.type) }.isFailure
+            }
+            if (unknownType != null) {
+                logger.warn("Invalid banner pattern type '${unknownType.type}' submitted by player $submitterId for guild $guildId")
                 return false
             }
 

--- a/src/main/kotlin/net/lumalyte/lg/infrastructure/services/GuildServiceBukkit.kt
+++ b/src/main/kotlin/net/lumalyte/lg/infrastructure/services/GuildServiceBukkit.kt
@@ -488,7 +488,7 @@ class GuildServiceBukkit(
             // Check if requesting guild has the perk
             val progressionService = org.koin.core.context.GlobalContext.get()
                 .get<net.lumalyte.lg.application.services.ProgressionService>()
-            if (!progressionService.hasPerkUnlocked(guildId, net.lumalyte.lg.application.services.PerkType.ALLY_HOME_ACCESS)) {
+            if (!progressionService.hasPerkUnlocked(guildId, net.lumalyte.lg.domain.values.PerkType.ALLY_HOME_ACCESS)) {
                 return emptyMap()
             }
 
@@ -502,7 +502,7 @@ class GuildServiceBukkit(
                 val allyGuildId = relation.getOtherGuild(guildId)
 
                 // Ally must also have the perk unlocked (mutual requirement)
-                if (!progressionService.hasPerkUnlocked(allyGuildId, net.lumalyte.lg.application.services.PerkType.ALLY_HOME_ACCESS)) {
+                if (!progressionService.hasPerkUnlocked(allyGuildId, net.lumalyte.lg.domain.values.PerkType.ALLY_HOME_ACCESS)) {
                     continue
                 }
 

--- a/src/main/kotlin/net/lumalyte/lg/infrastructure/services/ProgressionConfigService.kt
+++ b/src/main/kotlin/net/lumalyte/lg/infrastructure/services/ProgressionConfigService.kt
@@ -1,6 +1,6 @@
 package net.lumalyte.lg.infrastructure.services
 
-import net.lumalyte.lg.application.services.PerkType
+import net.lumalyte.lg.domain.values.PerkType
 import net.lumalyte.lg.config.*
 import org.bukkit.Material
 import org.bukkit.configuration.file.FileConfiguration

--- a/src/main/kotlin/net/lumalyte/lg/infrastructure/services/ProgressionServiceBukkit.kt
+++ b/src/main/kotlin/net/lumalyte/lg/infrastructure/services/ProgressionServiceBukkit.kt
@@ -6,6 +6,8 @@ import net.kyori.adventure.text.format.TextDecoration
 import net.kyori.adventure.title.Title
 import net.lumalyte.lg.application.persistence.ProgressionRepository
 import net.lumalyte.lg.application.services.*
+import net.lumalyte.lg.domain.values.ExperienceSource
+import net.lumalyte.lg.domain.values.PerkType
 import net.lumalyte.lg.domain.entities.*
 import net.lumalyte.lg.domain.events.GuildLevelUpEvent
 import org.bukkit.Bukkit

--- a/src/main/kotlin/net/lumalyte/lg/infrastructure/services/scheduling/SchedulerServiceBukkit.kt
+++ b/src/main/kotlin/net/lumalyte/lg/infrastructure/services/scheduling/SchedulerServiceBukkit.kt
@@ -1,7 +1,7 @@
 package net.lumalyte.lg.infrastructure.services.scheduling
 
 import net.lumalyte.lg.application.services.scheduling.SchedulerService
-import net.lumalyte.lg.application.services.scheduling.Task
+import net.lumalyte.lg.domain.services.Task
 import org.bukkit.plugin.Plugin
 import org.bukkit.scheduler.BukkitRunnable
 

--- a/src/main/kotlin/net/lumalyte/lg/infrastructure/services/scheduling/TaskBukkit.kt
+++ b/src/main/kotlin/net/lumalyte/lg/infrastructure/services/scheduling/TaskBukkit.kt
@@ -1,6 +1,6 @@
 package net.lumalyte.lg.infrastructure.services.scheduling
 
-import net.lumalyte.lg.application.services.scheduling.Task
+import net.lumalyte.lg.domain.services.Task
 import org.bukkit.scheduler.BukkitRunnable
 
 class TaskBukkit(private val runnable: BukkitRunnable) : Task {

--- a/src/main/kotlin/net/lumalyte/lg/interaction/menus/bedrock/BedrockGuildProgressionInfoMenu.kt
+++ b/src/main/kotlin/net/lumalyte/lg/interaction/menus/bedrock/BedrockGuildProgressionInfoMenu.kt
@@ -137,31 +137,31 @@ class BedrockGuildProgressionInfoMenu(
         """.trimMargin()
     }
 
-    private fun getLocalizedPerkName(perk: net.lumalyte.lg.application.services.PerkType): String {
+    private fun getLocalizedPerkName(perk: net.lumalyte.lg.domain.values.PerkType): String {
         return when (perk) {
             // Claim perks
-            net.lumalyte.lg.application.services.PerkType.INCREASED_CLAIM_BLOCKS -> "Increased Claim Blocks"
-            net.lumalyte.lg.application.services.PerkType.INCREASED_CLAIM_COUNT -> "Increased Claim Count"
-            net.lumalyte.lg.application.services.PerkType.FASTER_CLAIM_REGEN -> "Faster Claim Regeneration"
+            net.lumalyte.lg.domain.values.PerkType.INCREASED_CLAIM_BLOCKS -> "Increased Claim Blocks"
+            net.lumalyte.lg.domain.values.PerkType.INCREASED_CLAIM_COUNT -> "Increased Claim Count"
+            net.lumalyte.lg.domain.values.PerkType.FASTER_CLAIM_REGEN -> "Faster Claim Regeneration"
 
             // Bank perks
-            net.lumalyte.lg.application.services.PerkType.HIGHER_BANK_BALANCE -> "Higher Bank Balance"
-            net.lumalyte.lg.application.services.PerkType.BANK_INTEREST -> "Bank Interest"
-            net.lumalyte.lg.application.services.PerkType.INCREASED_BANK_LIMIT -> "Increased Bank Limit"
-            net.lumalyte.lg.application.services.PerkType.REDUCED_WITHDRAWAL_FEES -> "Reduced Withdrawal Fees"
+            net.lumalyte.lg.domain.values.PerkType.HIGHER_BANK_BALANCE -> "Higher Bank Balance"
+            net.lumalyte.lg.domain.values.PerkType.BANK_INTEREST -> "Bank Interest"
+            net.lumalyte.lg.domain.values.PerkType.INCREASED_BANK_LIMIT -> "Increased Bank Limit"
+            net.lumalyte.lg.domain.values.PerkType.REDUCED_WITHDRAWAL_FEES -> "Reduced Withdrawal Fees"
 
             // Home perks
-            net.lumalyte.lg.application.services.PerkType.ADDITIONAL_HOMES -> "Additional Homes"
-            net.lumalyte.lg.application.services.PerkType.TELEPORT_COOLDOWN_REDUCTION -> "Teleport Cooldown Reduction"
-            net.lumalyte.lg.application.services.PerkType.HOME_TELEPORT_SOUND_EFFECTS -> "Home Teleport Sound Effects"
+            net.lumalyte.lg.domain.values.PerkType.ADDITIONAL_HOMES -> "Additional Homes"
+            net.lumalyte.lg.domain.values.PerkType.TELEPORT_COOLDOWN_REDUCTION -> "Teleport Cooldown Reduction"
+            net.lumalyte.lg.domain.values.PerkType.HOME_TELEPORT_SOUND_EFFECTS -> "Home Teleport Sound Effects"
 
             // Audio/Visual perks
-            net.lumalyte.lg.application.services.PerkType.CUSTOM_BANNER_COLORS -> "Custom Banner Colors"
-            net.lumalyte.lg.application.services.PerkType.ANIMATED_EMOJIS -> "Animated Emojis"
-            net.lumalyte.lg.application.services.PerkType.SPECIAL_PARTICLES -> "Special Particles"
-            net.lumalyte.lg.application.services.PerkType.ANNOUNCEMENT_SOUND_EFFECTS -> "Announcement Sound Effects"
-            net.lumalyte.lg.application.services.PerkType.WAR_DECLARATION_SOUND_EFFECTS -> "War Declaration Sound Effects"
-            net.lumalyte.lg.application.services.PerkType.ALLY_HOME_ACCESS -> "Ally Home Teleportation"
+            net.lumalyte.lg.domain.values.PerkType.CUSTOM_BANNER_COLORS -> "Custom Banner Colors"
+            net.lumalyte.lg.domain.values.PerkType.ANIMATED_EMOJIS -> "Animated Emojis"
+            net.lumalyte.lg.domain.values.PerkType.SPECIAL_PARTICLES -> "Special Particles"
+            net.lumalyte.lg.domain.values.PerkType.ANNOUNCEMENT_SOUND_EFFECTS -> "Announcement Sound Effects"
+            net.lumalyte.lg.domain.values.PerkType.WAR_DECLARATION_SOUND_EFFECTS -> "War Declaration Sound Effects"
+            net.lumalyte.lg.domain.values.PerkType.ALLY_HOME_ACCESS -> "Ally Home Teleportation"
         }
     }
 

--- a/src/main/kotlin/net/lumalyte/lg/interaction/menus/guild/GuildHomeMenu.kt
+++ b/src/main/kotlin/net/lumalyte/lg/interaction/menus/guild/GuildHomeMenu.kt
@@ -55,13 +55,13 @@ class GuildHomeMenu(private val menuNavigator: MenuNavigator, private val player
         addHomeAccessButtons(pane)
 
         // Ally home teleport buttons (if perk unlocked)
-        if (progressionService.hasPerkUnlocked(guild.id, net.lumalyte.lg.application.services.PerkType.ALLY_HOME_ACCESS)) {
+        if (progressionService.hasPerkUnlocked(guild.id, net.lumalyte.lg.domain.values.PerkType.ALLY_HOME_ACCESS)) {
             addAllyHomeButtons(pane, 0, 5)
             addAllyHomeAccessButton(pane)
         }
 
         // Back button (shift down if ally homes shown)
-        val backRow = if (progressionService.hasPerkUnlocked(guild.id, net.lumalyte.lg.application.services.PerkType.ALLY_HOME_ACCESS)) 5 else 5
+        val backRow = if (progressionService.hasPerkUnlocked(guild.id, net.lumalyte.lg.domain.values.PerkType.ALLY_HOME_ACCESS)) 5 else 5
         addBackButton(pane, 8, backRow)
 
         gui.show(player)

--- a/src/test/kotlin/net/lumalyte/lg/application/services/PenaltyServiceTest.kt
+++ b/src/test/kotlin/net/lumalyte/lg/application/services/PenaltyServiceTest.kt
@@ -4,6 +4,7 @@ import io.mockk.every
 import io.mockk.mockk
 import io.mockk.verify
 import net.lumalyte.lg.application.persistence.PenaltyRepository
+import net.lumalyte.lg.domain.values.ExperienceSource
 import net.lumalyte.lg.config.StrikesConfig
 import net.lumalyte.lg.config.StrikesPenaltiesConfig
 import net.lumalyte.lg.domain.entities.Guild

--- a/src/test/kotlin/net/lumalyte/lg/architecture/LayerRulesTest.kt
+++ b/src/test/kotlin/net/lumalyte/lg/architecture/LayerRulesTest.kt
@@ -1,0 +1,39 @@
+package net.lumalyte.lg.architecture
+
+import com.lemonappdev.konsist.api.Konsist
+import com.lemonappdev.konsist.api.architecture.KoArchitectureCreator.assertArchitecture
+import com.lemonappdev.konsist.api.architecture.Layer
+import org.junit.jupiter.api.Test
+
+class LayerRulesTest {
+
+    @Test
+    fun `domain layer depends on nothing outside domain and kotlin stdlib`() {
+        Konsist.scopeFromProduction().assertArchitecture {
+            val domain = Layer("domain", "net.lumalyte.lg.domain..")
+            val application = Layer("application", "net.lumalyte.lg.application..")
+            val infrastructure = Layer("infrastructure", "net.lumalyte.lg.infrastructure..")
+            domain.dependsOnNothing()
+        }
+    }
+
+    @Test
+    fun `application layer depends only on domain`() {
+        Konsist.scopeFromProduction().assertArchitecture {
+            val domain = Layer("domain", "net.lumalyte.lg.domain..")
+            val application = Layer("application", "net.lumalyte.lg.application..")
+            val infrastructure = Layer("infrastructure", "net.lumalyte.lg.infrastructure..")
+            application.dependsOn(domain)
+        }
+    }
+
+    @Test
+    fun `infrastructure layer depends only on application and domain`() {
+        Konsist.scopeFromProduction().assertArchitecture {
+            val domain = Layer("domain", "net.lumalyte.lg.domain..")
+            val application = Layer("application", "net.lumalyte.lg.application..")
+            val infrastructure = Layer("infrastructure", "net.lumalyte.lg.infrastructure..")
+            infrastructure.dependsOn(application, domain)
+        }
+    }
+}

--- a/src/test/kotlin/net/lumalyte/lg/domain/values/BannerDesignTest.kt
+++ b/src/test/kotlin/net/lumalyte/lg/domain/values/BannerDesignTest.kt
@@ -1,0 +1,50 @@
+package net.lumalyte.lg.domain.values
+
+import org.junit.jupiter.api.Assertions.assertFalse
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+
+class BannerDesignTest {
+
+    @Test
+    fun `valid design with a known pattern type is accepted`() {
+        val design = BannerDesignData(
+            baseColor = BannerColor.RED,
+            patterns = listOf(BannerPattern("STRIPE_TOP", BannerColor.WHITE))
+        )
+        assertTrue(design.isValid())
+    }
+
+    @Test
+    fun `design with no patterns is valid`() {
+        val design = BannerDesignData(baseColor = BannerColor.BLUE)
+        assertTrue(design.isValid())
+    }
+
+    @Test
+    fun `blank pattern type is rejected`() {
+        val design = BannerDesignData(
+            baseColor = BannerColor.RED,
+            patterns = listOf(BannerPattern("   ", BannerColor.WHITE))
+        )
+        assertFalse(design.isValid())
+    }
+
+    @Test
+    fun `more than six patterns is rejected`() {
+        val design = BannerDesignData(
+            baseColor = BannerColor.RED,
+            patterns = List(7) { BannerPattern("STRIPE_TOP", BannerColor.WHITE) }
+        )
+        assertFalse(design.isValid())
+    }
+
+    @Test
+    fun `six patterns is the limit and is accepted`() {
+        val design = BannerDesignData(
+            baseColor = BannerColor.RED,
+            patterns = List(6) { BannerPattern("STRIPE_TOP", BannerColor.WHITE) }
+        )
+        assertTrue(design.isValid())
+    }
+}


### PR DESCRIPTION
## PR-0 — SPEAR bootstrap: docs, architecture guard, domain purity

Sets up the Spec-Proven Engineering with Architectural Requirements (SPEAR) baseline for LumaGuilds, per the 2026-08-09 unwired-features audit (`lumaguilds-audit-2026-08-09.md`).

### Contents
1. **SPEAR docs** (`docs/`): `requirements.md` — 44 EARS requirements (REQ-001..044) mapping every audit finding (2 critical, 10 high, 13 medium, 15 low); `tasks.md` — 45 tasks grouped into 11 dependency-ordered PRs (PR-0..PR-9); `tech-stack.md`; `implementation.md` (layer rules).
2. **Konsist architecture guard** (`LayerRulesTest`): domain ← application ← infrastructure, enforced on every build. Konsist 0.17.3 added to `build.gradle.kts`.
3. **Domain layer purity** (required to make the guard green): relocated `BannerDesignData`/`BannerPattern`/`BannerColor` → `domain/values`, `ExperienceSource`/`PerkType` → `domain/values`, `Task` → `domain/services`; updated all consumers; deleted the stale `application/services/scheduling/Task.kt`. This resolves the domain→application leak that the June `fix/audit-domain` branch targeted (never merged).

### Verification
- `LayerRulesTest` 3/3 green (domain / application / infrastructure rules)
- Full suite: **370/370 tests green**
- Zero references to the old type locations

### Notes
- `.claude/spear-state.json` (phase tracking) is gitignored, phase `idle`.
- Feature PRs branch from this base: PR-1 (permission alignment) is stacked on top.

See `docs/tasks.md` for the full PR roadmap (bank, combat/wars, claims, lang migration, UI completion, tech debt).
