### PR TITLE
fix: wire RoseChat channel provider on PluginEnableEvent (reverse load order)

### DIFF
--- a/src/main/kotlin/net/lumalyte/lg/LumaGuilds.kt
+++ b/src/main/kotlin/net/lumalyte/lg/LumaGuilds.kt
@@ -972,8 +972,14 @@ class LumaGuilds : JavaPlugin() {
         val guildDisbandedListener = get().get<net.lumalyte.lg.infrastructure.listeners.GuildDisbandedListener>()
         server.pluginManager.registerEvents(guildDisbandedListener, this)
 
-        // Clean up RoseChat channels when guild status changes
-        if (server.pluginManager.isPluginEnabled("RoseChat")) {
+        // Clean up RoseChat channels when guild status changes.
+        // LumaGuilds can enable BEFORE RoseChat despite `depend: [RoseChat]`
+        // (observed on the Fuji test server: RoseChat enabled ~4 minutes later),
+        // so an `isPluginEnabled("RoseChat")` guard alone would silently skip
+        // the provider registration and guild/ally/modchat channels would never
+        // load. Mirror the LiteBans pattern: wire immediately when RoseChat is
+        // already enabled, otherwise register on its PluginEnableEvent.
+        val wireRoseChatHook = {
             val roseChatCleanupListener = get().get<net.lumalyte.lg.infrastructure.listeners.RoseChatCleanupListener>()
             server.pluginManager.registerEvents(roseChatCleanupListener, this)
             logColored("✓ RoseChat integration registered for chat cleanup")
@@ -988,6 +994,16 @@ class LumaGuilds : JavaPlugin() {
             // now that the provider exists (RoseChat's first attempt at startup
             // found no provider and skipped the guild sections).
             registerRoseChatChannels()
+        }
+        when {
+            server.pluginManager.isPluginEnabled("RoseChat") -> wireRoseChatHook()
+            server.pluginManager.getPlugin("RoseChat") != null -> {
+                // RoseChat loaded but not yet enabled (reverse load order) — wire when it enables.
+                server.pluginManager.registerEvents(
+                    net.lumalyte.lg.infrastructure.listeners.RoseChatEnableListener { wireRoseChatHook() },
+                    this,
+                )
+            }
         }
 
         // Register admin override listener (for logout cleanup) - only when claims enabled

--- a/src/main/kotlin/net/lumalyte/lg/infrastructure/listeners/RoseChatEnableListener.kt
+++ b/src/main/kotlin/net/lumalyte/lg/infrastructure/listeners/RoseChatEnableListener.kt
@@ -1,0 +1,37 @@
+package net.lumalyte.lg.infrastructure.listeners
+
+import org.bukkit.event.EventHandler
+import org.bukkit.event.EventPriority
+import org.bukkit.event.Listener
+import org.bukkit.event.server.PluginEnableEvent
+import org.slf4j.LoggerFactory
+
+/**
+ * Waits for RoseChat to finish enabling before wiring the guild/ally/modchat
+ * channel provider.
+ *
+ * LumaGuilds' own onEnable can run BEFORE RoseChat's onEnable even with
+ * `depend: [RoseChat]` (observed on the Fuji test server: LumaGuilds enabled
+ * at T+0, RoseChat ~4 minutes later). At that point
+ * `isPluginEnabled("RoseChat")` is false, so the guarded registration in
+ * onEnable would silently never run and the guild channels in channels.yml
+ * would fail to load ("Attempted to load LumaGuilds channel ... but LumaGuilds
+ * is not installed!").
+ *
+ * This listener fires on PluginEnableEvent for RoseChat and calls
+ * [onRoseChatEnabled]. The caller should also attempt registration once
+ * immediately, covering the normal load order (RoseChat already enabled).
+ */
+class RoseChatEnableListener(
+    private val onRoseChatEnabled: () -> Unit,
+) : Listener {
+
+    private val logger = LoggerFactory.getLogger(javaClass)
+
+    @EventHandler(priority = EventPriority.MONITOR, ignoreCancelled = true)
+    fun onPluginEnable(event: PluginEnableEvent) {
+        if (event.plugin.name != "RoseChat") return
+        logger.info("RoseChat enabled — wiring LumaGuilds channel provider now.")
+        onRoseChatEnabled()
+    }
+}


### PR DESCRIPTION
## Problem

Guild/ally/modchat channels silently fail to load when LumaGuilds enables **before** RoseChat. The `isPluginEnabled("RoseChat")` guard in `onEnable` is false at that point, so `registerRoseChatChannels()` never runs and RoseChat logs:

```
[RoseChat] Attempted to load LumaGuilds channel 'guild' but LumaGuilds is not installed!
[RoseChat] Loaded RoseChat channels: global, staff   ← guild/ally/modchat missing
```

This ordering happens even with `depend: [RoseChat]` — **reproduced on the Fuji test server** (Leaf fork, same Paper lineage as production): LumaGuilds enabled at T+0, RoseChat ~16s-4min later. Enabling LumaGuilds first was consistent across boots.

## Fix

Mirror the existing `LiteBansEnableListener` pattern (same bug class, same solution):

- New `RoseChatEnableListener` — fires on `PluginEnableEvent` for RoseChat and wires the hook then.
- `LumaGuilds.kt` — extract the RoseChat wiring into a lambda; call it immediately when RoseChat is already enabled, otherwise register the enable listener. Graceful no-op when RoseChat isn't installed.

## Verified on Fuji (test server, 1.21.11)

**Before (stock LumaGuilds 2.1.13 + hook-free RoseChat):** fiasco reproduced — "Attempted to load LumaGuilds channel 'guild' but LumaGuilds is not installed!", no guild channels.

**After (this fix):**
```
[18:06:44] [RoseChat] Enabling RoseChat vRC-2
[18:06:45] [RoseChatEnableListener] RoseChat enabled — wiring LumaGuilds channel provider now.
[18:09:46] [RoseChat] Loaded LumaGuilds channels: guild, guild-modchat, guild-ally
[18:09:46] [LumaGuilds] ✓ LumaGuilds RoseChat channels registered (guild, guild-ally, guild-modchat)
```

## Why this matters now

Enthusia-RoseChat PR #3/#4 are removing the dead RoseChat-side LumaGuilds hook (it never compiled and duplicated this provider). That makes this fallback the **only** registration path for the reverse load order — without it, a hook-free RoseChat jar + stock LumaGuilds = dead guild chat.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Fixes

- `LumaGuilds.kt`: Register RoseChat channels immediately when enabled, or defer registration until `PluginEnableEvent`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->