### PR TITLE
ci: add Koin graph smoke test — force-resolve every definition before release

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -57,6 +57,11 @@ jobs:
         ROSE_JAR=$(ls build/libs/RoseChat-RC-2*.jar | grep -v -- '-sources\|-javadoc' | head -1)
         cp "$ROSE_JAR" "$GITHUB_WORKSPACE/libs/RoseChat-RC-2.jar"
 
+    - name: Test with Gradle
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      run: ./gradlew test
+
     - name: Build Gradle using shadowJar
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -63,6 +63,16 @@ jobs:
           mkdir -p "$GITHUB_WORKSPACE/libs"
           cp "$ROSE_JAR" "$GITHUB_WORKSPACE/libs/RoseChat-RC-2.jar"
 
+      # Run the full test suite, including the Koin graph smoke test. The v2.1.23
+      # release shipped a jar whose Koin graph referenced an unregistered type — a
+      # class-presence check would pass that jar (the class file exists; the
+      # registration doesn't). KoinGraphSmokeTest force-resolves every definition,
+      # so a broken graph fails here, before the artifact is published.
+      - name: Test with Gradle
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: ./gradlew test --no-daemon -PreleaseVersion=${{ steps.bump.outputs.version }}
+
       - name: Build shadowJar
         run: ./gradlew shadowJar --no-daemon -PreleaseVersion=${{ steps.bump.outputs.version }}
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -71,10 +71,13 @@ jobs:
       - name: Test with Gradle
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: ./gradlew test --no-daemon -PreleaseVersion=${{ steps.bump.outputs.version }}
+          RELEASE_VERSION: ${{ steps.bump.outputs.version }}
+        run: ./gradlew test --no-daemon "-PreleaseVersion=$RELEASE_VERSION"
 
       - name: Build shadowJar
-        run: ./gradlew shadowJar --no-daemon -PreleaseVersion=${{ steps.bump.outputs.version }}
+        env:
+          RELEASE_VERSION: ${{ steps.bump.outputs.version }}
+        run: ./gradlew shadowJar --no-daemon "-PreleaseVersion=$RELEASE_VERSION"
 
       - name: Create Release
         uses: softprops/action-gh-release@v2

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -73,6 +73,10 @@ dependencies {
     }
     compileOnly("com.github.placeholderapi:placeholderapi:2.11.6")
     compileOnly("com.artillexstudios:AxKothAPI:4")
+    // The Koin graph smoke test constructs every service (incl. placeholder + KOTH
+    // hooks) — these APIs must be on the test classpath too.
+    testImplementation("com.github.placeholderapi:placeholderapi:2.11.6")
+    testImplementation("com.artillexstudios:AxKothAPI:4")
     // RoseChat is required at compile-time for the GuildChatListener channel switch.
     // Drop the built jar into libs/ from the RoseChat project (libs/ is gitignored).
     compileOnly(files("libs/RoseChat-RC-2.jar"))
@@ -84,6 +88,9 @@ dependencies {
     // compileOnly: LiteBans bundles the API at runtime, shading it would cause
     // a version conflict. jitpack.io is declared in repositories above.
     compileOnly("com.gitlab.ruany:LiteBansAPI:0.6.1")
+    // The Koin graph smoke test constructs every service, including the LiteBans
+    // strike hook — the API must be on the test classpath too.
+    testImplementation("com.gitlab.ruany:LiteBansAPI:0.6.1")
 
     // EnthusiaMarket public API (net.badgersmc.em.api.ShopGuildLookup) for guild-shop
     // integration. Slim api-only jar (one interface, depends only on Bukkit) — NOT the

--- a/src/main/kotlin/net/lumalyte/lg/di/Modules.kt
+++ b/src/main/kotlin/net/lumalyte/lg/di/Modules.kt
@@ -190,6 +190,7 @@ import kotlinx.coroutines.asCoroutineDispatcher
 import net.milkbowl.vault.chat.Chat
 import org.bukkit.configuration.file.FileConfiguration
 import org.bukkit.plugin.Plugin
+import org.bukkit.plugin.java.JavaPlugin
 import org.koin.core.module.dsl.singleOf
 import org.koin.core.qualifier.named
 import org.koin.dsl.module
@@ -204,6 +205,7 @@ fun coreModule(plugin: LumaGuilds, storage: Storage<*>) = module {
     // Plugin dependencies
     single<Plugin> { plugin }
     single<LumaGuilds> { plugin }
+    single<JavaPlugin> { plugin }
     single<File> { plugin.dataFolder }
     single<FileConfiguration> { plugin.config }
     single<Chat?> { plugin.metadata }

--- a/src/test/kotlin/net/lumalyte/lg/di/KoinGraphSmokeTest.kt
+++ b/src/test/kotlin/net/lumalyte/lg/di/KoinGraphSmokeTest.kt
@@ -1,0 +1,134 @@
+package net.lumalyte.lg.di
+
+import io.mockk.every
+import io.mockk.mockk
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import net.kyori.adventure.text.logger.slf4j.ComponentLogger
+import net.lumalyte.lg.LumaGuilds
+import net.lumalyte.lg.infrastructure.persistence.migrations.SQLiteMigrations
+import net.lumalyte.lg.infrastructure.persistence.storage.SQLiteStorage
+import org.bukkit.configuration.file.YamlConfiguration
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.koin.core.annotation.KoinInternalApi
+import org.koin.core.context.GlobalContext
+import org.koin.core.context.startKoin
+import org.koin.core.context.stopKoin
+import org.koin.core.instance.ResolutionContext
+import org.koin.core.parameter.ParametersHolder
+import org.mockbukkit.mockbukkit.MockBukkit
+import java.nio.file.Files
+import java.nio.file.Path
+import java.util.logging.Logger
+
+/**
+ * Boot smoke test: composes the REAL Koin graph — the same `appModule` the server
+ * builds — and force-constructs every registered definition.
+ *
+ * Guards against the v2.1.23 failure mode: a module referenced a type
+ * (`GetClaimAtPosition`) that had no registration. The plugin enabled, cleaned the
+ * database, then crashed with `NoDefinitionFoundException` mid-boot. A class-presence
+ * check in the release workflow would have PASSED the broken jar (the class file was
+ * there; what was missing was the Koin registration). This test catches the real
+ * failure: it resolves every definition eagerly, so any missing registration throws
+ * `InstanceNotFoundException` (Koin 4) immediately.
+ *
+ * Uses MockBukkit for a realistic Bukkit environment and a real in-memory SQLite
+ * storage so the graph is as close to production as possible.
+ *
+ * The instance registry iteration uses `@KoinInternalApi` surfaces (InstanceRegistry,
+ * InstanceFactory) — deliberately, since the whole point is to enumerate every
+ * registered definition regardless of what the public `getAll` overload exposes.
+ */
+@OptIn(KoinInternalApi::class)
+internal class KoinGraphSmokeTest {
+
+    private lateinit var tempDir: Path
+
+    @BeforeEach
+    fun setUp() {
+        MockBukkit.mock()
+        tempDir = Files.createTempDirectory("lg-graph-test")
+    }
+
+    @AfterEach
+    fun tearDown() {
+        stopKoin()
+        MockBukkit.unmock()
+    }
+
+    @Test
+    fun `every definition in the real koin graph resolves`() {
+        val plugin = mockk<LumaGuilds>(relaxed = true)
+        every { plugin.dataFolder } returns tempDir.toFile()
+        every { plugin.config } returns YamlConfiguration()
+        every { plugin.logger } returns Logger.getLogger("LumaGuilds-GraphTest")
+        every { plugin.pluginScope } returns CoroutineScope(Dispatchers.IO)
+
+        val storage = SQLiteStorage(tempDir.toFile())
+
+        // Run DB migrations before composing the graph (same order as production
+        // onEnable: initDatabase → startKoin). The repos preload data at construction
+        // time and need the schema to exist.
+        every { plugin.getComponentLogger() } returns ComponentLogger.logger("LumaGuilds-GraphTest")
+        storage.connection.getConnection().use { conn ->
+            SQLiteMigrations(plugin, conn, claimsEnabled = true).migrate()
+        }
+
+        startKoin {
+            modules(appModule(plugin, storage, claimsEnabled = true))
+        }
+
+        val koin = GlobalContext.get()
+        val rootScope = koin.scopeRegistry.rootScope
+        val factories = koin.instanceRegistry.instances.values.toList()
+
+        assertTrue(factories.isNotEmpty(), "Koin graph registered zero definitions")
+
+        // Force-construct every registered definition by calling its factory.
+        // A definition whose constructor references an unregistered type throws
+        // InstanceNotFoundException (Koin 4) / NoDefinitionFoundException (Koin 3).
+        val failures = mutableListOf<String>()
+        for (factory in factories) {
+            val bean = factory.beanDefinition
+            val context = ResolutionContext(
+                logger = koin.logger,
+                scope = rootScope,
+                clazz = bean.primaryType,
+                qualifier = bean.qualifier,
+                parameters = ParametersHolder()
+            )
+            try {
+                factory.get(context)
+            } catch (e: Throwable) {
+                val name = bean.primaryType.simpleName ?: bean.primaryType.toString()
+                failures.add("$name: ${e::class.simpleName} — ${causeChain(e)}")
+            }
+        }
+
+        assertTrue(
+            failures.isEmpty(),
+            "Koin graph has ${failures.size} unresolvable definition(s):\n" +
+                failures.joinToString("\n")
+        )
+    }
+
+    /** Flattens the root-cause chain into a readable one-liner. */
+    private fun causeChain(t: Throwable): String {
+        val parts = mutableListOf<String>()
+        var current: Throwable? = t
+        var depth = 0
+        while (current != null && depth < 6) {
+            val msg = current.message?.replace('\n', ' ')?.trim()
+            if (!msg.isNullOrEmpty()) {
+                parts.add("${current::class.simpleName}: $msg")
+            }
+            current = current.cause
+            depth++
+        }
+        return parts.joinToString(" ← ")
+    }
+}

--- a/src/test/kotlin/net/lumalyte/lg/di/KoinGraphSmokeTest.kt
+++ b/src/test/kotlin/net/lumalyte/lg/di/KoinGraphSmokeTest.kt
@@ -78,42 +78,47 @@ internal class KoinGraphSmokeTest {
             SQLiteMigrations(plugin, conn, claimsEnabled = true).migrate()
         }
 
-        startKoin {
-            modules(appModule(plugin, storage, claimsEnabled = true))
-        }
-
-        val koin = GlobalContext.get()
-        val rootScope = koin.scopeRegistry.rootScope
-        val factories = koin.instanceRegistry.instances.values.toList()
-
-        assertTrue(factories.isNotEmpty(), "Koin graph registered zero definitions")
-
-        // Force-construct every registered definition by calling its factory.
-        // A definition whose constructor references an unregistered type throws
-        // InstanceNotFoundException (Koin 4) / NoDefinitionFoundException (Koin 3).
-        val failures = mutableListOf<String>()
-        for (factory in factories) {
-            val bean = factory.beanDefinition
-            val context = ResolutionContext(
-                logger = koin.logger,
-                scope = rootScope,
-                clazz = bean.primaryType,
-                qualifier = bean.qualifier,
-                parameters = ParametersHolder()
-            )
-            try {
-                factory.get(context)
-            } catch (e: Throwable) {
-                val name = bean.primaryType.simpleName ?: bean.primaryType.toString()
-                failures.add("$name: ${e::class.simpleName} — ${causeChain(e)}")
+        try {
+            startKoin {
+                modules(appModule(plugin, storage, claimsEnabled = true))
             }
-        }
 
-        assertTrue(
-            failures.isEmpty(),
-            "Koin graph has ${failures.size} unresolvable definition(s):\n" +
-                failures.joinToString("\n")
-        )
+            val koin = GlobalContext.get()
+            val rootScope = koin.scopeRegistry.rootScope
+            val factories = koin.instanceRegistry.instances.values.toList()
+
+            assertTrue(factories.isNotEmpty(), "Koin graph registered zero definitions")
+
+            // Force-construct every registered definition by calling its factory.
+            // A definition whose constructor references an unregistered type throws
+            // InstanceNotFoundException (Koin 4) / NoDefinitionFoundException (Koin 3).
+            val failures = mutableListOf<String>()
+            for (factory in factories) {
+                val bean = factory.beanDefinition
+                val context = ResolutionContext(
+                    logger = koin.logger,
+                    scope = rootScope,
+                    clazz = bean.primaryType,
+                    qualifier = bean.qualifier,
+                    parameters = ParametersHolder()
+                )
+                try {
+                    factory.get(context)
+                } catch (e: Throwable) {
+                    val name = bean.primaryType.simpleName ?: bean.primaryType.toString()
+                    failures.add("$name: ${e::class.simpleName} — ${causeChain(e)}")
+                }
+            }
+
+            assertTrue(
+                failures.isEmpty(),
+                "Koin graph has ${failures.size} unresolvable definition(s):\n" +
+                    failures.joinToString("\n")
+            )
+        } finally {
+            // Close the HikariCP connection pool before the temp directory is deleted
+            storage.connection.close()
+        }
     }
 
     /** Flattens the root-cause chain into a readable one-liner. */


### PR DESCRIPTION
## What

**KoinGraphSmokeTest** — composes the real `appModule` (MockBukkit + real SQLite, migrations run pre-Koin like prod) and force-constructs **every** registered definition via `InstanceRegistry.getInstances()` iteration. The old `getAll()` form silently returned empty; this catches the exact v2.1.23 failure mode: a missing Koin registration throws during resolution.

**Workflow fix** — the class-presence "Verify artifact contents" steps in `build.yml` and `release.yml` were the wrong guard (they pass a broken jar — the class file exists, the *registration* doesn't). Replaced with `./gradlew test` so the graph smoke test runs before any artifact is published.

**Test classpath** — the compileOnly APIs the graph touches (LiteBans, PlaceholderAPI, AxKoth) are now on `testImplementation` so the test can resolve those definitions.

## Bug caught

`BreakClaimAnchor` injects `JavaPlugin` by type (`singleOf(::BreakClaimAnchor)`) but the graph only bound `Plugin`/`LumaGuilds` — no `JavaPlugin` key. Would crash the first time a player broke a claim anchor. Fixed: `coreModule` now registers `single<JavaPlugin> { plugin }`.

## Verification

- `./gradlew test` — full suite green, including the new graph smoke test
- Rebased on latest main (includes #95–#99)
- MockBukkit + real SQLiteStorage, same migration order as prod

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

### Fixes
- Register `JavaPlugin` in `coreModule` so `BreakClaimAnchor` resolves correctly.

### Features
- Run the Gradle test suite in `build.yml` and `release.yml` before artifact creation.
- Add a Koin graph smoke test that resolves every definition with MockBukkit and SQLite.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->