### PR TITLE
feat(pr4): combat config enforcement + war declaration flow (LG-401..405)

### DIFF
--- a/docs/tasks.md
+++ b/docs/tasks.md
@@ -118,30 +118,30 @@ PR grouping: tasks under each `## PR-n` header ship together in one pull request
 
 ## PR-4 — Combat & wars (knobs + real services)
 
-- [ ] **LG-401** Enforce combat config: war duration, grace period, max simultaneous wars, kill/win/lose XP, kill cooldown, same-player kill limit, anti-griefing
+- [x] **LG-401** Enforce combat config: war duration, grace period, max simultaneous wars, kill/win/lose XP, kill cooldown, same-player kill limit, anti-griefing
   - Tag: `TDD`
   - References: REQ-008
-  - Evidence:
+  - Evidence: `WarConfigEnforcementTest` (10 cases: duration cap, max-wars base+progression, no-auto-accept, reject, anti-farming). `WarServiceBukkit.kt` — `effectiveWarDuration` (duration cap), `maxWarsForGuild` (config base, progression refines up), grace-aware expiry in `processExpiredWars`, `awardWarExperience`/`awardWarKillExperience` (win/lose/kill XP). `WarKillTrackingListener.kt` — farming check suppresses kill XP. `CombatAntiGriefListener.kt` — explosion block-damage suppressed for warring players when `anti_griefing_enabled`.
   - Files: `infrastructure/services/WarServiceBukkit.kt`, combat listener
-- [ ] **LG-402** Implement `CombatServiceBukkit.getPlayerGuilds()` and `getRelationType()` against the guild/relation domain
+- [x] **LG-402** Implement `CombatServiceBukkit.getPlayerGuilds()` and `getRelationType()` against the guild/relation domain
   - Tag: `TDD`
   - References: REQ-014
-  - Evidence:
+  - Evidence: `CombatServiceBukkit.kt` injects `MemberService` + `RelationService`; `getPlayerGuilds()` → `memberService.getPlayerGuilds()`, `getRelationType()` → `relationService.getRelationType()`. DI: `Modules.kt` `CombatServiceBukkit(get(), get(), get())`.
   - Files: `infrastructure/services/CombatServiceBukkit.kt:119-129`
-- [ ] **LG-403** War declaration accept/decline flow (no instant auto-accept)
+- [x] **LG-403** War declaration accept/decline flow (no instant auto-accept)
   - Tag: `TDD`
   - References: REQ-024
-  - Evidence:
+  - Evidence: `declareWar()` returns `WarDeclaration?` and delegates to `createWarDeclaration()` (promoted to `WarService` interface) — no auto-accept. `acceptWarDeclaration()` activates: ACTIVE + startedAt + objectives + warStats + `GuildWarDeclaredEvent`. All three menus (Java + 2 Bedrock) route through `createWarDeclaration`; auto-accept shortcuts and menu-side escrow/`refundWager()` removed. Tested in `WarConfigEnforcementTest`.
   - Files: `WarServiceBukkit.kt:80`, declaration menu
-- [ ] **LG-404** Load and enforce `combat.war_farming_cooldown_hours`
+- [x] **LG-404** Load and enforce `combat.war_farming_cooldown_hours`
   - Tag: `TDD`
   - References: REQ-026
-  - Evidence:
+  - Evidence: `ConfigServiceBukkit.loadCombatConfig()` now reads `war_farming_cooldown_hours` (was silently defaulting to 1h); consumed by `getWarFarmingCooldownSeconds()`.
   - Files: `config.yml:408`, war service
-- [ ] **LG-405** War declaration escrow withdraw completed in the war service
+- [x] **LG-405** War declaration escrow withdraw completed in the war service
   - Tag: `TDD`
   - References: REQ-039
-  - Evidence:
+  - Evidence: Escrow is now entirely service-side — `createWager` (in `WarServiceBukkit`) deducts both guilds on acceptance; the declaration menus no longer move bank funds (removed menu-side `bankService.withdraw` + `refundWager()`). Defending-guild wager match still via `createWager` after `acceptWarDeclaration`.
   - Files: `GuildWarDeclarationMenu.kt:527`, war escrow service
 
 ---

--- a/docs/tasks.md
+++ b/docs/tasks.md
@@ -141,7 +141,7 @@ PR grouping: tasks under each `## PR-n` header ship together in one pull request
 - [x] **LG-405** War declaration escrow withdraw completed in the war service
   - Tag: `TDD`
   - References: REQ-039
-  - Evidence: Escrow is now entirely service-side — `createWager` (in `WarServiceBukkit`) deducts both guilds on acceptance; the declaration menus no longer move bank funds (removed menu-side `bankService.withdraw` + `refundWager()`). Defending-guild wager match still via `createWager` after `acceptWarDeclaration`.
+  - Evidence: `acceptWarDeclaration` now escrows via `createWager` internally (both guilds deducted, `WarServiceBukkit.kt:145-155`). Declaration + acceptance menus (Java + Bedrock) no longer move bank funds — removed menu-side `bankService.withdraw` (was double-charging the defending guild) and dead `refundWager()`. Escrow verified by `WarConfigEnforcementTest` (`wager is escrowed on acceptance`).
   - Files: `GuildWarDeclarationMenu.kt:527`, war escrow service
 
 ---

--- a/src/main/kotlin/net/lumalyte/lg/LumaGuilds.kt
+++ b/src/main/kotlin/net/lumalyte/lg/LumaGuilds.kt
@@ -965,6 +965,7 @@ class LumaGuilds : JavaPlugin() {
 
         // Register war kill tracking listener
         server.pluginManager.registerEvents(net.lumalyte.lg.infrastructure.listeners.WarKillTrackingListener(), this)
+        server.pluginManager.registerEvents(net.lumalyte.lg.infrastructure.listeners.CombatAntiGriefListener(), this)
 
         // Close stale guild menus, clean up channels, and despawn bannerman displays when a guild is disbanded
         val guildDisbandedListener = get().get<net.lumalyte.lg.infrastructure.listeners.GuildDisbandedListener>()

--- a/src/main/kotlin/net/lumalyte/lg/application/services/WarService.kt
+++ b/src/main/kotlin/net/lumalyte/lg/application/services/WarService.kt
@@ -11,28 +11,8 @@ import java.util.UUID
 interface WarService {
 
     /**
-     * Declares war on another guild.
-     *
-     * REQ-024: this creates a PENDING war declaration requiring the defending
-     * guild's accept/decline — it no longer auto-accepts into an active war.
-     *
-     * @param declaringGuildId The ID of the declaring guild.
-     * @param defendingGuildId The ID of the defending guild.
-     * @param duration The duration of the war.
-     * @param objectives The war objectives.
-     * @param actorId The ID of the player declaring war.
-     * @return The war declaration if successful, null otherwise.
-     */
-    fun declareWar(
-        declaringGuildId: UUID,
-        defendingGuildId: UUID,
-        duration: Duration = Duration.ofDays(7),
-        objectives: Set<WarObjective> = emptySet(),
-        actorId: UUID
-    ): WarDeclaration?
-
-    /**
-     * Creates a pending war declaration (explicit wager/terms variant).
+     * Creates a pending war declaration (REQ-024: no auto-accept — the defending
+     * guild must accept or decline before a war starts).
      *
      * @return The created declaration, or null if one already exists between the guilds.
      */
@@ -235,6 +215,19 @@ interface WarService {
      * @return The wager if found, null otherwise.
      */
     fun getWager(warId: UUID): WarWager?
+
+    /**
+     * Records a war kill for anti-farming enforcement (REQ-008) and returns
+     * whether the kill exceeds the per-victim limit within the cooldown window.
+     * When true, callers should suppress XP/rewards for that kill.
+     */
+    fun recordWarKillAndCheckFarming(killerId: UUID, victimId: UUID): Boolean
+
+    /**
+     * Awards the configured `combat.kill_experience` (REQ-008) to the killer's
+     * guild for a war kill. Best-effort; progression failures are logged.
+     */
+    fun awardWarKillExperience(killerGuildId: UUID)
 
     /**
      * Gets war history for a guild.

--- a/src/main/kotlin/net/lumalyte/lg/application/services/WarService.kt
+++ b/src/main/kotlin/net/lumalyte/lg/application/services/WarService.kt
@@ -13,6 +13,9 @@ interface WarService {
     /**
      * Declares war on another guild.
      *
+     * REQ-024: this creates a PENDING war declaration requiring the defending
+     * guild's accept/decline — it no longer auto-accepts into an active war.
+     *
      * @param declaringGuildId The ID of the declaring guild.
      * @param defendingGuildId The ID of the defending guild.
      * @param duration The duration of the war.
@@ -26,7 +29,22 @@ interface WarService {
         duration: Duration = Duration.ofDays(7),
         objectives: Set<WarObjective> = emptySet(),
         actorId: UUID
-    ): War?
+    ): WarDeclaration?
+
+    /**
+     * Creates a pending war declaration (explicit wager/terms variant).
+     *
+     * @return The created declaration, or null if one already exists between the guilds.
+     */
+    fun createWarDeclaration(
+        declaringGuildId: UUID,
+        defendingGuildId: UUID,
+        duration: Duration,
+        objectives: Set<WarObjective>,
+        wagerAmount: Int = 0,
+        terms: String? = null,
+        actorId: UUID
+    ): WarDeclaration?
 
     /**
      * Accepts a war declaration.

--- a/src/main/kotlin/net/lumalyte/lg/di/Modules.kt
+++ b/src/main/kotlin/net/lumalyte/lg/di/Modules.kt
@@ -519,7 +519,7 @@ fun progressionModule() = module {
 
     // Services
     single<KillService> { KillServiceBukkit(get()) }
-    single<CombatService> { CombatServiceBukkit(get()) }
+    single<CombatService> { CombatServiceBukkit(get(), get(), get()) }
     single<ProgressionService> { ProgressionServiceBukkit(get(), get(), get(), get(), get(), get<LumaGuilds>()) }
     single<WarService> { WarServiceBukkit(get(), get(), get(), get()) }
     single<LeaderboardService> { LeaderboardServiceBukkit(get()) }

--- a/src/main/kotlin/net/lumalyte/lg/infrastructure/listeners/CombatAntiGriefListener.kt
+++ b/src/main/kotlin/net/lumalyte/lg/infrastructure/listeners/CombatAntiGriefListener.kt
@@ -1,0 +1,78 @@
+package net.lumalyte.lg.infrastructure.listeners
+
+import net.lumalyte.lg.application.services.ConfigService
+import net.lumalyte.lg.application.services.MemberService
+import net.lumalyte.lg.application.services.WarService
+import org.bukkit.block.Block
+import org.bukkit.entity.Player
+import org.bukkit.event.EventHandler
+import org.bukkit.event.Listener
+import org.bukkit.event.block.BlockExplodeEvent
+import org.bukkit.event.entity.EntityExplodeEvent
+import org.koin.core.component.KoinComponent
+import org.koin.core.component.inject
+import org.slf4j.LoggerFactory
+
+/**
+ * Anti-griefing enforcement (REQ-008, `combat.anti_griefing_enabled`).
+ *
+ * When enabled, explosive block destruction is suppressed for players who are
+ * currently in an active war — warring factions cannot level each other's
+ * builds with TNT/end crystals. Combat (entity damage) is unaffected; only
+ * terrain griefing via explosions is blocked. When the knob is disabled, war
+ * griefing behaves as before.
+ */
+class CombatAntiGriefListener : Listener, KoinComponent {
+
+    private val configService: ConfigService by inject()
+    private val warService: WarService by inject()
+    private val memberService: MemberService by inject()
+
+    private val logger = LoggerFactory.getLogger(CombatAntiGriefListener::class.java)
+
+    @EventHandler
+    fun onEntityExplode(event: EntityExplodeEvent) {
+        val sourcePlayer = event.entity?.let { entity ->
+            when (entity) {
+                is Player -> entity
+                else -> entity.location.world?.getNearbyEntities(entity.location, 3.0, 3.0, 3.0)
+                    ?.filterIsInstance<Player>()?.firstOrNull()
+            }
+        } ?: return
+
+        if (shouldBlockGriefing(sourcePlayer, event.blockList())) {
+            event.blockList().clear()
+        }
+    }
+
+    @EventHandler
+    fun onBlockExplode(event: BlockExplodeEvent) {
+        val sourcePlayer = event.block.world.getNearbyEntities(event.block.location, 3.0, 3.0, 3.0)
+            .filterIsInstance<Player>().firstOrNull() ?: return
+
+        if (shouldBlockGriefing(sourcePlayer, event.blockList())) {
+            event.blockList().clear()
+        }
+    }
+
+    /**
+     * Blocks the explosion's block damage when the flag is on and the nearby
+     * player belongs to a guild currently in an active war.
+     */
+    private fun shouldBlockGriefing(player: Player, blocks: List<Block>): Boolean {
+        if (blocks.isEmpty()) return false
+        if (!configService.loadConfig().combat.antiGriefingEnabled) return false
+
+        val playerGuilds = memberService.getPlayerGuilds(player.uniqueId)
+        if (playerGuilds.isEmpty()) return false
+
+        val inActiveWar = playerGuilds.any { guildId ->
+            warService.getWarsForGuild(guildId).any { it.isActive }
+        }
+
+        if (inActiveWar) {
+            logger.debug("Anti-grief: suppressing explosion block damage by warring player ${player.name}")
+        }
+        return inActiveWar
+    }
+}

--- a/src/main/kotlin/net/lumalyte/lg/infrastructure/listeners/CombatAntiGriefListener.kt
+++ b/src/main/kotlin/net/lumalyte/lg/infrastructure/listeners/CombatAntiGriefListener.kt
@@ -5,6 +5,7 @@ import net.lumalyte.lg.application.services.MemberService
 import net.lumalyte.lg.application.services.WarService
 import org.bukkit.block.Block
 import org.bukkit.entity.Player
+import org.bukkit.entity.TNTPrimed
 import org.bukkit.event.EventHandler
 import org.bukkit.event.Listener
 import org.bukkit.event.block.BlockExplodeEvent
@@ -21,6 +22,11 @@ import org.slf4j.LoggerFactory
  * builds with TNT/end crystals. Combat (entity damage) is unaffected; only
  * terrain griefing via explosions is blocked. When the knob is disabled, war
  * griefing behaves as before.
+ *
+ * Actor attribution: `EntityExplodeEvent` sources are resolved via
+ * `TNTPrimed.source` (the entity that ignited the TNT) when available. When no
+ * player source can be determined, the explosion is NOT attributed to anyone
+ * and block damage proceeds (explicit no-actor policy).
  */
 class CombatAntiGriefListener : Listener, KoinComponent {
 
@@ -32,13 +38,9 @@ class CombatAntiGriefListener : Listener, KoinComponent {
 
     @EventHandler
     fun onEntityExplode(event: EntityExplodeEvent) {
-        val sourcePlayer = event.entity?.let { entity ->
-            when (entity) {
-                is Player -> entity
-                else -> entity.location.world?.getNearbyEntities(entity.location, 3.0, 3.0, 3.0)
-                    ?.filterIsInstance<Player>()?.firstOrNull()
-            }
-        } ?: return
+        // Resolve the actor via explosion ownership (TNTPrimed.source), not proximity.
+        val sourcePlayer = (event.entity as? TNTPrimed)?.source as? Player
+            ?: return // No attributable player actor — explicit no-actor policy
 
         if (shouldBlockGriefing(sourcePlayer, event.blockList())) {
             event.blockList().clear()
@@ -47,17 +49,13 @@ class CombatAntiGriefListener : Listener, KoinComponent {
 
     @EventHandler
     fun onBlockExplode(event: BlockExplodeEvent) {
-        val sourcePlayer = event.block.world.getNearbyEntities(event.block.location, 3.0, 3.0, 3.0)
-            .filterIsInstance<Player>().firstOrNull() ?: return
-
-        if (shouldBlockGriefing(sourcePlayer, event.blockList())) {
-            event.blockList().clear()
-        }
+        // BlockExplodeEvent has no actor metadata — no-actor policy: never block.
+        // Player-caused TNT griefing is already handled by EntityExplodeEvent.
     }
 
     /**
-     * Blocks the explosion's block damage when the flag is on and the nearby
-     * player belongs to a guild currently in an active war.
+     * Blocks the explosion's block damage when the flag is on and the player
+     * belongs to a guild currently in an active war.
      */
     private fun shouldBlockGriefing(player: Player, blocks: List<Block>): Boolean {
         if (blocks.isEmpty()) return false

--- a/src/main/kotlin/net/lumalyte/lg/infrastructure/listeners/WarKillTrackingListener.kt
+++ b/src/main/kotlin/net/lumalyte/lg/infrastructure/listeners/WarKillTrackingListener.kt
@@ -2,6 +2,7 @@ package net.lumalyte.lg.infrastructure.listeners
 
 import net.lumalyte.lg.application.services.MemberService
 import net.lumalyte.lg.application.services.WarService
+import net.lumalyte.lg.infrastructure.services.WarServiceBukkit
 import net.lumalyte.lg.domain.entities.ObjectiveType
 import net.lumalyte.lg.domain.entities.WarStats
 import net.lumalyte.lg.domain.events.GuildWarKillEvent
@@ -88,8 +89,18 @@ class WarKillTrackingListener : Listener, KoinComponent {
 
                         // Update the war stats
                         if (warService.updateWarStats(updatedStats)) {
+                            // Anti-farming: suppress XP when the same killer exceeds
+                            // the per-victim kill limit within the cooldown (REQ-008)
+                            val isFarming = (warService as? WarServiceBukkit)
+                                ?.recordWarKillAndCheckFarming(killer.uniqueId, victim.uniqueId) == true
+
                             Bukkit.getPluginManager().callEvent(GuildWarKillEvent(war.id, killer.uniqueId, victim.uniqueId, killerGuild, victimGuild))
                             logger.info("War kill recorded: ${killer.name} (guild $killerGuild) killed ${victim.name} (guild $victimGuild) in war ${war.id}")
+
+                            // Award configured kill XP to the killer's guild (REQ-008)
+                            if (!isFarming) {
+                                (warService as? WarServiceBukkit)?.awardWarKillExperience(killerGuild)
+                            }
 
                             // Notify both players
                             killer.sendMessage("§6⚔ WAR KILL! §7You killed §c${victim.name}§7!")

--- a/src/main/kotlin/net/lumalyte/lg/infrastructure/listeners/WarKillTrackingListener.kt
+++ b/src/main/kotlin/net/lumalyte/lg/infrastructure/listeners/WarKillTrackingListener.kt
@@ -2,7 +2,6 @@ package net.lumalyte.lg.infrastructure.listeners
 
 import net.lumalyte.lg.application.services.MemberService
 import net.lumalyte.lg.application.services.WarService
-import net.lumalyte.lg.infrastructure.services.WarServiceBukkit
 import net.lumalyte.lg.domain.entities.ObjectiveType
 import net.lumalyte.lg.domain.entities.WarStats
 import net.lumalyte.lg.domain.events.GuildWarKillEvent
@@ -91,15 +90,14 @@ class WarKillTrackingListener : Listener, KoinComponent {
                         if (warService.updateWarStats(updatedStats)) {
                             // Anti-farming: suppress XP when the same killer exceeds
                             // the per-victim kill limit within the cooldown (REQ-008)
-                            val isFarming = (warService as? WarServiceBukkit)
-                                ?.recordWarKillAndCheckFarming(killer.uniqueId, victim.uniqueId) == true
+                            val isFarming = warService.recordWarKillAndCheckFarming(killer.uniqueId, victim.uniqueId)
 
                             Bukkit.getPluginManager().callEvent(GuildWarKillEvent(war.id, killer.uniqueId, victim.uniqueId, killerGuild, victimGuild))
                             logger.info("War kill recorded: ${killer.name} (guild $killerGuild) killed ${victim.name} (guild $victimGuild) in war ${war.id}")
 
                             // Award configured kill XP to the killer's guild (REQ-008)
                             if (!isFarming) {
-                                (warService as? WarServiceBukkit)?.awardWarKillExperience(killerGuild)
+                                warService.awardWarKillExperience(killerGuild)
                             }
 
                             // Notify both players

--- a/src/main/kotlin/net/lumalyte/lg/infrastructure/services/CombatServiceBukkit.kt
+++ b/src/main/kotlin/net/lumalyte/lg/infrastructure/services/CombatServiceBukkit.kt
@@ -1,13 +1,19 @@
 package net.lumalyte.lg.infrastructure.services
 
 import net.lumalyte.lg.application.services.CombatService
+import net.lumalyte.lg.application.services.MemberService
 import net.lumalyte.lg.application.services.ModeService
+import net.lumalyte.lg.application.services.RelationService
 import net.lumalyte.lg.domain.entities.GuildMode
 import net.lumalyte.lg.domain.entities.RelationType
 import org.slf4j.LoggerFactory
 import java.util.UUID
 
-class CombatServiceBukkit(private val modeService: ModeService) : CombatService {
+class CombatServiceBukkit(
+    private val modeService: ModeService,
+    private val memberService: MemberService,
+    private val relationService: RelationService
+) : CombatService {
 
     private val logger = LoggerFactory.getLogger(CombatServiceBukkit::class.java)
 
@@ -114,17 +120,11 @@ class CombatServiceBukkit(private val modeService: ModeService) : CombatService 
         return null
     }
 
-    // Helper methods to access services without circular dependencies
-    // These would normally be injected or accessed through a service locator
     private fun getPlayerGuilds(playerId: UUID): Set<UUID> {
-        // This would be injected in a real implementation
-        // For now, return empty set as a placeholder
-        return emptySet()
+        return memberService.getPlayerGuilds(playerId)
     }
 
-    private fun getRelationType(guildA: UUID, guildB: UUID): net.lumalyte.lg.domain.entities.RelationType {
-        // This would be injected in a real implementation
-        // For now, return NEUTRAL as a placeholder
-        return net.lumalyte.lg.domain.entities.RelationType.NEUTRAL
+    private fun getRelationType(guildA: UUID, guildB: UUID): RelationType {
+        return relationService.getRelationType(guildA, guildB)
     }
 }

--- a/src/main/kotlin/net/lumalyte/lg/infrastructure/services/ConfigServiceBukkit.kt
+++ b/src/main/kotlin/net/lumalyte/lg/infrastructure/services/ConfigServiceBukkit.kt
@@ -247,6 +247,7 @@ class ConfigServiceBukkit(private val config: FileConfiguration): ConfigService 
             samePlayerKillLimit = config.getInt("combat.same_player_kill_limit", 3),
             antiGriefingEnabled = config.getBoolean("combat.anti_griefing_enabled", true),
             warDeclarationCooldownHours = config.getInt("combat.war_declaration_cooldown_hours", 24),
+            warFarmingCooldownHours = config.getInt("combat.war_farming_cooldown_hours", 1),
             warDurationHours = config.getInt("combat.war_duration_hours", 168),
             warEndGracePeriodMinutes = config.getInt("combat.war_end_grace_period_minutes", 30),
             maxSimultaneousWars = config.getInt("combat.max_simultaneous_wars", 3),

--- a/src/main/kotlin/net/lumalyte/lg/infrastructure/services/ConfigServiceBukkit.kt
+++ b/src/main/kotlin/net/lumalyte/lg/infrastructure/services/ConfigServiceBukkit.kt
@@ -247,7 +247,11 @@ class ConfigServiceBukkit(private val config: FileConfiguration): ConfigService 
             samePlayerKillLimit = config.getInt("combat.same_player_kill_limit", 3),
             antiGriefingEnabled = config.getBoolean("combat.anti_griefing_enabled", true),
             warDeclarationCooldownHours = config.getInt("combat.war_declaration_cooldown_hours", 24),
-            warFarmingCooldownHours = config.getInt("combat.war_farming_cooldown_hours", 1),
+            warFarmingCooldownHours = config.getInt(
+                "combat.war_farming_cooldown_hours",
+                // Legacy key: existing deployments set guild.war_farming_cooldown_hours.
+                config.getInt("guild.war_farming_cooldown_hours", 1)
+            ),
             warDurationHours = config.getInt("combat.war_duration_hours", 168),
             warEndGracePeriodMinutes = config.getInt("combat.war_end_grace_period_minutes", 30),
             maxSimultaneousWars = config.getInt("combat.max_simultaneous_wars", 3),

--- a/src/main/kotlin/net/lumalyte/lg/infrastructure/services/WarServiceBukkit.kt
+++ b/src/main/kotlin/net/lumalyte/lg/infrastructure/services/WarServiceBukkit.kt
@@ -36,28 +36,8 @@ class WarServiceBukkit(
     private val warFarmingCooldowns = ConcurrentHashMap<UUID, Instant>()
     private val warDeclarationCooldowns = ConcurrentHashMap<UUID, Instant>()
 
-    override fun declareWar(
-        declaringGuildId: UUID,
-        defendingGuildId: UUID,
-        duration: Duration,
-        objectives: Set<WarObjective>,
-        actorId: UUID
-    ): WarDeclaration? {
-        // REQ-024: no auto-accept — a declaration requires the defending guild's
-        // accept/decline. This is exactly the createWarDeclaration flow.
-        return createWarDeclaration(
-            declaringGuildId = declaringGuildId,
-            defendingGuildId = defendingGuildId,
-            duration = duration,
-            objectives = objectives,
-            wagerAmount = 0,
-            terms = null,
-            actorId = actorId
-        )
-    }
-
     /**
-     * Creates a war declaration that requires acceptance
+     * Creates a war declaration that requires acceptance (REQ-024: no auto-accept).
      */
     override fun createWarDeclaration(
         declaringGuildId: UUID,
@@ -142,6 +122,17 @@ class WarServiceBukkit(
             wars[war.id] = war
             warStats[war.id] = WarStats(warId = war.id)
             warDeclarations.remove(declarationId)
+
+            // REQ-039: escrow the wager in the war service. Both guilds are
+            // deducted here (createWager validates funds + holds the pot);
+            // the declaring guild's pledge comes from the declaration, the
+            // defending guild matches it. Menus must NOT move bank funds.
+            if (declaration.wagerAmount > 0) {
+                val wager = createWager(war.id, declaration.wagerAmount, declaration.wagerAmount)
+                if (wager == null) {
+                    logger.warn("War ${war.id} accepted but wager escrow failed (${declaration.wagerAmount} each) — war continues without a pot")
+                }
+            }
 
             logger.info("War accepted and ACTIVE: ${war.id} (${war.declaringGuildId} vs ${war.defendingGuildId})")
             Bukkit.getPluginManager().callEvent(GuildWarDeclaredEvent(war.declaringGuildId, war.defendingGuildId, actorId))
@@ -341,7 +332,13 @@ class WarServiceBukkit(
 
     private fun awardGuildExperience(guildId: UUID, amount: Int) {
         try {
-            val progression = progressionRepository.getGuildProgression(guildId) ?: return
+            val progression = progressionRepository.getGuildProgression(guildId)
+            if (progression == null) {
+                // No progression row yet — cannot award. Log instead of silently
+                // discarding the configured war/kill XP (CodeRabbit: WarServiceBukkit.kt:351).
+                logger.warn("Cannot award $amount XP to guild $guildId — no progression row exists")
+                return
+            }
             progressionRepository.saveGuildProgression(
                 progression.copy(totalExperience = progression.totalExperience + amount)
             )
@@ -353,7 +350,7 @@ class WarServiceBukkit(
     /**
      * Awards the configured kill XP (REQ-008) to the killer's guild for a war kill.
      */
-    fun awardWarKillExperience(killerGuildId: UUID) {
+    override fun awardWarKillExperience(killerGuildId: UUID) {
         val killXp = configService.loadConfig().combat.killExperience
         if (killXp > 0) {
             awardGuildExperience(killerGuildId, killXp)
@@ -367,13 +364,14 @@ class WarServiceBukkit(
      * exceeded the per-victim kill limit within the cooldown window — callers
      * should suppress XP/rewards for such kills.
      */
-    fun recordWarKillAndCheckFarming(killerId: UUID, victimId: UUID): Boolean {
+    override fun recordWarKillAndCheckFarming(killerId: UUID, victimId: UUID): Boolean {
         val combat = configService.loadConfig().combat
         if (combat.killCooldownMinutes <= 0 || combat.samePlayerKillLimit <= 0) {
             // Anti-farming disabled — always allow
             return false
         }
 
+        maybePruneKillTracking()
         val now = Instant.now()
         val cooldownStart = now.minusSeconds(combat.killCooldownMinutes * 60L)
 
@@ -391,13 +389,47 @@ class WarServiceBukkit(
     }
 
     /**
-     * Checks whether a guild is at or above the configured max simultaneous wars (REQ-008).
+     * Bounds `killTracking` on a long-running server: once the map exceeds a
+     * sane size, prune entries whose cooldown window has elapsed.
+     */
+    private fun maybePruneKillTracking() {
+        if (killTracking.size > MAX_TRACKED_KILLERS) {
+            pruneKillTracking()
+        }
+    }
+
+    /**
+     * Prunes empty killer/victim entries so `killTracking` stays bounded on a
+     * long-running server (REQ-008 anti-farming state). Call whenever a cooldown
+     * window has fully elapsed for a pair.
+     */
+    fun pruneKillTracking(now: Instant = Instant.now()) {
+        val combat = configService.loadConfig().combat
+        if (combat.killCooldownMinutes <= 0) return
+        val cooldownStart = now.minusSeconds(combat.killCooldownMinutes * 60L)
+
+        killTracking.forEach { (killerId, byVictim) ->
+            byVictim.forEach { (victimId, kills) ->
+                synchronized(kills) {
+                    kills.removeAll { it.isBefore(cooldownStart) }
+                    if (kills.isEmpty()) byVictim.remove(victimId)
+                }
+            }
+            if (byVictim.isEmpty()) killTracking.remove(killerId)
+        }
+    }
+
+    /**
+     * Checks whether a guild is at or above the configured max simultaneous wars
+     * (REQ-008), refined upward by progression war slots — consistent with the
+     * check in `createWarDeclaration`.
      */
     override fun canGuildDeclareWar(guildId: UUID): Boolean {
         val activeWars = wars.values.filter {
             it.isActive && (it.declaringGuildId == guildId || it.defendingGuildId == guildId)
         }.size
-        return activeWars < configService.loadConfig().combat.maxSimultaneousWars
+        val maxWars = maxWarsForGuild(guildId, configService.loadConfig().combat.maxSimultaneousWars)
+        return activeWars < maxWars
     }
 
     override fun canPlayerManageWars(playerId: UUID, guildId: UUID): Boolean {
@@ -851,6 +883,9 @@ class WarServiceBukkit(
     }
 
     companion object {
+        /** Anti-farming tracking bound: prune once this many killers are tracked. */
+        private const val MAX_TRACKED_KILLERS = 10_000
+
         /**
          * REQ-008: caps a requested war duration at `combat.war_duration_hours`.
          */

--- a/src/main/kotlin/net/lumalyte/lg/infrastructure/services/WarServiceBukkit.kt
+++ b/src/main/kotlin/net/lumalyte/lg/infrastructure/services/WarServiceBukkit.kt
@@ -119,20 +119,30 @@ class WarServiceBukkit(
                 objectives = declaration.objectives
             )
 
+            // REQ-039: escrow is ATOMIC with acceptance. createWager requires the
+            // war to be registered (it looks up wars[warId] and deducts both guilds,
+            // rolling back the declaring guild if the defending deduction fails).
+            // If escrow fails, the war is rolled back and the declaration stays
+            // pending — a waged declaration can never become an unwagered war.
             wars[war.id] = war
             warStats[war.id] = WarStats(warId = war.id)
-            warDeclarations.remove(declarationId)
 
-            // REQ-039: escrow the wager in the war service. Both guilds are
-            // deducted here (createWager validates funds + holds the pot);
-            // the declaring guild's pledge comes from the declaration, the
-            // defending guild matches it. Menus must NOT move bank funds.
             if (declaration.wagerAmount > 0) {
                 val wager = createWager(war.id, declaration.wagerAmount, declaration.wagerAmount)
                 if (wager == null) {
-                    logger.warn("War ${war.id} accepted but wager escrow failed (${declaration.wagerAmount} each) — war continues without a pot")
+                    // Atomic rollback: remove the war we just registered; the
+                    // declaration remains pending so the defender can retry.
+                    wars.remove(war.id)
+                    warStats.remove(war.id)
+                    logger.warn(
+                        "War declaration $declarationId NOT accepted — wager escrow failed " +
+                            "(${declaration.wagerAmount} each). Declaration remains pending."
+                    )
+                    return null
                 }
             }
+
+            warDeclarations.remove(declarationId)
 
             logger.info("War accepted and ACTIVE: ${war.id} (${war.declaringGuildId} vs ${war.defendingGuildId})")
             Bukkit.getPluginManager().callEvent(GuildWarDeclaredEvent(war.declaringGuildId, war.defendingGuildId, actorId))

--- a/src/main/kotlin/net/lumalyte/lg/infrastructure/services/WarServiceBukkit.kt
+++ b/src/main/kotlin/net/lumalyte/lg/infrastructure/services/WarServiceBukkit.kt
@@ -28,6 +28,10 @@ class WarServiceBukkit(
     private val warDeclarations = ConcurrentHashMap<UUID, WarDeclaration>()
     private val warStats = ConcurrentHashMap<UUID, WarStats>()
     private val warWagers = ConcurrentHashMap<UUID, WarWager>()
+
+    // Tracks per-killer kill timestamps per victim, for anti-farming enforcement
+    // (REQ-008: kill_cooldown_minutes + same_player_kill_limit).
+    private val killTracking = ConcurrentHashMap<UUID, ConcurrentHashMap<UUID, MutableList<Instant>>>()
     private val peaceAgreements = ConcurrentHashMap<UUID, PeaceAgreement>()
     private val warFarmingCooldowns = ConcurrentHashMap<UUID, Instant>()
     private val warDeclarationCooldowns = ConcurrentHashMap<UUID, Instant>()
@@ -38,84 +42,30 @@ class WarServiceBukkit(
         duration: Duration,
         objectives: Set<WarObjective>,
         actorId: UUID
-    ): War? {
-        return try {
-            // Check if war already exists between these guilds
-            val existingWar = getCurrentWarBetweenGuilds(declaringGuildId, defendingGuildId)
-            if (existingWar != null) {
-                logger.warn("Cannot declare war - active war already exists between guilds $declaringGuildId and $defendingGuildId")
-                return null
-            }
-
-            // Check if pending declaration already exists
-            val existingDeclaration = warDeclarations.values.find {
-                (it.declaringGuildId == declaringGuildId && it.defendingGuildId == defendingGuildId) ||
-                (it.declaringGuildId == defendingGuildId && it.defendingGuildId == declaringGuildId)
-            }
-            if (existingDeclaration != null) {
-                logger.warn("Cannot declare war - pending declaration already exists between guilds $declaringGuildId and $defendingGuildId")
-                return null
-            }
-
-            // Check war slot limit (progression-based)
-            val currentWars = getWarsForGuild(declaringGuildId).filter { it.isActive }
-            // Calculate max wars based on progression level
-            val progression = progressionRepository.getGuildProgression(declaringGuildId)
-            val progressionConfig = progressionConfigService.getProgressionConfig()
-            val levelRewards = progressionConfig.getActiveLevelRewards()
-            var maxWars = 3 // Default base
-            if (progression != null) {
-                for (level in 1..progression.currentLevel) {
-                    val wars = levelRewards[level]?.warSlots ?: 3
-                    if (wars > maxWars) maxWars = wars
-                }
-            }
-
-            if (currentWars.size >= maxWars) {
-                logger.warn("Guild $declaringGuildId has reached war limit: ${currentWars.size}/$maxWars")
-                return null
-            }
-
-            // For now, create immediate war (legacy behavior)
-            // TODO: This should be updated to create WarDeclarations for proper acceptance flow
-            val war = War.create(
-                declaringGuildId = declaringGuildId,
-                defendingGuildId = defendingGuildId,
-                duration = duration
-            ).copy(
-                status = WarStatus.ACTIVE,  // Auto-accepted wars are immediately active
-                startedAt = Instant.now(),
-                objectives = objectives
-            )
-
-            wars[war.id] = war
-
-            // Initialize war stats
-            warStats[war.id] = WarStats(warId = war.id)
-
-            // Record war declaration for cooldown tracking
-            recordWarDeclaration(declaringGuildId)
-
-            logger.info("War declared and ACTIVE by guild $declaringGuildId against guild $defendingGuildId")
-            Bukkit.getPluginManager().callEvent(GuildWarDeclaredEvent(declaringGuildId, defendingGuildId, actorId))
-            war
-        } catch (e: Exception) {
-            // In-memory operation - catching runtime exceptions from state validation
-            logger.error("Error declaring war between $declaringGuildId and $defendingGuildId", e)
-            null
-        }
+    ): WarDeclaration? {
+        // REQ-024: no auto-accept — a declaration requires the defending guild's
+        // accept/decline. This is exactly the createWarDeclaration flow.
+        return createWarDeclaration(
+            declaringGuildId = declaringGuildId,
+            defendingGuildId = defendingGuildId,
+            duration = duration,
+            objectives = objectives,
+            wagerAmount = 0,
+            terms = null,
+            actorId = actorId
+        )
     }
 
     /**
      * Creates a war declaration that requires acceptance
      */
-    fun createWarDeclaration(
+    override fun createWarDeclaration(
         declaringGuildId: UUID,
         defendingGuildId: UUID,
         duration: Duration,
         objectives: Set<WarObjective>,
-        wagerAmount: Int = 0,
-        terms: String? = null,
+        wagerAmount: Int,
+        terms: String?,
         actorId: UUID
     ): WarDeclaration? {
         return try {
@@ -136,10 +86,20 @@ class WarServiceBukkit(
                 return null
             }
 
+            // Check war slot limit (REQ-008): config max, refined upward by progression
+            val currentWars = getWarsForGuild(declaringGuildId).filter { it.isActive }
+            val config = configService.loadConfig()
+            val maxWars = maxWarsForGuild(declaringGuildId, config.combat.maxSimultaneousWars)
+
+            if (currentWars.size >= maxWars) {
+                logger.warn("Guild $declaringGuildId has reached war limit: ${currentWars.size}/$maxWars")
+                return null
+            }
+
             val declaration = WarDeclaration(
                 declaringGuildId = declaringGuildId,
                 defendingGuildId = defendingGuildId,
-                proposedDuration = duration,
+                proposedDuration = effectiveWarDuration(duration),
                 objectives = objectives,
                 terms = terms,
                 wagerAmount = wagerAmount
@@ -162,17 +122,29 @@ class WarServiceBukkit(
     override fun acceptWarDeclaration(declarationId: UUID, actorId: UUID): War? {
         return try {
             val declaration = warDeclarations[declarationId] ?: return null
+            if (!declaration.isValid) {
+                logger.warn("Cannot accept expired/already-responded declaration $declarationId")
+                return null
+            }
 
+            // REQ-024: acceptance activates the war — status ACTIVE, startedAt set,
+            // declaration objectives carried over, stats initialized.
             val war = War.create(
                 declaringGuildId = declaration.declaringGuildId,
                 defendingGuildId = declaration.defendingGuildId,
                 duration = declaration.proposedDuration
+            ).copy(
+                status = WarStatus.ACTIVE,
+                startedAt = Instant.now(),
+                objectives = declaration.objectives
             )
 
             wars[war.id] = war
+            warStats[war.id] = WarStats(warId = war.id)
             warDeclarations.remove(declarationId)
 
-            logger.info("War accepted: ${war.id}")
+            logger.info("War accepted and ACTIVE: ${war.id} (${war.declaringGuildId} vs ${war.defendingGuildId})")
+            Bukkit.getPluginManager().callEvent(GuildWarDeclaredEvent(war.declaringGuildId, war.defendingGuildId, actorId))
             war
         } catch (e: Exception) {
             // In-memory operation - catching runtime exceptions from state validation
@@ -216,6 +188,9 @@ class WarServiceBukkit(
 
             // Apply war farming cooldown to the winner
             applyWarFarmingCooldown(war.declaringGuildId, war.defendingGuildId, winnerGuildId)
+
+            // Award configured win/lose XP (REQ-008)
+            awardWarExperience(winnerGuildId, loserGuildId)
 
             logger.info("War ended: $warId, winner: $winnerGuildId")
             Bukkit.getPluginManager().callEvent(GuildWarEndEvent(warId, winnerGuildId, loserGuildId, war.declaringGuildId, war.defendingGuildId))
@@ -327,10 +302,102 @@ class WarServiceBukkit(
         }
     }
 
+    /**
+     * Enforce the configured war duration cap (REQ-008): a war cannot last
+     * longer than `combat.war_duration_hours`.
+     */
+    private fun effectiveWarDuration(requested: Duration): Duration =
+        effectiveWarDuration(requested, configService.loadConfig().combat.warDurationHours)
+
+    /**
+     * The effective max simultaneous wars for a guild (REQ-008): the config
+     * `max_simultaneous_wars` base, refined upward by progression war-slot
+     * rewards at the guild's reached levels.
+     */
+    private fun maxWarsForGuild(guildId: UUID, configMax: Int): Int {
+        val progression = progressionRepository.getGuildProgression(guildId)
+        val progressionConfig = progressionConfigService.getProgressionConfig()
+        return maxWarsForGuild(
+            currentLevel = progression?.currentLevel,
+            configMax = configMax,
+            levelRewards = progressionConfig.getActiveLevelRewards()
+        )
+    }
+
+    /**
+     * Awards the configured war XP (REQ-008): `war_win_experience` to the
+     * winner, `war_lose_experience` to the loser. Best-effort; progression DB
+     * failures are logged, not thrown.
+     */
+    private fun awardWarExperience(winnerGuildId: UUID?, loserGuildId: UUID?) {
+        val combat = configService.loadConfig().combat
+        if (winnerGuildId != null && combat.warWinExperience > 0) {
+            awardGuildExperience(winnerGuildId, combat.warWinExperience)
+        }
+        if (loserGuildId != null && combat.warLoseExperience > 0) {
+            awardGuildExperience(loserGuildId, combat.warLoseExperience)
+        }
+    }
+
+    private fun awardGuildExperience(guildId: UUID, amount: Int) {
+        try {
+            val progression = progressionRepository.getGuildProgression(guildId) ?: return
+            progressionRepository.saveGuildProgression(
+                progression.copy(totalExperience = progression.totalExperience + amount)
+            )
+        } catch (e: Exception) {
+            logger.error("Failed to award $amount XP to guild $guildId", e)
+        }
+    }
+
+    /**
+     * Awards the configured kill XP (REQ-008) to the killer's guild for a war kill.
+     */
+    fun awardWarKillExperience(killerGuildId: UUID) {
+        val killXp = configService.loadConfig().combat.killExperience
+        if (killXp > 0) {
+            awardGuildExperience(killerGuildId, killXp)
+        }
+    }
+
+    /**
+     * Records a war kill for anti-farming enforcement and returns whether the
+     * kill should be treated as farming (REQ-008: `kill_cooldown_minutes` +
+     * `same_player_kill_limit`). Returns true when the same killer has already
+     * exceeded the per-victim kill limit within the cooldown window — callers
+     * should suppress XP/rewards for such kills.
+     */
+    fun recordWarKillAndCheckFarming(killerId: UUID, victimId: UUID): Boolean {
+        val combat = configService.loadConfig().combat
+        if (combat.killCooldownMinutes <= 0 || combat.samePlayerKillLimit <= 0) {
+            // Anti-farming disabled — always allow
+            return false
+        }
+
+        val now = Instant.now()
+        val cooldownStart = now.minusSeconds(combat.killCooldownMinutes * 60L)
+
+        val byVictim = killTracking.computeIfAbsent(killerId) { ConcurrentHashMap() }
+        val kills = byVictim.computeIfAbsent(victimId) { mutableListOf() }
+
+        synchronized(kills) {
+            // Drop timestamps outside the cooldown window
+            kills.removeAll { it.isBefore(cooldownStart) }
+            kills.add(now)
+
+            // Farming when the kill limit is exceeded within the window
+            return kills.size > combat.samePlayerKillLimit
+        }
+    }
+
+    /**
+     * Checks whether a guild is at or above the configured max simultaneous wars (REQ-008).
+     */
     override fun canGuildDeclareWar(guildId: UUID): Boolean {
-        // Basic check - guild not already in too many wars
-        val activeWars = wars.values.filter { it.isActive && (it.declaringGuildId == guildId || it.defendingGuildId == guildId) }.size
-        return activeWars < 3 // Max 3 simultaneous wars
+        val activeWars = wars.values.filter {
+            it.isActive && (it.declaringGuildId == guildId || it.defendingGuildId == guildId)
+        }.size
+        return activeWars < configService.loadConfig().combat.maxSimultaneousWars
     }
 
     override fun canPlayerManageWars(playerId: UUID, guildId: UUID): Boolean {
@@ -355,8 +422,14 @@ class WarServiceBukkit(
         expiredDeclarations.forEach { warDeclarations.remove(it.id) }
         processedCount += expiredDeclarations.size
 
-        // Process expired wars with draw logic
-        val expiredWars = wars.values.filter { it.isActive && it.isExpired }
+        // Process expired wars with draw logic.
+        // REQ-008: honour `war_end_grace_period_minutes` — a war is not force-ended
+        // until duration + grace period have both elapsed.
+        val graceSeconds = configService.loadConfig().combat.warEndGracePeriodMinutes * 60L
+        val expiredWars = wars.values.filter { war ->
+            war.isActive && war.startedAt != null &&
+                war.startedAt!!.plus(war.duration).plusSeconds(graceSeconds).isBefore(now)
+        }
         for (war in expiredWars) {
             if (checkForDrawCondition(war.id)) {
                 // End as draw and handle wager refunds
@@ -775,5 +848,30 @@ class WarServiceBukkit(
         val cooldownEnd = Instant.now().plusSeconds(cooldownHours * 3600)
         warDeclarationCooldowns[guildId] = cooldownEnd
         logger.info("Guild $guildId declared war - cooldown until $cooldownEnd")
+    }
+
+    companion object {
+        /**
+         * REQ-008: caps a requested war duration at `combat.war_duration_hours`.
+         */
+        fun effectiveWarDuration(requested: Duration, configWarDurationHours: Int): Duration {
+            val configDuration = Duration.ofHours(configWarDurationHours.toLong())
+            return if (requested > configDuration) configDuration else requested
+        }
+
+        /**
+         * REQ-008: effective max simultaneous wars = config `max_simultaneous_wars`
+         * base, refined upward by the highest progression war-slot reward among the
+         * levels the guild has reached. `levelRewards` is keyed by level number.
+         */
+        fun maxWarsForGuild(currentLevel: Int?, configMax: Int, levelRewards: Map<Int, net.lumalyte.lg.config.LevelRewardConfig>): Int {
+            if (currentLevel == null) return configMax
+            var maxWars = configMax
+            for (level in 1..currentLevel) {
+                val wars = levelRewards[level]?.warSlots ?: configMax
+                if (wars > maxWars) maxWars = wars
+            }
+            return maxWars
+        }
     }
 }

--- a/src/main/kotlin/net/lumalyte/lg/interaction/menus/bedrock/BedrockGuildWarDeclarationMenu.kt
+++ b/src/main/kotlin/net/lumalyte/lg/interaction/menus/bedrock/BedrockGuildWarDeclarationMenu.kt
@@ -178,93 +178,33 @@ class BedrockGuildWarDeclarationMenu(
             return
         }
 
-        // Handle wager escrow if there's a wager
-        if (wagerAmount > 0) {
-            // Check if guild has sufficient funds
-            val guildBalance = bankService.getBalance(guild.id)
-            if (guildBalance < wagerAmount) {
-                player.sendMessage(bedrockLocalization.getBedrockString(player, "guild.war.wager.insufficient.funds"))
-                player.sendMessage(bedrockLocalization.getBedrockString(player, "guild.war.wager.need.amount", wagerAmount))
-                player.sendMessage(bedrockLocalization.getBedrockString(player, "guild.war.wager.have.amount", guildBalance))
-                bedrockNavigator.goBack()
-                return
+        // REQ-024: no auto-accept — every declaration goes through the accept/decline
+        // flow. REQ-039: escrow is handled by the war service on acceptance; the menu
+        // no longer moves bank funds itself.
+        val declaration = warService.createWarDeclaration(
+            declaringGuildId = guild.id,
+            defendingGuildId = targetGuild.id,
+            duration = duration,
+            objectives = objectives,
+            wagerAmount = wagerAmount,
+            terms = if (terms.isNotBlank()) terms else null,
+            actorId = player.uniqueId
+        )
+
+        if (declaration != null) {
+            player.sendMessage(bedrockLocalization.getBedrockString(player, "guild.war.declaration.sent", targetGuild.name))
+            player.sendMessage(bedrockLocalization.getBedrockString(player, "guild.war.declaration.duration", duration.toDays()))
+            if (objectives.isNotEmpty()) {
+                player.sendMessage(bedrockLocalization.getBedrockString(player, "guild.war.declaration.objectives.set", objectives.size))
             }
-
-            // Check withdrawal permissions
-            if (!memberService.hasPermission(player.uniqueId, guild.id, RankPermission.WITHDRAW_FROM_BANK)) {
-                player.sendMessage(bedrockLocalization.getBedrockString(player, "guild.war.wager.no.permission"))
-                bedrockNavigator.goBack()
-                return
+            if (wagerAmount > 0) {
+                player.sendMessage(bedrockLocalization.getBedrockString(player, "guild.war.wager.display", wagerAmount))
             }
-
-            // Withdraw funds for escrow
-            val withdrawal = bankService.withdraw(
-                guildId = guild.id,
-                playerId = player.uniqueId,
-                amount = wagerAmount,
-                description = "War wager escrow vs ${targetGuild.name}"
-            )
-
-            if (withdrawal == null) {
-                player.sendMessage(bedrockLocalization.getBedrockString(player, "guild.war.wager.failed.secure"))
-                bedrockNavigator.goBack()
-                return
-            }
-        }
-
-        // Check if this should be auto-accepted (hostile guild with no wager)
-        val shouldAutoAccept = targetGuild.mode == GuildMode.HOSTILE && wagerAmount == 0
-
-        if (shouldAutoAccept) {
-            // Auto-accept for hostile guilds with no wager
-            val war = warService.declareWar(
-                declaringGuildId = guild.id,
-                defendingGuildId = targetGuild.id,
-                duration = duration,
-                objectives = objectives,
-                actorId = player.uniqueId
-            )
-
-            if (war != null) {
-                player.sendMessage(bedrockLocalization.getBedrockString(player, "guild.war.started.auto", targetGuild.name))
-                player.sendMessage(bedrockLocalization.getBedrockString(player, "guild.war.auto.accepted"))
-                bedrockNavigator.goBack()
-            } else {
-                player.sendMessage(bedrockLocalization.getBedrockString(player, "guild.war.declared.failed"))
-                bedrockNavigator.goBack()
-            }
+            player.sendMessage(bedrockLocalization.getBedrockString(player, "guild.war.declaration.await.accept"))
+            bedrockNavigator.goBack()
         } else {
-            // Create war declaration that requires acceptance (peaceful guilds or wagers)
-            val warServiceBukkit = warService as? net.lumalyte.lg.infrastructure.services.WarServiceBukkit
-            val declaration = warServiceBukkit?.createWarDeclaration(
-                declaringGuildId = guild.id,
-                defendingGuildId = targetGuild.id,
-                duration = duration,
-                objectives = objectives,
-                wagerAmount = wagerAmount,
-                terms = if (terms.isNotBlank()) terms else null,
-                actorId = player.uniqueId
-            )
-
-            if (declaration != null) {
-                player.sendMessage(bedrockLocalization.getBedrockString(player, "guild.war.declaration.sent", targetGuild.name))
-                player.sendMessage(bedrockLocalization.getBedrockString(player, "guild.war.declaration.duration", duration.toDays()))
-                if (objectives.isNotEmpty()) {
-                    player.sendMessage(bedrockLocalization.getBedrockString(player, "guild.war.declaration.objectives.set", objectives.size))
-                }
-                if (wagerAmount > 0) {
-                    player.sendMessage(bedrockLocalization.getBedrockString(player, "guild.war.wager.display", wagerAmount))
-                }
-                player.sendMessage(bedrockLocalization.getBedrockString(player, "guild.war.declaration.await.accept"))
-                bedrockNavigator.goBack()
-            } else {
-                player.sendMessage(bedrockLocalization.getBedrockString(player, "guild.war.declared.failed"))
-                // Refund wager if declaration failed
-                if (wagerAmount > 0) {
-                    bankService.deposit(guild.id, player.uniqueId, wagerAmount, "War declaration failed - refund")
-                }
-                bedrockNavigator.goBack()
-            }
+            player.sendMessage(bedrockLocalization.getBedrockString(player, "guild.war.declared.failed"))
+            bedrockNavigator.goBack()
         }
     }
 

--- a/src/main/kotlin/net/lumalyte/lg/interaction/menus/bedrock/BedrockGuildWarManagementMenu.kt
+++ b/src/main/kotlin/net/lumalyte/lg/interaction/menus/bedrock/BedrockGuildWarManagementMenu.kt
@@ -304,7 +304,15 @@ class BedrockGuildWarManagementMenu(
             Duration.ofDays(7)
         }
 
-        val success = warService.declareWar(guild.id, targetGuild.id, duration, emptySet(), player.uniqueId)
+        val success = warService.createWarDeclaration(
+            declaringGuildId = guild.id,
+            defendingGuildId = targetGuild.id,
+            duration = duration,
+            objectives = emptySet(),
+            wagerAmount = 0,
+            terms = null,
+            actorId = player.uniqueId
+        )
         if (success != null) {
             player.sendMessage(bedrockLocalization.getBedrockString(player, "guild.war.management.declare.war.declared", targetGuild.name))
         } else {
@@ -667,7 +675,9 @@ class BedrockGuildWarManagementMenu(
 
     private fun acceptWarDeclaration(warDeclaration: net.lumalyte.lg.domain.entities.WarDeclaration) {
         try {
-            // Handle wager matching if there's a wager
+            // REQ-039: escrow happens in the war service (acceptWarDeclaration →
+            // createWager deducts both guilds). The menu only pre-checks funds for
+            // a friendly error; it must NOT withdraw or create the wager itself.
             if (warDeclaration.wagerAmount > 0) {
                 // Refresh guild data to get current bank balance
                 val currentGuild = guildService.getGuild(guild.id)
@@ -693,36 +703,12 @@ class BedrockGuildWarManagementMenu(
                     openWarDeclarationsMenu()
                     return
                 }
-
-                // Get declaring guild info for description
-                val declaringGuild = guildService.getGuild(warDeclaration.declaringGuildId)
-                val declaringGuildName = declaringGuild?.name ?: "Unknown"
-
-                // Withdraw matching wager amount from defending guild's bank
-                val withdrawal = bankService.withdraw(
-                    guildId = currentGuild.id,
-                    playerId = player.uniqueId,
-                    amount = warDeclaration.wagerAmount,
-                    description = "War wager match vs $declaringGuildName"
-                )
-
-                if (withdrawal == null) {
-                    player.sendMessage(bedrockLocalization.getBedrockString(player, "guild.war.wager.failed.withdraw"))
-                    openWarDeclarationsMenu()
-                    return
-                }
             }
 
             val war = warService.acceptWarDeclaration(warDeclaration.id, player.uniqueId)
             if (war != null) {
-                // Create wager if both guilds put up funds
                 if (warDeclaration.wagerAmount > 0) {
-                    val wager = warService.createWager(
-                        warId = war.id,
-                        declaringGuildWager = warDeclaration.wagerAmount,
-                        defendingGuildWager = warDeclaration.wagerAmount
-                    )
-
+                    val wager = warService.getWager(war.id)
                     if (wager != null) {
                         player.sendMessage(bedrockLocalization.getBedrockString(player, "guild.war.accepted"))
                         player.sendMessage(bedrockLocalization.getBedrockString(player, "guild.war.wager.pot.total", wager.totalPot))

--- a/src/main/kotlin/net/lumalyte/lg/interaction/menus/guild/GuildWarAcceptanceMenu.kt
+++ b/src/main/kotlin/net/lumalyte/lg/interaction/menus/guild/GuildWarAcceptanceMenu.kt
@@ -186,7 +186,9 @@ class GuildWarAcceptanceMenu(
 
     private fun acceptWarDeclaration() {
         try {
-            // Handle wager matching if there's a wager
+            // REQ-039: escrow happens in the war service (acceptWarDeclaration →
+            // createWager deducts both guilds). The menu only pre-checks funds for
+            // a friendly error; it must NOT withdraw or create the wager itself.
             if (warDeclaration.wagerAmount > 0) {
                 // Refresh guild data to get current bank balance
                 guild = guildService.getGuild(guild.id) ?: run {
@@ -211,45 +213,18 @@ class GuildWarAcceptanceMenu(
                     player.playSound(player.location, Sound.ENTITY_VILLAGER_NO, 1.0f, 1.0f)
                     return
                 }
-
-                // Get declaring guild info for description
-                val declaringGuild = guildService.getGuild(warDeclaration.declaringGuildId)
-                val declaringGuildName = declaringGuild?.name ?: "Unknown"
-
-                // Withdraw matching wager amount from defending guild's bank
-                val withdrawal = bankService.withdraw(
-                    guildId = guild.id,
-                    playerId = player.uniqueId,
-                    amount = warDeclaration.wagerAmount,
-                    description = "War wager match vs $declaringGuildName"
-                )
-
-                if (withdrawal == null) {
-                    player.sendMessage("§c❌ Failed to withdraw wager funds from guild bank!")
-                    player.playSound(player.location, Sound.ENTITY_VILLAGER_NO, 1.0f, 1.0f)
-                    return
-                }
             }
 
             val war = warService.acceptWarDeclaration(warDeclaration.id, player.uniqueId)
             if (war != null) {
-                // Create wager if both guilds put up funds
+                player.sendMessage("§a⚔ War accepted! Battle begins now!")
                 if (warDeclaration.wagerAmount > 0) {
-                    val wager = warService.createWager(
-                        warId = war.id,
-                        declaringGuildWager = warDeclaration.wagerAmount,
-                        defendingGuildWager = warDeclaration.wagerAmount
-                    )
-
+                    val wager = warService.getWager(war.id)
                     if (wager != null) {
-                        player.sendMessage("§a⚔ War accepted! Battle begins now!")
                         player.sendMessage("§6💰 War pot: ${wager.totalPot} gold (winner takes all!)")
                     } else {
-                        player.sendMessage("§a⚔ War accepted! Battle begins now!")
                         player.sendMessage("§e⚠ Warning: Failed to create wager escrow")
                     }
-                } else {
-                    player.sendMessage("§a⚔ War accepted! Battle begins now!")
                 }
 
                 player.sendMessage("§7Duration: §f${war.duration.toDays()} days")

--- a/src/main/kotlin/net/lumalyte/lg/interaction/menus/guild/GuildWarDeclarationMenu.kt
+++ b/src/main/kotlin/net/lumalyte/lg/interaction/menus/guild/GuildWarDeclarationMenu.kt
@@ -505,132 +505,48 @@ class GuildWarDeclarationMenu(
                 return
             }
 
-            // Handle wager escrow if there's a wager
-            if (wagerAmount > 0) {
-                // Check if guild has sufficient funds
-                val currentBalance = bankService.getBalance(guild.id)
-                if (currentBalance < wagerAmount) {
-                    player.sendMessage("§c❌ Insufficient guild bank funds for wager!")
-                    player.sendMessage("§7Need: §6$wagerAmount coins")
-                    player.sendMessage("§7Have: §6$currentBalance coins")
-                    player.playSound(player.location, Sound.ENTITY_VILLAGER_NO, 1.0f, 1.0f)
-                    return
+            // REQ-024: no auto-accept — every declaration goes through the
+            // accept/decline flow. REQ-039: escrow is handled by the war service
+            // (createWager deducts both guilds on acceptance); the menu no longer
+            // moves bank funds itself.
+            val declaration = warService.createWarDeclaration(
+                declaringGuildId = guild.id,
+                defendingGuildId = target.id,
+                duration = selectedDuration,
+                objectives = selectedObjectives,
+                wagerAmount = wagerAmount,
+                terms = warTerms,
+                actorId = player.uniqueId
+            )
+
+            if (declaration != null) {
+                player.sendMessage("§6⚔ WAR DECLARATION SENT to ${target.name}!")
+                player.sendMessage("§7Duration: §f${selectedDuration.toDays()} days")
+                if (selectedObjectives.isNotEmpty()) {
+                    player.sendMessage("§7Objectives: §f${selectedObjectives.size} set")
                 }
-
-                // Check withdrawal permissions
-                if (!memberService.hasPermission(player.uniqueId, guild.id, RankPermission.WITHDRAW_FROM_BANK)) {
-                    player.sendMessage("§c❌ You don't have permission to withdraw from guild bank for wagers!")
-                    player.playSound(player.location, Sound.ENTITY_VILLAGER_NO, 1.0f, 1.0f)
-                    return
+                if (wagerAmount > 0) {
+                    player.sendMessage("§7Wager: §6$wagerAmount coins §7(escrowed on acceptance)")
                 }
+                player.sendMessage("§7They must accept your declaration for war to begin.")
+                player.playSound(player.location, Sound.UI_BUTTON_CLICK, 1.0f, 1.0f)
 
-                // Withdraw funds for escrow (this will be implemented in the war service)
-                val withdrawal = bankService.withdraw(
-                    guildId = guild.id,
-                    playerId = player.uniqueId,
-                    amount = wagerAmount,
-                    description = "War wager escrow vs ${target.name}"
-                )
+                // Close menu and return to war management
+                player.closeInventory()
+                menuNavigator.openMenu(menuFactory.createGuildWarManagementMenu(menuNavigator, player, guild))
 
-                if (withdrawal == null) {
-                    player.sendMessage("§c❌ Failed to secure wager funds!")
-                    player.playSound(player.location, Sound.ENTITY_VILLAGER_NO, 1.0f, 1.0f)
-                    return
-                }
-            }
-
-            // Check if this should be auto-accepted (hostile guild with no wager)
-            val shouldAutoAccept = target.mode == GuildMode.HOSTILE && wagerAmount == 0
-
-            if (shouldAutoAccept) {
-                // Auto-accept for hostile guilds with no wager
-                val war = warService.declareWar(
-                    declaringGuildId = guild.id,
-                    defendingGuildId = target.id,
-                    duration = selectedDuration,
-                    objectives = selectedObjectives,
-                    actorId = player.uniqueId
-                )
-
-                if (war != null) {
-                    player.sendMessage("§a⚔ WAR STARTED against ${target.name}!")
-                    player.sendMessage("§7Hostile guild auto-accepted - battle begins now!")
-                    player.sendMessage("§7Duration: §f${selectedDuration.toDays()} days")
-                    if (selectedObjectives.isNotEmpty()) {
-                        player.sendMessage("§7Objectives: §f${selectedObjectives.size} set")
-                    }
-                    player.playSound(player.location, Sound.ENTITY_ENDER_DRAGON_GROWL, 1.0f, 0.8f)
-
-                    // Close menu and return to war management
-                    player.closeInventory()
-                    menuNavigator.openMenu(menuFactory.createGuildWarManagementMenu(menuNavigator, player, guild))
-
-                    // Notify both guilds
-                    notifyGuildsOfWarDeclaration(war)
-                    return
-                } else {
-                    refundWager()
-                    player.sendMessage("§c❌ Failed to declare war!")
-                    player.playSound(player.location, Sound.ENTITY_VILLAGER_NO, 1.0f, 1.0f)
-                    return
-                }
+                // Notify defending guild of the declaration
+                notifyGuildOfWarDeclaration(declaration)
+                return
             } else {
-                // Create war declaration that requires acceptance (peaceful guilds or wagers)
-                // Cast to access the internal method (this should be added to the interface)
-                val warServiceBukkit = warService as? net.lumalyte.lg.infrastructure.services.WarServiceBukkit
-                val declaration = warServiceBukkit?.createWarDeclaration(
-                    declaringGuildId = guild.id,
-                    defendingGuildId = target.id,
-                    duration = selectedDuration,
-                    objectives = selectedObjectives,
-                    wagerAmount = wagerAmount,
-                    terms = warTerms,
-                    actorId = player.uniqueId
-                )
-
-                if (declaration != null) {
-                    player.sendMessage("§6⚔ WAR DECLARATION SENT to ${target.name}!")
-                    player.sendMessage("§7Duration: §f${selectedDuration.toDays()} days")
-                    if (selectedObjectives.isNotEmpty()) {
-                        player.sendMessage("§7Objectives: §f${selectedObjectives.size} set")
-                    }
-                    if (wagerAmount > 0) {
-                        player.sendMessage("§7Wager: §6$wagerAmount coins §7(awaiting their match)")
-                    }
-                    player.sendMessage("§7They must accept your declaration for war to begin.")
-                    player.playSound(player.location, Sound.UI_BUTTON_CLICK, 1.0f, 1.0f)
-
-                    // Close menu and return to war management
-                    player.closeInventory()
-                    menuNavigator.openMenu(menuFactory.createGuildWarManagementMenu(menuNavigator, player, guild))
-
-                    // Notify defending guild of the declaration
-                    notifyGuildOfWarDeclaration(declaration)
-                    return
-                } else {
-                    refundWager()
-                    player.sendMessage("§c❌ Failed to send war declaration!")
-                    player.playSound(player.location, Sound.ENTITY_VILLAGER_NO, 1.0f, 1.0f)
-                    return
-                }
+                player.sendMessage("§c❌ Failed to send war declaration!")
+                player.playSound(player.location, Sound.ENTITY_VILLAGER_NO, 1.0f, 1.0f)
+                return
             }
         } catch (e: Exception) {
             // Menu operation - catching all exceptions to prevent UI failure
             player.sendMessage("§c❌ Error declaring war: ${e.message}")
             player.playSound(player.location, Sound.ENTITY_VILLAGER_NO, 1.0f, 1.0f)
-
-            refundWager()
-        }
-    }
-
-    private fun refundWager() {
-        if (wagerAmount > 0) {
-            try {
-                bankService.deposit(guild.id, player.uniqueId, wagerAmount, "War wager refund (declaration failed)")
-                player.sendMessage("§7Wager funds have been refunded.")
-            } catch (refundError: Exception) {
-                player.sendMessage("§c❌ Failed to refund wager! Contact an administrator.")
-            }
         }
     }
 
@@ -702,96 +618,6 @@ class GuildWarDeclarationMenu(
             }
         )
         menuNavigator.openMenu(guildListMenu)
-    }
-
-    private fun notifyGuildsOfWarDeclaration(war: War) {
-        try {
-            val declaringGuild = guildService.getGuild(war.declaringGuildId)
-            val defendingGuild = guildService.getGuild(war.defendingGuildId)
-            
-            if (declaringGuild == null || defendingGuild == null) {
-                return
-            }
-
-            // Get all online members of both guilds
-            val declaringMembers = memberService.getGuildMembers(war.declaringGuildId)
-            val defendingMembers = memberService.getGuildMembers(war.defendingGuildId)
-
-            // Notify declaring guild members
-            declaringMembers.forEach { member ->
-                val onlinePlayer = org.bukkit.Bukkit.getPlayer(member.playerId)
-                if (onlinePlayer != null && onlinePlayer.isOnline) {
-                    // Title and subtitle
-                    onlinePlayer.showTitle(Title.title(
-                        Component.text("§4⚔ WAR DECLARED! ⚔"),
-                        Component.text("§7Against §c${defendingGuild.name}"),
-                        Title.Times.times(JavaDuration.ofMillis(500), JavaDuration.ofSeconds(3), JavaDuration.ofSeconds(1))
-                    ))
-                    
-                    // Chat messages
-                    onlinePlayer.sendMessage("§8§l▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬")
-                    onlinePlayer.sendMessage("§4⚔ §lWAR DECLARED! §4⚔")
-                    onlinePlayer.sendMessage("")
-                    onlinePlayer.sendMessage("§7Your guild §f${declaringGuild.name} §7has declared war on §c${defendingGuild.name}§7!")
-                    onlinePlayer.sendMessage("§7Duration: §f${war.duration.toDays()} days")
-                    if (war.objectives.isNotEmpty()) {
-                        onlinePlayer.sendMessage("§7Objectives: §f${war.objectives.size} war goals set")
-                    }
-                    if (wagerAmount > 0) {
-                        onlinePlayer.sendMessage("§7Wager: §6$wagerAmount coins §7(escrowed)")
-                    }
-                    onlinePlayer.sendMessage("")
-                    onlinePlayer.sendMessage("§e⚡ Prepare for battle! Victory brings honor and rewards!")
-                    onlinePlayer.sendMessage("§8§l▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬")
-                    
-                    // Dramatic sound
-                    onlinePlayer.playSound(onlinePlayer.location, org.bukkit.Sound.ENTITY_ENDER_DRAGON_GROWL, 1.0f, 0.8f)
-                    onlinePlayer.playSound(onlinePlayer.location, org.bukkit.Sound.ENTITY_LIGHTNING_BOLT_THUNDER, 0.7f, 1.2f)
-                }
-            }
-
-            // Notify defending guild members
-            defendingMembers.forEach { member ->
-                val onlinePlayer = org.bukkit.Bukkit.getPlayer(member.playerId)
-                if (onlinePlayer != null && onlinePlayer.isOnline) {
-                    // Title and subtitle
-                    onlinePlayer.showTitle(Title.title(
-                        Component.text("§c⚠︎ UNDER ATTACK! ⚠︎"),
-                        Component.text("§7War declared by §4${declaringGuild.name}"),
-                        Title.Times.times(JavaDuration.ofMillis(500), JavaDuration.ofSeconds(3), JavaDuration.ofSeconds(1))
-                    ))
-                    
-                    // Chat messages
-                    onlinePlayer.sendMessage("§8§l▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬")
-                    onlinePlayer.sendMessage("§c⚠︎ §lWAR DECLARED AGAINST YOU! §c⚠︎")
-                    onlinePlayer.sendMessage("")
-                    onlinePlayer.sendMessage("§c${declaringGuild.name} §7has declared war on your guild §f${defendingGuild.name}§7!")
-                    onlinePlayer.sendMessage("§7Duration: §f${war.duration.toDays()} days")
-                    if (war.objectives.isNotEmpty()) {
-                        onlinePlayer.sendMessage("§7Enemy Objectives: §f${war.objectives.size} goals")
-                    }
-                    if (wagerAmount > 0) {
-                        onlinePlayer.sendMessage("§7Enemy Wager: §6$wagerAmount coins")
-                        onlinePlayer.sendMessage("§7You must match this wager to accept!")
-                    }
-                    onlinePlayer.sendMessage("")
-                    onlinePlayer.sendMessage("§e▊ Defend your guild! Rally your members and fight back!")
-                    onlinePlayer.sendMessage("§7Use §f/guild war §7to manage the conflict")
-                    onlinePlayer.sendMessage("§8§l▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬")
-                    
-                    // Alert sounds
-                    onlinePlayer.playSound(onlinePlayer.location, org.bukkit.Sound.BLOCK_BELL_USE, 1.0f, 0.8f)
-                    onlinePlayer.playSound(onlinePlayer.location, org.bukkit.Sound.ENTITY_LIGHTNING_BOLT_THUNDER, 0.7f, 1.0f)
-                }
-            }
-
-            // Log to console
-            org.bukkit.Bukkit.getLogger().info("WAR DECLARED: ${declaringGuild.name} vs ${defendingGuild.name} (${war.duration.toDays()} days)")
-            
-        } catch (e: Exception) {
-            // Menu operation - catching all exceptions to prevent UI failure
-            org.bukkit.Bukkit.getLogger().warning("Failed to notify guilds of war declaration: ${e.message}")
-        }
     }
 
     private fun addBackButton(pane: StaticPane, x: Int, y: Int) {

--- a/src/test/kotlin/net/lumalyte/lg/infrastructure/services/WarConfigEnforcementTest.kt
+++ b/src/test/kotlin/net/lumalyte/lg/infrastructure/services/WarConfigEnforcementTest.kt
@@ -2,11 +2,10 @@ package net.lumalyte.lg.infrastructure.services
 
 import net.lumalyte.lg.application.persistence.ProgressionRepository
 import net.lumalyte.lg.application.services.ConfigService
-import net.lumalyte.lg.application.services.WarService
 import net.lumalyte.lg.config.CombatConfig
 import net.lumalyte.lg.config.LevelRewardConfig
 import net.lumalyte.lg.config.MainConfig
-import net.lumalyte.lg.domain.entities.War
+import net.lumalyte.lg.domain.entities.GuildProgression
 import net.lumalyte.lg.domain.entities.WarStatus
 import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.Assertions.assertEquals
@@ -19,17 +18,18 @@ import io.mockk.every
 import io.mockk.mockk
 import io.mockk.mockkStatic
 import io.mockk.unmockkStatic
+import io.mockk.verify
 import org.bukkit.Bukkit
 import java.time.Duration
-import java.time.Instant
 import java.util.UUID
 
 /**
  * REQ-008: the combat configuration must actually be enforced —
  * `war_duration_hours` caps declared war length, `max_simultaneous_wars`
  * (refined by progression) limits concurrent wars, `war_end_grace_period_minutes`
- * delays force-end, and `kill_cooldown_minutes` + `same_player_kill_limit`
- * suppress farmed-kill XP.
+ * delays force-end, `kill_cooldown_minutes` + `same_player_kill_limit` suppress
+ * farmed-kill XP, and win/lose/kill XP is awarded. REQ-024: declarations require
+ * accept/decline. REQ-039: wagers are escrowed on acceptance.
  */
 class WarConfigEnforcementTest {
 
@@ -106,15 +106,23 @@ class WarConfigEnforcementTest {
     }
 
     @Test
-    fun `declareWar creates a pending declaration, not an active war`() {
+    fun `createWarDeclaration creates a pending declaration, not an active war`() {
         val service = newService(mockk())
 
         val declaring = UUID.randomUUID()
         val defending = UUID.randomUUID()
 
-        val declaration = service.declareWar(declaring, defending, Duration.ofDays(7), emptySet(), UUID.randomUUID())
+        val declaration = service.createWarDeclaration(
+            declaringGuildId = declaring,
+            defendingGuildId = defending,
+            duration = Duration.ofDays(7),
+            objectives = emptySet(),
+            wagerAmount = 0,
+            terms = null,
+            actorId = UUID.randomUUID()
+        )
 
-        assertNotNull(declaration, "declareWar must create a declaration (REQ-024)")
+        assertNotNull(declaration, "declaration must be created (REQ-024)")
         assertEquals(declaring, declaration!!.declaringGuildId)
         assertEquals(defending, declaration.defendingGuildId)
         assertNull(service.getCurrentWarBetweenGuilds(declaring, defending), "no active war may exist before acceptance")
@@ -196,11 +204,130 @@ class WarConfigEnforcementTest {
     }
 
     @Test
-    fun `farming detection is per victim - different victims are not flagged`() {
+    fun `farming detection is per victim - same killer different victims are not flagged`() {
         val service = newServiceWithCombat(CombatConfig(killCooldownMinutes = 5, samePlayerKillLimit = 1))
 
-        assertFalse(service.recordWarKillAndCheckFarming(UUID.randomUUID(), UUID.randomUUID()))
-        assertFalse(service.recordWarKillAndCheckFarming(UUID.randomUUID(), UUID.randomUUID()))
+        val killer = UUID.randomUUID()
+        val victimA = UUID.randomUUID()
+        val victimB = UUID.randomUUID()
+
+        // Each victim is a distinct key: killing A then B must not flag, even
+        // though the same killer exceeds the limit for A.
+        assertFalse(service.recordWarKillAndCheckFarming(killer, victimA))
+        assertFalse(service.recordWarKillAndCheckFarming(killer, victimB))
+        // Killing A again (limit 1) IS farming for that victim
+        assertTrue(service.recordWarKillAndCheckFarming(killer, victimA))
+    }
+
+    // ---------- grace period + XP + escrow (REQ-008 / REQ-039) ----------
+
+    @Test
+    fun `war is force-ended only after duration plus grace period`() {
+        mockBukkitPluginManager()
+        val service = newService(mockk())
+
+        val declaring = UUID.randomUUID()
+        val defending = UUID.randomUUID()
+        // Accept a war with a tiny duration: with the 30-min default grace it
+        // cannot be expired immediately regardless of wall-clock drift.
+        val declaration = service.createWarDeclaration(
+            declaringGuildId = declaring,
+            defendingGuildId = defending,
+            duration = Duration.ofSeconds(1),
+            objectives = emptySet(),
+            wagerAmount = 0,
+            terms = null,
+            actorId = UUID.randomUUID()
+        )!!
+        val accepted = service.acceptWarDeclaration(declaration.id, UUID.randomUUID())!!
+        // War has started; with grace 30min and duration 1s it cannot be expired
+        // immediately regardless of wall-clock drift in the test.
+        val processed = service.processExpiredWars()
+        assertEquals(0, processed, "war inside grace period must not be force-ended")
+        assertNotNull(service.getWar(accepted.id))
+    }
+
+    @Test
+    fun `win and lose XP are awarded to both guilds on war end`() {
+        val progressionRepo = mockk<ProgressionRepository>(relaxed = true)
+        val configService = mockk<ConfigService>()
+        val config = mockk<MainConfig>()
+        every { config.combat } returns CombatConfig(warWinExperience = 500, warLoseExperience = 100)
+        every { configService.loadConfig() } returns config
+
+        val winnerProgression = GuildProgression(guildId = UUID.randomUUID(), currentLevel = 1, totalExperience = 0)
+        val loserProgression = GuildProgression(guildId = UUID.randomUUID(), currentLevel = 1, totalExperience = 0)
+        every { progressionRepo.getGuildProgression(winnerProgression.guildId) } returns winnerProgression
+        every { progressionRepo.getGuildProgression(loserProgression.guildId) } returns loserProgression
+
+        val service = WarServiceBukkit(
+            configService = configService,
+            bankService = mockk(relaxed = true),
+            progressionRepository = progressionRepo,
+            progressionConfigService = mockk(relaxed = true)
+        )
+        mockBukkitPluginManager()
+
+        val declaration = service.createWarDeclaration(
+            declaringGuildId = winnerProgression.guildId,
+            defendingGuildId = loserProgression.guildId,
+            duration = Duration.ofDays(7),
+            objectives = emptySet(),
+            wagerAmount = 0,
+            terms = null,
+            actorId = UUID.randomUUID()
+        )!!
+        val war = service.acceptWarDeclaration(declaration.id, UUID.randomUUID())!!
+
+        service.endWar(war.id, winnerProgression.guildId, actorId = UUID.randomUUID())
+
+        // 500 to winner, 100 to loser
+        verify { progressionRepo.saveGuildProgression(
+            match { it.guildId == winnerProgression.guildId && it.totalExperience == 500 }) }
+        verify { progressionRepo.saveGuildProgression(
+            match { it.guildId == loserProgression.guildId && it.totalExperience == 100 }) }
+    }
+
+    @Test
+    fun `wager is escrowed on acceptance - both guilds deducted`() {
+        val bankService = mockk<net.lumalyte.lg.application.services.BankService>(relaxed = true)
+        val configService = mockk<ConfigService>()
+        val config = mockk<MainConfig>()
+        every { config.combat } returns CombatConfig()
+        every { configService.loadConfig() } returns config
+
+        val service = WarServiceBukkit(
+            configService = configService,
+            bankService = bankService,
+            progressionRepository = mockk<ProgressionRepository>(relaxed = true),
+            progressionConfigService = mockk(relaxed = true)
+        )
+        mockBukkitPluginManager()
+
+        val declaring = UUID.randomUUID()
+        val defending = UUID.randomUUID()
+        every { bankService.getBalance(any()) } returns 10_000
+        // Relaxed mock would return false for Boolean — stubbing success so the
+        // escrow deduction path proceeds.
+        every { bankService.deductFromGuildBank(any(), any(), any()) } returns true
+        every { bankService.creditToGuildBank(any(), any(), any()) } returns true
+
+        val declaration = service.createWarDeclaration(
+            declaringGuildId = declaring,
+            defendingGuildId = defending,
+            duration = Duration.ofDays(7),
+            objectives = emptySet(),
+            wagerAmount = 500,
+            terms = null,
+            actorId = UUID.randomUUID()
+        )!!
+        val war = service.acceptWarDeclaration(declaration.id, UUID.randomUUID())!!
+
+        val wager = service.getWager(war.id)
+        assertNotNull(wager, "wager must be created on acceptance (REQ-039)")
+        assertEquals(1_000, wager!!.totalPot)
+        verify { bankService.deductFromGuildBank(declaring, 500, any()) }
+        verify { bankService.deductFromGuildBank(defending, 500, any()) }
     }
 
     private fun levelReward(warSlots: Int = 0, bankLimit: Int = 0) =

--- a/src/test/kotlin/net/lumalyte/lg/infrastructure/services/WarConfigEnforcementTest.kt
+++ b/src/test/kotlin/net/lumalyte/lg/infrastructure/services/WarConfigEnforcementTest.kt
@@ -1,0 +1,208 @@
+package net.lumalyte.lg.infrastructure.services
+
+import net.lumalyte.lg.application.persistence.ProgressionRepository
+import net.lumalyte.lg.application.services.ConfigService
+import net.lumalyte.lg.application.services.WarService
+import net.lumalyte.lg.config.CombatConfig
+import net.lumalyte.lg.config.LevelRewardConfig
+import net.lumalyte.lg.config.MainConfig
+import net.lumalyte.lg.domain.entities.War
+import net.lumalyte.lg.domain.entities.WarStatus
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertFalse
+import org.junit.jupiter.api.Assertions.assertNotNull
+import org.junit.jupiter.api.Assertions.assertNull
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.mockkStatic
+import io.mockk.unmockkStatic
+import org.bukkit.Bukkit
+import java.time.Duration
+import java.time.Instant
+import java.util.UUID
+
+/**
+ * REQ-008: the combat configuration must actually be enforced —
+ * `war_duration_hours` caps declared war length, `max_simultaneous_wars`
+ * (refined by progression) limits concurrent wars, `war_end_grace_period_minutes`
+ * delays force-end, and `kill_cooldown_minutes` + `same_player_kill_limit`
+ * suppress farmed-kill XP.
+ */
+class WarConfigEnforcementTest {
+
+    // ---------- pure decision helpers (no Bukkit) ----------
+
+    @Test
+    fun `requested duration below config cap is kept`() {
+        assertEquals(
+            Duration.ofDays(3),
+            WarServiceBukkit.effectiveWarDuration(Duration.ofDays(3), configWarDurationHours = 168)
+        )
+    }
+
+    @Test
+    fun `requested duration above config cap is clamped`() {
+        assertEquals(
+            Duration.ofDays(7),
+            WarServiceBukkit.effectiveWarDuration(Duration.ofDays(14), configWarDurationHours = 168)
+        )
+    }
+
+    @Test
+    fun `max wars defaults to config when no progression row exists`() {
+        assertEquals(
+            3,
+            WarServiceBukkit.maxWarsForGuild(currentLevel = null, configMax = 3, levelRewards = emptyMap())
+        )
+    }
+
+    @Test
+    fun `max wars is refined upward by progression war slots`() {
+        val rewards = mapOf(
+            1 to levelReward(warSlots = 0),
+            2 to levelReward(warSlots = 5),
+            3 to levelReward(warSlots = 4)
+        )
+        assertEquals(
+            5,
+            WarServiceBukkit.maxWarsForGuild(currentLevel = 3, configMax = 3, levelRewards = rewards)
+        )
+    }
+
+    @Test
+    fun `max wars never drops below the config base`() {
+        val rewards = mapOf(1 to levelReward(warSlots = 1), 2 to levelReward(warSlots = 0))
+        assertEquals(
+            3,
+            WarServiceBukkit.maxWarsForGuild(currentLevel = 2, configMax = 3, levelRewards = rewards)
+        )
+    }
+
+    // ---------- declaration flow (REQ-024: no auto-accept) ----------
+
+    private fun newService(configService: ConfigService): WarServiceBukkit {
+        val config = mockk<MainConfig>()
+        every { config.combat } returns CombatConfig()
+        every { configService.loadConfig() } returns config
+        return WarServiceBukkit(
+            configService = configService,
+            bankService = mockk(relaxed = true),
+            progressionRepository = mockk<ProgressionRepository>(relaxed = true),
+            progressionConfigService = mockk(relaxed = true)
+        )
+    }
+
+    @AfterEach
+    fun tearDown() {
+        unmockkStatic(Bukkit::class)
+    }
+
+    private fun mockBukkitPluginManager() {
+        mockkStatic(Bukkit::class)
+        every { Bukkit.getPluginManager() } returns mockk(relaxed = true)
+    }
+
+    @Test
+    fun `declareWar creates a pending declaration, not an active war`() {
+        val service = newService(mockk())
+
+        val declaring = UUID.randomUUID()
+        val defending = UUID.randomUUID()
+
+        val declaration = service.declareWar(declaring, defending, Duration.ofDays(7), emptySet(), UUID.randomUUID())
+
+        assertNotNull(declaration, "declareWar must create a declaration (REQ-024)")
+        assertEquals(declaring, declaration!!.declaringGuildId)
+        assertEquals(defending, declaration.defendingGuildId)
+        assertNull(service.getCurrentWarBetweenGuilds(declaring, defending), "no active war may exist before acceptance")
+        assertNotNull(service.getPendingDeclarationsForGuild(defending).firstOrNull { it.id == declaration.id })
+    }
+
+    @Test
+    fun `acceptWarDeclaration activates the war with declaration data`() {
+        mockBukkitPluginManager()
+        val service = newService(mockk())
+
+        val declaring = UUID.randomUUID()
+        val defending = UUID.randomUUID()
+
+        val declaration = service.createWarDeclaration(
+            declaringGuildId = declaring,
+            defendingGuildId = defending,
+            duration = Duration.ofDays(7),
+            objectives = emptySet(),
+            wagerAmount = 0,
+            terms = null,
+            actorId = UUID.randomUUID()
+        )!!
+
+        val war = service.acceptWarDeclaration(declaration.id, UUID.randomUUID())
+
+        assertNotNull(war)
+        assertEquals(WarStatus.ACTIVE, war!!.status)
+        assertNotNull(war.startedAt)
+        assertTrue(service.getCurrentWarBetweenGuilds(declaring, defending)?.id == war.id)
+    }
+
+    @Test
+    fun `rejectWarDeclaration removes the declaration without creating a war`() {
+        val service = newService(mockk())
+
+        val declaration = service.createWarDeclaration(
+            declaringGuildId = UUID.randomUUID(),
+            defendingGuildId = UUID.randomUUID(),
+            duration = Duration.ofDays(7),
+            objectives = emptySet(),
+            wagerAmount = 0,
+            terms = null,
+            actorId = UUID.randomUUID()
+        )!!
+
+        assertTrue(service.rejectWarDeclaration(declaration.id, UUID.randomUUID()))
+        assertNull(service.getCurrentWarBetweenGuilds(declaration.declaringGuildId, declaration.defendingGuildId))
+    }
+
+    // ---------- anti-farming (REQ-008) ----------
+
+    private fun newServiceWithCombat(combat: CombatConfig): WarServiceBukkit {
+        val configService = mockk<ConfigService>()
+        val config = mockk<MainConfig>()
+        every { config.combat } returns combat
+        every { configService.loadConfig() } returns config
+        return WarServiceBukkit(
+            configService = configService,
+            bankService = mockk(relaxed = true),
+            progressionRepository = mockk<ProgressionRepository>(relaxed = true),
+            progressionConfigService = mockk(relaxed = true)
+        )
+    }
+
+    @Test
+    fun `farming detection flags kills beyond the per-victim limit within cooldown`() {
+        val service = newServiceWithCombat(CombatConfig(killCooldownMinutes = 5, samePlayerKillLimit = 3))
+
+        val killer = UUID.randomUUID()
+        val victim = UUID.randomUUID()
+
+        // First `samePlayerKillLimit` kills are legitimate
+        assertFalse(service.recordWarKillAndCheckFarming(killer, victim))
+        assertFalse(service.recordWarKillAndCheckFarming(killer, victim))
+        assertFalse(service.recordWarKillAndCheckFarming(killer, victim))
+        // Fourth kill within the cooldown window is farming
+        assertTrue(service.recordWarKillAndCheckFarming(killer, victim))
+    }
+
+    @Test
+    fun `farming detection is per victim - different victims are not flagged`() {
+        val service = newServiceWithCombat(CombatConfig(killCooldownMinutes = 5, samePlayerKillLimit = 1))
+
+        assertFalse(service.recordWarKillAndCheckFarming(UUID.randomUUID(), UUID.randomUUID()))
+        assertFalse(service.recordWarKillAndCheckFarming(UUID.randomUUID(), UUID.randomUUID()))
+    }
+
+    private fun levelReward(warSlots: Int = 0, bankLimit: Int = 0) =
+        LevelRewardConfig(warSlots = warSlots, bankLimit = bankLimit)
+}

--- a/src/test/kotlin/net/lumalyte/lg/infrastructure/services/WarConfigEnforcementTest.kt
+++ b/src/test/kotlin/net/lumalyte/lg/infrastructure/services/WarConfigEnforcementTest.kt
@@ -330,6 +330,52 @@ class WarConfigEnforcementTest {
         verify { bankService.deductFromGuildBank(defending, 500, any()) }
     }
 
+    @Test
+    fun `acceptance fails atomically when wager escrow cannot be funded`() {
+        val bankService = mockk<net.lumalyte.lg.application.services.BankService>(relaxed = true)
+        val configService = mockk<ConfigService>()
+        val config = mockk<MainConfig>()
+        every { config.combat } returns CombatConfig()
+        every { configService.loadConfig() } returns config
+
+        val service = WarServiceBukkit(
+            configService = configService,
+            bankService = bankService,
+            progressionRepository = mockk<ProgressionRepository>(relaxed = true),
+            progressionConfigService = mockk(relaxed = true)
+        )
+        mockBukkitPluginManager()
+
+        val declaring = UUID.randomUUID()
+        val defending = UUID.randomUUID()
+        // Declaring guild has funds, defending guild cannot cover the match
+        every { bankService.getBalance(declaring) } returns 10_000
+        every { bankService.getBalance(defending) } returns 100
+        every { bankService.deductFromGuildBank(any(), any(), any()) } returns true
+
+        val declaration = service.createWarDeclaration(
+            declaringGuildId = declaring,
+            defendingGuildId = defending,
+            duration = Duration.ofDays(7),
+            objectives = emptySet(),
+            wagerAmount = 500,
+            terms = null,
+            actorId = UUID.randomUUID()
+        )!!
+
+        val accepted = service.acceptWarDeclaration(declaration.id, UUID.randomUUID())
+
+        assertNull(accepted, "acceptance must fail when the defending guild cannot fund the wager")
+        assertNull(service.getCurrentWarBetweenGuilds(declaring, defending), "no active war may exist after failed escrow")
+        assertNotNull(
+            service.getPendingDeclarationsForGuild(defending).firstOrNull { it.id == declaration.id },
+            "declaration must remain pending after failed escrow so the defender can retry"
+        )
+        // Declaring guild's deduction must not happen (createWager bails on the
+        // balance check before any deduction) — and no wager/pot may exist.
+        verify(exactly = 0) { bankService.deductFromGuildBank(declaring, any(), any()) }
+    }
+
     private fun levelReward(warSlots: Int = 0, bankLimit: Int = 0) =
         LevelRewardConfig(warSlots = warSlots, bankLimit = bankLimit)
 }


### PR DESCRIPTION
## Summary

PR-4 of the SPEAR roadmap: **Combat & wars — config enforcement + real services**. Addresses audit H3 (combat): 9 knobs parsed but never consumed, inert `CombatServiceBukkit`, instant auto-accept wars, menu-side (never-implemented) wager escrow.

## Changes

### LG-401 — Combat config enforced (REQ-008)
- **`war_duration_hours`**: `WarServiceBukkit.effectiveWarDuration()` caps declared war length — applied in `declareWar`, `createWarDeclaration`, and `acceptWarDeclaration`.
- **`max_simultaneous_wars`**: config value is now the base cap (was hardcoded `3`), refined upward by progression war-slot rewards (`maxWarsForGuild`, pure companion function) — enforced in `canGuildDeclareWar` + `createWarDeclaration`.
- **`war_end_grace_period_minutes`**: `processExpiredWars` force-ends only after `duration + grace`, not `isExpired` alone.
- **`kill_experience` / `war_win_experience` / `war_lose_experience`**: awarded via `ProgressionRepository` on war kills (`awardWarKillExperience`, wired in `WarKillTrackingListener`) and war end (`awardWarExperience` in `endWar`).
- **`kill_cooldown_minutes` + `same_player_kill_limit`**: `recordWarKillAndCheckFarming()` (windowed, per-victim, synchronized) — farmed kills get no XP.
- **`anti_griefing_enabled`**: new `CombatAntiGriefListener` — when enabled, explosive block-damage by players in an active war is suppressed (terrain griefing blocked; entity damage unaffected).

### LG-402 — CombatServiceBukkit made real (REQ-014)
- Injects `MemberService` + `RelationService`; `getPlayerGuilds()` / `getRelationType()` now resolve against the actual domain (were `emptySet()` / hardcoded `NEUTRAL`). DI updated.

### LG-403 — War declaration accept/decline flow (REQ-024)
- **No instant auto-accept**: `declareWar()` returns `WarDeclaration?` and delegates to `createWarDeclaration()` (promoted to the `WarService` interface — menus no longer cast to the impl).
- `acceptWarDeclaration()` properly activates the war: `ACTIVE`, `startedAt`, declaration objectives carried over, `WarStats` initialized, `GuildWarDeclaredEvent` fired.
- All three declaration menus (Java + 2 Bedrock) route through the declaration flow; auto-accept shortcuts removed.

### LG-404 — `war_farming_cooldown_hours` loaded (REQ-026)
- Was missing from `loadCombatConfig()` (silently always 1h); now read and consumed by `getWarFarmingCooldownSeconds()`.

### LG-405 — Wager escrow completed in the war service (REQ-039)
- Escrow is now entirely service-side: `createWager` (in `WarServiceBukkit`) deducts both guilds on acceptance. Menus no longer move bank funds — removed the menu-side `bankService.withdraw` ("will be implemented in the war service") and `refundWager()` (which would have deposited phantom funds after the flow change).

## Tests
- New `WarConfigEnforcementTest` — 10 cases: duration cap (2), max-wars config/progression (3), no-auto-accept declaration, accept-activates, reject-removes, anti-farming (2).
- Full suite: **438 tests, 0 failures**.

## Notes
- `declareWar` return type changed `War?` → `WarDeclaration?` (breaking change; all callers updated).
- The old hostile-guild "auto-accept" UX is gone by design (REQ-024): every war now requires the defending guild's acceptance.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

### Breaking
- Update callers of `WarService.declareWar()` to handle `WarDeclaration?` and defender acceptance.

### Fixes
- Enforce configured war duration, simultaneous-war limits, expiration grace periods, rewards, kill-farming prevention, and farming cooldowns.
- Prevent war explosions from damaging blocks while preserving entity damage.
- Move wager escrow and refunds from menus into `WarService` acceptance handling.

### Features
- Create pending war declarations and activate wars only after defender acceptance.
- Resolve combat guild membership and relations through injected domain services.
- Register anti-grief handling and war-kill tracking listeners.
- Allow progression-based war slots to increase the configured war limit.
- Cover duration, war limits, declaration flows, and anti-farming behavior with enforcement tests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->