### PR TITLE
fix: unify guild progression curve — fresh guilds no longer show wrong XP-to-next

### DIFF
--- a/src/main/kotlin/net/lumalyte/lg/di/Modules.kt
+++ b/src/main/kotlin/net/lumalyte/lg/di/Modules.kt
@@ -514,7 +514,7 @@ fun socialModule() = module {
 fun progressionModule() = module {
     // Repositories
     single<KillRepository> { KillRepositorySQLite(get()) }
-    single<ProgressionRepository> { ProgressionRepositorySQLite(get()) }
+    single<ProgressionRepository> { ProgressionRepositorySQLite(get(), get()) }
     single<LeaderboardRepository> { LeaderboardRepositorySQLite(get()) }
 
     // Services

--- a/src/main/kotlin/net/lumalyte/lg/domain/entities/Progression.kt
+++ b/src/main/kotlin/net/lumalyte/lg/domain/entities/Progression.kt
@@ -45,52 +45,19 @@ data class GuildProgression(
     companion object {
         /**
          * Creates a new guild progression with default values.
+         *
+         * @param guildId the guild this progression belongs to
+         * @param experienceForNextLevel XP required for the first level-up, taken from
+         * the config-driven [net.lumalyte.lg.domain.values.ProgressionCurve] — never
+         * hardcode a second formula here (regression: a hardcoded `800 * (level-1)^1.3`
+         * variant made fresh guilds show 1200 XP-to-next vs 2369 everywhere else).
          */
-        fun create(guildId: UUID): GuildProgression {
+        fun create(guildId: UUID, experienceForNextLevel: Int): GuildProgression {
             return GuildProgression(
                 guildId = guildId,
-                experienceForNextLevel = calculateExperienceForLevel(2),
+                experienceForNextLevel = experienceForNextLevel,
                 unlockedPerks = setOf(PerkType.CUSTOM_BANNER_COLORS, PerkType.ANIMATED_EMOJIS) // Always unlocked
             )
-        }
-
-        /**
-         * Calculates the experience required for a specific level.
-         * Uses a balanced growth formula that starts reasonable and has a gradual taper-off.
-         * Formula: baseXP * (level^1.3) + (level * 200) for competitive but fair progression
-         */
-        fun calculateExperienceForLevel(level: Int): Int {
-            if (level <= 1) return 0
-            val baseXP = 800.0
-            val exponent = 1.3 // Gentler curve than 1.5
-            val linearBonus = level * 200 // Adds linear growth to prevent harsh walls
-            return (baseXP * Math.pow(level.toDouble() - 1, exponent) + linearBonus).toInt()
-        }
-
-        /**
-         * Calculates the total experience required to reach a specific level.
-         */
-        fun calculateTotalExperienceForLevel(targetLevel: Int): Int {
-            var total = 0
-            for (level in 2..targetLevel) {
-                total += calculateExperienceForLevel(level)
-            }
-            return total
-        }
-
-        /**
-         * Determines the level for a given total experience amount.
-         */
-        fun calculateLevelFromExperience(totalExperience: Int): Int {
-            var level = 1
-            var remainingXP = totalExperience
-
-            while (remainingXP >= calculateExperienceForLevel(level + 1)) {
-                remainingXP -= calculateExperienceForLevel(level + 1)
-                level++
-            }
-
-            return level
         }
     }
 }

--- a/src/main/kotlin/net/lumalyte/lg/domain/values/ProgressionCurve.kt
+++ b/src/main/kotlin/net/lumalyte/lg/domain/values/ProgressionCurve.kt
@@ -1,0 +1,64 @@
+package net.lumalyte.lg.domain.values
+
+import kotlin.math.pow
+
+/**
+ * The guild leveling curve — single source of truth for XP math.
+ *
+ * Threshold from [currentLevel] to the next level:
+ * `baseXp * (currentLevel + 1)^exponent + (currentLevel + 1) * linearBonusPerLevel`.
+ *
+ * Used by both the progression service (awards, penalties, menus) and the
+ * repository (default rows, stale-value healing) so the two can never disagree.
+ * Regression this fixes: `GuildProgression.create()` hardcoded a *different*
+ * formula (`800 * (level-1)^1.3 + level*200`), so freshly created guilds showed
+ * 1200 XP-to-next while every guild that had earned XP showed 2369 at level 1.
+ */
+class ProgressionCurve(
+    private val baseXp: Double,
+    private val exponent: Double,
+    private val linearBonusPerLevel: Int,
+) {
+
+    /** XP required to go from [currentLevel] to the next level. */
+    fun experienceForNextLevel(currentLevel: Int): Int {
+        val nextLevel = currentLevel + 1
+        return (baseXp * nextLevel.toDouble().pow(exponent) + (nextLevel * linearBonusPerLevel)).toInt()
+    }
+
+    /** Cumulative XP required to reach the start of [targetLevel]. */
+    fun totalExperienceForLevel(targetLevel: Int): Int {
+        if (targetLevel <= 1) return 0
+        var totalXp = 0
+        for (level in 1 until targetLevel) {
+            totalXp += experienceForNextLevel(level)
+        }
+        return totalXp
+    }
+
+    /**
+     * Level for a given total XP. Capped at 101 — the level-up loop's safety cap
+     * (matches the historical behaviour: level 101 is the max, XP keeps
+     * accumulating beyond it as a sink).
+     */
+    fun levelFromExperience(totalExperience: Int): Int {
+        if (totalExperience <= 0) return 1
+
+        var currentLevel = 1
+        var experienceUsed = 0
+        while (true) {
+            val xpNeeded = experienceForNextLevel(currentLevel)
+            if (experienceUsed + xpNeeded > totalExperience) break
+            experienceUsed += xpNeeded
+            currentLevel++
+
+            // Safety check to prevent infinite loops
+            if (currentLevel > 100) break
+        }
+        return currentLevel
+    }
+
+    /** XP earned within the current level (0 .. threshold-1). */
+    fun experienceInCurrentLevel(totalExperience: Int): Int =
+        totalExperience - totalExperienceForLevel(levelFromExperience(totalExperience))
+}

--- a/src/main/kotlin/net/lumalyte/lg/domain/values/ProgressionCurve.kt
+++ b/src/main/kotlin/net/lumalyte/lg/domain/values/ProgressionCurve.kt
@@ -1,5 +1,6 @@
 package net.lumalyte.lg.domain.values
 
+import net.lumalyte.lg.config.ProgressionConfig
 import kotlin.math.pow
 
 /**
@@ -61,4 +62,14 @@ class ProgressionCurve(
     /** XP earned within the current level (0 .. threshold-1). */
     fun experienceInCurrentLevel(totalExperience: Int): Int =
         totalExperience - totalExperienceForLevel(levelFromExperience(totalExperience))
+
+    companion object {
+        /**
+         * The single config-to-curve accessor. Every caller (progression service,
+         * repository) must go through this so the curve can never be constructed
+         * differently in two places.
+         */
+        fun from(config: ProgressionConfig): ProgressionCurve =
+            ProgressionCurve(config.baseXp, config.levelExponent, config.linearBonusPerLevel)
+    }
 }

--- a/src/main/kotlin/net/lumalyte/lg/infrastructure/persistence/guilds/ProgressionRepositorySQLite.kt
+++ b/src/main/kotlin/net/lumalyte/lg/infrastructure/persistence/guilds/ProgressionRepositorySQLite.kt
@@ -26,10 +26,21 @@ class ProgressionRepositorySQLite(
     private val guildProgressions: MutableMap<UUID, GuildProgression> = mutableMapOf()
     private val activityMetrics: MutableMap<UUID, GuildActivityMetrics> = mutableMapOf()
 
+    // Memoized curve, invalidated when the config values change (reload-safe).
+    private var curveCacheKey: String? = null
+    private var curveCache: ProgressionCurve? = null
+
     /** The config-driven leveling curve — single source of truth for XP math. */
     private fun curve(): ProgressionCurve {
         val config = configService.loadConfig().progression
-        return ProgressionCurve(config.baseXp, config.levelExponent, config.linearBonusPerLevel)
+        val key = "${config.baseXp}|${config.levelExponent}|${config.linearBonusPerLevel}"
+        curveCache?.let { cached ->
+            if (curveCacheKey == key) return cached
+        }
+        val built = ProgressionCurve.from(config)
+        curveCache = built
+        curveCacheKey = key
+        return built
     }
 
     init {
@@ -143,9 +154,20 @@ class ProgressionRepositorySQLite(
         try {
             val results = storage.connection.getResults(sql)
             val curve = curve()
+            val pendingHeals = mutableListOf<Pair<UUID, Int>>()
             for (result in results) {
                 val progression = mapResultSetToGuildProgression(result)
-                guildProgressions[progression.guildId] = healStaleNextLevel(progression, curve)
+                if (hasStaleNextLevel(
+                        progression.totalExperience, progression.currentLevel,
+                        progression.experienceThisLevel, progression.experienceForNextLevel, curve
+                    )
+                ) {
+                    pendingHeals += progression.guildId to curve.experienceForNextLevel(progression.currentLevel)
+                }
+                guildProgressions[progression.guildId] = progression
+            }
+            if (pendingHeals.isNotEmpty()) {
+                applyStaleNextLevelHeals(pendingHeals)
             }
         } catch (e: SQLException) {
             throw DatabaseOperationException("Failed to preload guild progressions", e)
@@ -153,30 +175,36 @@ class ProgressionRepositorySQLite(
     }
 
     /**
-     * Rewrites `experience_for_next_level` when it doesn't match the config curve and the
-     * row is otherwise internally consistent. Self-heals the regression where
+     * Rewrites `experience_for_next_level` for rows that don't match the config curve but
+     * are otherwise internally consistent. Self-heals the regression where
      * `GuildProgression.create()` used a hardcoded different formula (fresh guilds stored
-     * 1200 instead of 2369 at level 1); converges after one boot.
+     * 1200 instead of 2369 at level 1); converges after one boot. All rows are applied in
+     * a single transaction so the heal costs one fsync on the startup thread.
      */
-    private fun healStaleNextLevel(progression: GuildProgression, curve: ProgressionCurve): GuildProgression {
-        val expectedNext = curve.experienceForNextLevel(progression.currentLevel)
-        if (!hasStaleNextLevel(
-                progression.totalExperience, progression.currentLevel,
-                progression.experienceThisLevel, progression.experienceForNextLevel, curve
-            )
-        ) {
-            return progression
-        }
-        return try {
-            storage.connection.executeUpdate(
-                "UPDATE guild_progression SET experience_for_next_level = ? WHERE guild_id = ?",
-                expectedNext, progression.guildId.toString()
-            )
-            logger.info("Healed stale experience_for_next_level for guild {} ({} -> {})", progression.guildId, progression.experienceForNextLevel, expectedNext)
-            progression.copy(experienceForNextLevel = expectedNext)
+    private fun applyStaleNextLevelHeals(pendingHeals: List<Pair<UUID, Int>>) {
+        var committed = false
+        try {
+            storage.connection.executeUpdate("BEGIN")
+            for ((guildId, expectedNext) in pendingHeals) {
+                storage.connection.executeUpdate(
+                    "UPDATE guild_progression SET experience_for_next_level = ? WHERE guild_id = ?",
+                    expectedNext, guildId.toString()
+                )
+                guildProgressions[guildId] = guildProgressions[guildId]?.copy(experienceForNextLevel = expectedNext)
+                    ?: GuildProgression.create(guildId, expectedNext)
+            }
+            storage.connection.executeUpdate("COMMIT")
+            committed = true
+            logger.info("Healed stale experience_for_next_level for {} guild(s) ({} total rows checked)", pendingHeals.size, guildProgressions.size)
         } catch (e: SQLException) {
-            logger.warn("Failed to heal stale experience_for_next_level for guild {}: {}", progression.guildId, e.message)
-            progression
+            if (!committed) {
+                try {
+                    storage.connection.executeUpdate("ROLLBACK")
+                } catch (rollbackError: SQLException) {
+                    logger.warn("Rollback failed after heal error: {}", rollbackError.message)
+                }
+            }
+            logger.warn("Failed to heal stale experience_for_next_level for {} guild(s): {}", pendingHeals.size, e.message)
         }
     }
 

--- a/src/main/kotlin/net/lumalyte/lg/infrastructure/persistence/guilds/ProgressionRepositorySQLite.kt
+++ b/src/main/kotlin/net/lumalyte/lg/infrastructure/persistence/guilds/ProgressionRepositorySQLite.kt
@@ -6,20 +6,31 @@ import net.lumalyte.lg.application.errors.DatabaseOperationException
 import net.lumalyte.lg.application.persistence.ProgressionRepository
 import net.lumalyte.lg.application.persistence.ActivityMetricType
 import net.lumalyte.lg.application.persistence.ProgressionStats
+import net.lumalyte.lg.application.services.ConfigService
 import net.lumalyte.lg.domain.entities.*
 import net.lumalyte.lg.domain.values.ExperienceSource
 import net.lumalyte.lg.domain.values.PerkType
+import net.lumalyte.lg.domain.values.ProgressionCurve
 import net.lumalyte.lg.infrastructure.persistence.storage.Storage
 import org.slf4j.LoggerFactory
 import java.sql.SQLException
 import java.time.Instant
 import java.util.UUID
 
-class ProgressionRepositorySQLite(private val storage: Storage<Database>) : ProgressionRepository {
+class ProgressionRepositorySQLite(
+    private val storage: Storage<Database>,
+    private val configService: ConfigService,
+) : ProgressionRepository {
 
     private val logger = LoggerFactory.getLogger(ProgressionRepositorySQLite::class.java)
     private val guildProgressions: MutableMap<UUID, GuildProgression> = mutableMapOf()
     private val activityMetrics: MutableMap<UUID, GuildActivityMetrics> = mutableMapOf()
+
+    /** The config-driven leveling curve — single source of truth for XP math. */
+    private fun curve(): ProgressionCurve {
+        val config = configService.loadConfig().progression
+        return ProgressionCurve(config.baseXp, config.levelExponent, config.linearBonusPerLevel)
+    }
 
     init {
         // Try to create tables and preload, but don't fail if migration hasn't run yet
@@ -131,12 +142,41 @@ class ProgressionRepositorySQLite(private val storage: Storage<Database>) : Prog
 
         try {
             val results = storage.connection.getResults(sql)
+            val curve = curve()
             for (result in results) {
                 val progression = mapResultSetToGuildProgression(result)
-                guildProgressions[progression.guildId] = progression
+                guildProgressions[progression.guildId] = healStaleNextLevel(progression, curve)
             }
         } catch (e: SQLException) {
             throw DatabaseOperationException("Failed to preload guild progressions", e)
+        }
+    }
+
+    /**
+     * Rewrites `experience_for_next_level` when it doesn't match the config curve and the
+     * row is otherwise internally consistent. Self-heals the regression where
+     * `GuildProgression.create()` used a hardcoded different formula (fresh guilds stored
+     * 1200 instead of 2369 at level 1); converges after one boot.
+     */
+    private fun healStaleNextLevel(progression: GuildProgression, curve: ProgressionCurve): GuildProgression {
+        val expectedNext = curve.experienceForNextLevel(progression.currentLevel)
+        if (!hasStaleNextLevel(
+                progression.totalExperience, progression.currentLevel,
+                progression.experienceThisLevel, progression.experienceForNextLevel, curve
+            )
+        ) {
+            return progression
+        }
+        return try {
+            storage.connection.executeUpdate(
+                "UPDATE guild_progression SET experience_for_next_level = ? WHERE guild_id = ?",
+                expectedNext, progression.guildId.toString()
+            )
+            logger.info("Healed stale experience_for_next_level for guild {} ({} -> {})", progression.guildId, progression.experienceForNextLevel, expectedNext)
+            progression.copy(experienceForNextLevel = expectedNext)
+        } catch (e: SQLException) {
+            logger.warn("Failed to heal stale experience_for_next_level for guild {}: {}", progression.guildId, e.message)
+            progression
         }
     }
 
@@ -284,8 +324,10 @@ class ProgressionRepositorySQLite(private val storage: Storage<Database>) : Prog
             val exists = result?.getInt("count") ?: 0 > 0
 
             if (!exists) {
-                // Create default progression
-                val defaultProgression = GuildProgression.create(guildId)
+                // Create default progression using the config-driven curve (never a
+                // hardcoded second formula — regression: fresh guilds showed 1200
+                // XP-to-next while the curve says 2369 at level 1).
+                val defaultProgression = GuildProgression.create(guildId, curve().experienceForNextLevel(1))
                 if (saveGuildProgression(defaultProgression)) {
                     guildProgressions[guildId] = defaultProgression
                     return defaultProgression
@@ -626,6 +668,27 @@ class ProgressionRepositorySQLite(private val storage: Storage<Database>) : Prog
             }
         } catch (e: SQLException) {
             throw DatabaseOperationException("Failed to get recent level ups", e)
+        }
+    }
+
+    companion object {
+        /**
+         * True when the stored `experience_for_next_level` doesn't match the config curve
+         * for the guild's level AND the row is otherwise internally consistent
+         * (total == cumulative thresholds + xp-this-level) — i.e. it's safe to rewrite.
+         *
+         * Regression: `GuildProgression.create()` hardcoded a different formula, leaving
+         * fresh guilds (0 XP) with 1200 instead of the curve's 2369 at level 1.
+         */
+        fun hasStaleNextLevel(
+            totalExperience: Int,
+            level: Int,
+            experienceThisLevel: Int,
+            storedNext: Int,
+            curve: ProgressionCurve,
+        ): Boolean {
+            if (storedNext == curve.experienceForNextLevel(level)) return false
+            return totalExperience == curve.totalExperienceForLevel(level) + experienceThisLevel
         }
     }
 }

--- a/src/main/kotlin/net/lumalyte/lg/infrastructure/services/ProgressionServiceBukkit.kt
+++ b/src/main/kotlin/net/lumalyte/lg/infrastructure/services/ProgressionServiceBukkit.kt
@@ -30,10 +30,21 @@ class ProgressionServiceBukkit(
 
     private val logger = LoggerFactory.getLogger(ProgressionServiceBukkit::class.java)
 
+    // Memoized curve, invalidated when the config values change (reload-safe).
+    private var curveCacheKey: String? = null
+    private var curveCache: ProgressionCurve? = null
+
     /** The config-driven leveling curve — single source of truth for XP math. */
     private fun curve(): ProgressionCurve {
         val config = configService.loadConfig().progression
-        return ProgressionCurve(config.baseXp, config.levelExponent, config.linearBonusPerLevel)
+        val key = "${config.baseXp}|${config.levelExponent}|${config.linearBonusPerLevel}"
+        curveCache?.let { cached ->
+            if (curveCacheKey == key) return cached
+        }
+        val built = ProgressionCurve.from(config)
+        curveCache = built
+        curveCacheKey = key
+        return built
     }
 
     override fun awardExperience(guildId: UUID, experience: Int, source: ExperienceSource): Int? {

--- a/src/main/kotlin/net/lumalyte/lg/infrastructure/services/ProgressionServiceBukkit.kt
+++ b/src/main/kotlin/net/lumalyte/lg/infrastructure/services/ProgressionServiceBukkit.kt
@@ -8,6 +8,7 @@ import net.lumalyte.lg.application.persistence.ProgressionRepository
 import net.lumalyte.lg.application.services.*
 import net.lumalyte.lg.domain.values.ExperienceSource
 import net.lumalyte.lg.domain.values.PerkType
+import net.lumalyte.lg.domain.values.ProgressionCurve
 import net.lumalyte.lg.domain.entities.*
 import net.lumalyte.lg.domain.events.GuildLevelUpEvent
 import org.bukkit.Bukkit
@@ -17,7 +18,6 @@ import java.time.Duration
 import java.time.Instant
 import java.time.temporal.ChronoUnit
 import java.util.UUID
-import kotlin.math.pow
 
 class ProgressionServiceBukkit(
     private val progressionRepository: ProgressionRepository,
@@ -29,6 +29,12 @@ class ProgressionServiceBukkit(
 ) : ProgressionService {
 
     private val logger = LoggerFactory.getLogger(ProgressionServiceBukkit::class.java)
+
+    /** The config-driven leveling curve — single source of truth for XP math. */
+    private fun curve(): ProgressionCurve {
+        val config = configService.loadConfig().progression
+        return ProgressionCurve(config.baseXp, config.levelExponent, config.linearBonusPerLevel)
+    }
 
     override fun awardExperience(guildId: UUID, experience: Int, source: ExperienceSource): Int? {
         try {
@@ -45,7 +51,7 @@ class ProgressionServiceBukkit(
 
             // Get or create guild progression
             val progression = progressionRepository.getGuildProgression(guildId)
-                ?: GuildProgression.create(guildId)
+                ?: GuildProgression.create(guildId, getExperienceForNextLevel(1))
 
             val oldLevel = progression.currentLevel
             val newTotalExperience = progression.totalExperience + experience
@@ -100,24 +106,14 @@ class ProgressionServiceBukkit(
         }
     }
 
-    override fun getExperienceForNextLevel(currentLevel: Int): Int {
-        val config = configService.loadConfig().progression
-        
-        // Use the configurable leveling curve
-        val baseXp = config.baseXp
-        val exponent = config.levelExponent
-        val linearBonus = config.linearBonusPerLevel
-        
-        // Calculate XP needed for next level: base * (level^exponent) + (level * linearBonus)
-        val nextLevel = currentLevel + 1
-        return (baseXp * nextLevel.toDouble().pow(exponent) + (nextLevel * linearBonus)).toInt()
-    }
+    override fun getExperienceForNextLevel(currentLevel: Int): Int =
+        curve().experienceForNextLevel(currentLevel)
 
     override fun removeExperience(guildId: UUID, amount: Int, source: ExperienceSource): Int {
         try {
             if (amount <= 0) return getLevelFromExperience(progressionRepository.getGuildProgression(guildId)?.totalExperience ?: 0)
             val progression = progressionRepository.getGuildProgression(guildId)
-                ?: GuildProgression.create(guildId)
+                ?: GuildProgression.create(guildId, getExperienceForNextLevel(1))
 
             val newTotalExperience = (progression.totalExperience - amount).coerceAtLeast(0)
             val newLevel = getLevelFromExperience(newTotalExperience)
@@ -154,7 +150,7 @@ class ProgressionServiceBukkit(
     override fun reduceLevel(guildId: UUID, levels: Int, source: ExperienceSource): Int {
         try {
             val progression = progressionRepository.getGuildProgression(guildId)
-                ?: GuildProgression.create(guildId)
+                ?: GuildProgression.create(guildId, getExperienceForNextLevel(1))
 
             val currentLevel = progression.currentLevel
             val targetLevel = (currentLevel - levels).coerceAtLeast(1)
@@ -191,39 +187,11 @@ class ProgressionServiceBukkit(
         }
     }
 
-    override fun getTotalExperienceForLevel(targetLevel: Int): Int {
-        if (targetLevel <= 1) return 0
-        
-        var totalXp = 0
-        for (level in 1 until targetLevel) {
-            totalXp += getExperienceForNextLevel(level)
-        }
-        return totalXp
-    }
+    override fun getTotalExperienceForLevel(targetLevel: Int): Int =
+        curve().totalExperienceForLevel(targetLevel)
 
-    override fun getLevelFromExperience(totalExperience: Int): Int {
-        if (totalExperience <= 0) return 1
-        
-        var currentLevel = 1
-        var experienceUsed = 0
-        
-        while (true) {
-            val xpNeeded = getExperienceForNextLevel(currentLevel)
-            if (experienceUsed + xpNeeded > totalExperience) {
-                break
-            }
-            experienceUsed += xpNeeded
-            currentLevel++
-            
-            // Safety check to prevent infinite loops
-            if (currentLevel > 100) {
-                logger.warn("Level calculation exceeded maximum level (100) for experience $totalExperience")
-                break
-            }
-        }
-        
-        return currentLevel
-    }
+    override fun getLevelFromExperience(totalExperience: Int): Int =
+        curve().levelFromExperience(totalExperience)
 
     override fun getLevelProgress(totalExperience: Int): Pair<Int, Int> {
         val currentLevel = getLevelFromExperience(totalExperience)
@@ -236,11 +204,8 @@ class ProgressionServiceBukkit(
     /**
      * Gets the experience within the current level (0 to experienceForNextLevel-1).
      */
-    private fun getExperienceInCurrentLevel(totalExperience: Int): Int {
-        val currentLevel = getLevelFromExperience(totalExperience)
-        val totalXpForCurrentLevel = getTotalExperienceForLevel(currentLevel)
-        return totalExperience - totalXpForCurrentLevel
-    }
+    private fun getExperienceInCurrentLevel(totalExperience: Int): Int =
+        curve().experienceInCurrentLevel(totalExperience)
 
     override fun getPerksForLevel(level: Int): List<PerkType> {
         val configs = LevelPerkConfig.getDefaultConfigs(configService.loadConfig().claimsEnabled)

--- a/src/test/kotlin/net/lumalyte/lg/domain/values/ProgressionCurveTest.kt
+++ b/src/test/kotlin/net/lumalyte/lg/domain/values/ProgressionCurveTest.kt
@@ -1,0 +1,55 @@
+package net.lumalyte.lg.domain.values
+
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Test
+
+/**
+ * Tests for [ProgressionCurve] — the single source of truth for guild XP math.
+ *
+ * Anchor values locked from the production DB: every stored
+ * `experience_for_next_level` that was ever written by the service matches this
+ * curve (level 1 -> 2369, level 3 -> 5650, ...).
+ */
+class ProgressionCurveTest {
+
+    private val curve = ProgressionCurve(baseXp = 800.0, exponent = 1.3, linearBonusPerLevel = 200)
+
+    @Test
+    fun `experience for next level matches the service curve`() {
+        // 800 * 2^1.3 + 2*200 = 2369.6 -> 2369 (the value every non-fresh guild stored)
+        assertEquals(2369, curve.experienceForNextLevel(1))
+        // 800 * 4^1.3 + 4*200 = 5650.3 -> 5650
+        assertEquals(5650, curve.experienceForNextLevel(3))
+        // level 0 -> threshold for level 1: 800 * 1^1.3 + 1*200 = 1000
+        assertEquals(1000, curve.experienceForNextLevel(0))
+    }
+
+    @Test
+    fun `cumulative totals`() {
+        assertEquals(0, curve.totalExperienceForLevel(1))
+        assertEquals(2369, curve.totalExperienceForLevel(2))
+        assertEquals(2369 + 3936, curve.totalExperienceForLevel(3)) // 3936 = 800*3^1.3 + 600
+    }
+
+    @Test
+    fun `level from experience`() {
+        assertEquals(1, curve.levelFromExperience(0))
+        assertEquals(1, curve.levelFromExperience(2368))
+        assertEquals(2, curve.levelFromExperience(2369))
+        assertEquals(2, curve.levelFromExperience(5000))
+        assertEquals(3, curve.levelFromExperience(2369 + 3936))
+    }
+
+    @Test
+    fun `experience in current level`() {
+        assertEquals(0, curve.experienceInCurrentLevel(2369))
+        assertEquals(100, curve.experienceInCurrentLevel(2469))
+        assertEquals(2631, curve.experienceInCurrentLevel(5000)) // 5000 - 2369 (start of level 2)
+    }
+
+    @Test
+    fun `caps at level 101 like the service loop`() {
+        assertEquals(101, curve.levelFromExperience(17_518_681)) // prod max total XP
+        assertEquals(101, curve.levelFromExperience(Int.MAX_VALUE / 2))
+    }
+}

--- a/src/test/kotlin/net/lumalyte/lg/infrastructure/persistence/guilds/ProgressionRepositorySQLiteHealTest.kt
+++ b/src/test/kotlin/net/lumalyte/lg/infrastructure/persistence/guilds/ProgressionRepositorySQLiteHealTest.kt
@@ -1,0 +1,43 @@
+package net.lumalyte.lg.infrastructure.persistence.guilds
+
+import net.lumalyte.lg.domain.values.ProgressionCurve
+import org.junit.jupiter.api.Assertions.assertFalse
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+
+/**
+ * Regression: `GuildProgression.create()` hardcoded a different formula than the
+ * service curve, so fresh guilds stored `experience_for_next_level = 1200` while
+ * every guild that had earned XP stored 2369 (level 1). The preload heal rewrites
+ * exactly those rows — only when the row is otherwise internally consistent.
+ */
+class ProgressionRepositorySQLiteHealTest {
+
+    private val curve = ProgressionCurve(baseXp = 800.0, exponent = 1.3, linearBonusPerLevel = 200)
+
+    @Test
+    fun `heals fresh guilds with the hardcoded 1200 value`() {
+        // fresh guild: 0 XP, level 1, 0 this-level, stored 1200 (old create() formula)
+        assertTrue(ProgressionRepositorySQLite.hasStaleNextLevel(0, 1, 0, 1200, curve))
+    }
+
+    @Test
+    fun `does not touch rows already on the curve`() {
+        // fresh guild with the correct curve value
+        assertFalse(ProgressionRepositorySQLite.hasStaleNextLevel(0, 1, 0, 2369, curve))
+        // leveled guild: total == cumulative + this, next matches curve (level 2 -> 3936)
+        assertFalse(ProgressionRepositorySQLite.hasStaleNextLevel(2369 + 100, 2, 100, 3936, curve))
+    }
+
+    @Test
+    fun `heals stale-but-otherwise-consistent rows`() {
+        // guild at level 1 with XP, still holding the old hardcoded 1200
+        assertTrue(ProgressionRepositorySQLite.hasStaleNextLevel(500, 1, 500, 1200, curve))
+    }
+
+    @Test
+    fun `never rewrites internally inconsistent rows`() {
+        // total doesn't match cumulative thresholds + this-level -> leave alone
+        assertFalse(ProgressionRepositorySQLite.hasStaleNextLevel(9999, 1, 500, 1200, curve))
+    }
+}

--- a/src/test/kotlin/net/lumalyte/lg/infrastructure/persistence/guilds/ProgressionRepositorySQLiteHealTest.kt
+++ b/src/test/kotlin/net/lumalyte/lg/infrastructure/persistence/guilds/ProgressionRepositorySQLiteHealTest.kt
@@ -25,8 +25,12 @@ class ProgressionRepositorySQLiteHealTest {
     fun `does not touch rows already on the curve`() {
         // fresh guild with the correct curve value
         assertFalse(ProgressionRepositorySQLite.hasStaleNextLevel(0, 1, 0, 2369, curve))
-        // leveled guild: total == cumulative + this, next matches curve (level 2 -> 3936)
-        assertFalse(ProgressionRepositorySQLite.hasStaleNextLevel(2369 + 100, 2, 100, 3936, curve))
+    }
+
+    @Test
+    fun `heals stale rows whose totals are consistent`() {
+        // stale next (1200 != 3936 for level 2) AND total == cumulative + this -> heal
+        assertTrue(ProgressionRepositorySQLite.hasStaleNextLevel(2369 + 100, 2, 100, 1200, curve))
     }
 
     @Test


### PR DESCRIPTION
## Summary

Freshly created guilds showed **1200 XP-to-next** in the progression menu while every guild that had earned XP showed **2369** at level 1 — then the number snapped to 2369 after the guild's first XP event. Verified against the production DB snapshot: 90 of 276 guilds (all 0 XP) store the wrong value.

## Root cause

Two different leveling formulas in one codebase:
- `GuildProgression.create()` → hardcoded `800 * (level-1)^1.3 + level*200` → 1200 at level 1
- `ProgressionServiceBukkit` (awards, penalties, level derivation) → config-driven `800 * (level+1)^1.3 + (level+1)*200` → 2369 at level 1

## Fix

- New **`ProgressionCurve`** (domain value): the single, config-driven source of truth for all XP math
- `ProgressionServiceBukkit` math delegates to it (zero behavior change)
- `GuildProgression.create(guildId, experienceForNextLevel)` — the hardcoded duplicate formula is deleted; all 4 call sites pass the curve value
- `ProgressionRepositorySQLite` creates defaults from the curve and **heals stale rows at preload** (only rows that are otherwise internally consistent; converges after one boot — same self-heal pattern as the rank fix in #98)

## Verification

- All other progression data on prod is consistent with the curve (totals, levels, the 101 cap) — this was the only discrepancy
- Tests: curve math locked to prod-verified anchors (2369, 5650), heal-decision matrix
- Fuji boot test against the real DB snapshot: 90 rows healed, plugin enables cleanly

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Breaking
- Update callers of `GuildProgression.create` and removed progression calculation helpers to use `ProgressionCurve`.

## Fixes
- Guild progression: heal stale, consistent `experience_for_next_level` values during preload and use configured level-one defaults.
- Progression calculations: use one configuration-driven `ProgressionCurve` across Bukkit services and SQLite persistence.

## Features
- Add `ProgressionCurve` with level thresholds, cumulative XP, level lookup, current-level XP, and the level-101 cap.
- Add tests for production curve anchors, healing decisions, and internally inconsistent rows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->