### PR TITLE
fix: self-heal rank permission enum drift — unknown values no longer crash preload

### DIFF
--- a/src/main/kotlin/net/lumalyte/lg/infrastructure/persistence/guilds/RankRepositorySQLite.kt
+++ b/src/main/kotlin/net/lumalyte/lg/infrastructure/persistence/guilds/RankRepositorySQLite.kt
@@ -41,12 +41,25 @@ class RankRepositorySQLite(private val storage: Storage<Database>) : RankReposit
     
     private fun preload() {
         val sql = "SELECT * FROM ranks ORDER BY guild_id, priority"
-        
+
         try {
             val results = storage.connection.getResults(sql)
             for (result in results) {
                 val rank = mapResultSetToRank(result)
                 ranks[rank.id] = rank
+                // Self-clean: persist the parsed (cleaned) set back when the stored
+                // permissions column contains values that no longer exist in the enum.
+                // Atomic per-row UPDATE, converges after one boot — no operator SQL needed.
+                val rawPermissions = result.getString("permissions")
+                if (hasStalePermissions(rawPermissions, rank.permissions)) {
+                    val cleaned = rank.permissions.joinToString(",") { it.name }
+                    storage.connection.executeUpdate(
+                        "UPDATE ranks SET permissions = ? WHERE id = ?",
+                        cleaned,
+                        rank.id.toString()
+                    )
+                    logger.info("Cleaned stale permissions for rank {} (stored '{}' -> '{}')", rank.id, rawPermissions, cleaned)
+                }
             }
         } catch (e: SQLException) {
             throw DatabaseOperationException("Failed to preload ranks", e)
@@ -201,6 +214,17 @@ class RankRepositorySQLite(private val storage: Storage<Database>) : RankReposit
                     }
                 }
                 .toSet()
+        }
+
+        /**
+         * True when the stored `permissions` column contains values not present in
+         * [RankPermission] — i.e. the row needs its cleaned set written back.
+         * Order and duplicates in the stored string do not count as stale.
+         */
+        fun hasStalePermissions(permissionsStr: String?, parsed: Set<RankPermission>): Boolean {
+            if (permissionsStr.isNullOrBlank()) return false
+            val storedTokens = permissionsStr.split(",").map { it.trim() }.filter { it.isNotBlank() }.toSet()
+            return storedTokens != parsed.map { it.name }.toSet()
         }
     }
 

--- a/src/main/kotlin/net/lumalyte/lg/infrastructure/persistence/guilds/RankRepositorySQLite.kt
+++ b/src/main/kotlin/net/lumalyte/lg/infrastructure/persistence/guilds/RankRepositorySQLite.kt
@@ -6,13 +6,14 @@ import net.lumalyte.lg.application.persistence.RankRepository
 import net.lumalyte.lg.domain.entities.Rank
 import net.lumalyte.lg.domain.entities.RankPermission
 import net.lumalyte.lg.infrastructure.persistence.storage.Storage
+import org.slf4j.LoggerFactory
 import java.sql.SQLException
 import java.util.UUID
 
 class RankRepositorySQLite(private val storage: Storage<Database>) : RankRepository {
-    
+
     private val ranks: MutableMap<UUID, Rank> = mutableMapOf()
-    
+
     init {
         createRankTable()
         preload()
@@ -60,9 +61,7 @@ class RankRepositorySQLite(private val storage: Storage<Database>) : RankReposit
         val permissionsStr = rs.getString("permissions")
         val icon = rs.getString("icon")
 
-        val permissions = if (permissionsStr != null) {
-            permissionsStr.split(",").filter { it.isNotBlank() }.map { RankPermission.valueOf(it.trim()) }.toSet()
-        } else emptySet()
+        val permissions = parseRankPermissions(permissionsStr)
 
         return Rank(
             id = id,
@@ -169,13 +168,41 @@ class RankRepositorySQLite(private val storage: Storage<Database>) : RankReposit
     }
     
     override fun isNameTaken(guildId: UUID, name: String): Boolean = getByName(guildId, name) != null
-    
+
     override fun getNextPriority(guildId: UUID): Int {
         val existingRanks = getByGuild(guildId)
         return if (existingRanks.isEmpty()) 0 else existingRanks.maxOf { it.priority } + 1
     }
-    
+
     override fun getCountByGuild(guildId: UUID): Int = getByGuild(guildId).size
+
+    companion object {
+        private val logger = LoggerFactory.getLogger(RankRepositorySQLite::class.java)
+
+        /**
+         * Parses a stored `permissions` column into enum values, skipping unknown names.
+         *
+         * Self-heals enum/DB drift: permission values removed from [RankPermission]
+         * (e.g. `EXPORT_BANK_DATA` after the CSV export removal, #90) remain in live
+         * rank rows and must not crash preload. Unknown names are dropped with a warning;
+         * the cleaned set is persisted the next time the rank is saved.
+         */
+        fun parseRankPermissions(permissionsStr: String?): Set<RankPermission> {
+            if (permissionsStr.isNullOrBlank()) return emptySet()
+            return permissionsStr.split(",")
+                .filter { it.isNotBlank() }
+                .mapNotNull { raw ->
+                    val name = raw.trim()
+                    try {
+                        RankPermission.valueOf(name)
+                    } catch (e: IllegalArgumentException) {
+                        logger.warn("Unknown rank permission '$name' in DB — ignoring (cleaned on next rank save)")
+                        null
+                    }
+                }
+                .toSet()
+        }
+    }
 
     override fun swapPriorities(rankAId: UUID, rankBId: UUID): Boolean {
         val rankA = ranks[rankAId] ?: return false

--- a/src/test/kotlin/net/lumalyte/lg/infrastructure/persistence/guilds/RankRepositorySQLiteParseTest.kt
+++ b/src/test/kotlin/net/lumalyte/lg/infrastructure/persistence/guilds/RankRepositorySQLiteParseTest.kt
@@ -2,6 +2,7 @@ package net.lumalyte.lg.infrastructure.persistence.guilds
 
 import net.lumalyte.lg.domain.entities.RankPermission
 import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertFalse
 import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.Test
 
@@ -44,5 +45,22 @@ class RankRepositorySQLiteParseTest {
             setOf(RankPermission.MANAGE_RANKS),
             RankRepositorySQLite.parseRankPermissions("MANAGE_RANKS,MANAGE_RANKS")
         )
+    }
+
+    @Test
+    fun `detects stale rows that need cleanup`() {
+        assertTrue(RankRepositorySQLite.hasStalePermissions("MANAGE_RANKS,EXPORT_BANK_DATA", setOf(RankPermission.MANAGE_RANKS)))
+        assertTrue(RankRepositorySQLite.hasStalePermissions("EXPORT_BANK_DATA", emptySet()))
+        assertTrue(RankRepositorySQLite.hasStalePermissions("EXPORT_BANK_DATA,MANAGE_MEMBERS", setOf(RankPermission.MANAGE_MEMBERS)))
+    }
+
+    @Test
+    fun `does not rewrite clean rows`() {
+        // order and duplicates are not stale
+        assertFalse(RankRepositorySQLite.hasStalePermissions("MANAGE_RANKS", setOf(RankPermission.MANAGE_RANKS)))
+        assertFalse(RankRepositorySQLite.hasStalePermissions("MANAGE_MEMBERS,MANAGE_RANKS", setOf(RankPermission.MANAGE_RANKS, RankPermission.MANAGE_MEMBERS)))
+        assertFalse(RankRepositorySQLite.hasStalePermissions("MANAGE_RANKS,MANAGE_RANKS", setOf(RankPermission.MANAGE_RANKS)))
+        assertFalse(RankRepositorySQLite.hasStalePermissions(null, emptySet()))
+        assertFalse(RankRepositorySQLite.hasStalePermissions("", emptySet()))
     }
 }

--- a/src/test/kotlin/net/lumalyte/lg/infrastructure/persistence/guilds/RankRepositorySQLiteParseTest.kt
+++ b/src/test/kotlin/net/lumalyte/lg/infrastructure/persistence/guilds/RankRepositorySQLiteParseTest.kt
@@ -1,0 +1,48 @@
+package net.lumalyte.lg.infrastructure.persistence.guilds
+
+import net.lumalyte.lg.domain.entities.RankPermission
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+
+/**
+ * Rank-permission DB parsing — self-healing against enum/DB drift.
+ *
+ * Regression: `EXPORT_BANK_DATA` was removed from [RankPermission] in #90 (CSV export
+ * removal) but remained in live rank rows, crashing plugin enable via
+ * `RankPermission.valueOf` in preload. The parser must skip unknown names instead.
+ */
+class RankRepositorySQLiteParseTest {
+
+    @Test
+    fun `parses known permissions`() {
+        assertEquals(
+            setOf(RankPermission.MANAGE_RANKS, RankPermission.MANAGE_MEMBERS),
+            RankRepositorySQLite.parseRankPermissions("MANAGE_RANKS, MANAGE_MEMBERS")
+        )
+    }
+
+    @Test
+    fun `skips unknown permissions instead of crashing`() {
+        // EXPORT_BANK_DATA no longer exists in the enum — must be dropped, not fatal.
+        assertEquals(
+            setOf(RankPermission.MANAGE_RANKS),
+            RankRepositorySQLite.parseRankPermissions("MANAGE_RANKS,EXPORT_BANK_DATA")
+        )
+    }
+
+    @Test
+    fun `handles null blank and whitespace-only values`() {
+        assertTrue(RankRepositorySQLite.parseRankPermissions(null).isEmpty())
+        assertTrue(RankRepositorySQLite.parseRankPermissions("").isEmpty())
+        assertTrue(RankRepositorySQLite.parseRankPermissions("   ,, ").isEmpty())
+    }
+
+    @Test
+    fun `deduplicates repeated permissions`() {
+        assertEquals(
+            setOf(RankPermission.MANAGE_RANKS),
+            RankRepositorySQLite.parseRankPermissions("MANAGE_RANKS,MANAGE_RANKS")
+        )
+    }
+}


### PR DESCRIPTION
## Summary

Fixes a hard plugin-enable crash: `RankRepositorySQLite.preload()` did a raw `RankPermission.valueOf(...)` on every stored permission. `EXPORT_BANK_DATA` was removed from the enum in #90 (LG-208, CSV export removal) but remains in live rank rows — so the first rank containing it throws `IllegalArgumentException` and the whole Koin graph fails (`Could not create instance for GuildService`).

## Fix

`parseRankPermissions()` (pure companion function) skips unknown names with a warning instead of crashing. Self-healing: the cleaned permission set is persisted the next time the rank is saved, so the stale DB value clears itself without operator SQL (per EnthusiaSMP rule — no manual DB edits).

## Test Plan

- [x] `./gradlew test` — full suite green, incl. new `RankRepositorySQLiteParseTest` (known / unknown / blank / dedup cases)
- [ ] Fuji test server: seed a rank with `EXPORT_BANK_DATA`, verify plugin enables + warns

Note: sibling repositories (`BankRepositorySQLite` `TransactionType.valueOf`, etc.) share the raw-`valueOf` pattern — same latent risk if their enums ever drift; not changed here (out of scope).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Fixes
- Prevent `RankRepositorySQLite.preload()` from crashing on unknown stored `RankPermission` values.
- Skip blank and unknown permission names, log a warning, and persist the cleaned set when the rank is saved.
- Cover known, unknown, blank, and duplicate permissions with parser tests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->