### PR TITLE
feat(pr3): real bank settings — config enforcement + automation/budget/security/history menus

### DIFF
--- a/docs/tasks.md
+++ b/docs/tasks.md
@@ -88,30 +88,30 @@ PR grouping: tasks under each `## PR-n` header ship together in one pull request
 
 ## PR-3 — Bank features (knobs + real menus)
 
-- [ ] **LG-301** Enforce bank config: interest accrual task, max balance, audit retention, suspicious-transaction detection + auto-lock
+- [x] **LG-301** Enforce bank config: interest accrual task, max balance, audit retention, suspicious-transaction detection + auto-lock
   - Tag: `TDD`
   - References: REQ-009
-  - Evidence:
-  - Files: `infrastructure/services/BankServiceBukkit.kt`, bank config model
-- [ ] **LG-302** Bank automation menu: persisted settings, real save, real next-run time + status
+  - Evidence: `BankSettings`/`BankSettingsRepositorySQLite` (bank_settings table) + `BankAutomationService` (interest accrual, per-guild rate override, 30-period catch-up, audit pruning) + `BankInterestScheduler` (5-min BancRunnable, wired in LumaGuilds.onEnable/onDisable); deposit ceiling = min(config cap, progression limit); suspicious-transaction auto-lock on deposit+withdrawal (system actor UUID(0,0) + audit entry); `deleteAuditsOlderThan` per `audit_log_retention_days`. Tests: `BankAutomationServiceTest` (7), `BankConfigEnforcementTest` (6), `BankSettingsRepositorySQLiteTest` (3) — 16 GREEN.
+  - Files: `infrastructure/services/BankServiceBukkit.kt`, `infrastructure/services/BankInterestScheduler.kt`, `application/services/BankAutomationService.kt`, `application/persistence/BankSettingsRepository.kt`, `infrastructure/persistence/guilds/BankSettingsRepositorySQLite.kt`, `domain/entities/BankSettings.kt`, bank config model
+- [x] **LG-302** Bank automation menu: persisted settings, real save, real next-run time + status
   - Tag: `TDD`
   - References: REQ-010
-  - Evidence:
+  - Evidence: `GuildBankAutomationMenu` loads/saves via `BankSettingsRepository`; interest rate via `ChatInputHandler`; Save persists with failure message; next-run shows real `getNextInterestRun()`; status derived from active-automation count + configured rate.
   - Files: `interaction/menus/GuildBankAutomationMenu.kt`, automation persistence
-- [ ] **LG-303** Bank budget menu: real persisted budget + save
+- [x] **LG-303** Bank budget menu: real persisted budget + save
   - Tag: `TDD`
   - References: REQ-011
-  - Evidence:
+  - Evidence: `GuildBankBudgetMenu` loads real persisted monthly/weekly/daily budgets; 3 chat-input buttons; Save persists all three with success/failure feedback.
   - Files: `interaction/menus/GuildBankBudgetMenu.kt`, budget persistence
-- [ ] **LG-304** Bank transaction history: renders actual transactions; search/type/member/date filters functional
+- [x] **LG-304** Bank transaction history: renders actual transactions; search/type/member/date filters functional
   - Tag: `TDD`
   - References: REQ-012
-  - Evidence:
+  - Evidence: `GuildBankTransactionHistoryMenu` renders into StaticPane (10/page, prev/next + page indicator at slots 6-8); empty-state = localized `MENU_BANK_HISTORY_NO_TRANSACTIONS` item; type filter cycles TransactionType; date filter cycles 24h/7d/30d presets with real cutoff in `loadTransactions`; member filter = slot-click PaginatedPane submenu from `MemberService.getGuildMembers`; search wired via `ChatInputHandler` (matches actor name or description).
   - Files: `interaction/menus/GuildBankTransactionHistoryMenu.kt`, transaction repository
-- [ ] **LG-305** Bank security menu: dual-auth threshold setting implemented
+- [x] **LG-305** Bank security menu: dual-auth threshold setting implemented
   - Tag: `TDD`
   - References: REQ-031
-  - Evidence:
+  - Evidence: `GuildBankSecurityMenu` loads/saves dual-auth threshold from/to `BankSettingsRepository`; chat input wired; SAVE persists.
   - Files: bank security menu, dual-auth config
 
 ---

--- a/docs/tasks.md
+++ b/docs/tasks.md
@@ -91,23 +91,23 @@ PR grouping: tasks under each `## PR-n` header ship together in one pull request
 - [x] **LG-301** Enforce bank config: interest accrual task, max balance, audit retention, suspicious-transaction detection + auto-lock
   - Tag: `TDD`
   - References: REQ-009
-  - Evidence: `BankSettings`/`BankSettingsRepositorySQLite` (bank_settings table) + `BankAutomationService` (interest accrual, per-guild rate override, 30-period catch-up, audit pruning) + `BankInterestScheduler` (5-min BancRunnable, wired in LumaGuilds.onEnable/onDisable); deposit ceiling = min(config cap, progression limit); suspicious-transaction auto-lock on deposit+withdrawal (system actor UUID(0,0) + audit entry); `deleteAuditsOlderThan` per `audit_log_retention_days`. Tests: `BankAutomationServiceTest` (7), `BankConfigEnforcementTest` (6), `BankSettingsRepositorySQLiteTest` (3) — 16 GREEN.
+  - Evidence: `BankSettings`/`BankSettingsRepositorySQLite` (bank_settings table) + `BankAutomationService` (interest accrual, per-guild rate override, 30-period catch-up, audit pruning) + `BankInterestScheduler` (five-minute scheduled task, wired in LumaGuilds.onEnable/onDisable); deposit ceiling = min(config cap, progression limit); suspicious-transaction auto-lock on deposit+withdrawal (system actor UUID(0,0) + audit entry); `deleteAuditsOlderThan` per `audit_log_retention_days`. Tests: `BankAutomationServiceTest` (7), `BankConfigEnforcementTest` (6), `BankSettingsRepositorySQLiteTest` (3) — 16 GREEN.
   - Files: `infrastructure/services/BankServiceBukkit.kt`, `infrastructure/services/BankInterestScheduler.kt`, `application/services/BankAutomationService.kt`, `application/persistence/BankSettingsRepository.kt`, `infrastructure/persistence/guilds/BankSettingsRepositorySQLite.kt`, `domain/entities/BankSettings.kt`, bank config model
 - [x] **LG-302** Bank automation menu: persisted settings, real save, real next-run time + status
   - Tag: `TDD`
   - References: REQ-010
   - Evidence: `GuildBankAutomationMenu` loads/saves via `BankSettingsRepository`; interest rate via `ChatInputHandler`; Save persists with failure message; next-run shows real `getNextInterestRun()`; status derived from active-automation count + configured rate.
-  - Files: `interaction/menus/GuildBankAutomationMenu.kt`, automation persistence
+  - Files: `interaction/menus/guild/GuildBankAutomationMenu.kt`, automation persistence
 - [x] **LG-303** Bank budget menu: real persisted budget + save
   - Tag: `TDD`
   - References: REQ-011
   - Evidence: `GuildBankBudgetMenu` loads real persisted monthly/weekly/daily budgets; 3 chat-input buttons; Save persists all three with success/failure feedback.
-  - Files: `interaction/menus/GuildBankBudgetMenu.kt`, budget persistence
+  - Files: `interaction/menus/guild/GuildBankBudgetMenu.kt`, budget persistence
 - [x] **LG-304** Bank transaction history: renders actual transactions; search/type/member/date filters functional
   - Tag: `TDD`
   - References: REQ-012
   - Evidence: `GuildBankTransactionHistoryMenu` renders into StaticPane (10/page, prev/next + page indicator at slots 6-8); empty-state = localized `MENU_BANK_HISTORY_NO_TRANSACTIONS` item; type filter cycles TransactionType; date filter cycles 24h/7d/30d presets with real cutoff in `loadTransactions`; member filter = slot-click PaginatedPane submenu from `MemberService.getGuildMembers`; search wired via `ChatInputHandler` (matches actor name or description).
-  - Files: `interaction/menus/GuildBankTransactionHistoryMenu.kt`, transaction repository
+  - Files: `interaction/menus/guild/GuildBankTransactionHistoryMenu.kt`, transaction repository
 - [x] **LG-305** Bank security menu: dual-auth threshold setting implemented
   - Tag: `TDD`
   - References: REQ-031

--- a/src/main/kotlin/net/lumalyte/lg/LumaGuilds.kt
+++ b/src/main/kotlin/net/lumalyte/lg/LumaGuilds.kt
@@ -49,6 +49,7 @@ class LumaGuilds : JavaPlugin() {
     private lateinit var scheduler: BukkitScheduler
     lateinit var pluginScope: CoroutineScope
     private lateinit var dailyWarCostsScheduler: DailyWarCostsScheduler
+    private lateinit var bankInterestScheduler: net.lumalyte.lg.infrastructure.services.BankInterestScheduler
     private var experienceTransactionCleanupScheduler: net.lumalyte.lg.infrastructure.services.ExperienceTransactionCleanupScheduler? = null
     internal lateinit var vaultProtectionListener: net.lumalyte.lg.infrastructure.listeners.VaultProtectionListener
     private val componentLogger = getComponentLogger()
@@ -174,6 +175,9 @@ class LumaGuilds : JavaPlugin() {
 
         // Initialize daily war costs scheduler
         initDailyWarCostsScheduler()
+
+        // Initialize bank interest scheduler (interest accrual + audit pruning)
+        initBankInterestScheduler()
 
         // Initialize experience transaction cleanup scheduler
         initExperienceTransactionCleanupScheduler()
@@ -1073,6 +1077,21 @@ class LumaGuilds : JavaPlugin() {
     }
 
     /**
+     * Initializes the bank interest scheduler (interest accrual + audit-log pruning).
+     */
+    private fun initBankInterestScheduler() {
+        try {
+            val bankAutomationService = get().get<net.lumalyte.lg.application.services.BankAutomationService>()
+            bankInterestScheduler = net.lumalyte.lg.infrastructure.services.BankInterestScheduler(this, bankAutomationService)
+            bankInterestScheduler.start()
+            logColored("✓ Bank interest scheduler started")
+        } catch (e: Exception) {
+            // Broad exception handling acceptable - scheduler failure shouldn't prevent plugin load
+            logColored("❌ Failed to initialize bank interest scheduler: ${e.message}")
+        }
+    }
+
+    /**
      * Initializes the daily war costs scheduler.
      */
     private fun initDailyWarCostsScheduler() {
@@ -1253,6 +1272,11 @@ class LumaGuilds : JavaPlugin() {
         // Stop the daily war costs scheduler
         if (::dailyWarCostsScheduler.isInitialized) {
             dailyWarCostsScheduler.stopDailyScheduler()
+        }
+
+        // Stop the bank interest scheduler
+        if (::bankInterestScheduler.isInitialized) {
+            bankInterestScheduler.stop()
         }
 
         // Stop the experience transaction cleanup scheduler

--- a/src/main/kotlin/net/lumalyte/lg/application/persistence/BankRepository.kt
+++ b/src/main/kotlin/net/lumalyte/lg/application/persistence/BankRepository.kt
@@ -62,6 +62,15 @@ interface BankRepository {
     fun getAuditForGuild(guildId: UUID, limit: Int? = null): List<BankAudit>
 
     /**
+     * Deletes audit entries older than the given cutoff for a guild (retention enforcement).
+     *
+     * @param guildId The ID of the guild.
+     * @param cutoff Audits strictly older than this instant are removed.
+     * @return The number of audits deleted.
+     */
+    fun deleteAuditsOlderThan(guildId: UUID, cutoff: java.time.Instant): Int
+
+    /**
      * Gets the total number of transactions for a guild.
      *
      * @param guildId The ID of the guild.

--- a/src/main/kotlin/net/lumalyte/lg/application/persistence/BankSettingsRepository.kt
+++ b/src/main/kotlin/net/lumalyte/lg/application/persistence/BankSettingsRepository.kt
@@ -1,0 +1,26 @@
+package net.lumalyte.lg.application.persistence
+
+import net.lumalyte.lg.domain.entities.BankSettings
+import java.util.UUID
+
+/**
+ * Repository for per-guild bank settings (automation, budgets, dual-auth threshold).
+ */
+interface BankSettingsRepository {
+
+    /**
+     * Gets the persisted settings for a guild.
+     *
+     * @param guildId The ID of the guild.
+     * @return The settings, or null if none have been persisted yet.
+     */
+    fun getByGuildId(guildId: UUID): BankSettings?
+
+    /**
+     * Inserts or replaces the persisted settings for a guild.
+     *
+     * @param settings The settings to persist.
+     * @return true if successful, false otherwise.
+     */
+    fun upsert(settings: BankSettings): Boolean
+}

--- a/src/main/kotlin/net/lumalyte/lg/application/services/BankAutomationService.kt
+++ b/src/main/kotlin/net/lumalyte/lg/application/services/BankAutomationService.kt
@@ -1,0 +1,118 @@
+package net.lumalyte.lg.application.services
+
+import net.lumalyte.lg.application.persistence.BankRepository
+import net.lumalyte.lg.application.persistence.BankSettingsRepository
+import net.lumalyte.lg.application.persistence.GuildRepository
+import net.lumalyte.lg.domain.entities.BankSettings
+import net.lumalyte.lg.domain.entities.Guild
+import org.slf4j.LoggerFactory
+import java.time.Instant
+import java.time.temporal.ChronoUnit
+import java.util.UUID
+
+/**
+ * Scheduled bank automation (REQ-009):
+ * - interest accrual per `bank.interest_rate_percent` / `bank.interest_compound_period_hours`
+ *   (per-guild [BankSettings.interestRate] overrides the global rate when persisted)
+ * - audit-log retention pruning per `bank.audit_log_retention_days`
+ *
+ * Driven by [net.lumalyte.lg.infrastructure.services.BankInterestScheduler].
+ */
+class BankAutomationService(
+    private val bankRepository: BankRepository,
+    private val bankSettingsRepository: BankSettingsRepository,
+    private val guildRepository: GuildRepository,
+    private val bankService: BankService,
+    private val configService: ConfigService
+) {
+
+    private val logger = LoggerFactory.getLogger(BankAutomationService::class.java)
+
+    /** Maximum catch-up periods applied in a single run (prevents runaway accrual). */
+    private val maxCatchUpPeriods = 30
+
+    /**
+     * Accrues interest for every guild whose compound period has elapsed.
+     *
+     * @return The number of interest credits applied.
+     */
+    fun accrueInterest(): Int {
+        val config = configService.loadConfig()
+        val periodHours = config.bank.interestCompoundPeriodHours.toLong()
+        val now = Instant.now()
+        var credited = 0
+
+        for (guild in guildRepository.getAll()) {
+            try {
+                credited += accrueForGuild(guild, periodHours, now)
+            } catch (e: Exception) {
+                logger.error("Failed to accrue interest for guild ${guild.id}", e)
+            }
+        }
+        return credited
+    }
+
+    private fun accrueForGuild(guild: Guild, periodHours: Long, now: Instant): Int {
+        val settings = bankSettingsRepository.getByGuildId(guild.id)
+        // Never accrued (or fresh row): start the clock now — no retroactive interest.
+        val lastAccrual = settings
+            ?.takeIf { it.lastInterestAccrual > 0L }
+            ?.let { Instant.ofEpochMilli(it.lastInterestAccrual) }
+            ?: now
+
+        if (lastAccrual.plus(periodHours, ChronoUnit.HOURS).isAfter(now)) {
+            return 0 // Period not yet elapsed
+        }
+
+        val rate = settings?.interestRate ?: configService.loadConfig().bank.interestRatePercent
+        val balance = bankService.getBalance(guild.id)
+        val interestPerPeriod = (balance * rate).toInt()
+
+        var cursor = lastAccrual
+        var periods = 0
+        while (periods < maxCatchUpPeriods && !cursor.plus(periodHours, ChronoUnit.HOURS).isAfter(now)) {
+            cursor = cursor.plus(periodHours, ChronoUnit.HOURS)
+            periods++
+            if (interestPerPeriod > 0) {
+                bankService.creditToGuildBank(guild.id, interestPerPeriod, "Interest accrual")
+            }
+        }
+
+        val updated = (settings ?: BankSettings(guild.id)).copy(lastInterestAccrual = cursor.toEpochMilli())
+        bankSettingsRepository.upsert(updated)
+        return if (interestPerPeriod > 0) periods else 0
+    }
+
+    /**
+     * Prunes audit entries older than the retention window.
+     *
+     * @return The total number of audit entries deleted.
+     */
+    fun pruneAuditLogs(): Int {
+        val retentionDays = configService.loadConfig().bank.auditLogRetentionDays.toLong()
+        val cutoff = Instant.now().minus(retentionDays, ChronoUnit.DAYS)
+        var pruned = 0
+
+        for (guild in guildRepository.getAll()) {
+            try {
+                pruned += bankRepository.deleteAuditsOlderThan(guild.id, cutoff)
+            } catch (e: Exception) {
+                logger.error("Failed to prune audit log for guild ${guild.id}", e)
+            }
+        }
+        return pruned
+    }
+
+    /**
+     * Computes the next scheduled interest accrual for a guild's menu display.
+     *
+     * @param guildId The ID of the guild.
+     * @return The next run instant, or null when the guild has no accrual history.
+     */
+    fun getNextInterestRun(guildId: UUID): Instant? {
+        val settings = bankSettingsRepository.getByGuildId(guildId) ?: return null
+        if (settings.lastInterestAccrual <= 0L) return null
+        return Instant.ofEpochMilli(settings.lastInterestAccrual)
+            .plus(configService.loadConfig().bank.interestCompoundPeriodHours.toLong(), ChronoUnit.HOURS)
+    }
+}

--- a/src/main/kotlin/net/lumalyte/lg/application/services/BankAutomationService.kt
+++ b/src/main/kotlin/net/lumalyte/lg/application/services/BankAutomationService.kt
@@ -54,17 +54,28 @@ class BankAutomationService(
 
     private fun accrueForGuild(guild: Guild, periodHours: Long, now: Instant): Int {
         val settings = bankSettingsRepository.getByGuildId(guild.id)
+
         // Never accrued (or fresh row): start the clock now — no retroactive interest.
-        val lastAccrual = settings
-            ?.takeIf { it.lastInterestAccrual > 0L }
-            ?.let { Instant.ofEpochMilli(it.lastInterestAccrual) }
-            ?: now
+        // Persist the initial timestamp BEFORE the period check so the next run
+        // sees an initialized clock instead of re-initializing (which would
+        // otherwise reset on every run and never accrue).
+        if (settings == null || settings.lastInterestAccrual <= 0L) {
+            val initialized = (settings ?: BankSettings(guild.id))
+                .copy(lastInterestAccrual = now.toEpochMilli())
+            if (!bankSettingsRepository.upsert(initialized)) {
+                logger.error("Failed to initialize interest clock for guild ${guild.id}; skipping accrual")
+                return 0
+            }
+            return 0 // clock just started; the period has not elapsed
+        }
+
+        val lastAccrual = Instant.ofEpochMilli(settings.lastInterestAccrual)
 
         if (lastAccrual.plus(periodHours, ChronoUnit.HOURS).isAfter(now)) {
             return 0 // Period not yet elapsed
         }
 
-        val rate = settings?.interestRate ?: configService.loadConfig().bank.interestRatePercent
+        val rate = settings.interestRate ?: configService.loadConfig().bank.interestRatePercent
         val balance = bankService.getBalance(guild.id)
         val interestPerPeriod = (balance * rate).toInt()
 
@@ -73,14 +84,27 @@ class BankAutomationService(
         while (periods < maxCatchUpPeriods && !cursor.plus(periodHours, ChronoUnit.HOURS).isAfter(now)) {
             cursor = cursor.plus(periodHours, ChronoUnit.HOURS)
             periods++
-            if (interestPerPeriod > 0) {
-                bankService.creditToGuildBank(guild.id, interestPerPeriod, "Interest accrual")
-            }
         }
 
-        val updated = (settings ?: BankSettings(guild.id)).copy(lastInterestAccrual = cursor.toEpochMilli())
-        bankSettingsRepository.upsert(updated)
-        return if (interestPerPeriod > 0) periods else 0
+        // Persist the advanced marker BEFORE crediting. If the marker write fails,
+        // skip crediting entirely — the next run retries from the old marker, so no
+        // period can be double-credited (money safety). If a credit fails partway,
+        // the marker has already advanced, so at worst one period is skipped —
+        // never duplicated.
+        val updated = settings.copy(lastInterestAccrual = cursor.toEpochMilli())
+        if (!bankSettingsRepository.upsert(updated)) {
+            logger.error("Failed to persist interest accrual marker for guild ${guild.id}; skipping accrual")
+            return 0
+        }
+
+        var credited = 0
+        repeat(periods) {
+            if (interestPerPeriod > 0) {
+                bankService.creditToGuildBank(guild.id, interestPerPeriod, "Interest accrual")
+                credited++
+            }
+        }
+        return credited
     }
 
     /**

--- a/src/main/kotlin/net/lumalyte/lg/di/Modules.kt
+++ b/src/main/kotlin/net/lumalyte/lg/di/Modules.kt
@@ -560,9 +560,15 @@ fun progressionModule() = module {
 fun economyModule() = module {
     // Repositories
     single<BankRepository> { BankRepositorySQLite(get()) }
+    single<net.lumalyte.lg.application.persistence.BankSettingsRepository> {
+        net.lumalyte.lg.infrastructure.persistence.guilds.BankSettingsRepositorySQLite(get())
+    }
 
     // Services
-    single<BankService> { BankServiceBukkit(get(), get(), get(), get(), get(), get(), get(), get()) }
+    single<BankService> { BankServiceBukkit(get(), get(), get(), get(), get(), get(), get(), get(), get()) }
+    single<net.lumalyte.lg.application.services.BankAutomationService> {
+        net.lumalyte.lg.application.services.BankAutomationService(get(), get(), get(), get(), get())
+    }
     single<net.lumalyte.lg.application.services.PhysicalCurrencyService> {
         net.lumalyte.lg.infrastructure.services.PhysicalCurrencyServiceBukkit(get(), get())
     }

--- a/src/main/kotlin/net/lumalyte/lg/domain/entities/BankSettings.kt
+++ b/src/main/kotlin/net/lumalyte/lg/domain/entities/BankSettings.kt
@@ -1,0 +1,22 @@
+package net.lumalyte.lg.domain.entities
+
+import java.util.UUID
+
+/**
+ * Per-guild bank automation, budget, and security settings (REQ-010/011/031).
+ *
+ * Persisted via [net.lumalyte.lg.application.persistence.BankSettingsRepository];
+ * values are the menu-editable knobs, distinct from the global [net.lumalyte.lg.config.BankConfig].
+ */
+data class BankSettings(
+    val guildId: UUID,
+    var scheduledDepositsEnabled: Boolean = false,
+    var autoRewardsEnabled: Boolean = true,
+    var recurringPaymentsEnabled: Boolean = false,
+    var interestRate: Double = 0.02, // fraction (0.02 = 2%) per compound period
+    var dualAuthThreshold: Int = 1000,
+    var monthlyBudget: Int = 10000,
+    var weeklyBudget: Int = 2500,
+    var dailyBudget: Int = 500,
+    var lastInterestAccrual: Long = 0L // epoch millis; 0 = never accrued
+)

--- a/src/main/kotlin/net/lumalyte/lg/infrastructure/persistence/guilds/BankRepositorySQLite.kt
+++ b/src/main/kotlin/net/lumalyte/lg/infrastructure/persistence/guilds/BankRepositorySQLite.kt
@@ -289,11 +289,13 @@ class BankRepositorySQLite(private val storage: Storage<Database>) : BankReposit
     }
 
     override fun deleteAuditsOlderThan(guildId: UUID, cutoff: java.time.Instant): Int {
-        // Timestamps are stored as ISO-8601 UTC strings (Instant.toString), so
-        // lexicographic comparison is chronologically correct.
+        // Timestamps are stored as ISO-8601 UTC strings (Instant.toString). Raw
+        // text comparison is NOT chronologically correct when fractional seconds
+        // differ (e.g. "…00:00:00Z" vs "…00:00:00.001Z" compare wrong), so parse
+        // both sides with julianday(), which understands ISO-8601 incl. fractions.
         val sql = """
             DELETE FROM bank_audit
-            WHERE guild_id = ? AND timestamp < ?
+            WHERE guild_id = ? AND julianday(timestamp) < julianday(?)
         """.trimIndent()
 
         return try {

--- a/src/main/kotlin/net/lumalyte/lg/infrastructure/persistence/guilds/BankRepositorySQLite.kt
+++ b/src/main/kotlin/net/lumalyte/lg/infrastructure/persistence/guilds/BankRepositorySQLite.kt
@@ -288,6 +288,25 @@ class BankRepositorySQLite(private val storage: Storage<Database>) : BankReposit
         }
     }
 
+    override fun deleteAuditsOlderThan(guildId: UUID, cutoff: java.time.Instant): Int {
+        // Timestamps are stored as ISO-8601 UTC strings (Instant.toString), so
+        // lexicographic comparison is chronologically correct.
+        val sql = """
+            DELETE FROM bank_audit
+            WHERE guild_id = ? AND timestamp < ?
+        """.trimIndent()
+
+        return try {
+            val rowsAffected = storage.connection.executeUpdate(sql, guildId.toString(), cutoff.toString())
+            if (rowsAffected > 0) {
+                audits.entries.removeAll { it.value.guildId == guildId && it.value.timestamp.isBefore(cutoff) }
+            }
+            rowsAffected
+        } catch (e: SQLException) {
+            throw DatabaseOperationException("Failed to prune bank audit log", e)
+        }
+    }
+
     override fun getTransactionCountForGuild(guildId: UUID): Int {
         val sql = "SELECT COUNT(*) as count FROM bank_transactions WHERE guild_id = ?"
 

--- a/src/main/kotlin/net/lumalyte/lg/infrastructure/persistence/guilds/BankSettingsRepositorySQLite.kt
+++ b/src/main/kotlin/net/lumalyte/lg/infrastructure/persistence/guilds/BankSettingsRepositorySQLite.kt
@@ -89,7 +89,8 @@ class BankSettingsRepositorySQLite(private val storage: Storage<Database>) : Ban
     }
 
     override fun getByGuildId(guildId: UUID): BankSettings? {
-        return settingsByGuild[guildId]
+        // Return a copy so callers cannot mutate the cached policy without upsert.
+        return settingsByGuild[guildId]?.copy()
     }
 
     override fun upsert(settings: BankSettings): Boolean {
@@ -117,7 +118,9 @@ class BankSettingsRepositorySQLite(private val storage: Storage<Database>) : Ban
             )
 
             if (rowsAffected > 0) {
-                settingsByGuild[settings.guildId] = settings
+                // Store a copy so later mutations of the caller's instance cannot
+                // silently diverge the cached policy from SQLite.
+                settingsByGuild[settings.guildId] = settings.copy()
                 true
             } else {
                 false

--- a/src/main/kotlin/net/lumalyte/lg/infrastructure/persistence/guilds/BankSettingsRepositorySQLite.kt
+++ b/src/main/kotlin/net/lumalyte/lg/infrastructure/persistence/guilds/BankSettingsRepositorySQLite.kt
@@ -1,0 +1,130 @@
+package net.lumalyte.lg.infrastructure.persistence.guilds
+
+import co.aikar.idb.Database
+import net.lumalyte.lg.application.errors.DatabaseOperationException
+import net.lumalyte.lg.application.persistence.BankSettingsRepository
+import net.lumalyte.lg.domain.entities.BankSettings
+import net.lumalyte.lg.infrastructure.persistence.storage.Storage
+import org.slf4j.LoggerFactory
+import java.sql.SQLException
+import java.util.UUID
+
+/**
+ * SQLite-backed per-guild bank settings (REQ-010/011/031).
+ * Follows the preload-into-memory pattern of the other repositories.
+ */
+class BankSettingsRepositorySQLite(private val storage: Storage<Database>) : BankSettingsRepository {
+
+    private val logger = LoggerFactory.getLogger(BankSettingsRepositorySQLite::class.java)
+
+    private val settingsByGuild: MutableMap<UUID, BankSettings> = mutableMapOf()
+
+    init {
+        createSettingsTable()
+        preload()
+    }
+
+    private fun createSettingsTable() {
+        val sql = """
+            CREATE TABLE IF NOT EXISTS bank_settings (
+                guild_id TEXT PRIMARY KEY,
+                scheduled_deposits_enabled INTEGER NOT NULL DEFAULT 0,
+                auto_rewards_enabled INTEGER NOT NULL DEFAULT 1,
+                recurring_payments_enabled INTEGER NOT NULL DEFAULT 0,
+                interest_rate REAL NOT NULL DEFAULT 0.02,
+                dual_auth_threshold INTEGER NOT NULL DEFAULT 1000,
+                monthly_budget INTEGER NOT NULL DEFAULT 10000,
+                weekly_budget INTEGER NOT NULL DEFAULT 2500,
+                daily_budget INTEGER NOT NULL DEFAULT 500,
+                last_interest_accrual INTEGER NOT NULL DEFAULT 0
+            )
+        """.trimIndent()
+
+        try {
+            storage.connection.executeUpdate(sql)
+        } catch (e: SQLException) {
+            throw DatabaseOperationException("Failed to create bank settings table", e)
+        }
+    }
+
+    private fun preload() {
+        val sql = """
+            SELECT guild_id, scheduled_deposits_enabled, auto_rewards_enabled, recurring_payments_enabled,
+                   interest_rate, dual_auth_threshold, monthly_budget, weekly_budget, daily_budget, last_interest_accrual
+            FROM bank_settings
+        """.trimIndent()
+
+        try {
+            val results = storage.connection.getResults(sql)
+            for (result in results) {
+                val settings = mapResultSetToSettings(result)
+                settingsByGuild[settings.guildId] = settings
+            }
+        } catch (e: SQLException) {
+            throw DatabaseOperationException("Failed to preload bank settings", e)
+        }
+    }
+
+    private fun mapResultSetToSettings(rs: co.aikar.idb.DbRow): BankSettings {
+        return BankSettings(
+            guildId = UUID.fromString(rs.getString("guild_id")),
+            scheduledDepositsEnabled = rs.getInt("scheduled_deposits_enabled") == 1,
+            autoRewardsEnabled = rs.getInt("auto_rewards_enabled") == 1,
+            recurringPaymentsEnabled = rs.getInt("recurring_payments_enabled") == 1,
+            interestRate = when (val v = rs.get<Any?>("interest_rate")) {
+                is Number -> v.toDouble()
+                is String -> v.toDoubleOrNull() ?: 0.02
+                else -> 0.02
+            },
+            dualAuthThreshold = rs.getInt("dual_auth_threshold"),
+            monthlyBudget = rs.getInt("monthly_budget"),
+            weeklyBudget = rs.getInt("weekly_budget"),
+            dailyBudget = rs.getInt("daily_budget"),
+            lastInterestAccrual = when (val v = rs.get<Any?>("last_interest_accrual")) {
+                is Number -> v.toLong()
+                is String -> v.toLongOrNull() ?: 0L
+                else -> 0L
+            }
+        )
+    }
+
+    override fun getByGuildId(guildId: UUID): BankSettings? {
+        return settingsByGuild[guildId]
+    }
+
+    override fun upsert(settings: BankSettings): Boolean {
+        val sql = """
+            INSERT OR REPLACE INTO bank_settings (
+                guild_id, scheduled_deposits_enabled, auto_rewards_enabled, recurring_payments_enabled,
+                interest_rate, dual_auth_threshold, monthly_budget, weekly_budget, daily_budget, last_interest_accrual
+            )
+            VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+        """.trimIndent()
+
+        return try {
+            val rowsAffected = storage.connection.executeUpdate(
+                sql,
+                settings.guildId.toString(),
+                if (settings.scheduledDepositsEnabled) 1 else 0,
+                if (settings.autoRewardsEnabled) 1 else 0,
+                if (settings.recurringPaymentsEnabled) 1 else 0,
+                settings.interestRate,
+                settings.dualAuthThreshold,
+                settings.monthlyBudget,
+                settings.weeklyBudget,
+                settings.dailyBudget,
+                settings.lastInterestAccrual
+            )
+
+            if (rowsAffected > 0) {
+                settingsByGuild[settings.guildId] = settings
+                true
+            } else {
+                false
+            }
+        } catch (e: SQLException) {
+            logger.error("Failed to upsert bank settings for guild ${settings.guildId}", e)
+            false
+        }
+    }
+}

--- a/src/main/kotlin/net/lumalyte/lg/infrastructure/services/BankInterestScheduler.kt
+++ b/src/main/kotlin/net/lumalyte/lg/infrastructure/services/BankInterestScheduler.kt
@@ -1,0 +1,62 @@
+package net.lumalyte.lg.infrastructure.services
+
+import net.lumalyte.lg.application.services.BankAutomationService
+import org.bukkit.plugin.Plugin
+import org.bukkit.scheduler.BukkitRunnable
+import org.slf4j.LoggerFactory
+
+/**
+ * Periodic bank automation driver (REQ-009): interest accrual + audit-log pruning.
+ *
+ * Runs every 5 minutes; each run accrues interest for every guild whose compound
+ * period has elapsed (catch-up capped by [BankAutomationService]) and prunes
+ * expired audit entries.
+ */
+class BankInterestScheduler(
+    private val plugin: Plugin,
+    private val bankAutomationService: BankAutomationService
+) {
+
+    private val logger = LoggerFactory.getLogger(BankInterestScheduler::class.java)
+
+    private var scheduledTask: BukkitRunnable? = null
+
+    private val runIntervalTicks = 5L * 60L * 20L // 5 minutes (20 ticks per second)
+
+    /** Starts the periodic scheduler. Safe to call once at plugin enable. */
+    fun start() {
+        if (scheduledTask != null) return
+
+        scheduledTask = object : BukkitRunnable() {
+            override fun run() {
+                try {
+                    val credited = bankAutomationService.accrueInterest()
+                    if (credited > 0) {
+                        logger.info("Bank interest accrued for $credited guild(s)")
+                    }
+                } catch (e: Exception) {
+                    logger.error("Error running bank interest accrual", e)
+                }
+
+                try {
+                    val pruned = bankAutomationService.pruneAuditLogs()
+                    if (pruned > 0) {
+                        logger.info("Pruned $pruned expired bank audit entr${if (pruned == 1) "y" else "ies"}")
+                    }
+                } catch (e: Exception) {
+                    logger.error("Error pruning bank audit logs", e)
+                }
+            }
+        }
+
+        scheduledTask?.runTaskTimer(plugin, runIntervalTicks, runIntervalTicks)
+        logger.info("Bank interest scheduler started (every 5 minutes)")
+    }
+
+    /** Stops the periodic scheduler. */
+    fun stop() {
+        scheduledTask?.cancel()
+        scheduledTask = null
+        logger.info("Bank interest scheduler stopped")
+    }
+}

--- a/src/main/kotlin/net/lumalyte/lg/infrastructure/services/BankInterestScheduler.kt
+++ b/src/main/kotlin/net/lumalyte/lg/infrastructure/services/BankInterestScheduler.kt
@@ -29,13 +29,19 @@ class BankInterestScheduler(
 
         scheduledTask = object : BukkitRunnable() {
             override fun run() {
+                // NOTE: intentionally runs on the main thread — the accrual path
+                // (creditToGuildBank → VaultInventoryManager.depositGold →
+                // updateGoldBalanceButton) mutates a live Bukkit Inventory, so it
+                // cannot be moved to a worker thread. Matches DailyWarCostsScheduler.
                 try {
                     val credited = bankAutomationService.accrueInterest()
                     if (credited > 0) {
                         logger.info("Bank interest accrued for $credited guild(s)")
                     }
-                } catch (e: Exception) {
-                    logger.error("Error running bank interest accrual", e)
+                } catch (e: net.lumalyte.lg.application.errors.DatabaseOperationException) {
+                    logger.error("Database error running bank interest accrual", e)
+                } catch (e: IllegalStateException) {
+                    logger.error("Service error running bank interest accrual", e)
                 }
 
                 try {
@@ -43,8 +49,10 @@ class BankInterestScheduler(
                     if (pruned > 0) {
                         logger.info("Pruned $pruned expired bank audit entr${if (pruned == 1) "y" else "ies"}")
                     }
-                } catch (e: Exception) {
-                    logger.error("Error pruning bank audit logs", e)
+                } catch (e: net.lumalyte.lg.application.errors.DatabaseOperationException) {
+                    logger.error("Database error pruning bank audit logs", e)
+                } catch (e: IllegalStateException) {
+                    logger.error("Service error pruning bank audit logs", e)
                 }
             }
         }

--- a/src/main/kotlin/net/lumalyte/lg/infrastructure/services/BankServiceBukkit.kt
+++ b/src/main/kotlin/net/lumalyte/lg/infrastructure/services/BankServiceBukkit.kt
@@ -43,6 +43,29 @@ class BankServiceBukkit(
             if (progressionLimit == null) configCap else minOf(configCap, progressionLimit)
 
         /**
+         * Highest bankLimit across the levels a guild has reached, or null when no
+         * level actually grants one (then the config cap applies alone).
+         *
+         * NOTE: `bankLimit` defaults to 0 in the config model when a level has no
+         * explicit `bank_limit`, and 0 means "no bank limit granted at this level".
+         * Treating 0 as a real limit would collapse the ceiling to 0 for guilds
+         * whose progression levels carry no bank_limit rewards, and then
+         * effectiveMaxBalance(cap, 0) = 0 would block EVERY deposit.
+         */
+        fun computeProgressionBankLimit(
+            levelRewards: Map<Int, net.lumalyte.lg.config.LevelRewardConfig>,
+            currentLevel: Int
+        ): Int? {
+            var limit: Int? = null
+            for (level in 1..currentLevel) {
+                val balance = levelRewards[level]?.bankLimit ?: continue
+                if (balance <= 0) continue // 0 = not granted; skip
+                if (limit == null || balance > limit) limit = balance
+            }
+            return limit
+        }
+
+        /**
          * Suspicious-transaction auto-lock decision (REQ-009): triggers at/above
          * `bank.suspicious_transaction_threshold` only when `bank.auto_lock_suspicious_accounts` is enabled.
          */
@@ -169,17 +192,32 @@ class BankServiceBukkit(
                 return null
             }
 
+            // Suspicious-transaction auto-lock (REQ-009): refuse BEFORE any funds
+            // move and freeze the account, so a qualifying transaction can never
+            // succeed. (Previously this ran after the transfer, so the suspicious
+            // deposit always landed and the freeze only blocked the next one.)
+            val bankConfig = getConfig().bank
+            if (shouldAutoLock(amount, bankConfig.suspiciousTransactionThreshold, bankConfig.autoLockSuspiciousAccounts)) {
+                guildService.setBankFrozen(guildId, true, SYSTEM_ACTOR)
+                recordAudit(BankAudit(
+                    guildId = guildId,
+                    actorId = SYSTEM_ACTOR,
+                    action = AuditAction.PERMISSION_DENIED,
+                    details = "Account auto-locked: suspicious transaction refused (deposit of $amount)"
+                ))
+                logger.warn("Guild $guildId auto-locked; suspicious deposit of $amount refused")
+                return null
+            }
+
             // Check guild bank balance limit: progression-derived, capped by the config ceiling (REQ-009)
             val currentBalance = getBalance(guildId)
             val progression = progressionRepository.getGuildProgression(guildId)
             val progressionConfig = progressionConfigService.getProgressionConfig()
             val levelRewards = progressionConfig.getActiveLevelRewards()
-            var progressionLimit: Int? = null
-            if (progression != null) {
-                for (level in 1..progression.currentLevel) {
-                    val balance = levelRewards[level]?.bankLimit ?: 0
-                    if (progressionLimit == null || balance > progressionLimit) progressionLimit = balance
-                }
+            val progressionLimit = if (progression != null) {
+                computeProgressionBankLimit(levelRewards, progression.currentLevel)
+            } else {
+                null
             }
             val maxBalance = effectiveMaxBalance(getConfig().bank.maxBankBalance, progressionLimit)
             if (currentBalance + amount > maxBalance) {
@@ -261,19 +299,6 @@ class BankServiceBukkit(
             ))
 
             logger.info("Player $playerId deposited $amount to guild $guildId (balance: $newBalance)")
-
-            // Suspicious-transaction auto-lock (REQ-009)
-            val bankConfig = getConfig().bank
-            if (shouldAutoLock(amount, bankConfig.suspiciousTransactionThreshold, bankConfig.autoLockSuspiciousAccounts)) {
-                guildService.setBankFrozen(guildId, true, SYSTEM_ACTOR)
-                recordAudit(BankAudit(
-                    guildId = guildId,
-                    actorId = SYSTEM_ACTOR,
-                    action = AuditAction.PERMISSION_DENIED,
-                    details = "Account auto-locked: suspicious transaction detected (deposit of $amount)"
-                ))
-                logger.warn("Guild $guildId auto-locked after suspicious deposit of $amount")
-            }
 
             // Award progression XP for bank deposits
             try {
@@ -358,6 +383,23 @@ class BankServiceBukkit(
                     action = AuditAction.PERMISSION_DENIED,
                     details = "Invalid withdrawal amount: $amount"
                 ))
+                return null
+            }
+
+            // Suspicious-transaction auto-lock (REQ-009): refuse BEFORE any funds
+            // move and freeze the account, so a qualifying transaction can never
+            // succeed. (Previously this ran after the transfer, so the suspicious
+            // withdrawal always landed and the freeze only blocked the next one.)
+            val bankConfig = getConfig().bank
+            if (shouldAutoLock(amount, bankConfig.suspiciousTransactionThreshold, bankConfig.autoLockSuspiciousAccounts)) {
+                guildService.setBankFrozen(guildId, true, SYSTEM_ACTOR)
+                recordAudit(BankAudit(
+                    guildId = guildId,
+                    actorId = SYSTEM_ACTOR,
+                    action = AuditAction.PERMISSION_DENIED,
+                    details = "Account auto-locked: suspicious transaction refused (withdrawal of $amount)"
+                ))
+                logger.warn("Guild $guildId auto-locked; suspicious withdrawal of $amount refused")
                 return null
             }
 
@@ -451,19 +493,6 @@ class BankServiceBukkit(
             }
 
             logger.info("Player $playerId withdrew $amount from guild $guildId (fee: $fee, balance: $newBalance)")
-
-            // Suspicious-transaction auto-lock (REQ-009)
-            val bankConfig = getConfig().bank
-            if (shouldAutoLock(amount, bankConfig.suspiciousTransactionThreshold, bankConfig.autoLockSuspiciousAccounts)) {
-                guildService.setBankFrozen(guildId, true, SYSTEM_ACTOR)
-                recordAudit(BankAudit(
-                    guildId = guildId,
-                    actorId = SYSTEM_ACTOR,
-                    action = AuditAction.PERMISSION_DENIED,
-                    details = "Account auto-locked: suspicious transaction detected (withdrawal of $amount)"
-                ))
-                logger.warn("Guild $guildId auto-locked after suspicious withdrawal of $amount")
-            }
 
             return transaction
         } catch (e: SQLException) {
@@ -697,7 +726,9 @@ class BankServiceBukkit(
 
     override fun deductFromGuildBank(guildId: UUID, amount: Int, reason: String?): Boolean {
         try {
-            val systemActor = UUID.randomUUID() // System deductions have no player actor
+            // System-initiated deductions use the stable SYSTEM_ACTOR so the audit
+            // trail can be filtered by system actor (interest, war costs, etc.).
+            val systemActor = SYSTEM_ACTOR
 
             // Debit the unified guild balance (store B). Atomic; -1 if insufficient.
             val debitedBalance = vaultInventoryManager.withdrawGold(guildId, systemActor, amount.toLong())
@@ -730,7 +761,9 @@ class BankServiceBukkit(
     override fun creditToGuildBank(guildId: UUID, amount: Int, reason: String?): Boolean {
         if (amount <= 0) return false
         try {
-            val systemActor = UUID.randomUUID() // System credits have no player actor
+            // System-initiated credits use the stable SYSTEM_ACTOR (interest accrual,
+            // admin credits) so the audit trail can be filtered by system actor.
+            val systemActor = SYSTEM_ACTOR
 
             // Credit the unified guild balance (store B). Atomic and immediately visible.
             val newBalance = try {

--- a/src/main/kotlin/net/lumalyte/lg/infrastructure/services/BankServiceBukkit.kt
+++ b/src/main/kotlin/net/lumalyte/lg/infrastructure/services/BankServiceBukkit.kt
@@ -27,8 +27,28 @@ class BankServiceBukkit(
     private val progressionConfigService: ProgressionConfigService,
     private val configService: ConfigService,
     private val guildRepository: net.lumalyte.lg.application.persistence.GuildRepository,
+    private val guildService: net.lumalyte.lg.application.services.GuildService,
     private val vaultInventoryManager: net.lumalyte.lg.application.services.VaultInventoryManager
 ) : BankService {
+
+    companion object {
+        /** Actor UUID for system-initiated actions (auto-lock, interest accrual). */
+        val SYSTEM_ACTOR: UUID = UUID(0L, 0L)
+
+        /**
+         * Effective deposit ceiling (REQ-009): `bank.max_bank_balance` is the hard cap;
+         * the progression-derived limit refines it downward when present.
+         */
+        fun effectiveMaxBalance(configCap: Int, progressionLimit: Int?): Int =
+            if (progressionLimit == null) configCap else minOf(configCap, progressionLimit)
+
+        /**
+         * Suspicious-transaction auto-lock decision (REQ-009): triggers at/above
+         * `bank.suspicious_transaction_threshold` only when `bank.auto_lock_suspicious_accounts` is enabled.
+         */
+        fun shouldAutoLock(amount: Int, threshold: Int, autoLockEnabled: Boolean): Boolean =
+            autoLockEnabled && amount >= threshold
+    }
 
     private val logger = LoggerFactory.getLogger(BankServiceBukkit::class.java)
 
@@ -149,18 +169,19 @@ class BankServiceBukkit(
                 return null
             }
 
-            // Check guild bank balance limit (progression-based)
+            // Check guild bank balance limit: progression-derived, capped by the config ceiling (REQ-009)
             val currentBalance = getBalance(guildId)
             val progression = progressionRepository.getGuildProgression(guildId)
             val progressionConfig = progressionConfigService.getProgressionConfig()
             val levelRewards = progressionConfig.getActiveLevelRewards()
-            var maxBalance = 100000 // Default starting balance limit
+            var progressionLimit: Int? = null
             if (progression != null) {
                 for (level in 1..progression.currentLevel) {
                     val balance = levelRewards[level]?.bankLimit ?: 0
-                    if (balance > maxBalance) maxBalance = balance
+                    if (progressionLimit == null || balance > progressionLimit) progressionLimit = balance
                 }
             }
+            val maxBalance = effectiveMaxBalance(getConfig().bank.maxBankBalance, progressionLimit)
             if (currentBalance + amount > maxBalance) {
                 logger.warn("Deposit would exceed guild bank limit: $currentBalance + $amount > $maxBalance")
                 recordAudit(BankAudit(
@@ -240,6 +261,19 @@ class BankServiceBukkit(
             ))
 
             logger.info("Player $playerId deposited $amount to guild $guildId (balance: $newBalance)")
+
+            // Suspicious-transaction auto-lock (REQ-009)
+            val bankConfig = getConfig().bank
+            if (shouldAutoLock(amount, bankConfig.suspiciousTransactionThreshold, bankConfig.autoLockSuspiciousAccounts)) {
+                guildService.setBankFrozen(guildId, true, SYSTEM_ACTOR)
+                recordAudit(BankAudit(
+                    guildId = guildId,
+                    actorId = SYSTEM_ACTOR,
+                    action = AuditAction.PERMISSION_DENIED,
+                    details = "Account auto-locked: suspicious transaction detected (deposit of $amount)"
+                ))
+                logger.warn("Guild $guildId auto-locked after suspicious deposit of $amount")
+            }
 
             // Award progression XP for bank deposits
             try {
@@ -417,6 +451,20 @@ class BankServiceBukkit(
             }
 
             logger.info("Player $playerId withdrew $amount from guild $guildId (fee: $fee, balance: $newBalance)")
+
+            // Suspicious-transaction auto-lock (REQ-009)
+            val bankConfig = getConfig().bank
+            if (shouldAutoLock(amount, bankConfig.suspiciousTransactionThreshold, bankConfig.autoLockSuspiciousAccounts)) {
+                guildService.setBankFrozen(guildId, true, SYSTEM_ACTOR)
+                recordAudit(BankAudit(
+                    guildId = guildId,
+                    actorId = SYSTEM_ACTOR,
+                    action = AuditAction.PERMISSION_DENIED,
+                    details = "Account auto-locked: suspicious transaction detected (withdrawal of $amount)"
+                ))
+                logger.warn("Guild $guildId auto-locked after suspicious withdrawal of $amount")
+            }
+
             return transaction
         } catch (e: SQLException) {
             logger.error("Database error processing withdrawal for player $playerId from guild $guildId", e)

--- a/src/main/kotlin/net/lumalyte/lg/interaction/menus/guild/GuildBankAutomationMenu.kt
+++ b/src/main/kotlin/net/lumalyte/lg/interaction/menus/guild/GuildBankAutomationMenu.kt
@@ -4,9 +4,14 @@ import com.github.stefvanschie.inventoryframework.gui.GuiItem
 import com.github.stefvanschie.inventoryframework.gui.type.ChestGui
 import com.github.stefvanschie.inventoryframework.pane.Pane
 import com.github.stefvanschie.inventoryframework.pane.StaticPane
+import net.lumalyte.lg.application.persistence.BankSettingsRepository
+import net.lumalyte.lg.application.services.BankAutomationService
 import net.lumalyte.lg.application.services.BankService
+import net.lumalyte.lg.domain.entities.BankSettings
 import net.lumalyte.lg.domain.entities.Guild
 import net.lumalyte.lg.domain.values.LocalizationKeys
+import net.lumalyte.lg.interaction.listeners.ChatInputHandler
+import net.lumalyte.lg.interaction.listeners.ChatInputListener
 import net.lumalyte.lg.interaction.menus.Menu
 import net.lumalyte.lg.interaction.menus.MenuNavigator
 import net.kyori.adventure.text.Component
@@ -17,18 +22,24 @@ import org.bukkit.entity.Player
 import org.bukkit.inventory.ItemStack
 import org.koin.core.component.KoinComponent
 import org.koin.core.component.inject
-import java.time.LocalDateTime
+import java.time.Instant
+import java.time.ZoneId
+import java.time.format.DateTimeFormatter
 
 /**
- * Guild Bank Automation menu with scheduled tasks, rewards, and alerts
+ * Guild Bank Automation menu with scheduled tasks, rewards, and alerts (REQ-010)
  */
 class GuildBankAutomationMenu(
     private val menuNavigator: MenuNavigator,
     private val player: Player,
     private val guild: Guild
-) : Menu, KoinComponent {
+) : Menu, KoinComponent, ChatInputHandler {
 
     private val bankService: BankService by inject()
+    private val bankSettingsRepository: BankSettingsRepository by inject()
+    private val bankAutomationService: BankAutomationService by inject()
+    private val configService: net.lumalyte.lg.application.services.ConfigService by inject()
+    private val chatInputListener: ChatInputListener by inject()
     private val localizationProvider: net.lumalyte.lg.application.utilities.LocalizationProvider by inject()
     private val menuFactory: net.lumalyte.lg.interaction.menus.MenuFactory by inject()
 
@@ -38,11 +49,14 @@ class GuildBankAutomationMenu(
     private lateinit var automationPane: StaticPane
     private lateinit var rewardsPane: StaticPane
 
-    // Automation settings
+    // Automation settings (persisted per guild via BankSettingsRepository)
     private var scheduledDepositsEnabled: Boolean = false
     private var autoRewardsEnabled: Boolean = true
     private var recurringPaymentsEnabled: Boolean = false
-    private var interestRate: Double = 0.02 // 2% monthly interest
+    private var interestRate: Double = 0.02 // 2% per compound period (fraction)
+
+    // Active input mode for chat-based configuration
+    private var inputMode: String? = null
 
     // Active automations
     private var activeAutomations: MutableList<String> = mutableListOf()
@@ -78,14 +92,14 @@ class GuildBankAutomationMenu(
     }
 
     /**
-     * Load automation settings (placeholder for now)
+     * Load automation settings from the persisted per-guild settings (REQ-010).
      */
     private fun loadAutomationSettings() {
-        // TODO: Load from database/configuration
-        scheduledDepositsEnabled = false
-        autoRewardsEnabled = true
-        recurringPaymentsEnabled = false
-        interestRate = 0.02
+        val settings = bankSettingsRepository.getByGuildId(guild.id) ?: BankSettings(guild.id)
+        scheduledDepositsEnabled = settings.scheduledDepositsEnabled
+        autoRewardsEnabled = settings.autoRewardsEnabled
+        recurringPaymentsEnabled = settings.recurringPaymentsEnabled
+        interestRate = settings.interestRate
     }
 
     /**
@@ -290,8 +304,9 @@ class GuildBankAutomationMenu(
         )
         val interestGuiItem = GuiItem(interestItem) { event ->
             event.isCancelled = true
-            // TODO: Open interest rate input
-            player.sendMessage("§eInterest rate configuration coming soon!")
+            inputMode = "interestRate"
+            chatInputListener.startInputMode(player, this@GuildBankAutomationMenu)
+            player.sendMessage("§eType the interest rate as a decimal (e.g. 0.02 = 2% per compound period). Type 'cancel' to abort.")
         }
         automationPane.addItem(interestGuiItem, 4, 0)
 
@@ -387,48 +402,64 @@ class GuildBankAutomationMenu(
     }
 
     /**
-     * Update automation status display
+     * Update automation status display (REQ-010): real next-run time + honest status.
      */
     private fun updateAutomationStatus() {
-        // Next automation run time (placeholder)
-        val nextRun = LocalDateTime.now().plusHours(1)
+        // Real next run: last accrual + compound period, or the periodic scheduler cadence
+        val nextRun = bankAutomationService.getNextInterestRun(guild.id)
+        val nextRunText = nextRun?.let {
+            it.atZone(ZoneId.systemDefault()).format(DateTimeFormatter.ofPattern("MM/dd/yyyy HH:mm"))
+        } ?: "Pending first accrual"
+
         val nextRunItem = createMenuItem(
             Material.CLOCK,
-            "Next Automation Run",
+            "Next Interest Accrual",
             listOf(
-                nextRun.format(java.time.format.DateTimeFormatter.ofPattern("HH:mm")),
-                "Scheduled tasks will run automatically",
-                "Based on configured intervals"
+                nextRunText,
+                "Interest accrues every ${interestPeriodHours()} hours",
+                "Per guild balance at the configured rate"
             )
         )
         rewardsPane.addItem(GuiItem(nextRunItem), 4, 0)
 
-        // Automation health status
-        val healthItem = createMenuItem(
-            Material.GREEN_WOOL,
-            "Automation Status",
+        // Automation health status (derived from persisted settings, not hardcoded)
+        val activeCount = activeAutomations.size
+        val statusLore = if (activeCount > 0) {
             listOf(
-                "Status: Healthy",
-                "All automated processes running",
-                "${activeAutomations.size} active tasks"
+                "Status: ${activeCount} automation(s) configured",
+                "Interest rate: ${String.format("%.2f", interestRate * 100)}% per ${interestPeriodHours()}h",
+                "Scheduled deposits: ${if (scheduledDepositsEnabled) "ON" else "OFF"} | Auto-rewards: ${if (autoRewardsEnabled) "ON" else "OFF"}"
             )
+        } else {
+            listOf("Status: No automations configured", "Toggle settings above to enable")
+        }
+        val healthItem = createMenuItem(
+            if (activeCount > 0) Material.GREEN_WOOL else Material.GRAY_WOOL,
+            "Automation Status",
+            statusLore
         )
         rewardsPane.addItem(GuiItem(healthItem), 5, 0)
 
         // Recent automation activity
         val recentActivity = listOf(
-            "Auto-reward distributed (2 hours ago)",
-            "Budget alert sent (4 hours ago)",
-            "Interest calculated (1 day ago)"
+            "Interest accrual: every ${interestPeriodHours()}h",
+            "Audit retention: ${auditRetentionDays()} days",
+            "Scheduler: periodic (5 min checks)"
         )
 
         val activityItem = createMenuItem(
             Material.BOOK,
-            "Recent Automation Activity",
+            "Automation Configuration",
             recentActivity
         )
         rewardsPane.addItem(GuiItem(activityItem), 6, 1)
     }
+
+    private fun interestPeriodHours(): Int =
+        configService.loadConfig().bank.interestCompoundPeriodHours
+
+    private fun auditRetentionDays(): Int =
+        configService.loadConfig().bank.auditLogRetentionDays
 
     /**
      * Update automation display with latest data
@@ -445,11 +476,47 @@ class GuildBankAutomationMenu(
     }
 
     /**
-     * Save automation settings
+     * Save automation settings (REQ-010): persists all knobs per guild.
      */
     private fun saveAutomationSettings() {
-        // TODO: Save to database/configuration
-        player.sendMessage("§aAutomation settings would be saved to database")
+        val current = bankSettingsRepository.getByGuildId(guild.id) ?: BankSettings(guild.id)
+        val updated = current.copy(
+            scheduledDepositsEnabled = scheduledDepositsEnabled,
+            autoRewardsEnabled = autoRewardsEnabled,
+            recurringPaymentsEnabled = recurringPaymentsEnabled,
+            interestRate = interestRate
+        )
+        val saved = bankSettingsRepository.upsert(updated)
+        if (saved) {
+            player.sendMessage("§aAutomation settings saved!")
+        } else {
+            player.sendMessage("§cFailed to save automation settings.")
+        }
+    }
+
+    // ChatInputHandler interface methods (REQ-010)
+    override fun onChatInput(player: Player, input: String) {
+        when (inputMode) {
+            "interestRate" -> {
+                val rate = input.trim().toDoubleOrNull()
+                if (rate == null || rate < 0.0 || rate > 1.0) {
+                    player.sendMessage("§cInvalid interest rate. Enter a decimal between 0 and 1 (e.g. 0.02 = 2%).")
+                } else {
+                    interestRate = rate
+                    player.sendMessage("§aInterest rate set to ${String.format("%.2f", rate * 100)}% per compound period.")
+                }
+            }
+            else -> return
+        }
+        inputMode = null
+        checkActiveAutomations()
+        updateAutomationDisplay()
+        gui.update()
+    }
+
+    override fun onCancel(player: Player) {
+        inputMode = null
+        player.sendMessage("§eInterest rate input cancelled.")
     }
 
     /**

--- a/src/main/kotlin/net/lumalyte/lg/interaction/menus/guild/GuildBankAutomationMenu.kt
+++ b/src/main/kotlin/net/lumalyte/lg/interaction/menus/guild/GuildBankAutomationMenu.kt
@@ -22,7 +22,6 @@ import org.bukkit.entity.Player
 import org.bukkit.inventory.ItemStack
 import org.koin.core.component.KoinComponent
 import org.koin.core.component.inject
-import java.time.Instant
 import java.time.ZoneId
 import java.time.format.DateTimeFormatter
 
@@ -182,8 +181,9 @@ class GuildBankAutomationMenu(
         )
         val saveGuiItem = GuiItem(saveItem) { event ->
             event.isCancelled = true
+            // saveAutomationSettings() reports the upsert result itself — no
+            // unconditional success message here (would contradict a failure).
             saveAutomationSettings()
-            player.sendMessage("§aAutomation settings saved!")
         }
         mainPane.addItem(saveGuiItem, 7, 0)
 

--- a/src/main/kotlin/net/lumalyte/lg/interaction/menus/guild/GuildBankBudgetMenu.kt
+++ b/src/main/kotlin/net/lumalyte/lg/interaction/menus/guild/GuildBankBudgetMenu.kt
@@ -193,8 +193,9 @@ class GuildBankBudgetMenu(
         )
         val saveGuiItem = GuiItem(saveItem) { event ->
             event.isCancelled = true
+            // saveBudgetSettings() reports the upsert result itself — no
+            // unconditional success message here (would contradict a failure).
             saveBudgetSettings()
-            player.sendMessage("§aBudget settings saved!")
         }
         mainPane.addItem(saveGuiItem, 7, 0)
 
@@ -404,13 +405,17 @@ class GuildBankBudgetMenu(
 
     // ChatInputHandler interface methods (REQ-011)
     override fun onChatInput(player: Player, input: String) {
+        // Guard FIRST: if the listener session outlived the menu interaction,
+        // inputMode is null and this is ordinary chat — do not intercept it.
+        val mode = inputMode ?: return
+
         val amount = input.trim().toIntOrNull()
         if (amount == null || amount < 0) {
             player.sendMessage("§cInvalid amount. Enter a whole number of coins (0 or more).")
             inputMode = null
             return
         }
-        when (inputMode) {
+        when (mode) {
             "monthly" -> {
                 monthlyBudget = amount
                 player.sendMessage("§aMonthly budget set to $amount coins. Press Save to persist.")

--- a/src/main/kotlin/net/lumalyte/lg/interaction/menus/guild/GuildBankBudgetMenu.kt
+++ b/src/main/kotlin/net/lumalyte/lg/interaction/menus/guild/GuildBankBudgetMenu.kt
@@ -4,9 +4,13 @@ import com.github.stefvanschie.inventoryframework.gui.GuiItem
 import com.github.stefvanschie.inventoryframework.gui.type.ChestGui
 import com.github.stefvanschie.inventoryframework.pane.Pane
 import com.github.stefvanschie.inventoryframework.pane.StaticPane
+import net.lumalyte.lg.application.persistence.BankSettingsRepository
 import net.lumalyte.lg.application.services.BankService
+import net.lumalyte.lg.domain.entities.BankSettings
 import net.lumalyte.lg.domain.entities.Guild
 import net.lumalyte.lg.domain.values.LocalizationKeys
+import net.lumalyte.lg.interaction.listeners.ChatInputHandler
+import net.lumalyte.lg.interaction.listeners.ChatInputListener
 import net.lumalyte.lg.interaction.menus.Menu
 import net.lumalyte.lg.interaction.menus.MenuNavigator
 import net.kyori.adventure.text.Component
@@ -21,15 +25,17 @@ import java.time.Instant
 import java.time.temporal.ChronoUnit
 
 /**
- * Guild Bank Budget Management menu with spending limits and alerts
+ * Guild Bank Budget Management menu with spending limits and alerts (REQ-011)
  */
 class GuildBankBudgetMenu(
     private val menuNavigator: MenuNavigator,
     private val player: Player,
     private val guild: Guild
-) : Menu, KoinComponent {
+) : Menu, KoinComponent, ChatInputHandler {
 
     private val bankService: BankService by inject()
+    private val bankSettingsRepository: BankSettingsRepository by inject()
+    private val chatInputListener: ChatInputListener by inject()
     private val localizationProvider: net.lumalyte.lg.application.utilities.LocalizationProvider by inject()
     private val menuFactory: net.lumalyte.lg.interaction.menus.MenuFactory by inject()
 
@@ -39,11 +45,14 @@ class GuildBankBudgetMenu(
     private lateinit var budgetPane: StaticPane
     private lateinit var alertsPane: StaticPane
 
-    // Budget data
+    // Budget data (persisted per guild via BankSettingsRepository)
     private var monthlyBudget: Int = 0
     private var weeklyBudget: Int = 0
     private var dailyBudget: Int = 0
     private var budgetAlerts: MutableList<String> = mutableListOf()
+
+    // Active input mode for chat-based configuration
+    private var inputMode: String? = null
 
     init {
         loadBudgetSettings()
@@ -75,13 +84,13 @@ class GuildBankBudgetMenu(
     }
 
     /**
-     * Load budget settings (placeholder for now)
+     * Load budget settings from the persisted per-guild settings (REQ-011).
      */
     private fun loadBudgetSettings() {
-        // TODO: Load from database/configuration
-        monthlyBudget = 10000
-        weeklyBudget = 2500
-        dailyBudget = 500
+        val settings = bankSettingsRepository.getByGuildId(guild.id) ?: BankSettings(guild.id)
+        monthlyBudget = settings.monthlyBudget
+        weeklyBudget = settings.weeklyBudget
+        dailyBudget = settings.dailyBudget
     }
 
     /**
@@ -218,8 +227,9 @@ class GuildBankBudgetMenu(
         )
         val monthlyGuiItem = GuiItem(monthlyItem) { event ->
             event.isCancelled = true
-            // TODO: Open amount input for monthly budget
-            player.sendMessage("§eMonthly budget setting coming soon!")
+            inputMode = "monthly"
+            chatInputListener.startInputMode(player, this@GuildBankBudgetMenu)
+            player.sendMessage("§eType the monthly budget amount in coins. Type 'cancel' to abort.")
         }
         budgetPane.addItem(monthlyGuiItem, 0, 0)
 
@@ -235,8 +245,9 @@ class GuildBankBudgetMenu(
         )
         val weeklyGuiItem = GuiItem(weeklyItem) { event ->
             event.isCancelled = true
-            // TODO: Open amount input for weekly budget
-            player.sendMessage("§eWeekly budget setting coming soon!")
+            inputMode = "weekly"
+            chatInputListener.startInputMode(player, this@GuildBankBudgetMenu)
+            player.sendMessage("§eType the weekly budget amount in coins. Type 'cancel' to abort.")
         }
         budgetPane.addItem(weeklyGuiItem, 1, 0)
 
@@ -252,8 +263,9 @@ class GuildBankBudgetMenu(
         )
         val dailyGuiItem = GuiItem(dailyItem) { event ->
             event.isCancelled = true
-            // TODO: Open amount input for daily budget
-            player.sendMessage("§eDaily budget setting coming soon!")
+            inputMode = "daily"
+            chatInputListener.startInputMode(player, this@GuildBankBudgetMenu)
+            player.sendMessage("§eType the daily budget amount in coins. Type 'cancel' to abort.")
         }
         budgetPane.addItem(dailyGuiItem, 2, 0)
 
@@ -373,11 +385,55 @@ class GuildBankBudgetMenu(
     }
 
     /**
-     * Save budget settings
+     * Save budget settings (REQ-011): persists all three limits per guild.
      */
     private fun saveBudgetSettings() {
-        // TODO: Save to database/configuration
-        player.sendMessage("§aBudget settings would be saved to database")
+        val current = bankSettingsRepository.getByGuildId(guild.id) ?: BankSettings(guild.id)
+        val updated = current.copy(
+            monthlyBudget = monthlyBudget,
+            weeklyBudget = weeklyBudget,
+            dailyBudget = dailyBudget
+        )
+        val saved = bankSettingsRepository.upsert(updated)
+        if (saved) {
+            player.sendMessage("§aBudget settings saved!")
+        } else {
+            player.sendMessage("§cFailed to save budget settings.")
+        }
+    }
+
+    // ChatInputHandler interface methods (REQ-011)
+    override fun onChatInput(player: Player, input: String) {
+        val amount = input.trim().toIntOrNull()
+        if (amount == null || amount < 0) {
+            player.sendMessage("§cInvalid amount. Enter a whole number of coins (0 or more).")
+            inputMode = null
+            return
+        }
+        when (inputMode) {
+            "monthly" -> {
+                monthlyBudget = amount
+                player.sendMessage("§aMonthly budget set to $amount coins. Press Save to persist.")
+            }
+            "weekly" -> {
+                weeklyBudget = amount
+                player.sendMessage("§aWeekly budget set to $amount coins. Press Save to persist.")
+            }
+            "daily" -> {
+                dailyBudget = amount
+                player.sendMessage("§aDaily budget set to $amount coins. Press Save to persist.")
+            }
+            else -> return
+        }
+        inputMode = null
+        calculateAlerts()
+        updateBudgetDisplay()
+        gui.update()
+    }
+
+    override fun onCancel(player: Player) {
+        inputMode = null
+        player.sendMessage("§eBudget input cancelled.")
     }
 
     /**

--- a/src/main/kotlin/net/lumalyte/lg/interaction/menus/guild/GuildBankSecurityMenu.kt
+++ b/src/main/kotlin/net/lumalyte/lg/interaction/menus/guild/GuildBankSecurityMenu.kt
@@ -4,13 +4,17 @@ import com.github.stefvanschie.inventoryframework.gui.GuiItem
 import com.github.stefvanschie.inventoryframework.gui.type.ChestGui
 import com.github.stefvanschie.inventoryframework.pane.Pane
 import com.github.stefvanschie.inventoryframework.pane.StaticPane
+import net.lumalyte.lg.application.persistence.BankSettingsRepository
 import net.lumalyte.lg.application.services.BankService
 import net.lumalyte.lg.application.services.GuildService
 import net.lumalyte.lg.domain.entities.AuditAction
 import net.lumalyte.lg.domain.entities.BankAudit
+import net.lumalyte.lg.domain.entities.BankSettings
 import net.lumalyte.lg.domain.entities.BankTransaction
 import net.lumalyte.lg.domain.entities.Guild
 import net.lumalyte.lg.domain.values.LocalizationKeys
+import net.lumalyte.lg.interaction.listeners.ChatInputHandler
+import net.lumalyte.lg.interaction.listeners.ChatInputListener
 import net.lumalyte.lg.interaction.menus.Menu
 import net.lumalyte.lg.interaction.menus.MenuNavigator
 import net.kyori.adventure.text.Component
@@ -27,16 +31,18 @@ import java.time.ZoneId
 import java.time.temporal.ChronoUnit
 
 /**
- * Guild Bank Security and Audit menu with fraud detection and dual authorization
+ * Guild Bank Security and Audit menu with fraud detection and dual authorization (REQ-031)
  */
 class GuildBankSecurityMenu(
     private val menuNavigator: MenuNavigator,
     private val player: Player,
     private val guild: Guild
-) : Menu, KoinComponent {
+) : Menu, KoinComponent, ChatInputHandler {
 
     private val bankService: BankService by inject()
     private val guildService: GuildService by inject()
+    private val bankSettingsRepository: BankSettingsRepository by inject()
+    private val chatInputListener: ChatInputListener by inject()
     private val localizationProvider: net.lumalyte.lg.application.utilities.LocalizationProvider by inject()
 
     // GUI components
@@ -45,10 +51,13 @@ class GuildBankSecurityMenu(
     private lateinit var securityPane: StaticPane
     private lateinit var auditPane: StaticPane
 
-    // Security settings
+    // Security settings (dual-auth threshold persisted per guild)
     private var dualAuthThreshold: Int = 1000
     private var emergencyFreeze: Boolean = false
     private var securityAlerts: MutableList<String> = mutableListOf()
+
+    // Active input mode for chat-based configuration
+    private var inputMode: String? = null
 
     init {
         loadSecuritySettings()
@@ -79,10 +88,12 @@ class GuildBankSecurityMenu(
     }
 
     /**
-     * Load security settings from the guild entity.
+     * Load security settings: dual-auth threshold from persisted per-guild settings (REQ-031),
+     * freeze state from the guild entity.
      */
     private fun loadSecuritySettings() {
-        dualAuthThreshold = 1000
+        val settings = bankSettingsRepository.getByGuildId(guild.id) ?: BankSettings(guild.id)
+        dualAuthThreshold = settings.dualAuthThreshold
         // Read persisted freeze state from database via guild entity
         val currentGuild = guildService.getGuild(guild.id)
         emergencyFreeze = currentGuild?.bankFrozen ?: false
@@ -286,8 +297,9 @@ class GuildBankSecurityMenu(
         )
         val dualAuthGuiItem = GuiItem(dualAuthItem) { event ->
             event.isCancelled = true
-            // TODO: Open threshold input
-            player.sendMessage("§eDual authorization threshold setting coming soon!")
+            inputMode = "dualAuth"
+            chatInputListener.startInputMode(player, this@GuildBankSecurityMenu)
+            player.sendMessage("§eType the dual-authorization threshold in coins. Type 'cancel' to abort.")
         }
         securityPane.addItem(dualAuthGuiItem, 0, 0)
 
@@ -422,13 +434,44 @@ class GuildBankSecurityMenu(
     }
 
     /**
-     * Save security settings.
+     * Save security settings (REQ-031): persists the dual-auth threshold per guild.
      * Note: the emergency freeze toggle saves immediately via guildService.setBankFrozen().
-     * This button currently acknowledges that state — future settings (dual-auth threshold,
-     * fraud detection) can be persisted here when implemented.
      */
     private fun saveSecuritySettings() {
-        player.sendMessage("§aSecurity settings saved. (Emergency freeze state is always saved immediately on toggle.)")
+        val current = bankSettingsRepository.getByGuildId(guild.id) ?: BankSettings(guild.id)
+        val updated = current.copy(dualAuthThreshold = dualAuthThreshold)
+        val saved = bankSettingsRepository.upsert(updated)
+        if (saved) {
+            player.sendMessage("§aSecurity settings saved. (Emergency freeze state is always saved immediately on toggle.)")
+        } else {
+            player.sendMessage("§cFailed to save security settings.")
+        }
+    }
+
+    // ChatInputHandler interface methods (REQ-031)
+    override fun onChatInput(player: Player, input: String) {
+        val threshold = input.trim().toIntOrNull()
+        if (threshold == null || threshold < 0) {
+            player.sendMessage("§cInvalid threshold. Enter a whole number of coins (0 or more).")
+            inputMode = null
+            return
+        }
+        when (inputMode) {
+            "dualAuth" -> {
+                dualAuthThreshold = threshold
+                player.sendMessage("§aDual-authorization threshold set to $threshold coins. Press Save to persist.")
+            }
+            else -> return
+        }
+        inputMode = null
+        analyzeSecurityRisks()
+        updateSecurityDisplay()
+        gui.update()
+    }
+
+    override fun onCancel(player: Player) {
+        inputMode = null
+        player.sendMessage("§eDual-authorization threshold input cancelled.")
     }
 
     /**

--- a/src/main/kotlin/net/lumalyte/lg/interaction/menus/guild/GuildBankSecurityMenu.kt
+++ b/src/main/kotlin/net/lumalyte/lg/interaction/menus/guild/GuildBankSecurityMenu.kt
@@ -263,8 +263,9 @@ class GuildBankSecurityMenu(
         )
         val saveGuiItem = GuiItem(saveItem) { event ->
             event.isCancelled = true
+            // saveSecuritySettings() reports the upsert result itself — no
+            // unconditional success message here (would contradict a failure).
             saveSecuritySettings()
-            player.sendMessage("§aSecurity settings saved!")
         }
         mainPane.addItem(saveGuiItem, 7, 0)
 
@@ -450,13 +451,17 @@ class GuildBankSecurityMenu(
 
     // ChatInputHandler interface methods (REQ-031)
     override fun onChatInput(player: Player, input: String) {
+        // Guard FIRST: if the listener session outlived the menu interaction,
+        // inputMode is null and this is ordinary chat — do not intercept it.
+        val mode = inputMode ?: return
+
         val threshold = input.trim().toIntOrNull()
         if (threshold == null || threshold < 0) {
             player.sendMessage("§cInvalid threshold. Enter a whole number of coins (0 or more).")
             inputMode = null
             return
         }
-        when (inputMode) {
+        when (mode) {
             "dualAuth" -> {
                 dualAuthThreshold = threshold
                 player.sendMessage("§aDual-authorization threshold set to $threshold coins. Press Save to persist.")

--- a/src/main/kotlin/net/lumalyte/lg/interaction/menus/guild/GuildBankTransactionHistoryMenu.kt
+++ b/src/main/kotlin/net/lumalyte/lg/interaction/menus/guild/GuildBankTransactionHistoryMenu.kt
@@ -6,10 +6,13 @@ import com.github.stefvanschie.inventoryframework.pane.PaginatedPane
 import com.github.stefvanschie.inventoryframework.pane.Pane
 import com.github.stefvanschie.inventoryframework.pane.StaticPane
 import net.lumalyte.lg.application.services.BankService
+import net.lumalyte.lg.application.services.MemberService
 import net.lumalyte.lg.domain.entities.BankTransaction
 import net.lumalyte.lg.domain.entities.Guild
 import net.lumalyte.lg.domain.entities.TransactionType
 import net.lumalyte.lg.domain.values.LocalizationKeys
+import net.lumalyte.lg.interaction.listeners.ChatInputHandler
+import net.lumalyte.lg.interaction.listeners.ChatInputListener
 import net.lumalyte.lg.interaction.menus.Menu
 import net.lumalyte.lg.interaction.menus.MenuNavigator
 import net.kyori.adventure.text.Component
@@ -34,16 +37,18 @@ class GuildBankTransactionHistoryMenu(
     private val player: Player,
     private val guild: Guild,
     private var filter: TransactionFilter = TransactionFilter()
-) : Menu, KoinComponent {
+) : Menu, KoinComponent, ChatInputHandler {
 
     private val bankService: BankService by inject()
+    private val memberService: MemberService by inject()
     private val localizationProvider: net.lumalyte.lg.application.utilities.LocalizationProvider by inject()
     private val menuFactory: net.lumalyte.lg.interaction.menus.MenuFactory by inject()
+    private val chatInputListener: ChatInputListener by inject()
 
     // GUI components
     private lateinit var gui: ChestGui
     private lateinit var mainPane: StaticPane
-    private lateinit var transactionPane: PaginatedPane
+    private lateinit var transactionPane: StaticPane
     private lateinit var filterPane: StaticPane
 
     // Transaction data
@@ -53,6 +58,12 @@ class GuildBankTransactionHistoryMenu(
     // Pagination
     private val itemsPerPage = 10
     private var currentPage = 0
+
+    // Chat input mode (search)
+    private var inputMode: String? = null
+
+    // Date range presets (null = All time)
+    private val dateRangeOptions: List<String?> = listOf(null, "24h", "7d", "30d")
 
     init {
         loadTransactions()
@@ -90,7 +101,7 @@ class GuildBankTransactionHistoryMenu(
         gui.addPane(filterPane)
 
         // Create transaction display pane (bottom 4 rows)
-        transactionPane = PaginatedPane(0, 2, 9, 4, Pane.Priority.NORMAL)
+        transactionPane = StaticPane(0, 2, 9, 4, Pane.Priority.NORMAL)
         gui.addPane(transactionPane)
 
         setupNavigation()
@@ -155,23 +166,23 @@ class GuildBankTransactionHistoryMenu(
      * Setup filter controls
      */
     private fun setupFilters() {
-        // Transaction type filter
+        // Transaction type filter (click cycles through types)
         val typeFilterItem = createMenuItem(
             Material.HOPPER,
-            "Filter by Type",
-            listOf("Current: ${filter.typeFilter?.name ?: "All"}", "Click to change")
+            getLocalizedString(LocalizationKeys.MENU_BANK_HISTORY_FILTER_TYPE),
+            listOf("Current: ${typeFilterLabel(filter.typeFilter)}", "Click to cycle")
         )
         val typeFilterGuiItem = GuiItem(typeFilterItem) { event ->
             event.isCancelled = true
-            openTypeFilterMenu()
+            cycleTypeFilter()
         }
         filterPane.addItem(typeFilterGuiItem, 0, 0)
 
         // Member filter
         val memberFilterItem = createMenuItem(
             Material.PLAYER_HEAD,
-            "Filter by Member",
-            listOf("Current: ${filter.memberFilter ?: "All"}", "Click to change")
+            getLocalizedString(LocalizationKeys.MENU_BANK_HISTORY_FILTER_MEMBER),
+            listOf("Current: ${filter.memberFilter ?: "All"}", "Click to select")
         )
         val memberFilterGuiItem = GuiItem(memberFilterItem) { event ->
             event.isCancelled = true
@@ -179,35 +190,37 @@ class GuildBankTransactionHistoryMenu(
         }
         filterPane.addItem(memberFilterGuiItem, 1, 0)
 
-        // Date range filter
+        // Date range filter (click cycles through presets)
         val dateFilterItem = createMenuItem(
             Material.CLOCK,
             getLocalizedString(LocalizationKeys.MENU_BANK_HISTORY_FILTER_DATE),
-            listOf("Current: ${filter.dateRange ?: "All"}", "Click to change")
+            listOf("Current: ${dateRangeLabel(filter.dateRange)}", "Click to cycle")
         )
         val dateFilterGuiItem = GuiItem(dateFilterItem) { event ->
             event.isCancelled = true
-            openDateFilterMenu()
+            cycleDateFilter()
         }
         filterPane.addItem(dateFilterGuiItem, 2, 0)
 
         // Search filter
         val searchItem = createMenuItem(
             Material.COMPASS,
-            "Search Transactions",
-            listOf("Click to search")
+            getLocalizedString(LocalizationKeys.MENU_BANK_HISTORY_FILTER_SEARCH),
+            listOf(
+                "Current: ${filter.searchQuery ?: "None"}",
+                "Click to search by member or description"
+            )
         )
         val searchGuiItem = GuiItem(searchItem) { event ->
             event.isCancelled = true
-            // TODO: Open search dialog
-            player.sendMessage("§eSearch functionality coming soon!")
+            startSearchInput()
         }
         filterPane.addItem(searchGuiItem, 3, 0)
 
         // Clear filters
         val clearItem = createMenuItem(
             Material.WATER_BUCKET,
-            "Clear Filters",
+            getLocalizedString(LocalizationKeys.MENU_BANK_HISTORY_FILTER_CLEAR),
             listOf("Remove all filters")
         )
         val clearGuiItem = GuiItem(clearItem) { event ->
@@ -218,45 +231,57 @@ class GuildBankTransactionHistoryMenu(
             gui.update()
         }
         filterPane.addItem(clearGuiItem, 4, 0)
-
-        // Page navigation
-        updatePageNavigation()
     }
 
     /**
      * Setup transaction history display
      */
     private fun setupTransactionHistory() {
-        val currentItems = getCurrentPageItems()
-
-        if (currentItems.isEmpty()) {
-            // TODO: Add to pane when API is resolved
-            // val noTransactionsItem = createMenuItem(
-            //     Material.BARRIER,
-            //     getLocalizedString(LocalizationKeys.MENU_BANK_HISTORY_NO_TRANSACTIONS),
-            //     listOf("Try adjusting your filters")
-            // )
-            // transactionPane.addItem(GuiItem(noTransactionsItem))
-        } else {
-            // TODO: Add transaction items when API is resolved
-            // currentItems.forEach { transaction ->
-            //     val transactionItem = createTransactionItem(transaction)
-            //     transactionPane.addItem(GuiItem(transactionItem))
-            // }
-        }
-
-        // For now, show a placeholder message
-        player.sendMessage("§eTransaction history display coming soon!")
+        updateTransactionDisplay()
     }
 
     /**
      * Update page navigation controls
      */
     private fun updatePageNavigation() {
-        // Simplified navigation for now
         val totalPages = (filteredTransactions.size + itemsPerPage - 1) / itemsPerPage
 
+        // Clear stale navigation controls (slots 6-8 of filter row)
+        for (slot in 6..8) {
+            filterPane.removeItem(slot, 0)
+        }
+
         if (totalPages > 1) {
+            // Previous page button
+            if (currentPage > 0) {
+                val prevItem = createMenuItem(
+                    Material.ARROW,
+                    getLocalizedString(LocalizationKeys.MENU_BANK_HISTORY_PAGE_PREVIOUS),
+                    listOf("Go to page $currentPage")
+                )
+                val prevGuiItem = GuiItem(prevItem) { event ->
+                    event.isCancelled = true
+                    currentPage--
+                    updateTransactionDisplay()
+                }
+                filterPane.addItem(prevGuiItem, 7, 0)
+            }
+
+            // Next page button
+            if (currentPage < totalPages - 1) {
+                val nextItem = createMenuItem(
+                    Material.ARROW,
+                    getLocalizedString(LocalizationKeys.MENU_BANK_HISTORY_PAGE_NEXT),
+                    listOf("Go to page ${currentPage + 2}")
+                )
+                val nextGuiItem = GuiItem(nextItem) { event ->
+                    event.isCancelled = true
+                    currentPage++
+                    updateTransactionDisplay()
+                }
+                filterPane.addItem(nextGuiItem, 8, 0)
+            }
+
             // Page indicator
             val pageItem = createMenuItem(
                 Material.PAPER,
@@ -271,29 +296,167 @@ class GuildBankTransactionHistoryMenu(
      * Update the transaction display
      */
     private fun updateTransactionDisplay() {
-        // Clear existing items (simplified approach)
-        // For now, recreate the transaction display each time
+        transactionPane.clear()
 
-        if (filteredTransactions.isEmpty()) {
-            // Add a "no transactions" message to the filter pane temporarily
+        val currentItems = getCurrentPageItems()
+
+        if (currentItems.isEmpty()) {
             val noTransactionsItem = createMenuItem(
                 Material.BARRIER,
                 getLocalizedString(LocalizationKeys.MENU_BANK_HISTORY_NO_TRANSACTIONS),
                 listOf("Try adjusting your filters")
             )
-            // Note: We'll handle this display differently for now
+            transactionPane.addItem(GuiItem(noTransactionsItem), 4, 1)
         } else {
-            // Display logic will be handled in setupTransactionHistory
+            var slotIndex = 0
+            currentItems.forEach { transaction ->
+                val transactionItem = createTransactionItem(transaction)
+                val row = slotIndex / 9
+                val col = slotIndex % 9
+                transactionPane.addItem(GuiItem(transactionItem), col, row)
+                slotIndex++
+            }
         }
+
+        updatePageNavigation()
     }
 
     /**
      * Get transactions for the current page
      */
     private fun getCurrentPageItems(): List<BankTransaction> {
+        if (filteredTransactions.isEmpty()) return emptyList()
         val startIndex = currentPage * itemsPerPage
+        if (startIndex >= filteredTransactions.size) return emptyList()
         val endIndex = minOf(startIndex + itemsPerPage, filteredTransactions.size)
         return filteredTransactions.subList(startIndex, endIndex)
+    }
+
+    /**
+     * Cycle the type filter to the next transaction type
+     */
+    private fun cycleTypeFilter() {
+        val options: List<TransactionType?> = listOf(null) + TransactionType.entries
+        val currentIndex = options.indexOf(filter.typeFilter)
+        filter = filter.copy(typeFilter = options[(currentIndex + 1) % options.size])
+        loadTransactions()
+        updateTransactionDisplay()
+        gui.update()
+    }
+
+    /**
+     * Cycle the date range filter to the next preset
+     */
+    private fun cycleDateFilter() {
+        val currentIndex = dateRangeOptions.indexOf(filter.dateRange)
+        filter = filter.copy(dateRange = dateRangeOptions[(currentIndex + 1) % dateRangeOptions.size])
+        loadTransactions()
+        updateTransactionDisplay()
+        gui.update()
+    }
+
+    /**
+     * Open a slot-click selection menu of guild members to filter by
+     */
+    private fun openMemberFilterMenu() {
+        val members = memberService.getGuildMembers(guild.id).sortedBy { member ->
+            Bukkit.getOfflinePlayer(member.playerId).name ?: ""
+        }
+
+        val memberGui = ChestGui(6, "Select Member to Filter By")
+        memberGui.setOnGlobalClick { event -> event.isCancelled = true }
+
+        val memberPane = PaginatedPane(0, 0, 9, 5)
+        memberGui.addPane(memberPane)
+
+        val memberItems = mutableListOf<GuiItem>()
+
+        // "All members" option to clear the filter
+        val allItem = createMenuItem(
+            Material.BARRIER,
+            "All Members",
+            listOf("Clear member filter")
+        )
+        memberItems += GuiItem(allItem) { event ->
+            event.isCancelled = true
+            filter = filter.copy(memberFilter = null)
+            player.closeInventory()
+            loadTransactions()
+            updateTransactionDisplay()
+            gui.update()
+            gui.show(player)
+        }
+
+        members.forEach { member ->
+            val name = Bukkit.getOfflinePlayer(member.playerId).name ?: "Unknown Player"
+            val memberItem = createMenuItem(
+                Material.PLAYER_HEAD,
+                name,
+                listOf("Click to filter by $name")
+            )
+            memberItems += GuiItem(memberItem) { event ->
+                event.isCancelled = true
+                filter = filter.copy(memberFilter = name)
+                player.closeInventory()
+                loadTransactions()
+                updateTransactionDisplay()
+                gui.update()
+                gui.show(player)
+            }
+        }
+
+        // Populate pages with members (45 per page = 9x5 grid)
+        memberPane.populateWithGuiItems(memberItems)
+
+        // Navigation row
+        val navPane = StaticPane(0, 5, 9, 1)
+        memberGui.addPane(navPane)
+
+        val backItem = createMenuItem(
+            Material.ARROW,
+            getLocalizedString(LocalizationKeys.MENU_BANK_BACK_TO_CONTROL_PANEL),
+            listOf("Back to transaction history")
+        )
+        navPane.addItem(GuiItem(backItem) { event ->
+            event.isCancelled = true
+            player.closeInventory()
+            gui.show(player)
+        }, 0, 0)
+
+        memberGui.show(player)
+    }
+
+    /**
+     * Start chat input mode for the search query
+     */
+    private fun startSearchInput() {
+        inputMode = "search"
+        chatInputListener.startInputMode(player, this)
+        player.sendMessage("§eType a search term (matches member name or description). Type 'cancel' to abort.")
+    }
+
+    override fun onChatInput(player: Player, input: String) {
+        when (inputMode) {
+            "search" -> {
+                val query = input.trim()
+                if (query.isEmpty()) {
+                    player.sendMessage("§cSearch term cannot be empty.")
+                } else {
+                    filter = filter.copy(searchQuery = query)
+                    loadTransactions()
+                    updateTransactionDisplay()
+                    gui.update()
+                    player.sendMessage("§aSearching for: §f$query §a(${filteredTransactions.size} matches)")
+                }
+            }
+            else -> return
+        }
+        inputMode = null
+    }
+
+    override fun onCancel(player: Player) {
+        inputMode = null
+        player.sendMessage("§eSearch cancelled.")
     }
 
     /**
@@ -342,7 +505,9 @@ class GuildBankTransactionHistoryMenu(
         // Load all transactions for this guild
         allTransactions = bankService.getTransactionHistory(guild.id, null)
 
-        // Apply filters
+        // Compute date cutoff once for the date range filter
+        val dateCutoff = dateRangeCutoff(filter.dateRange)
+
         filteredTransactions = allTransactions.filter { transaction ->
             // Type filter
             if (filter.typeFilter != null && transaction.type != filter.typeFilter) {
@@ -358,8 +523,18 @@ class GuildBankTransactionHistoryMenu(
             }
 
             // Date range filter
-            if (filter.dateRange != null) {
-                // TODO: Implement date range filtering
+            if (dateCutoff != null && transaction.timestamp.isBefore(dateCutoff)) {
+                return@filter false
+            }
+
+            // Search query (matches member name or description)
+            if (!filter.searchQuery.isNullOrBlank()) {
+                val query = filter.searchQuery!!.lowercase()
+                val actorName = Bukkit.getOfflinePlayer(transaction.actorId).name?.lowercase() ?: ""
+                val description = transaction.description?.lowercase() ?: ""
+                if (query !in actorName && query !in description) {
+                    return@filter false
+                }
             }
 
             true
@@ -370,27 +545,41 @@ class GuildBankTransactionHistoryMenu(
     }
 
     /**
-     * Open transaction type filter menu
+     * Convert a date range preset string to an Instant cutoff (null = all time)
      */
-    private fun openTypeFilterMenu() {
-        // TODO: Create filter selection menu
-        player.sendMessage("§eType filter menu coming soon!")
+    private fun dateRangeCutoff(range: String?): Instant? {
+        val now = Instant.now()
+        return when (range) {
+            "24h" -> now.minusSeconds(24 * 60 * 60)
+            "7d" -> now.minusSeconds(7 * 24 * 60 * 60)
+            "30d" -> now.minusSeconds(30 * 24 * 60 * 60)
+            else -> null
+        }
     }
 
     /**
-     * Open member filter menu
+     * Human-readable label for a date range preset
      */
-    private fun openMemberFilterMenu() {
-        // TODO: Create member selection menu
-        player.sendMessage("§eMember filter menu coming soon!")
+    private fun dateRangeLabel(range: String?): String {
+        return when (range) {
+            "24h" -> "Last 24 Hours"
+            "7d" -> "Last 7 Days"
+            "30d" -> "Last 30 Days"
+            else -> "All Time"
+        }
     }
 
     /**
-     * Open date filter menu
+     * Human-readable label for a transaction type filter
      */
-    private fun openDateFilterMenu() {
-        // TODO: Create date range selection menu
-        player.sendMessage("§eDate filter menu coming soon!")
+    private fun typeFilterLabel(type: TransactionType?): String {
+        return when (type) {
+            null -> "All"
+            TransactionType.DEPOSIT -> "Deposits"
+            TransactionType.WITHDRAWAL -> "Withdrawals"
+            TransactionType.FEE -> "Fees"
+            TransactionType.DEDUCTION -> "Deductions"
+        }
     }
 
     /**
@@ -442,4 +631,3 @@ data class TransactionFilter(
     val dateRange: String? = null,
     val searchQuery: String? = null
 )
-

--- a/src/main/kotlin/net/lumalyte/lg/interaction/menus/guild/GuildBankTransactionHistoryMenu.kt
+++ b/src/main/kotlin/net/lumalyte/lg/interaction/menus/guild/GuildBankTransactionHistoryMenu.kt
@@ -15,6 +15,7 @@ import net.lumalyte.lg.interaction.listeners.ChatInputHandler
 import net.lumalyte.lg.interaction.listeners.ChatInputListener
 import net.lumalyte.lg.interaction.menus.Menu
 import net.lumalyte.lg.interaction.menus.MenuNavigator
+import net.lumalyte.lg.common.PluginKeys
 import net.kyori.adventure.text.Component
 import net.kyori.adventure.text.format.NamedTextColor
 import net.kyori.adventure.text.format.TextDecoration
@@ -28,6 +29,7 @@ import java.time.Instant
 import java.time.LocalDateTime
 import java.time.ZoneId
 import java.time.format.DateTimeFormatter
+import java.util.UUID
 
 /**
  * Guild Bank Transaction History menu with pagination, filtering, and search
@@ -62,8 +64,9 @@ class GuildBankTransactionHistoryMenu(
     // Chat input mode (search)
     private var inputMode: String? = null
 
-    // Date range presets (null = All time)
-    private val dateRangeOptions: List<String?> = listOf(null, "24h", "7d", "30d")
+    // Resolved actor name cache (built once per load to avoid repeated
+    // Bukkit.getOfflinePlayer calls on the main thread)
+    private var actorNames: Map<UUID, String> = emptyMap()
 
     init {
         loadTransactions()
@@ -263,6 +266,7 @@ class GuildBankTransactionHistoryMenu(
                     event.isCancelled = true
                     currentPage--
                     updateTransactionDisplay()
+                    gui.update()
                 }
                 filterPane.addItem(prevGuiItem, 7, 0)
             }
@@ -278,6 +282,7 @@ class GuildBankTransactionHistoryMenu(
                     event.isCancelled = true
                     currentPage++
                     updateTransactionDisplay()
+                    gui.update()
                 }
                 filterPane.addItem(nextGuiItem, 8, 0)
             }
@@ -296,6 +301,11 @@ class GuildBankTransactionHistoryMenu(
      * Update the transaction display
      */
     private fun updateTransactionDisplay() {
+        // Refresh filter controls so labels/lore reflect the current filter.
+        // StaticPane.addItem replaces the item at the same coordinates, so this
+        // does not create duplicates.
+        setupFilters()
+
         transactionPane.clear()
 
         val currentItems = getCurrentPageItems()
@@ -348,8 +358,9 @@ class GuildBankTransactionHistoryMenu(
      * Cycle the date range filter to the next preset
      */
     private fun cycleDateFilter() {
-        val currentIndex = dateRangeOptions.indexOf(filter.dateRange)
-        filter = filter.copy(dateRange = dateRangeOptions[(currentIndex + 1) % dateRangeOptions.size])
+        val currentIndex = DateRangePreset.entries.indexOfFirst { it.key == filter.dateRange }
+        val next = DateRangePreset.entries[(currentIndex + 1) % DateRangePreset.entries.size]
+        filter = filter.copy(dateRange = next.key)
         loadTransactions()
         updateTransactionDisplay()
         gui.update()
@@ -359,9 +370,12 @@ class GuildBankTransactionHistoryMenu(
      * Open a slot-click selection menu of guild members to filter by
      */
     private fun openMemberFilterMenu() {
-        val members = memberService.getGuildMembers(guild.id).sortedBy { member ->
-            Bukkit.getOfflinePlayer(member.playerId).name ?: ""
+        // Resolve each member name once before sorting/rendering.
+        val members = memberService.getGuildMembers(guild.id)
+        val memberNames = members.associate { member ->
+            member.playerId to (Bukkit.getOfflinePlayer(member.playerId).name ?: "Unknown Player")
         }
+        val sortedMembers = members.sortedBy { memberNames[it.playerId]?.lowercase() }
 
         val memberGui = ChestGui(6, "Select Member to Filter By")
         memberGui.setOnGlobalClick { event -> event.isCancelled = true }
@@ -380,15 +394,19 @@ class GuildBankTransactionHistoryMenu(
         memberItems += GuiItem(allItem) { event ->
             event.isCancelled = true
             filter = filter.copy(memberFilter = null)
-            player.closeInventory()
-            loadTransactions()
-            updateTransactionDisplay()
-            gui.update()
-            gui.show(player)
+            // Defer inventory transitions out of the click handler to avoid
+            // client desync / items stuck on the cursor.
+            Bukkit.getScheduler().runTask(PluginKeys.getPlugin(), Runnable {
+                player.closeInventory()
+                loadTransactions()
+                updateTransactionDisplay()
+                gui.update()
+                gui.show(player)
+            })
         }
 
-        members.forEach { member ->
-            val name = Bukkit.getOfflinePlayer(member.playerId).name ?: "Unknown Player"
+        sortedMembers.forEach { member ->
+            val name = memberNames[member.playerId] ?: "Unknown Player"
             val memberItem = createMenuItem(
                 Material.PLAYER_HEAD,
                 name,
@@ -397,11 +415,14 @@ class GuildBankTransactionHistoryMenu(
             memberItems += GuiItem(memberItem) { event ->
                 event.isCancelled = true
                 filter = filter.copy(memberFilter = name)
-                player.closeInventory()
-                loadTransactions()
-                updateTransactionDisplay()
-                gui.update()
-                gui.show(player)
+                // Defer inventory transitions out of the click handler.
+                Bukkit.getScheduler().runTask(PluginKeys.getPlugin(), Runnable {
+                    player.closeInventory()
+                    loadTransactions()
+                    updateTransactionDisplay()
+                    gui.update()
+                    gui.show(player)
+                })
             }
         }
 
@@ -419,8 +440,11 @@ class GuildBankTransactionHistoryMenu(
         )
         navPane.addItem(GuiItem(backItem) { event ->
             event.isCancelled = true
-            player.closeInventory()
-            gui.show(player)
+            // Defer inventory transition out of the click handler.
+            Bukkit.getScheduler().runTask(PluginKeys.getPlugin(), Runnable {
+                player.closeInventory()
+                gui.show(player)
+            })
         }, 0, 0)
 
         memberGui.show(player)
@@ -463,7 +487,7 @@ class GuildBankTransactionHistoryMenu(
      * Create a transaction item for display
      */
     private fun createTransactionItem(transaction: BankTransaction): ItemStack {
-        val actorName = Bukkit.getOfflinePlayer(transaction.actorId).name ?: "Unknown"
+        val actorName = actorNames[transaction.actorId] ?: "Unknown"
         val timestamp = formatTimestamp(transaction.timestamp)
 
         val material = when (transaction.type) {
@@ -505,6 +529,13 @@ class GuildBankTransactionHistoryMenu(
         // Load all transactions for this guild
         allTransactions = bankService.getTransactionHistory(guild.id, null)
 
+        // Resolve each distinct actor UUID once (getOfflinePlayer can block on a
+        // profile lookup and both paths run on the main thread in response to a
+        // menu click — do not call it per element).
+        actorNames = allTransactions.map { it.actorId }.distinct().associateWith { actorId ->
+            Bukkit.getOfflinePlayer(actorId).name ?: "Unknown"
+        }
+
         // Compute date cutoff once for the date range filter
         val dateCutoff = dateRangeCutoff(filter.dateRange)
 
@@ -516,7 +547,7 @@ class GuildBankTransactionHistoryMenu(
 
             // Member filter
             if (filter.memberFilter != null) {
-                val actorName = Bukkit.getOfflinePlayer(transaction.actorId).name
+                val actorName = actorNames[transaction.actorId]
                 if (actorName != filter.memberFilter) {
                     return@filter false
                 }
@@ -530,7 +561,7 @@ class GuildBankTransactionHistoryMenu(
             // Search query (matches member name or description)
             if (!filter.searchQuery.isNullOrBlank()) {
                 val query = filter.searchQuery!!.lowercase()
-                val actorName = Bukkit.getOfflinePlayer(transaction.actorId).name?.lowercase() ?: ""
+                val actorName = actorNames[transaction.actorId]?.lowercase() ?: ""
                 val description = transaction.description?.lowercase() ?: ""
                 if (query !in actorName && query !in description) {
                     return@filter false
@@ -545,15 +576,11 @@ class GuildBankTransactionHistoryMenu(
     }
 
     /**
-     * Convert a date range preset string to an Instant cutoff (null = all time)
+     * Convert a date range preset to an Instant cutoff (null = all time)
      */
     private fun dateRangeCutoff(range: String?): Instant? {
-        val now = Instant.now()
-        return when (range) {
-            "24h" -> now.minusSeconds(24 * 60 * 60)
-            "7d" -> now.minusSeconds(7 * 24 * 60 * 60)
-            "30d" -> now.minusSeconds(30 * 24 * 60 * 60)
-            else -> null
+        return DateRangePreset.fromKey(range)?.cutoffSeconds?.let { seconds ->
+            Instant.now().minusSeconds(seconds)
         }
     }
 
@@ -561,12 +588,7 @@ class GuildBankTransactionHistoryMenu(
      * Human-readable label for a date range preset
      */
     private fun dateRangeLabel(range: String?): String {
-        return when (range) {
-            "24h" -> "Last 24 Hours"
-            "7d" -> "Last 7 Days"
-            "30d" -> "Last 30 Days"
-            else -> "All Time"
-        }
+        return DateRangePreset.fromKey(range)?.label ?: DateRangePreset.ALL.label
     }
 
     /**
@@ -631,3 +653,19 @@ data class TransactionFilter(
     val dateRange: String? = null,
     val searchQuery: String? = null
 )
+
+/**
+ * Date range presets for the transaction history filter. Single source of truth
+ * for the key (persisted in [TransactionFilter.dateRange]), the cutoff, and the
+ * display label — adding or renaming a preset requires one edit.
+ */
+enum class DateRangePreset(val key: String?, val label: String, val cutoffSeconds: Long?) {
+    ALL(null, "All Time", null),
+    LAST_24_HOURS("24h", "Last 24 Hours", 24 * 60 * 60),
+    LAST_7_DAYS("7d", "Last 7 Days", 7 * 24 * 60 * 60),
+    LAST_30_DAYS("30d", "Last 30 Days", 30 * 24 * 60 * 60);
+
+    companion object {
+        fun fromKey(key: String?): DateRangePreset? = entries.firstOrNull { it.key == key }
+    }
+}

--- a/src/test/kotlin/net/lumalyte/lg/application/services/BankAutomationServiceTest.kt
+++ b/src/test/kotlin/net/lumalyte/lg/application/services/BankAutomationServiceTest.kt
@@ -1,0 +1,164 @@
+package net.lumalyte.lg.application.services
+
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.verify
+import net.lumalyte.lg.application.persistence.BankRepository
+import net.lumalyte.lg.application.persistence.BankSettingsRepository
+import net.lumalyte.lg.application.persistence.GuildRepository
+import net.lumalyte.lg.config.BankConfig
+import net.lumalyte.lg.config.MainConfig
+import net.lumalyte.lg.domain.entities.BankSettings
+import net.lumalyte.lg.domain.entities.Guild
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertNull
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+import java.time.Instant
+import java.time.temporal.ChronoUnit
+import java.util.UUID
+
+/**
+ * REQ-009: interest accrual per `bank.interest_rate_percent` /
+ * `bank.interest_compound_period_hours`, audit-log retention, and next-run
+ * computation must come from real configuration + persisted settings.
+ */
+class BankAutomationServiceTest {
+
+    private val bankRepository = mockk<BankRepository>(relaxed = true)
+    private val settingsRepository = mockk<BankSettingsRepository>(relaxed = true)
+    private val guildRepository = mockk<GuildRepository>(relaxed = true)
+    private val bankService = mockk<BankService>(relaxed = true)
+    private val configService = mockk<ConfigService>(relaxed = true)
+
+    private fun service() = BankAutomationService(
+        bankRepository, settingsRepository, guildRepository, bankService, configService
+    )
+
+    private fun config(
+        ratePercent: Double = 0.005,
+        periodHours: Int = 24,
+        retentionDays: Int = 30
+    ) = MainConfig(bank = BankConfig(
+        interestRatePercent = ratePercent,
+        interestCompoundPeriodHours = periodHours,
+        auditLogRetentionDays = retentionDays
+    ))
+
+    @Test
+    fun `interest accrues once the compound period has elapsed`() {
+        val guildId = UUID.randomUUID()
+        val guild = Guild(id = guildId, name = "Guild", createdAt = Instant.now().minus(48, ChronoUnit.HOURS))
+        val settings = BankSettings(
+            guildId = guildId,
+            interestRate = 0.005,
+            lastInterestAccrual = Instant.now().minus(24, ChronoUnit.HOURS).toEpochMilli()
+        )
+        every { guildRepository.getAll() } returns setOf(guild)
+        every { settingsRepository.getByGuildId(guildId) } returns settings
+        every { bankService.getBalance(guildId) } returns 1000
+        every { configService.loadConfig() } returns config()
+
+        val credited = service().accrueInterest()
+
+        assertEquals(1, credited)
+        verify(exactly = 1) { bankService.creditToGuildBank(guildId, 5, "Interest accrual") }
+    }
+
+    @Test
+    fun `per-guild interest rate overrides config rate`() {
+        val guildId = UUID.randomUUID()
+        val guild = Guild(id = guildId, name = "Guild", createdAt = Instant.now().minus(48, ChronoUnit.HOURS))
+        val settings = BankSettings(
+            guildId = guildId,
+            interestRate = 0.10,
+            lastInterestAccrual = Instant.now().minus(24, ChronoUnit.HOURS).toEpochMilli()
+        )
+        every { guildRepository.getAll() } returns setOf(guild)
+        every { settingsRepository.getByGuildId(guildId) } returns settings
+        every { bankService.getBalance(guildId) } returns 1000
+        every { configService.loadConfig() } returns config()
+
+        service().accrueInterest()
+
+        verify(exactly = 1) { bankService.creditToGuildBank(guildId, 100, "Interest accrual") }
+    }
+
+    @Test
+    fun `no interest before the compound period elapses`() {
+        val guildId = UUID.randomUUID()
+        val guild = Guild(id = guildId, name = "Guild", createdAt = Instant.now().minus(2, ChronoUnit.HOURS))
+        val settings = BankSettings(
+            guildId = guildId,
+            lastInterestAccrual = Instant.now().minus(1, ChronoUnit.HOURS).toEpochMilli()
+        )
+        every { guildRepository.getAll() } returns setOf(guild)
+        every { settingsRepository.getByGuildId(guildId) } returns settings
+        every { bankService.getBalance(guildId) } returns 1000
+        every { configService.loadConfig() } returns config()
+
+        val credited = service().accrueInterest()
+
+        assertEquals(0, credited)
+        verify(exactly = 0) { bankService.creditToGuildBank(any(), any(), any()) }
+    }
+
+    @Test
+    fun `missed periods are caught up`() {
+        val guildId = UUID.randomUUID()
+        val guild = Guild(id = guildId, name = "Guild", createdAt = Instant.now().minus(100, ChronoUnit.HOURS))
+        val settings = BankSettings(
+            guildId = guildId,
+            interestRate = 0.005,
+            lastInterestAccrual = Instant.now().minus(72, ChronoUnit.HOURS).toEpochMilli()
+        )
+        every { guildRepository.getAll() } returns setOf(guild)
+        every { settingsRepository.getByGuildId(guildId) } returns settings
+        every { bankService.getBalance(guildId) } returns 1000
+        every { configService.loadConfig() } returns config()
+
+        val credited = service().accrueInterest()
+
+        assertEquals(3, credited)
+        verify(exactly = 3) { bankService.creditToGuildBank(guildId, 5, "Interest accrual") }
+    }
+
+    @Test
+    fun `pruneAuditLogs deletes audits older than retention window`() {
+        val guildId = UUID.randomUUID()
+        val guild = Guild(id = guildId, name = "Guild", createdAt = Instant.now())
+        every { guildRepository.getAll() } returns setOf(guild)
+        every { configService.loadConfig() } returns config(retentionDays = 30)
+        every { bankRepository.deleteAuditsOlderThan(guildId, any()) } returns 12
+
+        val pruned = service().pruneAuditLogs()
+
+        assertEquals(12, pruned)
+        val cutoffSlot = io.mockk.slot<Instant>()
+        verify(exactly = 1) { bankRepository.deleteAuditsOlderThan(guildId, capture(cutoffSlot)) }
+        val expected = Instant.now().minus(30, ChronoUnit.DAYS)
+        assertTrue(java.time.Duration.between(cutoffSlot.captured, expected).abs().toSeconds() < 5,
+            "cutoff must be ~30 days back, was ${cutoffSlot.captured}")
+    }
+
+    @Test
+    fun `next interest run is last accrual plus compound period`() {
+        val guildId = UUID.randomUUID()
+        val lastAccrual = Instant.now().minus(10, ChronoUnit.HOURS)
+        every { settingsRepository.getByGuildId(guildId) } returns
+            BankSettings(guildId = guildId, lastInterestAccrual = lastAccrual.toEpochMilli())
+        every { configService.loadConfig() } returns config(periodHours = 24)
+
+        val nextRun = service().getNextInterestRun(guildId)
+
+        assertEquals(lastAccrual.plus(24, ChronoUnit.HOURS).truncatedTo(ChronoUnit.SECONDS),
+            nextRun!!.truncatedTo(ChronoUnit.SECONDS))
+    }
+
+    @Test
+    fun `next interest run is null when no settings exist`() {
+        every { settingsRepository.getByGuildId(any()) } returns null
+
+        assertNull(service().getNextInterestRun(UUID.randomUUID()))
+    }
+}

--- a/src/test/kotlin/net/lumalyte/lg/application/services/BankAutomationServiceTest.kt
+++ b/src/test/kotlin/net/lumalyte/lg/application/services/BankAutomationServiceTest.kt
@@ -56,6 +56,7 @@ class BankAutomationServiceTest {
         )
         every { guildRepository.getAll() } returns setOf(guild)
         every { settingsRepository.getByGuildId(guildId) } returns settings
+        every { settingsRepository.upsert(any()) } returns true
         every { bankService.getBalance(guildId) } returns 1000
         every { configService.loadConfig() } returns config()
 
@@ -76,6 +77,7 @@ class BankAutomationServiceTest {
         )
         every { guildRepository.getAll() } returns setOf(guild)
         every { settingsRepository.getByGuildId(guildId) } returns settings
+        every { settingsRepository.upsert(any()) } returns true
         every { bankService.getBalance(guildId) } returns 1000
         every { configService.loadConfig() } returns config()
 
@@ -114,6 +116,7 @@ class BankAutomationServiceTest {
         )
         every { guildRepository.getAll() } returns setOf(guild)
         every { settingsRepository.getByGuildId(guildId) } returns settings
+        every { settingsRepository.upsert(any()) } returns true
         every { bankService.getBalance(guildId) } returns 1000
         every { configService.loadConfig() } returns config()
 
@@ -121,6 +124,87 @@ class BankAutomationServiceTest {
 
         assertEquals(3, credited)
         verify(exactly = 3) { bankService.creditToGuildBank(guildId, 5, "Interest accrual") }
+    }
+
+    @Test
+    fun `catch-up is capped at 30 periods so stale guilds cannot mint runaway interest`() {
+        val guildId = UUID.randomUUID()
+        val guild = Guild(id = guildId, name = "Guild", createdAt = Instant.now().minus(2000, ChronoUnit.HOURS))
+        // 31 periods elapsed (24h each) — must receive exactly 30 credits, not 31.
+        val settings = BankSettings(
+            guildId = guildId,
+            interestRate = 0.005,
+            lastInterestAccrual = Instant.now().minus(31 * 24, ChronoUnit.HOURS).toEpochMilli()
+        )
+        every { guildRepository.getAll() } returns setOf(guild)
+        every { settingsRepository.getByGuildId(guildId) } returns settings
+        every { settingsRepository.upsert(any()) } returns true
+        every { bankService.getBalance(guildId) } returns 1000
+        every { configService.loadConfig() } returns config()
+
+        val credited = service().accrueInterest()
+
+        assertEquals(30, credited)
+        verify(exactly = 30) { bankService.creditToGuildBank(guildId, 5, "Interest accrual") }
+    }
+
+    @Test
+    fun `fresh guild with no accrual history starts the clock without retroactive interest`() {
+        val guildId = UUID.randomUUID()
+        val guild = Guild(id = guildId, name = "Guild", createdAt = Instant.now())
+        every { guildRepository.getAll() } returns setOf(guild)
+        every { settingsRepository.getByGuildId(guildId) } returns null
+        every { settingsRepository.upsert(any()) } returns true
+        every { bankService.getBalance(guildId) } returns 1000
+        every { configService.loadConfig() } returns config()
+
+        val credited = service().accrueInterest()
+
+        assertEquals(0, credited)
+        verify(exactly = 0) { bankService.creditToGuildBank(any(), any(), any()) }
+        // The initial clock must be persisted so the next run sees it initialized.
+        val savedSettings = io.mockk.slot<BankSettings>()
+        verify(exactly = 1) { settingsRepository.upsert(capture(savedSettings)) }
+        assertTrue(savedSettings.captured.lastInterestAccrual > 0L,
+            "initial clock timestamp must be persisted")
+    }
+
+    @Test
+    fun `guild with zeroed accrual clock reinitializes instead of accruing retroactively`() {
+        val guildId = UUID.randomUUID()
+        val guild = Guild(id = guildId, name = "Guild", createdAt = Instant.now().minus(500, ChronoUnit.HOURS))
+        val zeroed = BankSettings(guildId = guildId, interestRate = 0.005, lastInterestAccrual = 0L)
+        every { guildRepository.getAll() } returns setOf(guild)
+        every { settingsRepository.getByGuildId(guildId) } returns zeroed
+        every { settingsRepository.upsert(any()) } returns true
+        every { bankService.getBalance(guildId) } returns 1000
+        every { configService.loadConfig() } returns config()
+
+        val credited = service().accrueInterest()
+
+        assertEquals(0, credited)
+        verify(exactly = 0) { bankService.creditToGuildBank(any(), any(), any()) }
+    }
+
+    @Test
+    fun `upsert failure skips crediting so no period can be double-credited`() {
+        val guildId = UUID.randomUUID()
+        val guild = Guild(id = guildId, name = "Guild", createdAt = Instant.now().minus(100, ChronoUnit.HOURS))
+        val settings = BankSettings(
+            guildId = guildId,
+            interestRate = 0.005,
+            lastInterestAccrual = Instant.now().minus(72, ChronoUnit.HOURS).toEpochMilli()
+        )
+        every { guildRepository.getAll() } returns setOf(guild)
+        every { settingsRepository.getByGuildId(guildId) } returns settings
+        every { settingsRepository.upsert(any()) } returns false // marker write fails
+        every { bankService.getBalance(guildId) } returns 1000
+        every { configService.loadConfig() } returns config()
+
+        val credited = service().accrueInterest()
+
+        assertEquals(0, credited)
+        verify(exactly = 0) { bankService.creditToGuildBank(any(), any(), any()) }
     }
 
     @Test

--- a/src/test/kotlin/net/lumalyte/lg/infrastructure/persistence/guilds/BankRepositoryAuditPruneTest.kt
+++ b/src/test/kotlin/net/lumalyte/lg/infrastructure/persistence/guilds/BankRepositoryAuditPruneTest.kt
@@ -1,0 +1,110 @@
+package net.lumalyte.lg.infrastructure.persistence.guilds
+
+import net.lumalyte.lg.domain.entities.AuditAction
+import net.lumalyte.lg.domain.entities.BankAudit
+import net.lumalyte.lg.infrastructure.persistence.storage.VirtualThreadSQLiteStorage
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertNull
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.io.TempDir
+import java.nio.file.Path
+import java.time.Instant
+import java.util.UUID
+
+/**
+ * Regression: deleteAuditsOlderThan must compare timestamps chronologically.
+ * Raw text comparison of Instant.toString() is wrong when fractional seconds
+ * differ — "…00:00:00Z" vs "…00:00:00.001Z" (a whole-second audit is EARLIER,
+ * but 'Z' sorts after '.', so text compare would retain it).
+ */
+class BankRepositoryAuditPruneTest {
+
+    @TempDir
+    lateinit var tempDir: Path
+
+    private lateinit var repository: BankRepositorySQLite
+    private lateinit var storage: VirtualThreadSQLiteStorage
+
+    @BeforeEach
+    fun setUp() {
+        storage = VirtualThreadSQLiteStorage(tempDir.toFile())
+        repository = BankRepositorySQLite(storage)
+    }
+
+    @AfterEach
+    fun tearDown() {
+        // Release the SQLite file handle so JUnit can delete the temp dir.
+        storage.connection.close()
+    }
+
+    private fun audit(guildId: UUID, id: UUID, timestamp: Instant): BankAudit {
+        return BankAudit(
+            id = id,
+            guildId = guildId,
+            actorId = UUID(0L, 0L),
+            action = AuditAction.DEPOSIT,
+            details = "test",
+            newBalance = 100,
+            timestamp = timestamp
+        )
+    }
+
+    @Test
+    fun `whole-second audit older than fractional cutoff IS pruned`() {
+        val guildId = UUID.randomUUID()
+        // Audit lands on a whole second; cutoff carries fractional seconds.
+        val oldAudit = audit(guildId, UUID.randomUUID(), Instant.parse("2026-01-01T00:00:00Z"))
+        val cutoff = Instant.parse("2026-01-01T00:00:00.500Z")
+
+        repository.recordAudit(oldAudit)
+        val pruned = repository.deleteAuditsOlderThan(guildId, cutoff)
+
+        assertEquals(1, pruned, "chronologically-older whole-second audit must be deleted")
+        assertNull(repository.getAuditForGuild(guildId).firstOrNull { it.id == oldAudit.id })
+    }
+
+    @Test
+    fun `fractional-second audit just inside the cutoff is pruned`() {
+        val guildId = UUID.randomUUID()
+        val oldAudit = audit(guildId, UUID.randomUUID(), Instant.parse("2026-01-01T00:00:00.250Z"))
+        val cutoff = Instant.parse("2026-01-01T00:00:00.500Z")
+
+        repository.recordAudit(oldAudit)
+        val pruned = repository.deleteAuditsOlderThan(guildId, cutoff)
+
+        assertEquals(1, pruned)
+        assertNull(repository.getAuditForGuild(guildId).firstOrNull { it.id == oldAudit.id })
+    }
+
+    @Test
+    fun `audit after the cutoff is retained regardless of fractional digits`() {
+        val guildId = UUID.randomUUID()
+        val newerAudit = audit(guildId, UUID.randomUUID(), Instant.parse("2026-01-01T00:00:01Z"))
+        val cutoff = Instant.parse("2026-01-01T00:00:00.500Z")
+
+        repository.recordAudit(newerAudit)
+        val pruned = repository.deleteAuditsOlderThan(guildId, cutoff)
+
+        assertEquals(0, pruned)
+        assertEquals(1, repository.getAuditForGuild(guildId).size)
+    }
+
+    @Test
+    fun `prune only affects the target guild`() {
+        val guildId = UUID.randomUUID()
+        val otherGuildId = UUID.randomUUID()
+        val oldAudit = audit(guildId, UUID.randomUUID(), Instant.parse("2026-01-01T00:00:00Z"))
+        val otherAudit = audit(otherGuildId, UUID.randomUUID(), Instant.parse("2026-01-01T00:00:00Z"))
+        val cutoff = Instant.parse("2026-01-01T00:00:00.500Z")
+
+        repository.recordAudit(oldAudit)
+        repository.recordAudit(otherAudit)
+        val pruned = repository.deleteAuditsOlderThan(guildId, cutoff)
+
+        assertEquals(1, pruned)
+        assertEquals(0, repository.getAuditForGuild(guildId).size)
+        assertEquals(1, repository.getAuditForGuild(otherGuildId).size)
+    }
+}

--- a/src/test/kotlin/net/lumalyte/lg/infrastructure/persistence/guilds/BankSettingsRepositorySQLiteTest.kt
+++ b/src/test/kotlin/net/lumalyte/lg/infrastructure/persistence/guilds/BankSettingsRepositorySQLiteTest.kt
@@ -1,0 +1,71 @@
+package net.lumalyte.lg.infrastructure.persistence.guilds
+
+import net.lumalyte.lg.domain.entities.BankSettings
+import net.lumalyte.lg.infrastructure.persistence.storage.VirtualThreadSQLiteStorage
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertNotNull
+import org.junit.jupiter.api.Assertions.assertNull
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.io.TempDir
+import java.nio.file.Path
+import java.util.UUID
+
+/**
+ * REQ-010/011/031: bank automation, budget, and security settings must be
+ * persisted per guild (no hardcoded fakes) and survive round-trips.
+ */
+class BankSettingsRepositorySQLiteTest {
+
+    @TempDir
+    lateinit var tempDir: Path
+
+    private lateinit var repository: BankSettingsRepositorySQLite
+
+    @BeforeEach
+    fun setUp() {
+        repository = BankSettingsRepositorySQLite(VirtualThreadSQLiteStorage(tempDir.toFile()))
+    }
+
+    @Test
+    fun `upsert then get round-trips all settings`() {
+        val guildId = UUID.randomUUID()
+        val settings = BankSettings(
+            guildId = guildId,
+            scheduledDepositsEnabled = true,
+            autoRewardsEnabled = false,
+            recurringPaymentsEnabled = true,
+            interestRate = 0.075,
+            dualAuthThreshold = 2500,
+            monthlyBudget = 20000,
+            weeklyBudget = 5000,
+            dailyBudget = 1000,
+            lastInterestAccrual = 1_700_000_000_000L
+        )
+
+        assertTrue(repository.upsert(settings))
+
+        val loaded = repository.getByGuildId(guildId)
+        assertNotNull(loaded)
+        assertEquals(settings, loaded)
+    }
+
+    @Test
+    fun `get for unknown guild returns null`() {
+        assertNull(repository.getByGuildId(UUID.randomUUID()))
+    }
+
+    @Test
+    fun `upsert overwrites existing row`() {
+        val guildId = UUID.randomUUID()
+        repository.upsert(BankSettings(guildId = guildId, monthlyBudget = 10000))
+        repository.upsert(BankSettings(guildId = guildId, monthlyBudget = 42000))
+
+        val loaded = repository.getByGuildId(guildId)
+        assertNotNull(loaded)
+        assertEquals(42000, loaded!!.monthlyBudget)
+        assertEquals(2500, loaded.weeklyBudget) // second write carried BankSettings defaults
+    }
+}

--- a/src/test/kotlin/net/lumalyte/lg/infrastructure/persistence/guilds/BankSettingsRepositorySQLiteTest.kt
+++ b/src/test/kotlin/net/lumalyte/lg/infrastructure/persistence/guilds/BankSettingsRepositorySQLiteTest.kt
@@ -23,10 +23,18 @@ class BankSettingsRepositorySQLiteTest {
     lateinit var tempDir: Path
 
     private lateinit var repository: BankSettingsRepositorySQLite
+    private lateinit var storage: VirtualThreadSQLiteStorage
 
     @BeforeEach
     fun setUp() {
-        repository = BankSettingsRepositorySQLite(VirtualThreadSQLiteStorage(tempDir.toFile()))
+        storage = VirtualThreadSQLiteStorage(tempDir.toFile())
+        repository = BankSettingsRepositorySQLite(storage)
+    }
+
+    @AfterEach
+    fun tearDown() {
+        // Release the SQLite file handle so JUnit can delete the temp dir.
+        storage.connection.close()
     }
 
     @Test
@@ -67,5 +75,49 @@ class BankSettingsRepositorySQLiteTest {
         assertNotNull(loaded)
         assertEquals(42000, loaded!!.monthlyBudget)
         assertEquals(2500, loaded.weeklyBudget) // second write carried BankSettings defaults
+    }
+
+    @Test
+    fun `settings persist to sqlite - a second repository over the same db sees them`() {
+        val guildId = UUID.randomUUID()
+        val settings = BankSettings(
+            guildId = guildId,
+            scheduledDepositsEnabled = true,
+            autoRewardsEnabled = false,
+            recurringPaymentsEnabled = true,
+            interestRate = 0.075,
+            dualAuthThreshold = 2500,
+            monthlyBudget = 20000,
+            weeklyBudget = 5000,
+            dailyBudget = 1000,
+            lastInterestAccrual = 1_700_000_000_000L
+        )
+
+        assertTrue(repository.upsert(settings))
+
+        // A fresh repository over the same database must preload the row from
+        // SQLite — this proves real persistence, not just the in-memory cache.
+        val secondStorage = VirtualThreadSQLiteStorage(tempDir.toFile())
+        try {
+            val secondRepo = BankSettingsRepositorySQLite(secondStorage)
+            val loaded = secondRepo.getByGuildId(guildId)
+            assertNotNull(loaded)
+            assertEquals(settings, loaded)
+        } finally {
+            secondStorage.connection.close()
+        }
+    }
+
+    @Test
+    fun `returned settings are copies - mutating them does not corrupt the cache`() {
+        val guildId = UUID.randomUUID()
+        repository.upsert(BankSettings(guildId = guildId, monthlyBudget = 10000))
+
+        val returned = repository.getByGuildId(guildId)
+        assertNotNull(returned)
+        returned!!.monthlyBudget = 99999 // caller mutation
+
+        // Cache (and a fresh read) must be unaffected.
+        assertEquals(10000, repository.getByGuildId(guildId)!!.monthlyBudget)
     }
 }

--- a/src/test/kotlin/net/lumalyte/lg/infrastructure/services/BankConfigEnforcementTest.kt
+++ b/src/test/kotlin/net/lumalyte/lg/infrastructure/services/BankConfigEnforcementTest.kt
@@ -29,6 +29,61 @@ class BankConfigEnforcementTest {
     }
 
     @Test
+    fun `progression loop yields null when no level grants a bankLimit - deposits stay open`() {
+        // Guild with a progression row but NO bankLimit rewards on any level
+        // (0 = "not granted" in the config model). Previously the loop treated 0
+        // as a real limit, so effectiveMaxBalance(cap, 0) = 0 blocked every
+        // deposit. Must be null → config cap applies.
+        val rewards = mapOf(
+            1 to levelReward(bankLimit = 0),
+            2 to levelReward(bankLimit = 0),
+            3 to levelReward(bankLimit = 0)
+        )
+
+        val limit = BankServiceBukkit.computeProgressionBankLimit(rewards, currentLevel = 3)
+
+        assertEquals(null, limit)
+        assertEquals(1_000_000, BankServiceBukkit.effectiveMaxBalance(1_000_000, limit))
+    }
+
+    @Test
+    fun `progression loop takes the highest bankLimit across reached levels`() {
+        val rewards = mapOf(
+            1 to levelReward(bankLimit = 50_000),
+            2 to levelReward(bankLimit = 200_000),
+            3 to levelReward(bankLimit = 100_000)
+        )
+
+        assertEquals(200_000, BankServiceBukkit.computeProgressionBankLimit(rewards, currentLevel = 3))
+    }
+
+    @Test
+    fun `progression loop ignores levels beyond the current level`() {
+        val rewards = mapOf(
+            1 to levelReward(bankLimit = 50_000),
+            2 to levelReward(bankLimit = 200_000),
+            3 to levelReward(bankLimit = 100_000)
+        )
+
+        assertEquals(50_000, BankServiceBukkit.computeProgressionBankLimit(rewards, currentLevel = 1))
+    }
+
+    @Test
+    fun `progression loop mixes granted and ungranted levels`() {
+        val rewards = mapOf(
+            1 to levelReward(bankLimit = 0),
+            2 to levelReward(bankLimit = 75_000),
+            3 to levelReward(bankLimit = 0)
+        )
+
+        assertEquals(75_000, BankServiceBukkit.computeProgressionBankLimit(rewards, currentLevel = 3))
+    }
+
+    private fun levelReward(bankLimit: Int): net.lumalyte.lg.config.LevelRewardConfig {
+        return net.lumalyte.lg.config.LevelRewardConfig(bankLimit = bankLimit)
+    }
+
+    @Test
     fun `auto-lock triggers at or above threshold when enabled`() {
         assertTrue(BankServiceBukkit.shouldAutoLock(50_000, 50_000, true))
         assertTrue(BankServiceBukkit.shouldAutoLock(75_000, 50_000, true))

--- a/src/test/kotlin/net/lumalyte/lg/infrastructure/services/BankConfigEnforcementTest.kt
+++ b/src/test/kotlin/net/lumalyte/lg/infrastructure/services/BankConfigEnforcementTest.kt
@@ -1,0 +1,46 @@
+package net.lumalyte.lg.infrastructure.services
+
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertFalse
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+
+/**
+ * REQ-009: `bank.max_bank_balance` must act as the hard ceiling on deposits
+ * (progression level limits refine it downward), and suspicious-transaction
+ * auto-lock must respect `bank.suspicious_transaction_threshold` +
+ * `bank.auto_lock_suspicious_accounts`.
+ */
+class BankConfigEnforcementTest {
+
+    @Test
+    fun `config cap applies when no progression limit exists`() {
+        assertEquals(1_000_000, BankServiceBukkit.effectiveMaxBalance(1_000_000, null))
+    }
+
+    @Test
+    fun `progression limit refines the config cap downward`() {
+        assertEquals(100_000, BankServiceBukkit.effectiveMaxBalance(1_000_000, 100_000))
+    }
+
+    @Test
+    fun `config cap wins when progression limit exceeds it`() {
+        assertEquals(1_000_000, BankServiceBukkit.effectiveMaxBalance(1_000_000, 2_000_000))
+    }
+
+    @Test
+    fun `auto-lock triggers at or above threshold when enabled`() {
+        assertTrue(BankServiceBukkit.shouldAutoLock(50_000, 50_000, true))
+        assertTrue(BankServiceBukkit.shouldAutoLock(75_000, 50_000, true))
+    }
+
+    @Test
+    fun `auto-lock does not trigger below threshold`() {
+        assertFalse(BankServiceBukkit.shouldAutoLock(49_999, 50_000, true))
+    }
+
+    @Test
+    fun `auto-lock never triggers when disabled`() {
+        assertFalse(BankServiceBukkit.shouldAutoLock(500_000, 50_000, false))
+    }
+}


### PR DESCRIPTION
## Summary

PR-3 of the SPEAR audit remediation: the bank feature knobs were parsed from config but never consumed, and the bank menus (automation/budget/transaction history/security) were in-memory fakes with "coming soon" buttons and no persistence. This PR makes all four real, backed by a new shared persistence layer.

## Changes

### New persistence layer
- **`BankSettings`** entity + **`BankSettingsRepository`** / **`BankSettingsRepositorySQLite`** — new `bank_settings` table (upsert + in-memory preload, Aikar `DbRow` mapping), wired in DI.
  - One row per guild covers automation + budgets + security — no schema duplication.

### LG-301 — Bank config enforcement (the 6 parsed-never-consumed knobs)
- Deposit ceiling now = `effectiveMaxBalance(config cap, progression limit)` — config is the hard cap, progression refines downward (was hardcoded floor ignoring config).
- **Suspicious-transaction auto-lock** on deposit AND withdrawal: ≥ `suspicious_transaction_threshold` + `auto_lock_suspicious_accounts` → `guildService.setBankFrozen` (system actor `UUID(0,0)`) + audit entry.
- **`BankAutomationService`**: interest accrual driven by `interest_rate_percent` / `interest_compound_period_hours`, per-guild rate override, 30-period catch-up cap.
- **`BankRepositorySQLite.deleteAuditsOlderThan`** + retention enforcement per `audit_log_retention_days`.
- **`BankInterestScheduler`** (5-min `BancRunnable`, same pattern as `DailyWarCostsScheduler`) started/stopped in `LumaGuilds.onEnable/onDisable`.

### LG-302 — Automation menu
Loads/saves via `BankSettingsRepository`; interest rate takes real chat input; **Save persists for real** (with failure message); next-run shows real `getNextInterestRun()`; "Healthy" hardcoded status replaced with derived active-automation count + configured rate.

### LG-303 — Budget menu
Loads real persisted budgets; 3 "coming soon" buttons now take chat input; Save persists all three limits with success/failure feedback.

### LG-304 — Transaction history menu (was: rendering commented out, filters dead)
- Renders actual transactions into the pane: 10/page with working prev/next + page indicator, real localized empty-state (no more chat "coming soon").
- **Type filter**: click cycles All → Deposits → Withdrawals → Fees → Deductions.
- **Date filter**: click cycles All → 24h → 7d → 30d with real cutoff applied in `loadTransactions`.
- **Member filter**: slot-click selection submenu populated from `MemberService.getGuildMembers`.
- **Search**: wired via `ChatInputHandler` — matches member name or transaction description.

### LG-305 — Security menu
Dual-auth threshold loads from/saves to persisted settings; chat input wired; the SAVE button now actually persists (previously only acknowledged the freeze state).

## Tests
- New: `BankSettingsRepositorySQLiteTest` (3), `BankAutomationServiceTest` (7), `BankConfigEnforcementTest` (6) — **16 new tests, all green**.
- Full suite: **414 tests, 0 failures**; `compileKotlin` / `compileTestKotlin` green.

## SPEAR
- LG-301..305 checked off in `docs/tasks.md` with evidence.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Fixes
- Transaction history: Render persisted transactions with pagination, filters, member selection, and search.

## Features
- Bank settings: Persist automation, budget, and security configuration per guild.
- Bank automation: Enforce balance caps and suspicious-transaction locks, accrue interest every five minutes, and prune expired audits.
- Bank menus: Accept validated chat input and report persistence failures.
- Bank persistence: Add SQLite storage and dependency-injection wiring for `BankSettings`.
- Test coverage: Add 16 tests for persistence, automation, and configuration enforcement.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->