### PR TITLE
feat: add %lumaguilds_guild_emoji_font% placeholder — raw glyph char + font tag

### DIFF
--- a/PLACEHOLDERAPI_README.md
+++ b/PLACEHOLDERAPI_README.md
@@ -19,6 +19,8 @@ All placeholders use the `%lumaguilds_` prefix.
 - `%lumaguilds_guild_name%` - Player's guild name
 - `%lumaguilds_guild_tag%` - Player's guild tag (formatted)
 - `%lumaguilds_guild_emoji%` - Player's guild emoji (Nexo format)
+- `%lumaguilds_guild_emoji_minimessage%` - Guild emoji as Nexo glyph tag (`<glyph:name>`) for MiniMessage formatters (Velocitab via NexoProxy)
+- `%lumaguilds_guild_emoji_font%` - Guild emoji as raw MiniMessage font fragment (`<font:<glyphfont>><char></font>`) for consumers without glyph-tag support (UnlimitedNameTags, IC-DiscordSRV-Addon playerlist, Velocitab via PapiProxyBridge)
 - `%lumaguilds_guild_level%` - Player's guild level
 - `%lumaguilds_guild_balance%` - Player's guild bank balance
 - `%lumaguilds_guild_mode%` - Player's guild mode (Peaceful/Hostile)

--- a/docs/placeholders.md
+++ b/docs/placeholders.md
@@ -19,6 +19,7 @@ Resolve to `""` (empty) if the player has no guild — except `has_guild`, which
 | `%lumaguilds_guild_tag_raw%` | Tag exactly as stored (may be legacy `&` codes or MiniMessage) |
 | `%lumaguilds_guild_emoji%` | Nexo placeholder (`%nexo_<name>%`) — resolves only where Nexo's PAPI expansion runs (backend) |
 | `%lumaguilds_guild_emoji_minimessage%` | Nexo glyph tag for MiniMessage formatters like Velocitab (rendered proxy-side via NexoProxy). Matching `:name:` values become `<glyph:name>`; null/blank returns empty; other values pass through unchanged |
+| `%lumaguilds_guild_emoji_font%` | Raw MiniMessage font fragment (`<font:<glyphfont>><char></font>`) for MiniMessage consumers without Nexo glyph-tag support (UnlimitedNameTags, IC-DiscordSRV-Addon playerlist, Velocitab via PapiProxyBridge). Resolves char/font from Nexo's FontManager; falls back to `<glyph:name>` when Nexo is unavailable |
 | `%lumaguilds_guild_level%` | Current level |
 | `%lumaguilds_guild_balance%` | Bank balance |
 | `%lumaguilds_guild_mode%` | `Peaceful` / `Hostile` |

--- a/src/main/kotlin/net/lumalyte/lg/infrastructure/placeholders/LumaGuildsExpansion.kt
+++ b/src/main/kotlin/net/lumalyte/lg/infrastructure/placeholders/LumaGuildsExpansion.kt
@@ -4,6 +4,7 @@ import net.lumalyte.lg.application.persistence.LeaderboardRepository
 import net.lumalyte.lg.application.persistence.ProgressionRepository
 import net.lumalyte.lg.application.services.*
 import net.lumalyte.lg.domain.entities.Guild
+import net.lumalyte.lg.infrastructure.services.NexoEmojiService
 import net.lumalyte.lg.utils.ColorCodeUtils
 import net.kyori.adventure.text.Component
 import net.kyori.adventure.text.format.NamedTextColor
@@ -38,6 +39,7 @@ import java.util.concurrent.ConcurrentHashMap
  * - %lumaguilds_guild_tag_plain% - Tag with all formatting stripped
  * - %lumaguilds_guild_emoji% - Player's guild emoji (converted to %nexo_<emoji>% format for backend tab/scoreboard/chat)
  * - %lumaguilds_guild_emoji_minimessage% - Player's guild emoji as Nexo glyph tag (<glyph:emoji>) for MiniMessage formatters (Velocitab via NexoProxy)
+ * - %lumaguilds_guild_emoji_font% - Player's guild emoji as raw font fragment (<font:<glyphfont>><char></font>) for MiniMessage consumers without glyph-tag support (UnlimitedNameTags, IC-DiscordSRV-Addon playerlist, Velocitab via PapiProxyBridge)
  * - %lumaguilds_guild_level% - Player's guild level
  * - %lumaguilds_guild_balance% - Player's guild bank balance
  * - %lumaguilds_guild_members% - Player's guild member count
@@ -90,6 +92,7 @@ class LumaGuildsExpansion : PlaceholderExpansion(), KoinComponent {
     private val relationService: RelationService by inject()
     private val progressionRepository: ProgressionRepository by inject()
     private val leaderboardRepository: LeaderboardRepository by inject()
+    private val nexoEmojiService: NexoEmojiService by inject()
 
     private val miniMessage = MiniMessage.miniMessage()
     private val plainSerializer = PlainTextComponentSerializer.plainText()
@@ -143,6 +146,7 @@ class LumaGuildsExpansion : PlaceholderExpansion(), KoinComponent {
             "guild_tag_plain" -> renderTagAsPlain(guild)
             "guild_emoji" -> convertEmojiToNexoPlaceholder(guild.emoji)
             "guild_emoji_minimessage" -> ColorCodeUtils.emojiToGlyphTag(guild.emoji)
+            "guild_emoji_font" -> nexoEmojiService.emojiToFontTag(guild.emoji)
             "guild_level" -> guild.level.toString()
             // BankService.getBalance resolves to the unified guild balance (store B: vault gold),
             // the single source of truth shared by /g bal, /g baltop, /g menu -> Bank and the vault.

--- a/src/main/kotlin/net/lumalyte/lg/infrastructure/services/NexoEmojiService.kt
+++ b/src/main/kotlin/net/lumalyte/lg/infrastructure/services/NexoEmojiService.kt
@@ -1,8 +1,12 @@
 package net.lumalyte.lg.infrastructure.services
 
 import net.lumalyte.lg.application.services.ConfigService
+import net.lumalyte.lg.utils.ColorCodeUtils
 import org.bukkit.entity.Player
 import org.slf4j.LoggerFactory
+
+/** Font used by Nexo glyphs when the glyph does not declare its own font. */
+private const val DEFAULT_GLYPH_FONT = "nexo:default"
 
 /**
  * Service for interacting with Nexo emojis.
@@ -109,11 +113,102 @@ class NexoEmojiService(
     /**
      * Creates an emoji placeholder from an emoji name.
      *
-     * @param emojiName The name of the emoji (e.g., "catsmileysmile").
-     * @return The formatted placeholder (e.g., ":catsmileysmile:").
+     * @param emojiName The name of the emoji (e.g. "catsmileysmile").
+     * @return The formatted placeholder (e.g. ":catsmileysmile:").
      */
     fun createEmojiPlaceholder(emojiName: String): String {
         return ":$emojiName:"
+    }
+
+    /**
+     * Converts a guild emoji (`:catsmileysmile:`) into a raw MiniMessage font fragment
+     * (`<font:nexo:default>\uE001</font>`) for consumers whose MiniMessage cannot resolve
+     * Nexo's custom `<glyph:...>` tag — e.g. UnlimitedNameTags (backend display-entity
+     * nametags), the InteractiveChatDiscordSrvAddon playerlist image renderer, and Velocitab
+     * via PapiProxyBridge. `<font:...>` is a standard Adventure tag and the char is drawn
+     * from the glyph's own font in the mandatory resource pack, so no glyph-tag registration
+     * is needed. This is the renderable counterpart to `%lumaguilds_guild_emoji_minimessage%`.
+     *
+     * Resolves the glyph char + font through Nexo's FontManager (same reflection path as
+     * [hasEmojiPermission]); falls back to the `<glyph:name>` tag when Nexo is absent or the
+     * char/font cannot be read (matching [ColorCodeUtils.emojiToGlyphTag] output).
+     *
+     * Non-`:name:` values pass through unchanged; null or blank return `""`.
+     */
+    fun emojiToFontTag(emoji: String?): String {
+        if (emoji.isNullOrBlank()) return ""
+        val emojiName = extractEmojiName(emoji) ?: return emoji
+        val glyph = resolveGlyphByName(emojiName) ?: return "<glyph:$emojiName>"
+        val char = reflectGlyphChar(glyph)
+        if (char.isNullOrBlank()) return "<glyph:$emojiName>"
+        val font = reflectGlyphFont(glyph) ?: DEFAULT_GLYPH_FONT
+        return "<font:$font>$char</font>"
+    }
+
+    /**
+     * Looks up a Nexo glyph object by name via FontManager reflection.
+     *
+     * @param name glyph id without colons (e.g. `catsmileysmile`).
+     * @return the glyph object, or null if Nexo/FontManager is unavailable or the lookup fails.
+     */
+    private fun resolveGlyphByName(name: String): Any? {
+        val fontManager = getFontManager() ?: return null
+        return try {
+            fontManager.javaClass.getMethod("glyphFromName", String::class.java).invoke(fontManager, name)
+        } catch (e: Exception) {
+            logger.debug("glyphFromName failed for '$name': ${e.message}")
+            null
+        }
+    }
+
+    /**
+     * Reflectively reads the glyph's unicode char. Tries common accessor names in order;
+     * the value may be a String (e.g. "\uE001"), a single Char, or a short String form.
+     */
+    private fun reflectGlyphChar(glyph: Any): String? {
+        for (accessor in listOf("getChar", "char", "getCharacter", "character", "getGlyphCode", "glyphCode", "getCode", "code")) {
+            val value = invokeNoArgGetter(glyph, accessor) ?: continue
+            when (value) {
+                is String -> if (value.isNotEmpty()) return value
+                is Char -> return value.toString()
+                else -> {
+                    val s = value.toString()
+                    if (s.isNotEmpty() && s.length <= 2) return s
+                }
+            }
+        }
+        return null
+    }
+
+    /**
+     * Reflectively reads the glyph's font key (e.g. `nexo:default`), or null when no
+     * accessor yields a usable value.
+     */
+    private fun reflectGlyphFont(glyph: Any): String? {
+        for (accessor in listOf("getFont", "font", "getFontName", "fontName", "getFontKey", "fontKey")) {
+            val value = invokeNoArgGetter(glyph, accessor)?.toString()?.trim() ?: continue
+            if (value.isBlank() || value == "null" || value == "minecraft") continue
+            return value
+        }
+        return null
+    }
+
+    /** Invokes a zero-arg getter reflectively, trying public then declared methods. */
+    private fun invokeNoArgGetter(target: Any, name: String): Any? {
+        for (publicFirst in listOf(true, false)) {
+            try {
+                val method = if (publicFirst) {
+                    target.javaClass.getMethod(name)
+                } else {
+                    target.javaClass.getDeclaredMethod(name)
+                }
+                method.trySetAccessible()
+                return method.invoke(target)
+            } catch (e: Exception) {
+                // try the next accessor variant
+            }
+        }
+        return null
     }
     
     /**

--- a/src/main/kotlin/net/lumalyte/lg/infrastructure/services/NexoEmojiService.kt
+++ b/src/main/kotlin/net/lumalyte/lg/infrastructure/services/NexoEmojiService.kt
@@ -8,6 +8,9 @@ import org.slf4j.LoggerFactory
 /** Font used by Nexo glyphs when the glyph does not declare its own font. */
 private const val DEFAULT_GLYPH_FONT = "nexo:default"
 
+/** Safe glyph id shape — rejects MiniMessage control characters (e.g. `x><reset>`). */
+private val VALID_GLYPH_ID = Regex("^[a-zA-Z0-9_-]+$")
+
 /**
  * Service for interacting with Nexo emojis.
  * Handles emoji validation and permission checking for guild emoji system.
@@ -138,6 +141,9 @@ class NexoEmojiService(
     fun emojiToFontTag(emoji: String?): String {
         if (emoji.isNullOrBlank()) return ""
         val emojiName = extractEmojiName(emoji) ?: return emoji
+        // Reject glyph ids containing MiniMessage control characters (e.g. ":x><reset>:")
+        // so they can never reach the generated tag — isValidEmojiFormat only checks delimiters.
+        if (!VALID_GLYPH_ID.matches(emojiName)) return emoji
         val glyph = resolveGlyphByName(emojiName) ?: return "<glyph:$emojiName>"
         val char = reflectGlyphChar(glyph)
         if (char.isNullOrBlank()) return "<glyph:$emojiName>"
@@ -155,7 +161,10 @@ class NexoEmojiService(
         val fontManager = getFontManager() ?: return null
         return try {
             fontManager.javaClass.getMethod("glyphFromName", String::class.java).invoke(fontManager, name)
-        } catch (e: Exception) {
+        } catch (e: ReflectiveOperationException) {
+            logger.debug("glyphFromName failed for '$name': ${e.message}")
+            null
+        } catch (e: IllegalArgumentException) {
             logger.debug("glyphFromName failed for '$name': ${e.message}")
             null
         }
@@ -163,14 +172,17 @@ class NexoEmojiService(
 
     /**
      * Reflectively reads the glyph's unicode char. Tries common accessor names in order;
-     * the value may be a String (e.g. "\uE001"), a single Char, or a short String form.
+     * the value may be a String (e.g. "\uE001"), a single Char, a short String form, or a
+     * collection (Nexo's `getChars()` — the first char is the primary rendering char).
      */
     private fun reflectGlyphChar(glyph: Any): String? {
-        for (accessor in listOf("getChar", "char", "getCharacter", "character", "getGlyphCode", "glyphCode", "getCode", "code")) {
+        for (accessor in listOf("getChars", "getChar", "char", "getCharacter", "character", "getGlyphCode", "glyphCode", "getCode", "code")) {
             val value = invokeNoArgGetter(glyph, accessor) ?: continue
             when (value) {
                 is String -> if (value.isNotEmpty()) return value
                 is Char -> return value.toString()
+                is Iterable<*> -> value.firstOrNull { it != null }?.let { return it.toString() }
+                is Array<*> -> value.firstOrNull { it != null }?.let { return it.toString() }
                 else -> {
                     val s = value.toString()
                     if (s.isNotEmpty() && s.length <= 2) return s
@@ -204,7 +216,9 @@ class NexoEmojiService(
                 }
                 method.trySetAccessible()
                 return method.invoke(target)
-            } catch (e: Exception) {
+            } catch (e: ReflectiveOperationException) {
+                // try the next accessor variant
+            } catch (e: IllegalArgumentException) {
                 // try the next accessor variant
             }
         }

--- a/src/main/kotlin/net/lumalyte/lg/utils/ColorCodeUtils.kt
+++ b/src/main/kotlin/net/lumalyte/lg/utils/ColorCodeUtils.kt
@@ -9,6 +9,9 @@ import net.kyori.adventure.text.serializer.legacy.LegacyComponentSerializer
  */
 object ColorCodeUtils {
 
+    /** Safe glyph id shape — rejects MiniMessage control characters (e.g. `x><reset>`). */
+    private val VALID_GLYPH_ID = Regex("^[a-zA-Z0-9_-]+$")
+
     /**
      * Converts a guild emoji (stored in Discord format, e.g. `:catsmileysmile:`) into
      * the Nexo glyph MiniMessage tag (`<glyph:catsmileysmile>`).
@@ -18,12 +21,16 @@ object ColorCodeUtils {
      * renders in MiniMessage formatters that have glyph support — e.g. Velocitab on the
      * proxy via NexoProxy, and backend chat/scoreboards via Nexo's formatting engine.
      *
-     * Non-`:name:` values pass through unchanged; null or blank return `""`.
+     * Non-`:name:` values pass through unchanged; null or blank return `""`. Emoji names
+     * containing MiniMessage control characters (anything outside `[a-zA-Z0-9_-]`) pass
+     * through unchanged so they can never inject tags into the generated output.
      */
     fun emojiToGlyphTag(emoji: String?): String {
         if (emoji.isNullOrBlank()) return ""
         if (emoji.startsWith(":") && emoji.endsWith(":") && emoji.length > 2) {
-            return "<glyph:${emoji.substring(1, emoji.length - 1)}>"
+            val name = emoji.substring(1, emoji.length - 1)
+            if (!VALID_GLYPH_ID.matches(name)) return emoji
+            return "<glyph:$name>"
         }
         return emoji
     }

--- a/src/test/kotlin/net/lumalyte/lg/infrastructure/services/NexoEmojiServiceFontTagTest.kt
+++ b/src/test/kotlin/net/lumalyte/lg/infrastructure/services/NexoEmojiServiceFontTagTest.kt
@@ -37,6 +37,15 @@ class NexoEmojiServiceFontTagTest {
     }
 
     @Test
+    fun `rejects emoji names with MiniMessage control characters`() {
+        // isValidEmojiFormat only checks delimiters; the glyph-id guard must stop
+        // MiniMessage control characters from reaching the generated tag.
+        assertEquals(":x><reset>:", service.emojiToFontTag(":x><reset>:"))
+        assertEquals(":<red>evil</red>:", service.emojiToFontTag(":<red>evil</red>:"))
+        assertEquals(":emoji with spaces:", service.emojiToFontTag(":emoji with spaces:"))
+    }
+
+    @Test
     fun `falls back to glyph tag when Nexo is unavailable`() {
         // No Bukkit server in unit tests -> getFontManager() is null -> <glyph:name>
         assertEquals("<glyph:catsmileysmile>", service.emojiToFontTag(":catsmileysmile:"))

--- a/src/test/kotlin/net/lumalyte/lg/infrastructure/services/NexoEmojiServiceFontTagTest.kt
+++ b/src/test/kotlin/net/lumalyte/lg/infrastructure/services/NexoEmojiServiceFontTagTest.kt
@@ -1,0 +1,46 @@
+package net.lumalyte.lg.infrastructure.services
+
+import io.mockk.mockk
+import net.lumalyte.lg.application.services.ConfigService
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Test
+
+/**
+ * Tests for [NexoEmojiService.emojiToFontTag] — the guild-emoji → raw
+ * `<font:<glyphfont>><char></font>` converter used by
+ * %lumaguilds_guild_emoji_font% (backend MiniMessage consumers: UnlimitedNameTags,
+ * IC-DiscordSRV-Addon playerlist image renderer, Velocitab via PapiProxyBridge).
+ *
+ * Without a running Bukkit server [NexoEmojiService.getFontManager] resolves to null,
+ * so these tests exercise the fallback path (Nexo `<glyph:name>` tag, matching
+ * [net.lumalyte.lg.utils.ColorCodeUtils.emojiToGlyphTag]). The Nexo char/font
+ * extraction itself is integration-only (requires live Nexo classes on a server).
+ */
+class NexoEmojiServiceFontTagTest {
+
+    private val service = NexoEmojiService(mockk<ConfigService>())
+
+    @Test
+    fun `returns empty for null or blank`() {
+        assertEquals("", service.emojiToFontTag(null))
+        assertEquals("", service.emojiToFontTag(""))
+        assertEquals("", service.emojiToFontTag("   "))
+        assertEquals("", service.emojiToFontTag("\t\n"))
+    }
+
+    @Test
+    fun `passes non-discord values through unchanged`() {
+        assertEquals(":weird", service.emojiToFontTag(":weird"))
+        assertEquals("plain", service.emojiToFontTag("plain"))
+        // ":": length 1, doesn't match the :name: guard -> passthrough (same as the glyph-tag converter)
+        assertEquals(":", service.emojiToFontTag(":"))
+    }
+
+    @Test
+    fun `falls back to glyph tag when Nexo is unavailable`() {
+        // No Bukkit server in unit tests -> getFontManager() is null -> <glyph:name>
+        assertEquals("<glyph:catsmileysmile>", service.emojiToFontTag(":catsmileysmile:"))
+        assertEquals("<glyph:clown>", service.emojiToFontTag(":clown:"))
+        assertEquals("<glyph:fire>", service.emojiToFontTag(":fire:"))
+    }
+}

--- a/src/test/kotlin/net/lumalyte/lg/utils/ColorCodeUtilsEmojiGlyphTest.kt
+++ b/src/test/kotlin/net/lumalyte/lg/utils/ColorCodeUtilsEmojiGlyphTest.kt
@@ -26,6 +26,15 @@ class ColorCodeUtilsEmojiGlyphTest {
     }
 
     @Test
+    fun `rejects emoji names with MiniMessage control characters`() {
+        // isValidEmojiFormat only checks delimiters; the glyph-id guard must stop
+        // MiniMessage control characters from reaching the generated tag.
+        assertEquals(":x><reset>:", ColorCodeUtils.emojiToGlyphTag(":x><reset>:"))
+        assertEquals(":<red>evil</red>:", ColorCodeUtils.emojiToGlyphTag(":<red>evil</red>:"))
+        assertEquals(":emoji with spaces:", ColorCodeUtils.emojiToGlyphTag(":emoji with spaces:"))
+    }
+
+    @Test
     fun `returns empty for null or blank`() {
         assertEquals("", ColorCodeUtils.emojiToGlyphTag(null))
         assertEquals("", ColorCodeUtils.emojiToGlyphTag(""))

--- a/wiki/docs/admins/placeholderapi.md
+++ b/wiki/docs/admins/placeholderapi.md
@@ -34,6 +34,7 @@ The same variants apply to `guild_display` and `guild_chat_format`.
 | `guild_tag_plain` | Text (plain) | Guild tag with formatting stripped |
 | `guild_emoji` | Text | Guild emoji, converted to Nexo PAPI format (`%nexo_<name>%`) — resolves only where Nexo's PAPI expansion runs (backend) |
 | `guild_emoji_minimessage` | Text | Guild emoji as Nexo glyph tag for MiniMessage formatters (Velocitab via NexoProxy). Matching `:name:` values become `<glyph:name>`; null/blank returns empty; other values pass through unchanged |
+| `guild_emoji_font` | Text | Guild emoji as raw MiniMessage font fragment (`<font:<glyphfont>><char></font>`) — renders in MiniMessage consumers without Nexo glyph-tag support (UnlimitedNameTags, IC-DiscordSRV-Addon playerlist, Velocitab via PapiProxyBridge). Resolves the char/font from Nexo's FontManager; falls back to `<glyph:name>` when Nexo is unavailable |
 | `guild_level` | Integer | Current guild level |
 | `guild_balance` | Integer | Virtual bank balance (coins) |
 | `guild_mode` | Text | `Peaceful` or `Hostile` |


### PR DESCRIPTION
## Summary

Adds `%lumaguilds_guild_emoji_font%` — the guild emoji as a raw MiniMessage font fragment (`<font:<glyphfont>><char></font>`), renderable by **any** MiniMessage consumer.

### Why

Nexo's `<glyph:...>` tag is a custom MiniMessage tag. It only resolves where Nexo registers it: NexoProxy (proxy-side) and Nexo's own netty chat formatting. Backend MiniMessage consumers — UnlimitedNameTags display entities, the InteractiveChatDiscordSrvAddon `/playerlist` image renderer (with the Nexo pack loaded), Velocitab via PapiProxyBridge — parse standard Adventure tags only, so `<glyph:...>` renders as literal text there (verified in-game 2026-08-12).

The existing placeholders can't fix this:
- `%lumaguilds_guild_emoji%` emits a nested `%nexo_<name>%` — dies in single-pass PAPI consumers, and even resolved, `%nexo_<id>%` returns the glyph tag (not the char) for glyphs in a custom font (EnthusiaSMP: `Glyphs.default_font: nexo:default`).
- `%lumaguilds_guild_emoji_minimessage%` emits `<glyph:name>` — unrenderable outside Nexo-registered contexts.

`<font:...>` IS a standard Adventure tag, and the glyph char draws from the mandatory pack — so the new form renders everywhere.

### Changes

- `NexoEmojiService.emojiToFontTag()`: resolves the glyph's char + font through Nexo's FontManager via reflection (same path as the existing `glyphFromName` validation); falls back to `<glyph:name>` when Nexo is unavailable or the char/font can't be read.
- `LumaGuildsExpansion`: wires `guild_emoji_font`.
- Tests: blank/passthrough/fallback paths (`NexoEmojiServiceFontTagTest`). The Nexo char/font extraction itself is integration-only (needs live Nexo classes).
- Docs: `docs/placeholders.md`, `wiki/docs/admins/placeholderapi.md`, `PLACEHOLDERAPI_README.md`.

### Consumers

- IC-DiscordSRV-Addon `PlayerFormat`: replace `%lumaguilds_guild_emoji%` with `%lumaguilds_guild_emoji_font%` (renders in the `/playerlist` image once the Nexo pack is loaded in `Resources.Order`).
- UnlimitedNameTags: `<font:nexo:default>%lumaguilds_guild_emoji_font%</font>`-style lines (or bare placeholder — it already carries its font).
- Velocitab: works via PapiProxyBridge (standard font tag; NexoProxy no longer required for the emoji).

### Test Plan

- [x] `./gradlew test` — full suite green
- [ ] Live: `/papi parse me %lumaguilds_guild_emoji_font%` for a guild with an emoji → expect `<font:nexo:default><char></font>`
- [ ] Live: IC `/playerlist` renders the glyph in the Discord image
- [ ] Live: UNT nametag line renders the glyph

Note: monorepo `enthusia-network` gitlink bump PR required after merge.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

### Features
- Add `%lumaguilds_guild_emoji_font%` to return a raw MiniMessage font fragment, resolve Nexo glyph data, fall back to `<glyph:name>`, and document supported consumers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->