### PR TITLE
feat: block guild XP from AFK/suspicious players via EnthusiaPlaytime

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -15,6 +15,7 @@ jobs:
     # bumping the ref can't silently reuse a stale cached jar.
     env:
       ROSECHAT_PREHOOK_REF: 3fe078a   # last RoseChat commit before the LumaGuilds hook
+      PLAYTIME_API_REF: 2a5b57d       # wsg138/PlayTimePlugin commit the API jar is built from
 
     permissions:
       contents: read
@@ -56,6 +57,33 @@ jobs:
         mkdir -p "$GITHUB_WORKSPACE/libs"
         ROSE_JAR=$(ls build/libs/RoseChat-RC-2*.jar | grep -v -- '-sources\|-javadoc' | head -1)
         cp "$ROSE_JAR" "$GITHUB_WORKSPACE/libs/RoseChat-RC-2.jar"
+
+# EnthusiaPlaytime is a Maven project; compiling its API classes directly is
+    # faster and more deterministic than a Maven build. The API surface (service
+    # interface + state enums + model POJOs) is pure java.util, so plain javac
+    # needs no external dependencies. Keep PLAYTIME_API_REF in sync with unit-test.yml.
+    - name: Cache EnthusiaPlaytime API jar
+      id: playtime-cache
+      uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
+      with:
+        path: libs/EnthusiaPlaytime-api.jar
+        key: playtime-api-${{ env.PLAYTIME_API_REF }}
+
+    - name: Build EnthusiaPlaytime API jar
+      if: steps.playtime-cache.outputs.cache-hit != 'true'
+      run: |
+        git clone https://github.com/wsg138/PlayTimePlugin.git /tmp/playtime
+        cd /tmp/playtime
+        git checkout "$PLAYTIME_API_REF"
+        mkdir -p "$GITHUB_WORKSPACE/libs" /tmp/playtime-classes
+        javac -d /tmp/playtime-classes \
+          src/main/java/org/enthusia/playtime/api/PlaytimeService.java \
+          src/main/java/org/enthusia/playtime/api/PlaytimeRange.java \
+          src/main/java/org/enthusia/playtime/api/PlaytimeMetric.java \
+          src/main/java/org/enthusia/playtime/activity/ActivityState.java \
+          src/main/java/org/enthusia/playtime/data/model/PlaytimeSnapshot.java \
+          src/main/java/org/enthusia/playtime/data/model/RangeTotals.java
+        jar cf "$GITHUB_WORKSPACE/libs/EnthusiaPlaytime-api.jar" -C /tmp/playtime-classes .
 
     - name: Test with Gradle
       env:

--- a/.github/workflows/unit-test.yml
+++ b/.github/workflows/unit-test.yml
@@ -17,6 +17,7 @@ jobs:
     # Single source of truth: cache key + build step both read this (see build.yml).
     env:
       ROSECHAT_PREHOOK_REF: 3fe078a   # last RoseChat commit before the LumaGuilds hook
+      PLAYTIME_API_REF: 2a5b57d       # wsg138/PlayTimePlugin commit the API jar is built from
 
     permissions:
       contents: read
@@ -54,6 +55,33 @@ jobs:
         mkdir -p "$GITHUB_WORKSPACE/libs"
         ROSE_JAR=$(ls build/libs/RoseChat-RC-2*.jar | grep -v -- '-sources\|-javadoc' | head -1)
         cp "$ROSE_JAR" "$GITHUB_WORKSPACE/libs/RoseChat-RC-2.jar"
+
+    # EnthusiaPlaytime is a Maven project; compiling its API classes directly is
+    # faster and more deterministic than a Maven build. The API surface (service
+    # interface + state enums + model POJOs) is pure java.util, so plain javac
+    # needs no external dependencies. Keep PLAYTIME_API_REF in sync with build.yml.
+    - name: Cache EnthusiaPlaytime API jar
+      id: playtime-cache
+      uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
+      with:
+        path: libs/EnthusiaPlaytime-api.jar
+        key: playtime-api-${{ env.PLAYTIME_API_REF }}
+
+    - name: Build EnthusiaPlaytime API jar
+      if: steps.playtime-cache.outputs.cache-hit != 'true'
+      run: |
+        git clone https://github.com/wsg138/PlayTimePlugin.git /tmp/playtime
+        cd /tmp/playtime
+        git checkout "$PLAYTIME_API_REF"
+        mkdir -p "$GITHUB_WORKSPACE/libs" /tmp/playtime-classes
+        javac -d /tmp/playtime-classes \
+          src/main/java/org/enthusia/playtime/api/PlaytimeService.java \
+          src/main/java/org/enthusia/playtime/api/PlaytimeRange.java \
+          src/main/java/org/enthusia/playtime/api/PlaytimeMetric.java \
+          src/main/java/org/enthusia/playtime/activity/ActivityState.java \
+          src/main/java/org/enthusia/playtime/data/model/PlaytimeSnapshot.java \
+          src/main/java/org/enthusia/playtime/data/model/RangeTotals.java
+        jar cf "$GITHUB_WORKSPACE/libs/EnthusiaPlaytime-api.jar" -C /tmp/playtime-classes .
 
     - name: Test with Gradle
       env:

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -80,7 +80,9 @@ dependencies {
     // RoseChat is required at compile-time for the GuildChatListener channel switch.
     // Drop the built jar into libs/ from the RoseChat project (libs/ is gitignored).
     compileOnly(files("libs/RoseChat-RC-2.jar"))
+    compileOnly(files("libs/EnthusiaPlaytime-api.jar"))
     testImplementation(files("libs/RoseChat-RC-2.jar"))
+    testImplementation(files("libs/EnthusiaPlaytime-api.jar"))
 
     // LiteBans API (litebans.api.* — Events/Entry/Database) for Guild Strikes.
     // Resolved from JitPack (official API repo: gitlab.com/ruany/LiteBansAPI),

--- a/src/main/kotlin/net/lumalyte/lg/application/services/PlaytimeActivityService.kt
+++ b/src/main/kotlin/net/lumalyte/lg/application/services/PlaytimeActivityService.kt
@@ -1,0 +1,16 @@
+package net.lumalyte.lg.application.services
+
+import org.bukkit.entity.Player
+
+/**
+ * Gates guild XP earning on the player's live activity state, so players flagged
+ * AFK or suspicious (autoclickers / macros / automated movement) earn no guild XP.
+ */
+interface PlaytimeActivityService {
+
+    /**
+     * True when the player's current activity state must not earn guild XP.
+     * Always false (never blocks) when the underlying plugin is unavailable.
+     */
+    fun isXpBlocked(player: Player): Boolean
+}

--- a/src/main/kotlin/net/lumalyte/lg/di/Modules.kt
+++ b/src/main/kotlin/net/lumalyte/lg/di/Modules.kt
@@ -107,6 +107,7 @@ import net.lumalyte.lg.application.persistence.BankRepository
 import net.lumalyte.lg.application.persistence.ProgressionRepository
 import net.lumalyte.lg.application.services.BankService
 import net.lumalyte.lg.application.services.ModeService
+import net.lumalyte.lg.application.services.PlaytimeActivityService
 import net.lumalyte.lg.application.services.ProgressionService
 import net.lumalyte.lg.application.services.GuildBannerService
 import net.lumalyte.lg.application.persistence.GuildBannerRepository
@@ -131,6 +132,7 @@ import net.lumalyte.lg.infrastructure.services.PartyServiceBukkit
 import net.lumalyte.lg.infrastructure.services.ChatServiceBukkit
 import net.lumalyte.lg.infrastructure.services.BankServiceBukkit
 import net.lumalyte.lg.infrastructure.services.ModeServiceBukkit
+import net.lumalyte.lg.infrastructure.services.PlaytimeActivityServiceBukkit
 import net.lumalyte.lg.infrastructure.services.ProgressionServiceBukkit
 import net.lumalyte.lg.infrastructure.services.CombatServiceBukkit
 import net.lumalyte.lg.infrastructure.services.GuildBannerServiceBukkit
@@ -523,6 +525,7 @@ fun progressionModule() = module {
     single<KillService> { KillServiceBukkit(get()) }
     single<CombatService> { CombatServiceBukkit(get(), get(), get(), get()) }
     single<ProgressionService> { ProgressionServiceBukkit(get(), get(), get(), get(), get(), get<LumaGuilds>()) }
+    single<PlaytimeActivityService> { PlaytimeActivityServiceBukkit() }
     single<WarService> { WarServiceBukkit(get(), get(), get(), get()) }
     single<LeaderboardService> { LeaderboardServiceBukkit(get()) }
     single {

--- a/src/main/kotlin/net/lumalyte/lg/infrastructure/listeners/ProgressionEventListener.kt
+++ b/src/main/kotlin/net/lumalyte/lg/infrastructure/listeners/ProgressionEventListener.kt
@@ -16,6 +16,7 @@ import net.lumalyte.lg.application.services.ConfigService
 import net.lumalyte.lg.domain.values.ExperienceSource
 import net.lumalyte.lg.application.services.LeaderboardService
 import net.lumalyte.lg.application.services.MemberService
+import net.lumalyte.lg.application.services.PlaytimeActivityService
 import net.lumalyte.lg.application.services.ProgressionService
 import net.lumalyte.lg.application.persistence.MemberRepository
 import net.lumalyte.lg.config.ProgressionConfig
@@ -67,6 +68,7 @@ class ProgressionEventListener : Listener, KoinComponent {
     private val configService: ConfigService by inject()
     private val asyncTaskService: AsyncTaskService by inject()
     private val leaderboardService: LeaderboardService by inject()
+    private val playtimeActivityService: PlaytimeActivityService by inject()
     private val plugin: Plugin by inject()
     private val virtualDispatcher: CoroutineDispatcher by inject(named("VirtualDispatcher"))
 
@@ -283,6 +285,7 @@ class ProgressionEventListener : Listener, KoinComponent {
      * Database operations run on virtual threads to avoid blocking main thread.
      */
     private fun awardExperience(player: Player, amount: Int, source: ExperienceSource) {
+        if (playtimeActivityService.isXpBlocked(player)) return
         val guildIds = playerGuildCache[player.uniqueId]
         if (guildIds.isNullOrEmpty()) return
         enqueueGuildExperience(guildIds, amount * lunarMultiplier(player), source)
@@ -293,6 +296,7 @@ class ProgressionEventListener : Listener, KoinComponent {
      * Batches XP awards and processes them async on virtual threads.
      */
     private fun awardExperienceWithCooldown(player: Player, amount: Int, source: ExperienceSource) {
+        if (playtimeActivityService.isXpBlocked(player)) return
         val guildIds = playerGuildCache[player.uniqueId]
         if (guildIds.isNullOrEmpty()) return
         awardExperienceWithCooldown(player.uniqueId, guildIds, amount, source, lunarMultiplier(player))

--- a/src/main/kotlin/net/lumalyte/lg/infrastructure/services/PlaytimeActivityServiceBukkit.kt
+++ b/src/main/kotlin/net/lumalyte/lg/infrastructure/services/PlaytimeActivityServiceBukkit.kt
@@ -1,0 +1,46 @@
+package net.lumalyte.lg.infrastructure.services
+
+import net.lumalyte.lg.application.services.PlaytimeActivityService
+import org.bukkit.Bukkit
+import org.bukkit.entity.Player
+import org.enthusia.playtime.activity.ActivityState
+import org.enthusia.playtime.api.PlaytimeService
+import org.slf4j.LoggerFactory
+
+/**
+ * Bridges EnthusiaPlaytime's live activity state into LumaGuilds so AFK / suspicious
+ * players don't earn guild XP (mob-farm kills, block macros, automated movement).
+ *
+ * Degrades gracefully: if EnthusiaPlaytime is missing or hasn't registered its service
+ * yet, nothing is ever blocked. The service is resolved through the Bukkit
+ * ServicesManager on every call so a PlayTime `/reload` (which re-registers the
+ * service) is picked up automatically, and `getLiveState` is a cheap in-memory lookup.
+ */
+class PlaytimeActivityServiceBukkit : PlaytimeActivityService {
+
+    private val logger = LoggerFactory.getLogger(PlaytimeActivityServiceBukkit::class.java)
+
+    override fun isXpBlocked(player: Player): Boolean {
+        val service = try {
+            Bukkit.getServicesManager().load(PlaytimeService::class.java)
+        } catch (e: Throwable) {
+            null // PlayTime absent — never block XP
+        } ?: return false
+
+        return try {
+            isBlockedState(service.getLiveState(player.uniqueId))
+        } catch (e: Exception) {
+            logger.debug("Failed to read live activity state for {}: {}", player.uniqueId, e.message)
+            false
+        }
+    }
+
+    companion object {
+        /**
+         * Pure decision: only AFK and SUSPICIOUS are blocked — ACTIVE and IDLE still earn.
+         * Unknown/unavailable state never blocks.
+         */
+        fun isBlockedState(state: ActivityState?): Boolean =
+            state == ActivityState.AFK || state == ActivityState.SUSPICIOUS
+    }
+}

--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -3,7 +3,7 @@ version: ${version}
 api-version: '1.21.11'
 load: STARTUP
 main: net.lumalyte.lg.LumaGuilds
-softdepend: [Vault, PlaceholderAPI, AxKoth, LiteBans]
+softdepend: [Vault, PlaceholderAPI, AxKoth, LiteBans, EnthusiaPlaytime]
 depend: [RoseChat]
 
 commands:

--- a/src/test/kotlin/net/lumalyte/lg/infrastructure/services/PlaytimeActivityServiceBukkitTest.kt
+++ b/src/test/kotlin/net/lumalyte/lg/infrastructure/services/PlaytimeActivityServiceBukkitTest.kt
@@ -1,0 +1,30 @@
+package net.lumalyte.lg.infrastructure.services
+
+import org.enthusia.playtime.activity.ActivityState
+import org.junit.jupiter.api.Assertions.assertFalse
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+
+/**
+ * Decision matrix for the PlayTime activity gate: only AFK and SUSPICIOUS block XP;
+ * ACTIVE and IDLE still earn; unknown/unavailable state never blocks.
+ */
+class PlaytimeActivityServiceBukkitTest {
+
+    @Test
+    fun `ACTIVE and IDLE still earn`() {
+        assertFalse(PlaytimeActivityServiceBukkit.isBlockedState(ActivityState.ACTIVE))
+        assertFalse(PlaytimeActivityServiceBukkit.isBlockedState(ActivityState.IDLE))
+    }
+
+    @Test
+    fun `AFK and SUSPICIOUS are blocked`() {
+        assertTrue(PlaytimeActivityServiceBukkit.isBlockedState(ActivityState.AFK))
+        assertTrue(PlaytimeActivityServiceBukkit.isBlockedState(ActivityState.SUSPICIOUS))
+    }
+
+    @Test
+    fun `unavailable state never blocks`() {
+        assertFalse(PlaytimeActivityServiceBukkit.isBlockedState(null))
+    }
+}


### PR DESCRIPTION
## Summary

Mob kills are **~80% of all guild XP** (84% for the maxed guilds) and the biggest chunk is farmed while AFK. This PR hooks EnthusiaPlaytime's live activity state into the guild XP award funnel so players flagged **AFK** or **SUSPICIOUS** (autoclicker/macro/automated movement) earn no guild XP. **ACTIVE and IDLE still earn.**

## How

- New `PlaytimeActivityService` (+ Bukkit impl): resolves `PlaytimeService` through the Bukkit **ServicesManager on every call** (cheap in-memory lookup; picks up PlayTime `/reload`s automatically)
- Guard added to both player-XP entry points in `ProgressionEventListener` — one choke point covers all player sources (mob kill, block break/place, crafting, smelting, fishing, enchanting, crops, player kills)
- **Degrades gracefully**: PlayTime absent/not-registered/error → never blocks (LG runs fine without it)
- `EnthusiaPlaytime-api.jar` (service interface + state enums + model POJOs, built from wsg138/PlayTimePlugin@`2a5b57d`) added to `libs/` as compileOnly — house pattern (RoseChat/EnthusiaMarket); CI builds it via plain `javac` in both workflows (no Maven needed), pinned + cached via `PLAYTIME_API_REF`
- `plugin.yml` softdepend: `EnthusiaPlaytime`

## Verification

- Unit tests: decision matrix (ACTIVE/IDLE earn, AFK/SUSPICIOUS blocked, null safe)
- Fuji boot test: plugin enables cleanly with EnthusiaPlaytime absent (degraded path)
- Full suite green

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Fixes
- ProgressionEventListener: Block guild XP for players in `AFK` or `SUSPICIOUS` activity states.

## Features
- PlaytimeActivityService: Resolve EnthusiaPlaytime dynamically and allow XP when unavailable or when activity lookup fails.
- Build and test workflows: Cache and compile the pinned EnthusiaPlaytime API dependency.
- plugin.yml: Declare EnthusiaPlaytime as a soft dependency.
- PlaytimeActivityServiceBukkitTest: Cover activity-state decisions and operation without EnthusiaPlaytime.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->