### PR TITLE
docs: fold PR #7 harvest map + level-100 baseline into backlog tasks

### DIFF
--- a/docs/tasks.md
+++ b/docs/tasks.md
@@ -322,6 +322,7 @@ PR grouping: tasks under each `## PR-n` header ship together in one pull request
   - Evidence:
   - Files: config section, `NexoEmojiService` (↳ LG-902 reflection cleanup)
   - Notes: lifecycle reconciliation — revoke on config-removal, guild rename/disband, member leave, and mapping change (A→B revokes A, grants B); tests cover grant, revoke, rename, config-removal, and value replacement
+  - Harvest: `CustomEmojiCommand` + `setEmojiAdmin()` from closed PR #7 (superseded) — rebuild admin-command flow against current rank/permission model
 
 ## PR-12 — Backlog: progression & economy (operator, Fain)
 
@@ -331,11 +332,15 @@ PR grouping: tasks under each `## PR-n` header ship together in one pull request
   - Evidence:
   - Files: progression services, XP listeners (↳ PR-4 anti-farming, LG-204)
   - Notes: deterministic acceptance tests — per-source caps, no-AFK-farm proof per source, XP/hour flat-or-decreasing across level bands (anti-stunting; must NOT rise with level)
+  - Baseline: guilds are ALREADY at level 100 on the live server — `ProgressionConfig.maxLevel` (default 30) is never read at runtime, so the cap is unenforced; the 100→200 curve is the priority, not 0→100
+  - Harvest: XP formula `500*(L-1)^1.15 + L*150`, rate limiting, source table from closed PR #7 `progression.yml` (rebased 0→200)
 - [ ] **LG-1202** Comprehensive 0–200 reward tier list — documented per-level rewards incl. new level-100+ perks
   - Tag: `DOC`
   - References: REQ-050
   - Evidence:
   - Files: docs + reward config/registry
+  - Baseline: guilds already past level 100 — prioritize 100→200 content (perks, homes at 125/150/175/200) over re-documenting 0→100
+  - Harvest: level-reward table from closed PR #7 `progression.yml` as the 0→100 starting point
 - [ ] **LG-1203** Extended guild home capacity at levels 125, 150, 175, 200 (raises cap; activation still costs gold — see LG-1206)
   - Tag: `TDD`
   - References: REQ-051
@@ -403,6 +408,7 @@ PR grouping: tasks under each `## PR-n` header ship together in one pull request
   - References: REQ-062
   - Evidence:
   - Files: `PlayerJoinEvent` handler (pattern: `apollo/GuildTeamListener.onPlayerJoin:26`), guild notification
+  - Harvest: `AnnouncementService` + `AnnouncementRepository` from closed PR #7 (superseded) — rebuild against current persistence (SQLite migrations)
 - [ ] **LG-1402** Rank prefixes in guild chat — member's rank shown next to name (legacy restore)
   - Tag: `TDD`
   - References: REQ-063
@@ -426,6 +432,7 @@ PR grouping: tasks under each `## PR-n` header ship together in one pull request
   - References: REQ-066
   - Evidence:
   - Files: `GuildStatisticsMenu.kt` (↳ LG-602 drill-downs, LG-806)
+  - Harvest: `InvitationService` + `GuildInvitationRepositorySQLite` (+ migration) from closed PR #7 (superseded) — verify schema against current migrations before reuse
 - [ ] **LG-1502** Dynamic spawn banners — physical spawn banners track top guilds by Guild Level Leaderboard
   - Tag: `TDD`
   - References: REQ-067
@@ -462,4 +469,5 @@ PR grouping: tasks under each `## PR-n` header ship together in one pull request
   - References: REQ-073
   - Evidence:
   - Files: guild delete path, broadcast
+  - Harvest: `AnnouncementService` + repo from closed PR #7 (superseded) — shared with LG-1401
 


### PR DESCRIPTION
## Summary

Folds the PR #7 harvest map into the backlog tasks in `docs/tasks.md`, after #7 was closed as superseded (guilds already at level 100 — the `maxLevel` config is never enforced at runtime).

## Changes (docs only)

| Task | Added |
|---|---|
| **LG-1201** (XP revamp) | Baseline: guilds already at L100, cap unenforced — 100→200 curve is the priority; harvest PR #7's XP formula + rate limiting + source table (rebased 0→200) |
| **LG-1202** (0-200 tier list) | Baseline: prioritize 100→200 content; harvest PR #7's level-reward table as the 0→100 starting point |
| **LG-1104** (custom emojis) | Harvest `CustomEmojiCommand` + `setEmojiAdmin()` from PR #7, rebuilt against the current rank/permission model |
| **LG-1401** (login notifications) | Harvest `AnnouncementService` + repo from PR #7 |
| **LG-1501** (invitation tracker) | Harvest `InvitationService` + `GuildInvitationRepositorySQLite` (verify schema against current migrations) |
| **LG-1508** (disband broadcasts) | Harvest `AnnouncementService` + repo (shared with LG-1401) |

No code changes. Pure docs — branch off `origin/main`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

### Features
- Update `docs/tasks.md` with level 100–200 progression requirements, XP formula, rate limits, and source data.
- Document level-reward data as the starting point for level 0–100 progression.
- Document custom guild emoji commands and admin permissions.
- Document announcement, invitation, and SQLite repository requirements.
- Record that guilds already exceed level 100 because `maxLevel` is not enforced at runtime.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->