### PR TITLE
feat(pr5): peaceful-mode claim PVP + vault claim validation + peaceful opt-in (LG-501..503)

### DIFF
--- a/docs/tasks.md
+++ b/docs/tasks.md
@@ -148,21 +148,21 @@ PR grouping: tasks under each `## PR-n` header ship together in one pull request
 
 ## PR-5 — Claims, peaceful mode & vault (Section B residuals)
 
-- [ ] **LG-501** Enforce peaceful-mode flags: claim PVP disabled, war declarations blocked
+- [x] **LG-501** Enforce peaceful-mode flags: claim PVP disabled (war declarations left as-is per operator decision)
   - Tag: `TDD`
   - References: REQ-007
-  - Evidence:
-  - Files: claim PVP listener, war service
-- [ ] **LG-502** Vault placement validates against claims when claims are enabled
+  - Evidence: `ModeServiceBukkit.isPvpAllowedInTerritory` now gates the peaceful-territory block on `guild.peaceful_mode_claim_pvp_disabled`; new `ClaimPvpProtectionListener` (registered in `registerClaimEvents`, i.e. only when claims are enabled) resolves the victim's claim via `GetClaimAtPosition` and enforces `CombatService.canAttack` for guild-owned claims. Verified by `PeacefulModeEnforcementTest` (territory block on/off). Note: `peaceful_mode_prevent_wars` intentionally NOT enforced — operator chose to leave war behavior unchanged.
+  - Files: `ModeServiceBukkit.kt`, `ClaimPvpProtectionListener.kt`, `LumaGuilds.kt`
+- [x] **LG-502** Vault placement validates against claims when claims are enabled
   - Tag: `TDD`
   - References: REQ-015
-  - Evidence:
-  - Files: `GuildVaultServiceBukkit.kt:273-276`, claim domain
-- [ ] **LG-503** Load and consume `peacefulGuildPvpOptIn` per guild
+  - Evidence: `GuildVaultServiceBukkit.isValidVaultLocation` now requires the location to be inside the guild's own claim (`claim.teamId == guild.id`) whenever `claims_enabled` is true; claims-disabled behavior unchanged (places anywhere). `GetClaimAtPosition` injected via constructor + DI. Verified by `PeacefulModeEnforcementTest` (4 vault cases: claims-off, no claim, other guild's claim, own claim).
+  - Files: `GuildVaultServiceBukkit.kt:273-276`, `Modules.kt`
+- [x] **LG-503** Load and consume `peacefulGuildPvpOptIn` per guild
   - Tag: `TDD`
   - References: REQ-027
-  - Evidence:
-  - Files: GuildConfig, peaceful-mode service
+  - Evidence: `peaceful_guild_pvp_opt_in` now loaded in `loadGuildConfig` (was dead field); `ModeServiceBukkit.isPvpAllowedBetween` consumes it — peaceful guilds are PvP-blocked by default, but when the opt-in is true their members can fight. Verified by `PeacefulModeEnforcementTest` (opt-in off blocks, opt-in on allows).
+  - Files: `ConfigServiceBukkit.kt`, `ModeServiceBukkit.kt`
 
 ---
 

--- a/docs/tasks.md
+++ b/docs/tasks.md
@@ -161,7 +161,7 @@ PR grouping: tasks under each `## PR-n` header ship together in one pull request
 - [x] **LG-503** Load and consume `peacefulGuildPvpOptIn` per guild
   - Tag: `TDD`
   - References: REQ-027
-  - Evidence: `peaceful_guild_pvp_opt_in` now loaded in `loadGuildConfig` (was dead field); `ModeServiceBukkit.isPvpAllowedBetween` consumes it — peaceful guilds are PvP-blocked by default, but when the opt-in is true their members can fight. Verified by `PeacefulModeEnforcementTest` (opt-in off blocks, opt-in on allows).
+  - Evidence: `peaceful_guild_pvp_opt_in` now loaded in `loadGuildConfig` (was dead field); `ModeServiceBukkit.isPvpAllowed` consumes it — peaceful guilds are PvP-blocked by default, but when the opt-in is true their members can fight. Verified by `PeacefulModeEnforcementTest` (opt-in off blocks, opt-in on allows).
   - Files: `ConfigServiceBukkit.kt`, `ModeServiceBukkit.kt`
 
 ---

--- a/src/main/kotlin/net/lumalyte/lg/LumaGuilds.kt
+++ b/src/main/kotlin/net/lumalyte/lg/LumaGuilds.kt
@@ -893,6 +893,7 @@ class LumaGuilds : JavaPlugin() {
         server.pluginManager.registerEvents(MoveToolListener(), this)
         server.pluginManager.registerEvents(PartitionUpdateListener(), this)
         server.pluginManager.registerEvents(PlayerClaimProtectionListener(), this)
+        server.pluginManager.registerEvents(ClaimPvpProtectionListener(), this)
         server.pluginManager.registerEvents(ToolRemovalListener(), this)
         server.pluginManager.registerEvents(WorldClaimProtectionListener(), this)
         server.pluginManager.registerEvents(CloseInventoryListener(), this)

--- a/src/main/kotlin/net/lumalyte/lg/di/Modules.kt
+++ b/src/main/kotlin/net/lumalyte/lg/di/Modules.kt
@@ -519,7 +519,7 @@ fun progressionModule() = module {
 
     // Services
     single<KillService> { KillServiceBukkit(get()) }
-    single<CombatService> { CombatServiceBukkit(get(), get(), get()) }
+    single<CombatService> { CombatServiceBukkit(get(), get(), get(), get()) }
     single<ProgressionService> { ProgressionServiceBukkit(get(), get(), get(), get(), get(), get<LumaGuilds>()) }
     single<WarService> { WarServiceBukkit(get(), get(), get(), get()) }
     single<LeaderboardService> { LeaderboardServiceBukkit(get()) }

--- a/src/main/kotlin/net/lumalyte/lg/di/Modules.kt
+++ b/src/main/kotlin/net/lumalyte/lg/di/Modules.kt
@@ -600,6 +600,7 @@ fun vaultModule() = module {
             get(),
             get(),
             get(),
+            get(),
             get()
         )
     }

--- a/src/main/kotlin/net/lumalyte/lg/infrastructure/services/CombatServiceBukkit.kt
+++ b/src/main/kotlin/net/lumalyte/lg/infrastructure/services/CombatServiceBukkit.kt
@@ -1,6 +1,7 @@
 package net.lumalyte.lg.infrastructure.services
 
 import net.lumalyte.lg.application.services.CombatService
+import net.lumalyte.lg.application.services.ConfigService
 import net.lumalyte.lg.application.services.MemberService
 import net.lumalyte.lg.application.services.ModeService
 import net.lumalyte.lg.application.services.RelationService
@@ -12,7 +13,8 @@ import java.util.UUID
 class CombatServiceBukkit(
     private val modeService: ModeService,
     private val memberService: MemberService,
-    private val relationService: RelationService
+    private val relationService: RelationService,
+    private val configService: ConfigService
 ) : CombatService {
 
     private val logger = LoggerFactory.getLogger(CombatServiceBukkit::class.java)
@@ -67,18 +69,21 @@ class CombatServiceBukkit(
             }
         }
 
-        // Check peaceful mode restrictions
-        for (attackerGuildId in attackerGuilds) {
-            val attackerMode = modeService.getGuildMode(attackerGuildId)
-            if (attackerMode == net.lumalyte.lg.domain.entities.GuildMode.PEACEFUL) {
-                return "Your guild is in Peaceful mode"
+        // Check peaceful mode restrictions (REQ-027: opt-in disables the block)
+        val guildPolicy = configService.loadConfig().guild
+        if (!guildPolicy.peacefulGuildPvpOptIn) {
+            for (attackerGuildId in attackerGuilds) {
+                val attackerMode = modeService.getGuildMode(attackerGuildId)
+                if (attackerMode == net.lumalyte.lg.domain.entities.GuildMode.PEACEFUL) {
+                    return "Your guild is in Peaceful mode"
+                }
             }
-        }
 
-        for (victimGuildId in victimGuilds) {
-            val victimMode = modeService.getGuildMode(victimGuildId)
-            if (victimMode == net.lumalyte.lg.domain.entities.GuildMode.PEACEFUL) {
-                return "Target's guild is in Peaceful mode"
+            for (victimGuildId in victimGuilds) {
+                val victimMode = modeService.getGuildMode(victimGuildId)
+                if (victimMode == net.lumalyte.lg.domain.entities.GuildMode.PEACEFUL) {
+                    return "Target's guild is in Peaceful mode"
+                }
             }
         }
 
@@ -98,8 +103,11 @@ class CombatServiceBukkit(
     override fun getTerritoryPvpBlockReason(playerId: UUID, territoryGuildId: UUID): String? {
         val territoryMode = modeService.getGuildMode(territoryGuildId)
 
-        // Check territory peaceful mode
-        if (territoryMode == net.lumalyte.lg.domain.entities.GuildMode.PEACEFUL) {
+        // Check territory peaceful mode (REQ-007: claim PvP disabled flag gates it)
+        val guildPolicy = configService.loadConfig().guild
+        if (territoryMode == net.lumalyte.lg.domain.entities.GuildMode.PEACEFUL &&
+            guildPolicy.peacefulModeClaimPvpDisabled
+        ) {
             return "Cannot PvP in Peaceful guild territory"
         }
 

--- a/src/main/kotlin/net/lumalyte/lg/infrastructure/services/ConfigServiceBukkit.kt
+++ b/src/main/kotlin/net/lumalyte/lg/infrastructure/services/ConfigServiceBukkit.kt
@@ -98,6 +98,7 @@ class ConfigServiceBukkit(private val config: FileConfiguration): ConfigService 
             hostileModeMinimumDays = config.getInt("guild.hostile_mode_minimum_days", 7),
             peacefulModeClaimPvpDisabled = config.getBoolean("guild.peaceful_mode_claim_pvp_disabled", true),
             peacefulModePreventWars = config.getBoolean("guild.peaceful_mode_prevent_wars", true),
+            peacefulGuildPvpOptIn = config.getBoolean("guild.peaceful_guild_pvp_opt_in", false),
             maxCustomRanks = config.getInt("guild.max_custom_ranks", 10),
             maxRankNameLength = config.getInt("guild.max_rank_name_length", 16),
             maxMembersPerGuild = config.getInt("guild.max_members_per_guild", 50),

--- a/src/main/kotlin/net/lumalyte/lg/infrastructure/services/GuildVaultServiceBukkit.kt
+++ b/src/main/kotlin/net/lumalyte/lg/infrastructure/services/GuildVaultServiceBukkit.kt
@@ -39,7 +39,8 @@ class GuildVaultServiceBukkit(
     private val configService: ConfigService,
     private val vaultInventoryManager: VaultInventoryManager,
     private val hologramService: VaultHologramService,
-    private val rankService: RankService
+    private val rankService: RankService,
+    private val getClaimAtPosition: net.lumalyte.lg.application.actions.claim.GetClaimAtPosition
 ) : GuildVaultService {
 
     private val logger = LoggerFactory.getLogger(GuildVaultServiceBukkit::class.java)
@@ -270,10 +271,27 @@ class GuildVaultServiceBukkit(
             return VaultResult.Success(true)
         }
 
-        // TODO: Add claim validation when claims are enabled
-        // When claims are enabled, validate that the location is within a guild claim
-        // For now, allow placement anywhere even when claims are enabled
-        logger.debug("Claims enabled but validation not yet implemented - allowing vault placement")
+        // REQ-015: when claims are enabled, the vault must be placed inside the
+        // guild's own claim (same rule as guild homes — see GuildCommand).
+        val claimResult = getClaimAtPosition.execute(
+            world.uid,
+            net.lumalyte.lg.domain.values.Position2D(location.blockX, location.blockZ)
+        )
+        val claim = when (claimResult) {
+            is net.lumalyte.lg.application.results.claim.GetClaimAtPositionResult.Success -> claimResult.claim
+            else -> {
+                logger.debug("Vault placement rejected - location is not inside a claim")
+                return VaultResult.Failure("Vault must be placed inside a guild claim")
+            }
+        }
+
+        if (claim.teamId != guild.id) {
+            logger.debug(
+                "Vault placement rejected - claim owned by ${claim.teamId}, guild is ${guild.id}"
+            )
+            return VaultResult.Failure("Vault must be placed inside your guild's own claim")
+        }
+
         return VaultResult.Success(true)
     }
 

--- a/src/main/kotlin/net/lumalyte/lg/infrastructure/services/ModeServiceBukkit.kt
+++ b/src/main/kotlin/net/lumalyte/lg/infrastructure/services/ModeServiceBukkit.kt
@@ -103,6 +103,9 @@ class ModeServiceBukkit(
             return true
         }
 
+        // Load the guild policy once per authorization check (REQ-027)
+        val guildPolicy = configService.loadConfig().guild
+
         // Check each guild combination
         for (attackerGuildId in attackerGuilds) {
             for (victimGuildId in victimGuilds) {
@@ -118,8 +121,7 @@ class ModeServiceBukkit(
                 // If either guild is peaceful, PvP is not allowed between their members
                 // (REQ-027: unless peacefulGuildPvpOptIn allows peaceful guilds to opt in)
                 if (attackerMode == GuildMode.PEACEFUL || victimMode == GuildMode.PEACEFUL) {
-                    val peacefulGuildOptIn = configService.loadConfig().guild.peacefulGuildPvpOptIn
-                    if (!peacefulGuildOptIn) {
+                    if (!guildPolicy.peacefulGuildPvpOptIn) {
                         return false
                     }
                 }
@@ -132,12 +134,10 @@ class ModeServiceBukkit(
             }
         }
 
-        // If one player has no guild and the other has a peaceful guild, PvP is not allowed
-        val peacefulGuildOptIn = configService.loadConfig().guild.peacefulGuildPvpOptIn
         for (attackerGuildId in attackerGuilds) {
             if (victimGuilds.isEmpty()) {
                 val attackerMode = getGuildMode(attackerGuildId)
-                if (attackerMode == GuildMode.PEACEFUL && !peacefulGuildOptIn) {
+                if (attackerMode == GuildMode.PEACEFUL && !guildPolicy.peacefulGuildPvpOptIn) {
                     return false
                 }
             }
@@ -146,7 +146,7 @@ class ModeServiceBukkit(
         for (victimGuildId in victimGuilds) {
             if (attackerGuilds.isEmpty()) {
                 val victimMode = getGuildMode(victimGuildId)
-                if (victimMode == GuildMode.PEACEFUL && !peacefulGuildOptIn) {
+                if (victimMode == GuildMode.PEACEFUL && !guildPolicy.peacefulGuildPvpOptIn) {
                     return false
                 }
             }
@@ -158,9 +158,12 @@ class ModeServiceBukkit(
     override fun isPvpAllowedInTerritory(playerId: UUID, territoryGuildId: UUID): Boolean {
         val territoryMode = getGuildMode(territoryGuildId)
 
+        // Load the guild policy once per authorization check (REQ-007)
+        val guildPolicy = configService.loadConfig().guild
+
         // If territory guild is peaceful and claim PvP disabling is enabled,
         // PvP is not allowed in their territory (REQ-007).
-        if (territoryMode == GuildMode.PEACEFUL && configService.loadConfig().guild.peacefulModeClaimPvpDisabled) {
+        if (territoryMode == GuildMode.PEACEFUL && guildPolicy.peacefulModeClaimPvpDisabled) {
             return false
         }
 

--- a/src/main/kotlin/net/lumalyte/lg/infrastructure/services/ModeServiceBukkit.kt
+++ b/src/main/kotlin/net/lumalyte/lg/infrastructure/services/ModeServiceBukkit.kt
@@ -116,8 +116,12 @@ class ModeServiceBukkit(
                 val victimMode = getGuildMode(victimGuildId)
 
                 // If either guild is peaceful, PvP is not allowed between their members
+                // (REQ-027: unless peacefulGuildPvpOptIn allows peaceful guilds to opt in)
                 if (attackerMode == GuildMode.PEACEFUL || victimMode == GuildMode.PEACEFUL) {
-                    return false
+                    val peacefulGuildOptIn = configService.loadConfig().guild.peacefulGuildPvpOptIn
+                    if (!peacefulGuildOptIn) {
+                        return false
+                    }
                 }
 
                 // If both guilds are hostile, check relations
@@ -129,10 +133,11 @@ class ModeServiceBukkit(
         }
 
         // If one player has no guild and the other has a peaceful guild, PvP is not allowed
+        val peacefulGuildOptIn = configService.loadConfig().guild.peacefulGuildPvpOptIn
         for (attackerGuildId in attackerGuilds) {
             if (victimGuilds.isEmpty()) {
                 val attackerMode = getGuildMode(attackerGuildId)
-                if (attackerMode == GuildMode.PEACEFUL) {
+                if (attackerMode == GuildMode.PEACEFUL && !peacefulGuildOptIn) {
                     return false
                 }
             }
@@ -141,7 +146,7 @@ class ModeServiceBukkit(
         for (victimGuildId in victimGuilds) {
             if (attackerGuilds.isEmpty()) {
                 val victimMode = getGuildMode(victimGuildId)
-                if (victimMode == GuildMode.PEACEFUL) {
+                if (victimMode == GuildMode.PEACEFUL && !peacefulGuildOptIn) {
                     return false
                 }
             }
@@ -153,8 +158,9 @@ class ModeServiceBukkit(
     override fun isPvpAllowedInTerritory(playerId: UUID, territoryGuildId: UUID): Boolean {
         val territoryMode = getGuildMode(territoryGuildId)
 
-        // If territory guild is peaceful, PvP is not allowed in their territory
-        if (territoryMode == GuildMode.PEACEFUL) {
+        // If territory guild is peaceful and claim PvP disabling is enabled,
+        // PvP is not allowed in their territory (REQ-007).
+        if (territoryMode == GuildMode.PEACEFUL && configService.loadConfig().guild.peacefulModeClaimPvpDisabled) {
             return false
         }
 

--- a/src/main/kotlin/net/lumalyte/lg/interaction/listeners/ClaimPvpProtectionListener.kt
+++ b/src/main/kotlin/net/lumalyte/lg/interaction/listeners/ClaimPvpProtectionListener.kt
@@ -1,0 +1,67 @@
+package net.lumalyte.lg.interaction.listeners
+
+import net.lumalyte.lg.application.actions.claim.GetClaimAtPosition
+import net.lumalyte.lg.application.results.claim.GetClaimAtPositionResult
+import net.lumalyte.lg.application.services.CombatService
+import net.lumalyte.lg.application.services.GuildService
+import org.bukkit.entity.Player
+import org.bukkit.entity.Projectile
+import org.bukkit.event.EventHandler
+import org.bukkit.event.EventPriority
+import org.bukkit.event.Listener
+import org.bukkit.event.entity.EntityDamageByEntityEvent
+import org.koin.core.component.KoinComponent
+import org.koin.core.component.inject
+import org.slf4j.LoggerFactory
+
+/**
+ * Enforces PvP rules inside guild claims (REQ-007).
+ *
+ * When a player damages another player, the victim's location is resolved to a
+ * claim; if the claim is owned by a guild, `CombatService.canAttack` decides
+ * whether the attack is legal (peaceful-mode territory PvP disabled, hostile
+ * relations, same-guild rules). Registered only when claims are enabled.
+ */
+class ClaimPvpProtectionListener : Listener, KoinComponent {
+
+    private val combatService: CombatService by inject()
+    private val getClaimAtPosition: GetClaimAtPosition by inject()
+    private val guildService: GuildService by inject()
+
+    private val logger = LoggerFactory.getLogger(ClaimPvpProtectionListener::class.java)
+
+    @EventHandler(priority = EventPriority.HIGH, ignoreCancelled = true)
+    fun onPlayerDamage(event: EntityDamageByEntityEvent) {
+        // Only player-vs-player damage is governed by claim territory PvP rules
+        val victim = event.entity as? Player ?: return
+        val damager = event.damager ?: return
+        val attacker = when (damager) {
+            is Player -> damager
+            is Projectile -> damager.shooter as? Player
+            else -> return
+        } ?: return
+        if (attacker.uniqueId == victim.uniqueId) return
+
+        // Resolve the claim at the victim's location (if any)
+        val claimResult = getClaimAtPosition.execute(
+            victim.world.uid,
+            net.lumalyte.lg.domain.values.Position2D(victim.location.blockX, victim.location.blockZ)
+        )
+        val claim = when (claimResult) {
+            is GetClaimAtPositionResult.Success -> claimResult.claim
+            else -> return // No claim — territory rules don't apply
+        }
+
+        // Claims may belong to a player or a guild (teamId). Territory PvP rules
+        // only apply to guild-owned claims.
+        val territoryGuildId = claim.teamId ?: return
+        if (guildService.getGuild(territoryGuildId) == null) return
+
+        if (!combatService.canAttack(attacker.uniqueId, victim.uniqueId, territoryGuildId)) {
+            logger.debug(
+                "Claim PvP blocked: ${attacker.name} -> ${victim.name} in claim of guild $territoryGuildId"
+            )
+            event.isCancelled = true
+        }
+    }
+}

--- a/src/main/kotlin/net/lumalyte/lg/interaction/listeners/ClaimPvpProtectionListener.kt
+++ b/src/main/kotlin/net/lumalyte/lg/interaction/listeners/ClaimPvpProtectionListener.kt
@@ -13,6 +13,7 @@ import org.bukkit.event.entity.EntityDamageByEntityEvent
 import org.koin.core.component.KoinComponent
 import org.koin.core.component.inject
 import org.slf4j.LoggerFactory
+import java.util.UUID
 
 /**
  * Enforces PvP rules inside guild claims (REQ-007).
@@ -21,6 +22,10 @@ import org.slf4j.LoggerFactory
  * claim; if the claim is owned by a guild, `CombatService.canAttack` decides
  * whether the attack is legal (peaceful-mode territory PvP disabled, hostile
  * relations, same-guild rules). Registered only when claims are enabled.
+ *
+ * The decision pipeline is split into internal functions so it can be tested
+ * without Bukkit server state: `resolveTerritoryGuild` (location → guild claim)
+ * and `shouldCancelPvp` (attacker/victim/territory → cancel?).
  */
 class ClaimPvpProtectionListener : Listener, KoinComponent {
 
@@ -35,33 +40,55 @@ class ClaimPvpProtectionListener : Listener, KoinComponent {
         // Only player-vs-player damage is governed by claim territory PvP rules
         val victim = event.entity as? Player ?: return
         val damager = event.damager ?: return
-        val attacker = when (damager) {
-            is Player -> damager
-            is Projectile -> damager.shooter as? Player
-            else -> return
-        } ?: return
+        val attacker = resolveAttacker(damager) ?: return
         if (attacker.uniqueId == victim.uniqueId) return
 
-        // Resolve the claim at the victim's location (if any)
-        val claimResult = getClaimAtPosition.execute(
+        val territoryGuildId = resolveTerritoryGuild(
             victim.world.uid,
-            net.lumalyte.lg.domain.values.Position2D(victim.location.blockX, victim.location.blockZ)
-        )
-        val claim = when (claimResult) {
-            is GetClaimAtPositionResult.Success -> claimResult.claim
-            else -> return // No claim — territory rules don't apply
-        }
+            victim.location.blockX,
+            victim.location.blockZ
+        ) ?: return
 
-        // Claims may belong to a player or a guild (teamId). Territory PvP rules
-        // only apply to guild-owned claims.
-        val territoryGuildId = claim.teamId ?: return
-        if (guildService.getGuild(territoryGuildId) == null) return
-
-        if (!combatService.canAttack(attacker.uniqueId, victim.uniqueId, territoryGuildId)) {
+        if (shouldCancelPvp(attacker.uniqueId, victim.uniqueId, territoryGuildId)) {
             logger.debug(
                 "Claim PvP blocked: ${attacker.name} -> ${victim.name} in claim of guild $territoryGuildId"
             )
             event.isCancelled = true
         }
     }
+
+    /**
+     * Resolves the attacker from a direct hit or a projectile's shooter.
+     * Returns null when there is no player actor (e.g. environmental damage).
+     */
+    internal fun resolveAttacker(damager: Any): Player? = when (damager) {
+        is Player -> damager
+        is Projectile -> damager.shooter as? Player
+        else -> null
+    }
+
+    /**
+     * Resolves the guild that owns the claim at the given block position, or
+     * null when there is no claim / no guild ownership. Territory PvP rules
+     * only apply to guild-owned claims.
+     */
+    internal fun resolveTerritoryGuild(worldId: UUID, blockX: Int, blockZ: Int): UUID? {
+        val claimResult = getClaimAtPosition.execute(
+            worldId,
+            net.lumalyte.lg.domain.values.Position2D(blockX, blockZ)
+        )
+        val claim = when (claimResult) {
+            is GetClaimAtPositionResult.Success -> claimResult.claim
+            else -> return null // No claim — territory rules don't apply
+        }
+        val territoryGuildId = claim.teamId ?: return null
+        if (guildService.getGuild(territoryGuildId) == null) return null
+        return territoryGuildId
+    }
+
+    /**
+     * Decides whether the attack must be cancelled in the given territory.
+     */
+    internal fun shouldCancelPvp(attackerId: UUID, victimId: UUID, territoryGuildId: UUID): Boolean =
+        !combatService.canAttack(attackerId, victimId, territoryGuildId)
 }

--- a/src/main/kotlin/net/lumalyte/lg/interaction/listeners/ClaimPvpProtectionListener.kt
+++ b/src/main/kotlin/net/lumalyte/lg/interaction/listeners/ClaimPvpProtectionListener.kt
@@ -43,18 +43,46 @@ class ClaimPvpProtectionListener : Listener, KoinComponent {
         val attacker = resolveAttacker(damager) ?: return
         if (attacker.uniqueId == victim.uniqueId) return
 
-        val territoryGuildId = resolveTerritoryGuild(
+        when (val resolution = resolveTerritoryGuild(
             victim.world.uid,
             victim.location.blockX,
             victim.location.blockZ
-        ) ?: return
+        )) {
+            // No claim — territory rules don't apply
+            TerritoryResolution.NoClaim -> Unit
 
-        if (shouldCancelPvp(attacker.uniqueId, victim.uniqueId, territoryGuildId)) {
-            logger.debug(
-                "Claim PvP blocked: ${attacker.name} -> ${victim.name} in claim of guild $territoryGuildId"
-            )
-            event.isCancelled = true
+            // Claim storage unavailable — fail closed: never allow damage we
+            // cannot verify is outside a protected claim.
+            TerritoryResolution.StorageError -> {
+                logger.error(
+                    "Claim PvP lookup failed at ${victim.world.uid} (${victim.location.blockX}, ${victim.location.blockZ}) " +
+                        "- cancelling damage from ${attacker.name} to ${victim.name} (fail closed)"
+                )
+                event.isCancelled = true
+            }
+
+            is TerritoryResolution.GuildClaim ->
+                if (shouldCancelPvp(attacker.uniqueId, victim.uniqueId, resolution.guildId)) {
+                    logger.debug(
+                        "Claim PvP blocked: ${attacker.name} -> ${victim.name} in claim of guild ${resolution.guildId}"
+                    )
+                    event.isCancelled = true
+                }
         }
+    }
+
+    /**
+     * Outcome of resolving the guild that owns the claim at a block position.
+     */
+    internal sealed class TerritoryResolution {
+        /** No claim exists at the position — territory rules don't apply. */
+        object NoClaim : TerritoryResolution()
+
+        /** Claim storage failed — the lookup could not be completed. */
+        object StorageError : TerritoryResolution()
+
+        /** A guild-owned claim exists at the position. */
+        data class GuildClaim(val guildId: UUID) : TerritoryResolution()
     }
 
     /**
@@ -69,21 +97,27 @@ class ClaimPvpProtectionListener : Listener, KoinComponent {
 
     /**
      * Resolves the guild that owns the claim at the given block position, or
-     * null when there is no claim / no guild ownership. Territory PvP rules
-     * only apply to guild-owned claims.
+     * NoClaim when there is no claim / no guild ownership. Territory PvP rules
+     * only apply to guild-owned claims. StorageError is kept distinct so
+     * callers can fail closed.
      */
-    internal fun resolveTerritoryGuild(worldId: UUID, blockX: Int, blockZ: Int): UUID? {
+    internal fun resolveTerritoryGuild(worldId: UUID, blockX: Int, blockZ: Int): TerritoryResolution {
         val claimResult = getClaimAtPosition.execute(
             worldId,
             net.lumalyte.lg.domain.values.Position2D(blockX, blockZ)
         )
-        val claim = when (claimResult) {
-            is GetClaimAtPositionResult.Success -> claimResult.claim
-            else -> return null // No claim — territory rules don't apply
+        return when (claimResult) {
+            is GetClaimAtPositionResult.Success -> {
+                val territoryGuildId = claimResult.claim.teamId
+                if (territoryGuildId != null && guildService.getGuild(territoryGuildId) != null) {
+                    TerritoryResolution.GuildClaim(territoryGuildId)
+                } else {
+                    TerritoryResolution.NoClaim
+                }
+            }
+            GetClaimAtPositionResult.NoClaimFound -> TerritoryResolution.NoClaim
+            GetClaimAtPositionResult.StorageError -> TerritoryResolution.StorageError
         }
-        val territoryGuildId = claim.teamId ?: return null
-        if (guildService.getGuild(territoryGuildId) == null) return null
-        return territoryGuildId
     }
 
     /**

--- a/src/test/kotlin/net/lumalyte/lg/infrastructure/services/PeacefulModeEnforcementTest.kt
+++ b/src/test/kotlin/net/lumalyte/lg/infrastructure/services/PeacefulModeEnforcementTest.kt
@@ -1,0 +1,222 @@
+package net.lumalyte.lg.infrastructure.services
+
+import net.lumalyte.lg.application.actions.claim.GetClaimAtPosition
+import net.lumalyte.lg.application.results.claim.GetClaimAtPositionResult
+import net.lumalyte.lg.application.services.ConfigService
+import net.lumalyte.lg.application.services.GuildService
+import net.lumalyte.lg.application.services.MemberService
+import net.lumalyte.lg.application.services.RelationService
+import net.lumalyte.lg.application.services.VaultResult
+import net.lumalyte.lg.config.GuildConfig
+import net.lumalyte.lg.config.MainConfig
+import net.lumalyte.lg.domain.entities.Claim
+import net.lumalyte.lg.domain.entities.Guild
+import net.lumalyte.lg.domain.entities.GuildMode
+import net.lumalyte.lg.domain.entities.RelationType
+import org.bukkit.Location
+import org.bukkit.World
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertFalse
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+import io.mockk.every
+import io.mockk.mockk
+import java.time.Instant
+import java.util.UUID
+
+/**
+ * PR-5 — REQ-007 (peaceful-mode claim PvP), REQ-015 (vault placement vs claims),
+ * REQ-027 (peacefulGuildPvpOptIn load + consume).
+ */
+class PeacefulModeEnforcementTest {
+
+    // ---------- REQ-027: peaceful guild PvP opt-in ----------
+
+    @Test
+    fun `peaceful guild PvP is blocked when opt-in is disabled (default)`() {
+        val service = modeService(peacefulGuildPvpOptIn = false)
+
+        val peaceful = UUID.randomUUID()
+        val hostile = UUID.randomUUID()
+        every { memberService.getPlayerGuilds(any()) } returnsMany listOf(setOf(peaceful), setOf(hostile))
+        every { guildService.getMode(peaceful) } returns GuildMode.PEACEFUL
+        every { guildService.getMode(hostile) } returns GuildMode.HOSTILE
+
+        assertFalse(service.isPvpAllowed(attackerId = peaceful, victimId = hostile))
+        assertFalse(service.isPvpAllowed(attackerId = hostile, victimId = peaceful))
+    }
+
+    @Test
+    fun `peaceful guild PvP is allowed when opt-in is enabled`() {
+        val service = modeService(peacefulGuildPvpOptIn = true)
+
+        val peaceful = UUID.randomUUID()
+        val hostile = UUID.randomUUID()
+        every { memberService.getPlayerGuilds(any()) } returnsMany listOf(setOf(peaceful), setOf(hostile))
+        every { guildService.getMode(peaceful) } returns GuildMode.PEACEFUL
+        every { guildService.getMode(hostile) } returns GuildMode.HOSTILE
+        every { relationService.getRelationType(peaceful, hostile) } returns RelationType.NEUTRAL
+
+        assertTrue(service.isPvpAllowed(attackerId = peaceful, victimId = hostile))
+    }
+
+    // ---------- REQ-007: peaceful-mode claim PvP disabled ----------
+
+    @Test
+    fun `peaceful territory blocks PvP when claim pvp disabled flag is on`() {
+        val service = modeService(peacefulModeClaimPvpDisabled = true)
+
+        val territoryGuild = UUID.randomUUID()
+        every { guildService.getMode(territoryGuild) } returns GuildMode.PEACEFUL
+
+        assertFalse(service.isPvpAllowedInTerritory(UUID.randomUUID(), territoryGuild))
+    }
+
+    @Test
+    fun `peaceful territory allows PvP when claim pvp disabled flag is off`() {
+        val service = modeService(peacefulModeClaimPvpDisabled = false)
+
+        val territoryGuild = UUID.randomUUID()
+        every { guildService.getMode(territoryGuild) } returns GuildMode.PEACEFUL
+        every { memberService.getPlayerGuilds(any()) } returns emptySet()
+
+        assertTrue(service.isPvpAllowedInTerritory(UUID.randomUUID(), territoryGuild))
+    }
+
+    // ---------- REQ-015: vault placement validates against claims ----------
+
+    @Test
+    fun `vault placement allowed anywhere when claims are disabled`() {
+        val service = vaultService(claimsEnabled = false, claimResult = GetClaimAtPositionResult.NoClaimFound)
+
+        val world = mockk<World>()
+        every { world.uid } returns UUID.randomUUID()
+        val location = mockk<Location>()
+        every { location.world } returns world
+        every { location.blockX } returns 10
+        every { location.blockZ } returns 20
+        every { world.isChunkLoaded(any(), any()) } returns true
+
+        val result = service.isValidVaultLocation(location, guild())
+        assertTrue((result as VaultResult.Success).data)
+    }
+
+    @Test
+    fun `vault placement rejected when not inside any claim`() {
+        val service = vaultService(claimsEnabled = true, claimResult = GetClaimAtPositionResult.NoClaimFound)
+
+        val world = mockk<World>()
+        every { world.uid } returns UUID.randomUUID()
+        val location = mockk<Location>()
+        every { location.world } returns world
+        every { location.blockX } returns 10
+        every { location.blockZ } returns 20
+        every { world.isChunkLoaded(any(), any()) } returns true
+
+        val result = service.isValidVaultLocation(location, guild())
+        assertTrue(result is VaultResult.Failure)
+    }
+
+    @Test
+    fun `vault placement rejected when claim belongs to another guild`() {
+        val otherGuildId = UUID.randomUUID()
+        val service = vaultService(
+            claimsEnabled = true,
+            claimResult = GetClaimAtPositionResult.Success(claim(otherGuildId))
+        )
+
+        val world = mockk<World>()
+        every { world.uid } returns UUID.randomUUID()
+        val location = mockk<Location>()
+        every { location.world } returns world
+        every { location.blockX } returns 10
+        every { location.blockZ } returns 20
+        every { world.isChunkLoaded(any(), any()) } returns true
+
+        val result = service.isValidVaultLocation(location, guild())
+        assertTrue(result is VaultResult.Failure)
+    }
+
+    @Test
+    fun `vault placement allowed inside own guild claim`() {
+        val guildId = UUID.randomUUID()
+        val service = vaultService(
+            claimsEnabled = true,
+            claimResult = GetClaimAtPositionResult.Success(claim(guildId))
+        )
+
+        val world = mockk<World>()
+        every { world.uid } returns UUID.randomUUID()
+        val location = mockk<Location>()
+        every { location.world } returns world
+        every { location.blockX } returns 10
+        every { location.blockZ } returns 20
+        every { world.isChunkLoaded(any(), any()) } returns true
+
+        val result = service.isValidVaultLocation(location, guild(guildId))
+        assertTrue((result as VaultResult.Success).data)
+    }
+
+    // ---------- helpers ----------
+
+    private val configService = mockk<ConfigService>()
+    private val memberService = mockk<MemberService>(relaxed = true)
+    private val guildService = mockk<GuildService>(relaxed = true)
+    private val relationService = mockk<RelationService>(relaxed = true)
+
+    private fun modeService(
+        peacefulGuildPvpOptIn: Boolean = false,
+        peacefulModeClaimPvpDisabled: Boolean = true,
+    ): ModeServiceBukkit {
+        val config = mockk<MainConfig>()
+        val guildConfig = mockk<GuildConfig>()
+        every { guildConfig.peacefulGuildPvpOptIn } returns peacefulGuildPvpOptIn
+        every { guildConfig.peacefulModeClaimPvpDisabled } returns peacefulModeClaimPvpDisabled
+        every { config.guild } returns guildConfig
+        every { configService.loadConfig() } returns config
+
+        return ModeServiceBukkit(guildService, memberService, relationService, configService)
+    }
+
+    private fun vaultService(
+        claimsEnabled: Boolean,
+        claimResult: GetClaimAtPositionResult,
+    ): GuildVaultServiceBukkit {
+        val config = mockk<MainConfig>()
+        every { config.claimsEnabled } returns claimsEnabled
+        every { configService.loadConfig() } returns config
+
+        val getClaimAtPosition = mockk<GetClaimAtPosition>()
+        every { getClaimAtPosition.execute(any(), any()) } returns claimResult
+
+        return GuildVaultServiceBukkit(
+            plugin = mockk(relaxed = true),
+            guildRepository = mockk(relaxed = true),
+            vaultRepository = mockk(relaxed = true),
+            memberRepository = mockk(relaxed = true),
+            configService = configService,
+            vaultInventoryManager = mockk(relaxed = true),
+            hologramService = mockk(relaxed = true),
+            rankService = mockk(relaxed = true),
+            getClaimAtPosition = getClaimAtPosition
+        )
+    }
+
+    private fun guild(id: UUID = UUID.randomUUID()): Guild =
+        mockk<Guild>(relaxed = true).apply {
+            every { this@apply.id } returns id
+        }
+
+    private fun claim(teamId: UUID?): Claim =
+        Claim(
+            id = UUID.randomUUID(),
+            worldId = UUID.randomUUID(),
+            playerId = UUID.randomUUID(),
+            teamId = teamId,
+            creationTime = Instant.now(),
+            name = "Test Claim",
+            description = "",
+            position = net.lumalyte.lg.domain.values.Position3D(0, 0, 0),
+            icon = "GRASS_BLOCK"
+        )
+}

--- a/src/test/kotlin/net/lumalyte/lg/interaction/listeners/ClaimPvpProtectionListenerTest.kt
+++ b/src/test/kotlin/net/lumalyte/lg/interaction/listeners/ClaimPvpProtectionListenerTest.kt
@@ -85,19 +85,20 @@ class ClaimPvpProtectionListenerTest {
         every { guildService.getGuild(territoryGuildId) } returns mockk(relaxed = true)
 
         val result = listener.resolveTerritoryGuild(worldId, 10, 20)
-        assertTrue(result == territoryGuildId)
+        assertTrue(result == ClaimPvpProtectionListener.TerritoryResolution.GuildClaim(territoryGuildId))
         verify { getClaimAtPosition.execute(worldId, net.lumalyte.lg.domain.values.Position2D(10, 20)) }
     }
 
     @Test
-    fun `resolveTerritoryGuild returns null when no claim exists`() {
+    fun `resolveTerritoryGuild returns no claim when no claim exists`() {
         every { getClaimAtPosition.execute(worldId, any()) } returns GetClaimAtPositionResult.NoClaimFound
 
-        assertTrue(listener.resolveTerritoryGuild(worldId, 10, 20) == null)
+        assertTrue(listener.resolveTerritoryGuild(worldId, 10, 20) ==
+            ClaimPvpProtectionListener.TerritoryResolution.NoClaim)
     }
 
     @Test
-    fun `resolveTerritoryGuild returns null for a personal claim without guild`() {
+    fun `resolveTerritoryGuild returns no claim for a personal claim without guild`() {
         val claim = Claim(
             id = UUID.randomUUID(),
             worldId = worldId,
@@ -111,7 +112,16 @@ class ClaimPvpProtectionListenerTest {
         )
         every { getClaimAtPosition.execute(worldId, any()) } returns GetClaimAtPositionResult.Success(claim)
 
-        assertTrue(listener.resolveTerritoryGuild(worldId, 10, 20) == null)
+        assertTrue(listener.resolveTerritoryGuild(worldId, 10, 20) ==
+            ClaimPvpProtectionListener.TerritoryResolution.NoClaim)
+    }
+
+    @Test
+    fun `resolveTerritoryGuild returns storage error when claim lookup fails`() {
+        every { getClaimAtPosition.execute(worldId, any()) } returns GetClaimAtPositionResult.StorageError
+
+        assertTrue(listener.resolveTerritoryGuild(worldId, 10, 20) ==
+            ClaimPvpProtectionListener.TerritoryResolution.StorageError)
     }
 
     // ---------- full event path ----------
@@ -160,6 +170,22 @@ class ClaimPvpProtectionListenerTest {
         listener.onPlayerDamage(event)
 
         assertFalse(event.isCancelled)
+        verify(exactly = 0) { combatService.canAttack(any(), any(), any()) }
+    }
+
+    @Test
+    fun `onPlayerDamage fails closed when claim lookup hits a storage error`() {
+        val attacker = player(UUID.randomUUID())
+        val victim = player(UUID.randomUUID())
+        every { getClaimAtPosition.execute(worldId, any()) } returns GetClaimAtPositionResult.StorageError
+
+        val event = damageEvent(attacker, victim)
+
+        listener.onPlayerDamage(event)
+
+        // Fail closed: damage is cancelled and canAttack is never consulted,
+        // because the claim status could not be verified.
+        assertTrue(event.isCancelled)
         verify(exactly = 0) { combatService.canAttack(any(), any(), any()) }
     }
 

--- a/src/test/kotlin/net/lumalyte/lg/interaction/listeners/ClaimPvpProtectionListenerTest.kt
+++ b/src/test/kotlin/net/lumalyte/lg/interaction/listeners/ClaimPvpProtectionListenerTest.kt
@@ -1,0 +1,226 @@
+package net.lumalyte.lg.interaction.listeners
+
+import net.lumalyte.lg.application.actions.claim.GetClaimAtPosition
+import net.lumalyte.lg.application.results.claim.GetClaimAtPositionResult
+import net.lumalyte.lg.application.services.CombatService
+import net.lumalyte.lg.application.services.GuildService
+import net.lumalyte.lg.domain.entities.Claim
+import org.bukkit.Location
+import org.bukkit.World
+import org.bukkit.entity.Player
+import org.bukkit.entity.Projectile
+import org.bukkit.event.entity.EntityDamageByEntityEvent
+import org.junit.jupiter.api.Assertions.assertFalse
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.verify
+import org.koin.core.context.startKoin
+import org.koin.core.context.stopKoin
+import org.koin.dsl.module
+import java.time.Instant
+import java.util.UUID
+
+/**
+ * PR-5 — REQ-007: ClaimPvpProtectionListener event-path tests.
+ *
+ * Verifies the full Bukkit pipeline: claim resolution at the victim's location,
+ * projectile-shooter resolution, `CombatService.canAttack` delegation, and
+ * cancellation of rejected damage (allowed and rejected attacks in a
+ * guild-owned claim).
+ */
+class ClaimPvpProtectionListenerTest {
+
+    private val combatService = mockk<CombatService>()
+    private val getClaimAtPosition = mockk<GetClaimAtPosition>()
+    private val guildService = mockk<GuildService>()
+
+    private val worldId = UUID.randomUUID()
+    private val territoryGuildId = UUID.randomUUID()
+
+    private lateinit var listener: ClaimPvpProtectionListener
+
+    @BeforeEach
+    fun setUp() {
+        stopKoin()
+        startKoin {
+            modules(module {
+                single { combatService }
+                single { getClaimAtPosition }
+                single { guildService }
+                single { ClaimPvpProtectionListener() }
+            })
+        }
+        listener = ClaimPvpProtectionListener()
+    }
+
+    // ---------- pipeline pieces ----------
+
+    @Test
+    fun `resolveAttacker returns direct player attacker`() {
+        val attacker = mockk<Player>(relaxed = true)
+        assertTrue(listener.resolveAttacker(attacker) === attacker)
+    }
+
+    @Test
+    fun `resolveAttacker returns projectile shooter`() {
+        val shooter = mockk<Player>(relaxed = true)
+        val projectile = mockk<Projectile>()
+        every { projectile.shooter } returns shooter
+
+        assertTrue(listener.resolveAttacker(projectile) === shooter)
+    }
+
+    @Test
+    fun `resolveAttacker returns null for non-player damager`() {
+        assertTrue(listener.resolveAttacker(mockk(relaxed = true)) == null)
+    }
+
+    @Test
+    fun `resolveTerritoryGuild returns guild for a guild-owned claim at position`() {
+        val claim = guildClaim(territoryGuildId)
+        every { getClaimAtPosition.execute(worldId, any()) } returns GetClaimAtPositionResult.Success(claim)
+        every { guildService.getGuild(territoryGuildId) } returns mockk(relaxed = true)
+
+        val result = listener.resolveTerritoryGuild(worldId, 10, 20)
+        assertTrue(result == territoryGuildId)
+        verify { getClaimAtPosition.execute(worldId, net.lumalyte.lg.domain.values.Position2D(10, 20)) }
+    }
+
+    @Test
+    fun `resolveTerritoryGuild returns null when no claim exists`() {
+        every { getClaimAtPosition.execute(worldId, any()) } returns GetClaimAtPositionResult.NoClaimFound
+
+        assertTrue(listener.resolveTerritoryGuild(worldId, 10, 20) == null)
+    }
+
+    @Test
+    fun `resolveTerritoryGuild returns null for a personal claim without guild`() {
+        val claim = Claim(
+            id = UUID.randomUUID(),
+            worldId = worldId,
+            playerId = UUID.randomUUID(),
+            teamId = null,
+            creationTime = Instant.now(),
+            name = "Personal Claim",
+            description = "",
+            position = net.lumalyte.lg.domain.values.Position3D(0, 0, 0),
+            icon = "GRASS_BLOCK"
+        )
+        every { getClaimAtPosition.execute(worldId, any()) } returns GetClaimAtPositionResult.Success(claim)
+
+        assertTrue(listener.resolveTerritoryGuild(worldId, 10, 20) == null)
+    }
+
+    // ---------- full event path ----------
+
+    @Test
+    fun `onPlayerDamage cancels rejected attack in guild-owned claim`() {
+        val attacker = player(UUID.randomUUID())
+        val victim = player(UUID.randomUUID())
+        every { getClaimAtPosition.execute(worldId, any()) } returns
+            GetClaimAtPositionResult.Success(guildClaim(territoryGuildId))
+        every { guildService.getGuild(territoryGuildId) } returns mockk(relaxed = true)
+        every { combatService.canAttack(attacker.uniqueId, victim.uniqueId, territoryGuildId) } returns false
+
+        val event = damageEvent(attacker, victim)
+
+        listener.onPlayerDamage(event)
+
+        assertTrue(event.isCancelled)
+        verify { combatService.canAttack(attacker.uniqueId, victim.uniqueId, territoryGuildId) }
+    }
+
+    @Test
+    fun `onPlayerDamage allows legal attack in guild-owned claim`() {
+        val attacker = player(UUID.randomUUID())
+        val victim = player(UUID.randomUUID())
+        every { getClaimAtPosition.execute(worldId, any()) } returns
+            GetClaimAtPositionResult.Success(guildClaim(territoryGuildId))
+        every { guildService.getGuild(territoryGuildId) } returns mockk(relaxed = true)
+        every { combatService.canAttack(attacker.uniqueId, victim.uniqueId, territoryGuildId) } returns true
+
+        val event = damageEvent(attacker, victim)
+
+        listener.onPlayerDamage(event)
+
+        assertFalse(event.isCancelled)
+    }
+
+    @Test
+    fun `onPlayerDamage ignores damage outside any claim`() {
+        val attacker = player(UUID.randomUUID())
+        val victim = player(UUID.randomUUID())
+        every { getClaimAtPosition.execute(worldId, any()) } returns GetClaimAtPositionResult.NoClaimFound
+
+        val event = damageEvent(attacker, victim)
+
+        listener.onPlayerDamage(event)
+
+        assertFalse(event.isCancelled)
+        verify(exactly = 0) { combatService.canAttack(any(), any(), any()) }
+    }
+
+    @Test
+    fun `onPlayerDamage ignores non-player victims`() {
+        val attacker = player(UUID.randomUUID())
+        val victim = mockk<org.bukkit.entity.Zombie>(relaxed = true)
+        val world = mockk<World>()
+        every { world.uid } returns worldId
+        every { victim.location } returns location(world)
+
+        val event = mockk<EntityDamageByEntityEvent>(relaxed = true)
+        every { event.entity } returns victim
+        every { event.damager } returns attacker
+
+        listener.onPlayerDamage(event)
+
+        assertFalse(event.isCancelled)
+        verify(exactly = 0) { combatService.canAttack(any(), any(), any()) }
+    }
+
+    // ---------- helpers ----------
+
+    private fun player(id: UUID): Player {
+        val p = mockk<Player>(relaxed = true)
+        every { p.uniqueId } returns id
+        val world = mockk<World>()
+        every { world.uid } returns worldId
+        every { p.location } returns location(world)
+        every { p.world } returns world
+        return p
+    }
+
+    private fun location(world: World): Location {
+        val loc = mockk<Location>()
+        every { loc.world } returns world
+        every { loc.blockX } returns 10
+        every { loc.blockZ } returns 20
+        return loc
+    }
+
+    private fun damageEvent(attacker: Player, victim: Player): EntityDamageByEntityEvent {
+        val event = mockk<EntityDamageByEntityEvent>(relaxed = true)
+        var cancelled = false
+        every { event.entity } returns victim
+        every { event.damager } returns attacker
+        every { event.isCancelled } answers { cancelled }
+        every { event.isCancelled = any() } answers { cancelled = arg(0) }
+        return event
+    }
+
+    private fun guildClaim(teamId: UUID): Claim =
+        Claim(
+            id = UUID.randomUUID(),
+            worldId = worldId,
+            playerId = UUID.randomUUID(),
+            teamId = teamId,
+            creationTime = Instant.now(),
+            name = "Guild Claim",
+            description = "",
+            position = net.lumalyte.lg.domain.values.Position3D(0, 0, 0),
+            icon = "GRASS_BLOCK"
+        )
+}


### PR DESCRIPTION
## Summary

PR-5 of the SPEAR roadmap: **Claims, peaceful mode & vault** — closes the last Section B residuals (audit H3/M11/H9). All three tasks are `TDD`, 8 new tests.

### LG-501 — Peaceful-mode claim PvP (REQ-007, scoped)

- `ModeServiceBukkit.isPvpAllowedInTerritory` now gates the peaceful-territory block behind `guild.peaceful_mode_claim_pvp_disabled` (was hardcoded off regardless of config).
- New `ClaimPvpProtectionListener`: for player-vs-player damage, resolves the victim's location to a claim via `GetClaimAtPosition`; for guild-owned claims it enforces `CombatService.canAttack` (peaceful territory, relations, same-guild rules). Registered in `registerClaimEvents()` — **only exists when claims are enabled**.
- ⚠️ **Scope note:** `peaceful_mode_prevent_wars` (war declarations blocked for peaceful guilds) is intentionally **NOT enforced** — operator decision to leave war behavior unchanged. Flag remains parsed, just not consumed. Revertible in one line if wanted later.

### LG-502 — Vault placement validates against claims (REQ-015)

- `GuildVaultServiceBukkit.isValidVaultLocation` fills the old `// TODO: Add claim validation when claims are enabled` — the vault must now be placed inside the **guild's own claim** (`claim.teamId == guild.id`), matching the guild-home rule.
- **Claims-disabled behavior unchanged** (places anywhere — verified by test).
- `GetClaimAtPosition` injected via constructor + `Modules.kt`.

### LG-503 — Load + consume `peacefulGuildPvpOptIn` (REQ-027)

- `peaceful_guild_pvp_opt_in` was a dead field in `GuildConfig` — never loaded, never read. Now loaded in `loadGuildConfig()` and consumed by `isPvpAllowedBetween`: peaceful guilds block PvP by default (`false`); with opt-in `true`, peaceful members can fight (both guilded and un-guilded opponent cases).

## Safety for claims-disabled setups (checked with the operator)

None of these changes affect a server with `claims_enabled: false`:
- Vault validation branches on `claimsEnabled` before any claim lookup → vaults place anywhere, as before
- `ClaimPvpProtectionListener` is only registered inside `registerClaimEvents()` (claims-on)
- Mode/opt-in changes keep config defaults = today's behavior

## Verification

- Full suite `--rerun-tasks`: **450 tests, 0 failures** (442 → +8 `PeacefulModeEnforcementTest`: territory PvP on/off, opt-in on/off, 4 vault-placement cases)
- Fuji boot-verify in progress


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Fixes
- Enforce configured PvP rules for peaceful guilds and peaceful territories.
- Validate vault placement against the owning guild’s claim when claims are enabled.
- Register claim PvP protection only when claims are enabled.

## Features
- Load and apply `peaceful_guild_pvp_opt_in` to peaceful-guild PvP checks.
- Handle direct and projectile attacks in guild-owned claims.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->