### PR TITLE
feat: release artifact guard — Koin graph smoke test, emoji font, rank drift, curve fix (#97 #98 #99)

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -57,6 +57,11 @@ jobs:
         ROSE_JAR=$(ls build/libs/RoseChat-RC-2*.jar | grep -v -- '-sources\|-javadoc' | head -1)
         cp "$ROSE_JAR" "$GITHUB_WORKSPACE/libs/RoseChat-RC-2.jar"
 
+    - name: Test with Gradle
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      run: ./gradlew test
+
     - name: Build Gradle using shadowJar
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -63,6 +63,16 @@ jobs:
           mkdir -p "$GITHUB_WORKSPACE/libs"
           cp "$ROSE_JAR" "$GITHUB_WORKSPACE/libs/RoseChat-RC-2.jar"
 
+      # Run the full test suite, including the Koin graph smoke test. The v2.1.23
+      # release shipped a jar whose Koin graph referenced an unregistered type — a
+      # class-presence check would pass that jar (the class file exists; the
+      # registration doesn't). KoinGraphSmokeTest force-resolves every definition,
+      # so a broken graph fails here, before the artifact is published.
+      - name: Test with Gradle
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: ./gradlew test --no-daemon -PreleaseVersion=${{ steps.bump.outputs.version }}
+
       - name: Build shadowJar
         run: ./gradlew shadowJar --no-daemon -PreleaseVersion=${{ steps.bump.outputs.version }}
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -71,10 +71,13 @@ jobs:
       - name: Test with Gradle
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: ./gradlew test --no-daemon -PreleaseVersion=${{ steps.bump.outputs.version }}
+          RELEASE_VERSION: ${{ steps.bump.outputs.version }}
+        run: ./gradlew test --no-daemon "-PreleaseVersion=$RELEASE_VERSION"
 
       - name: Build shadowJar
-        run: ./gradlew shadowJar --no-daemon -PreleaseVersion=${{ steps.bump.outputs.version }}
+        env:
+          RELEASE_VERSION: ${{ steps.bump.outputs.version }}
+        run: ./gradlew shadowJar --no-daemon "-PreleaseVersion=$RELEASE_VERSION"
 
       - name: Create Release
         uses: softprops/action-gh-release@v2

--- a/PLACEHOLDERAPI_README.md
+++ b/PLACEHOLDERAPI_README.md
@@ -19,6 +19,8 @@ All placeholders use the `%lumaguilds_` prefix.
 - `%lumaguilds_guild_name%` - Player's guild name
 - `%lumaguilds_guild_tag%` - Player's guild tag (formatted)
 - `%lumaguilds_guild_emoji%` - Player's guild emoji (Nexo format)
+- `%lumaguilds_guild_emoji_minimessage%` - Guild emoji as Nexo glyph tag (`<glyph:name>`) for MiniMessage formatters (Velocitab via NexoProxy)
+- `%lumaguilds_guild_emoji_font%` - Guild emoji as raw MiniMessage font fragment (`<font:<glyphfont>><char></font>`) for consumers without glyph-tag support (UnlimitedNameTags, IC-DiscordSRV-Addon playerlist, Velocitab via PapiProxyBridge)
 - `%lumaguilds_guild_level%` - Player's guild level
 - `%lumaguilds_guild_balance%` - Player's guild bank balance
 - `%lumaguilds_guild_mode%` - Player's guild mode (Peaceful/Hostile)

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -73,6 +73,10 @@ dependencies {
     }
     compileOnly("com.github.placeholderapi:placeholderapi:2.11.6")
     compileOnly("com.artillexstudios:AxKothAPI:4")
+    // The Koin graph smoke test constructs every service (incl. placeholder + KOTH
+    // hooks) — these APIs must be on the test classpath too.
+    testImplementation("com.github.placeholderapi:placeholderapi:2.11.6")
+    testImplementation("com.artillexstudios:AxKothAPI:4")
     // RoseChat is required at compile-time for the GuildChatListener channel switch.
     // Drop the built jar into libs/ from the RoseChat project (libs/ is gitignored).
     compileOnly(files("libs/RoseChat-RC-2.jar"))
@@ -84,6 +88,9 @@ dependencies {
     // compileOnly: LiteBans bundles the API at runtime, shading it would cause
     // a version conflict. jitpack.io is declared in repositories above.
     compileOnly("com.gitlab.ruany:LiteBansAPI:0.6.1")
+    // The Koin graph smoke test constructs every service, including the LiteBans
+    // strike hook — the API must be on the test classpath too.
+    testImplementation("com.gitlab.ruany:LiteBansAPI:0.6.1")
 
     // EnthusiaMarket public API (net.badgersmc.em.api.ShopGuildLookup) for guild-shop
     // integration. Slim api-only jar (one interface, depends only on Bukkit) — NOT the

--- a/docs/placeholders.md
+++ b/docs/placeholders.md
@@ -19,6 +19,7 @@ Resolve to `""` (empty) if the player has no guild — except `has_guild`, which
 | `%lumaguilds_guild_tag_raw%` | Tag exactly as stored (may be legacy `&` codes or MiniMessage) |
 | `%lumaguilds_guild_emoji%` | Nexo placeholder (`%nexo_<name>%`) — resolves only where Nexo's PAPI expansion runs (backend) |
 | `%lumaguilds_guild_emoji_minimessage%` | Nexo glyph tag for MiniMessage formatters like Velocitab (rendered proxy-side via NexoProxy). Matching `:name:` values become `<glyph:name>`; null/blank returns empty; other values pass through unchanged |
+| `%lumaguilds_guild_emoji_font%` | Raw MiniMessage font fragment (`<font:<glyphfont>><char></font>`) for MiniMessage consumers without Nexo glyph-tag support (UnlimitedNameTags, IC-DiscordSRV-Addon playerlist, Velocitab via PapiProxyBridge). Resolves char/font from Nexo's FontManager; falls back to `<glyph:name>` when Nexo is unavailable |
 | `%lumaguilds_guild_level%` | Current level |
 | `%lumaguilds_guild_balance%` | Bank balance |
 | `%lumaguilds_guild_mode%` | `Peaceful` / `Hostile` |

--- a/src/main/kotlin/net/lumalyte/lg/di/Modules.kt
+++ b/src/main/kotlin/net/lumalyte/lg/di/Modules.kt
@@ -514,7 +514,7 @@ fun socialModule() = module {
 fun progressionModule() = module {
     // Repositories
     single<KillRepository> { KillRepositorySQLite(get()) }
-    single<ProgressionRepository> { ProgressionRepositorySQLite(get()) }
+    single<ProgressionRepository> { ProgressionRepositorySQLite(get(), get()) }
     single<LeaderboardRepository> { LeaderboardRepositorySQLite(get()) }
 
     // Services

--- a/src/main/kotlin/net/lumalyte/lg/di/Modules.kt
+++ b/src/main/kotlin/net/lumalyte/lg/di/Modules.kt
@@ -190,6 +190,7 @@ import kotlinx.coroutines.asCoroutineDispatcher
 import net.milkbowl.vault.chat.Chat
 import org.bukkit.configuration.file.FileConfiguration
 import org.bukkit.plugin.Plugin
+import org.bukkit.plugin.java.JavaPlugin
 import org.koin.core.module.dsl.singleOf
 import org.koin.core.qualifier.named
 import org.koin.dsl.module
@@ -204,6 +205,7 @@ fun coreModule(plugin: LumaGuilds, storage: Storage<*>) = module {
     // Plugin dependencies
     single<Plugin> { plugin }
     single<LumaGuilds> { plugin }
+    single<JavaPlugin> { plugin }
     single<File> { plugin.dataFolder }
     single<FileConfiguration> { plugin.config }
     single<Chat?> { plugin.metadata }

--- a/src/main/kotlin/net/lumalyte/lg/domain/entities/Progression.kt
+++ b/src/main/kotlin/net/lumalyte/lg/domain/entities/Progression.kt
@@ -45,52 +45,19 @@ data class GuildProgression(
     companion object {
         /**
          * Creates a new guild progression with default values.
+         *
+         * @param guildId the guild this progression belongs to
+         * @param experienceForNextLevel XP required for the first level-up, taken from
+         * the config-driven [net.lumalyte.lg.domain.values.ProgressionCurve] — never
+         * hardcode a second formula here (regression: a hardcoded `800 * (level-1)^1.3`
+         * variant made fresh guilds show 1200 XP-to-next vs 2369 everywhere else).
          */
-        fun create(guildId: UUID): GuildProgression {
+        fun create(guildId: UUID, experienceForNextLevel: Int): GuildProgression {
             return GuildProgression(
                 guildId = guildId,
-                experienceForNextLevel = calculateExperienceForLevel(2),
+                experienceForNextLevel = experienceForNextLevel,
                 unlockedPerks = setOf(PerkType.CUSTOM_BANNER_COLORS, PerkType.ANIMATED_EMOJIS) // Always unlocked
             )
-        }
-
-        /**
-         * Calculates the experience required for a specific level.
-         * Uses a balanced growth formula that starts reasonable and has a gradual taper-off.
-         * Formula: baseXP * (level^1.3) + (level * 200) for competitive but fair progression
-         */
-        fun calculateExperienceForLevel(level: Int): Int {
-            if (level <= 1) return 0
-            val baseXP = 800.0
-            val exponent = 1.3 // Gentler curve than 1.5
-            val linearBonus = level * 200 // Adds linear growth to prevent harsh walls
-            return (baseXP * Math.pow(level.toDouble() - 1, exponent) + linearBonus).toInt()
-        }
-
-        /**
-         * Calculates the total experience required to reach a specific level.
-         */
-        fun calculateTotalExperienceForLevel(targetLevel: Int): Int {
-            var total = 0
-            for (level in 2..targetLevel) {
-                total += calculateExperienceForLevel(level)
-            }
-            return total
-        }
-
-        /**
-         * Determines the level for a given total experience amount.
-         */
-        fun calculateLevelFromExperience(totalExperience: Int): Int {
-            var level = 1
-            var remainingXP = totalExperience
-
-            while (remainingXP >= calculateExperienceForLevel(level + 1)) {
-                remainingXP -= calculateExperienceForLevel(level + 1)
-                level++
-            }
-
-            return level
         }
     }
 }

--- a/src/main/kotlin/net/lumalyte/lg/domain/values/ProgressionCurve.kt
+++ b/src/main/kotlin/net/lumalyte/lg/domain/values/ProgressionCurve.kt
@@ -1,0 +1,75 @@
+package net.lumalyte.lg.domain.values
+
+import net.lumalyte.lg.config.ProgressionConfig
+import kotlin.math.pow
+
+/**
+ * The guild leveling curve — single source of truth for XP math.
+ *
+ * Threshold from [currentLevel] to the next level:
+ * `baseXp * (currentLevel + 1)^exponent + (currentLevel + 1) * linearBonusPerLevel`.
+ *
+ * Used by both the progression service (awards, penalties, menus) and the
+ * repository (default rows, stale-value healing) so the two can never disagree.
+ * Regression this fixes: `GuildProgression.create()` hardcoded a *different*
+ * formula (`800 * (level-1)^1.3 + level*200`), so freshly created guilds showed
+ * 1200 XP-to-next while every guild that had earned XP showed 2369 at level 1.
+ */
+class ProgressionCurve(
+    private val baseXp: Double,
+    private val exponent: Double,
+    private val linearBonusPerLevel: Int,
+) {
+
+    /** XP required to go from [currentLevel] to the next level. */
+    fun experienceForNextLevel(currentLevel: Int): Int {
+        val nextLevel = currentLevel + 1
+        return (baseXp * nextLevel.toDouble().pow(exponent) + (nextLevel * linearBonusPerLevel)).toInt()
+    }
+
+    /** Cumulative XP required to reach the start of [targetLevel]. */
+    fun totalExperienceForLevel(targetLevel: Int): Int {
+        if (targetLevel <= 1) return 0
+        var totalXp = 0
+        for (level in 1 until targetLevel) {
+            totalXp += experienceForNextLevel(level)
+        }
+        return totalXp
+    }
+
+    /**
+     * Level for a given total XP. Capped at 101 — the level-up loop's safety cap
+     * (matches the historical behaviour: level 101 is the max, XP keeps
+     * accumulating beyond it as a sink).
+     */
+    fun levelFromExperience(totalExperience: Int): Int {
+        if (totalExperience <= 0) return 1
+
+        var currentLevel = 1
+        var experienceUsed = 0
+        while (true) {
+            val xpNeeded = experienceForNextLevel(currentLevel)
+            if (experienceUsed + xpNeeded > totalExperience) break
+            experienceUsed += xpNeeded
+            currentLevel++
+
+            // Safety check to prevent infinite loops
+            if (currentLevel > 100) break
+        }
+        return currentLevel
+    }
+
+    /** XP earned within the current level (0 .. threshold-1). */
+    fun experienceInCurrentLevel(totalExperience: Int): Int =
+        totalExperience - totalExperienceForLevel(levelFromExperience(totalExperience))
+
+    companion object {
+        /**
+         * The single config-to-curve accessor. Every caller (progression service,
+         * repository) must go through this so the curve can never be constructed
+         * differently in two places.
+         */
+        fun from(config: ProgressionConfig): ProgressionCurve =
+            ProgressionCurve(config.baseXp, config.levelExponent, config.linearBonusPerLevel)
+    }
+}

--- a/src/main/kotlin/net/lumalyte/lg/infrastructure/persistence/guilds/ProgressionRepositorySQLite.kt
+++ b/src/main/kotlin/net/lumalyte/lg/infrastructure/persistence/guilds/ProgressionRepositorySQLite.kt
@@ -6,20 +6,42 @@ import net.lumalyte.lg.application.errors.DatabaseOperationException
 import net.lumalyte.lg.application.persistence.ProgressionRepository
 import net.lumalyte.lg.application.persistence.ActivityMetricType
 import net.lumalyte.lg.application.persistence.ProgressionStats
+import net.lumalyte.lg.application.services.ConfigService
 import net.lumalyte.lg.domain.entities.*
 import net.lumalyte.lg.domain.values.ExperienceSource
 import net.lumalyte.lg.domain.values.PerkType
+import net.lumalyte.lg.domain.values.ProgressionCurve
 import net.lumalyte.lg.infrastructure.persistence.storage.Storage
 import org.slf4j.LoggerFactory
 import java.sql.SQLException
 import java.time.Instant
 import java.util.UUID
 
-class ProgressionRepositorySQLite(private val storage: Storage<Database>) : ProgressionRepository {
+class ProgressionRepositorySQLite(
+    private val storage: Storage<Database>,
+    private val configService: ConfigService,
+) : ProgressionRepository {
 
     private val logger = LoggerFactory.getLogger(ProgressionRepositorySQLite::class.java)
     private val guildProgressions: MutableMap<UUID, GuildProgression> = mutableMapOf()
     private val activityMetrics: MutableMap<UUID, GuildActivityMetrics> = mutableMapOf()
+
+    // Memoized curve, invalidated when the config values change (reload-safe).
+    private var curveCacheKey: String? = null
+    private var curveCache: ProgressionCurve? = null
+
+    /** The config-driven leveling curve — single source of truth for XP math. */
+    private fun curve(): ProgressionCurve {
+        val config = configService.loadConfig().progression
+        val key = "${config.baseXp}|${config.levelExponent}|${config.linearBonusPerLevel}"
+        curveCache?.let { cached ->
+            if (curveCacheKey == key) return cached
+        }
+        val built = ProgressionCurve.from(config)
+        curveCache = built
+        curveCacheKey = key
+        return built
+    }
 
     init {
         // Try to create tables and preload, but don't fail if migration hasn't run yet
@@ -131,12 +153,58 @@ class ProgressionRepositorySQLite(private val storage: Storage<Database>) : Prog
 
         try {
             val results = storage.connection.getResults(sql)
+            val curve = curve()
+            val pendingHeals = mutableListOf<Pair<UUID, Int>>()
             for (result in results) {
                 val progression = mapResultSetToGuildProgression(result)
+                if (hasStaleNextLevel(
+                        progression.totalExperience, progression.currentLevel,
+                        progression.experienceThisLevel, progression.experienceForNextLevel, curve
+                    )
+                ) {
+                    pendingHeals += progression.guildId to curve.experienceForNextLevel(progression.currentLevel)
+                }
                 guildProgressions[progression.guildId] = progression
+            }
+            if (pendingHeals.isNotEmpty()) {
+                applyStaleNextLevelHeals(pendingHeals)
             }
         } catch (e: SQLException) {
             throw DatabaseOperationException("Failed to preload guild progressions", e)
+        }
+    }
+
+    /**
+     * Rewrites `experience_for_next_level` for rows that don't match the config curve but
+     * are otherwise internally consistent. Self-heals the regression where
+     * `GuildProgression.create()` used a hardcoded different formula (fresh guilds stored
+     * 1200 instead of 2369 at level 1); converges after one boot. All rows are applied in
+     * a single transaction so the heal costs one fsync on the startup thread.
+     */
+    private fun applyStaleNextLevelHeals(pendingHeals: List<Pair<UUID, Int>>) {
+        var committed = false
+        try {
+            storage.connection.executeUpdate("BEGIN")
+            for ((guildId, expectedNext) in pendingHeals) {
+                storage.connection.executeUpdate(
+                    "UPDATE guild_progression SET experience_for_next_level = ? WHERE guild_id = ?",
+                    expectedNext, guildId.toString()
+                )
+                guildProgressions[guildId] = guildProgressions[guildId]?.copy(experienceForNextLevel = expectedNext)
+                    ?: GuildProgression.create(guildId, expectedNext)
+            }
+            storage.connection.executeUpdate("COMMIT")
+            committed = true
+            logger.info("Healed stale experience_for_next_level for {} guild(s) ({} total rows checked)", pendingHeals.size, guildProgressions.size)
+        } catch (e: SQLException) {
+            if (!committed) {
+                try {
+                    storage.connection.executeUpdate("ROLLBACK")
+                } catch (rollbackError: SQLException) {
+                    logger.warn("Rollback failed after heal error: {}", rollbackError.message)
+                }
+            }
+            logger.warn("Failed to heal stale experience_for_next_level for {} guild(s): {}", pendingHeals.size, e.message)
         }
     }
 
@@ -284,8 +352,10 @@ class ProgressionRepositorySQLite(private val storage: Storage<Database>) : Prog
             val exists = result?.getInt("count") ?: 0 > 0
 
             if (!exists) {
-                // Create default progression
-                val defaultProgression = GuildProgression.create(guildId)
+                // Create default progression using the config-driven curve (never a
+                // hardcoded second formula — regression: fresh guilds showed 1200
+                // XP-to-next while the curve says 2369 at level 1).
+                val defaultProgression = GuildProgression.create(guildId, curve().experienceForNextLevel(1))
                 if (saveGuildProgression(defaultProgression)) {
                     guildProgressions[guildId] = defaultProgression
                     return defaultProgression
@@ -626,6 +696,27 @@ class ProgressionRepositorySQLite(private val storage: Storage<Database>) : Prog
             }
         } catch (e: SQLException) {
             throw DatabaseOperationException("Failed to get recent level ups", e)
+        }
+    }
+
+    companion object {
+        /**
+         * True when the stored `experience_for_next_level` doesn't match the config curve
+         * for the guild's level AND the row is otherwise internally consistent
+         * (total == cumulative thresholds + xp-this-level) — i.e. it's safe to rewrite.
+         *
+         * Regression: `GuildProgression.create()` hardcoded a different formula, leaving
+         * fresh guilds (0 XP) with 1200 instead of the curve's 2369 at level 1.
+         */
+        fun hasStaleNextLevel(
+            totalExperience: Int,
+            level: Int,
+            experienceThisLevel: Int,
+            storedNext: Int,
+            curve: ProgressionCurve,
+        ): Boolean {
+            if (storedNext == curve.experienceForNextLevel(level)) return false
+            return totalExperience == curve.totalExperienceForLevel(level) + experienceThisLevel
         }
     }
 }

--- a/src/main/kotlin/net/lumalyte/lg/infrastructure/persistence/guilds/RankRepositorySQLite.kt
+++ b/src/main/kotlin/net/lumalyte/lg/infrastructure/persistence/guilds/RankRepositorySQLite.kt
@@ -6,13 +6,14 @@ import net.lumalyte.lg.application.persistence.RankRepository
 import net.lumalyte.lg.domain.entities.Rank
 import net.lumalyte.lg.domain.entities.RankPermission
 import net.lumalyte.lg.infrastructure.persistence.storage.Storage
+import org.slf4j.LoggerFactory
 import java.sql.SQLException
 import java.util.UUID
 
 class RankRepositorySQLite(private val storage: Storage<Database>) : RankRepository {
-    
+
     private val ranks: MutableMap<UUID, Rank> = mutableMapOf()
-    
+
     init {
         createRankTable()
         preload()
@@ -40,12 +41,25 @@ class RankRepositorySQLite(private val storage: Storage<Database>) : RankReposit
     
     private fun preload() {
         val sql = "SELECT * FROM ranks ORDER BY guild_id, priority"
-        
+
         try {
             val results = storage.connection.getResults(sql)
             for (result in results) {
                 val rank = mapResultSetToRank(result)
                 ranks[rank.id] = rank
+                // Self-clean: persist the parsed (cleaned) set back when the stored
+                // permissions column contains values that no longer exist in the enum.
+                // Atomic per-row UPDATE, converges after one boot — no operator SQL needed.
+                val rawPermissions = result.getString("permissions")
+                if (hasStalePermissions(rawPermissions, rank.permissions)) {
+                    val cleaned = rank.permissions.joinToString(",") { it.name }
+                    storage.connection.executeUpdate(
+                        "UPDATE ranks SET permissions = ? WHERE id = ?",
+                        cleaned,
+                        rank.id.toString()
+                    )
+                    logger.info("Cleaned stale permissions for rank {} (stored '{}' -> '{}')", rank.id, rawPermissions, cleaned)
+                }
             }
         } catch (e: SQLException) {
             throw DatabaseOperationException("Failed to preload ranks", e)
@@ -60,9 +74,7 @@ class RankRepositorySQLite(private val storage: Storage<Database>) : RankReposit
         val permissionsStr = rs.getString("permissions")
         val icon = rs.getString("icon")
 
-        val permissions = if (permissionsStr != null) {
-            permissionsStr.split(",").filter { it.isNotBlank() }.map { RankPermission.valueOf(it.trim()) }.toSet()
-        } else emptySet()
+        val permissions = parseRankPermissions(permissionsStr)
 
         return Rank(
             id = id,
@@ -169,13 +181,52 @@ class RankRepositorySQLite(private val storage: Storage<Database>) : RankReposit
     }
     
     override fun isNameTaken(guildId: UUID, name: String): Boolean = getByName(guildId, name) != null
-    
+
     override fun getNextPriority(guildId: UUID): Int {
         val existingRanks = getByGuild(guildId)
         return if (existingRanks.isEmpty()) 0 else existingRanks.maxOf { it.priority } + 1
     }
-    
+
     override fun getCountByGuild(guildId: UUID): Int = getByGuild(guildId).size
+
+    companion object {
+        private val logger = LoggerFactory.getLogger(RankRepositorySQLite::class.java)
+
+        /**
+         * Parses a stored `permissions` column into enum values, skipping unknown names.
+         *
+         * Self-heals enum/DB drift: permission values removed from [RankPermission]
+         * (e.g. `EXPORT_BANK_DATA` after the CSV export removal, #90) remain in live
+         * rank rows and must not crash preload. Unknown names are dropped with a warning;
+         * the cleaned set is persisted the next time the rank is saved.
+         */
+        fun parseRankPermissions(permissionsStr: String?): Set<RankPermission> {
+            if (permissionsStr.isNullOrBlank()) return emptySet()
+            return permissionsStr.split(",")
+                .filter { it.isNotBlank() }
+                .mapNotNull { raw ->
+                    val name = raw.trim()
+                    try {
+                        RankPermission.valueOf(name)
+                    } catch (e: IllegalArgumentException) {
+                        logger.warn("Unknown rank permission '$name' in DB — ignoring (cleaned on next rank save)")
+                        null
+                    }
+                }
+                .toSet()
+        }
+
+        /**
+         * True when the stored `permissions` column contains values not present in
+         * [RankPermission] — i.e. the row needs its cleaned set written back.
+         * Order and duplicates in the stored string do not count as stale.
+         */
+        fun hasStalePermissions(permissionsStr: String?, parsed: Set<RankPermission>): Boolean {
+            if (permissionsStr.isNullOrBlank()) return false
+            val storedTokens = permissionsStr.split(",").map { it.trim() }.filter { it.isNotBlank() }.toSet()
+            return storedTokens != parsed.map { it.name }.toSet()
+        }
+    }
 
     override fun swapPriorities(rankAId: UUID, rankBId: UUID): Boolean {
         val rankA = ranks[rankAId] ?: return false

--- a/src/main/kotlin/net/lumalyte/lg/infrastructure/placeholders/LumaGuildsExpansion.kt
+++ b/src/main/kotlin/net/lumalyte/lg/infrastructure/placeholders/LumaGuildsExpansion.kt
@@ -4,6 +4,7 @@ import net.lumalyte.lg.application.persistence.LeaderboardRepository
 import net.lumalyte.lg.application.persistence.ProgressionRepository
 import net.lumalyte.lg.application.services.*
 import net.lumalyte.lg.domain.entities.Guild
+import net.lumalyte.lg.infrastructure.services.NexoEmojiService
 import net.lumalyte.lg.utils.ColorCodeUtils
 import net.kyori.adventure.text.Component
 import net.kyori.adventure.text.format.NamedTextColor
@@ -38,6 +39,7 @@ import java.util.concurrent.ConcurrentHashMap
  * - %lumaguilds_guild_tag_plain% - Tag with all formatting stripped
  * - %lumaguilds_guild_emoji% - Player's guild emoji (converted to %nexo_<emoji>% format for backend tab/scoreboard/chat)
  * - %lumaguilds_guild_emoji_minimessage% - Player's guild emoji as Nexo glyph tag (<glyph:emoji>) for MiniMessage formatters (Velocitab via NexoProxy)
+ * - %lumaguilds_guild_emoji_font% - Player's guild emoji as raw font fragment (<font:<glyphfont>><char></font>) for MiniMessage consumers without glyph-tag support (UnlimitedNameTags, IC-DiscordSRV-Addon playerlist, Velocitab via PapiProxyBridge)
  * - %lumaguilds_guild_level% - Player's guild level
  * - %lumaguilds_guild_balance% - Player's guild bank balance
  * - %lumaguilds_guild_members% - Player's guild member count
@@ -90,6 +92,7 @@ class LumaGuildsExpansion : PlaceholderExpansion(), KoinComponent {
     private val relationService: RelationService by inject()
     private val progressionRepository: ProgressionRepository by inject()
     private val leaderboardRepository: LeaderboardRepository by inject()
+    private val nexoEmojiService: NexoEmojiService by inject()
 
     private val miniMessage = MiniMessage.miniMessage()
     private val plainSerializer = PlainTextComponentSerializer.plainText()
@@ -143,6 +146,7 @@ class LumaGuildsExpansion : PlaceholderExpansion(), KoinComponent {
             "guild_tag_plain" -> renderTagAsPlain(guild)
             "guild_emoji" -> convertEmojiToNexoPlaceholder(guild.emoji)
             "guild_emoji_minimessage" -> ColorCodeUtils.emojiToGlyphTag(guild.emoji)
+            "guild_emoji_font" -> nexoEmojiService.emojiToFontTag(guild.emoji)
             "guild_level" -> guild.level.toString()
             // BankService.getBalance resolves to the unified guild balance (store B: vault gold),
             // the single source of truth shared by /g bal, /g baltop, /g menu -> Bank and the vault.

--- a/src/main/kotlin/net/lumalyte/lg/infrastructure/services/NexoEmojiService.kt
+++ b/src/main/kotlin/net/lumalyte/lg/infrastructure/services/NexoEmojiService.kt
@@ -1,8 +1,15 @@
 package net.lumalyte.lg.infrastructure.services
 
 import net.lumalyte.lg.application.services.ConfigService
+import net.lumalyte.lg.utils.ColorCodeUtils
 import org.bukkit.entity.Player
 import org.slf4j.LoggerFactory
+
+/** Font used by Nexo glyphs when the glyph does not declare its own font. */
+private const val DEFAULT_GLYPH_FONT = "nexo:default"
+
+/** Safe glyph id shape — rejects MiniMessage control characters (e.g. `x><reset>`). */
+private val VALID_GLYPH_ID = Regex("^[a-zA-Z0-9_-]+$")
 
 /**
  * Service for interacting with Nexo emojis.
@@ -109,11 +116,113 @@ class NexoEmojiService(
     /**
      * Creates an emoji placeholder from an emoji name.
      *
-     * @param emojiName The name of the emoji (e.g., "catsmileysmile").
-     * @return The formatted placeholder (e.g., ":catsmileysmile:").
+     * @param emojiName The name of the emoji (e.g. "catsmileysmile").
+     * @return The formatted placeholder (e.g. ":catsmileysmile:").
      */
     fun createEmojiPlaceholder(emojiName: String): String {
         return ":$emojiName:"
+    }
+
+    /**
+     * Converts a guild emoji (`:catsmileysmile:`) into a raw MiniMessage font fragment
+     * (`<font:nexo:default>\uE001</font>`) for consumers whose MiniMessage cannot resolve
+     * Nexo's custom `<glyph:...>` tag — e.g. UnlimitedNameTags (backend display-entity
+     * nametags), the InteractiveChatDiscordSrvAddon playerlist image renderer, and Velocitab
+     * via PapiProxyBridge. `<font:...>` is a standard Adventure tag and the char is drawn
+     * from the glyph's own font in the mandatory resource pack, so no glyph-tag registration
+     * is needed. This is the renderable counterpart to `%lumaguilds_guild_emoji_minimessage%`.
+     *
+     * Resolves the glyph char + font through Nexo's FontManager (same reflection path as
+     * [hasEmojiPermission]); falls back to the `<glyph:name>` tag when Nexo is absent or the
+     * char/font cannot be read (matching [ColorCodeUtils.emojiToGlyphTag] output).
+     *
+     * Non-`:name:` values pass through unchanged; null or blank return `""`.
+     */
+    fun emojiToFontTag(emoji: String?): String {
+        if (emoji.isNullOrBlank()) return ""
+        val emojiName = extractEmojiName(emoji) ?: return emoji
+        // Reject glyph ids containing MiniMessage control characters (e.g. ":x><reset>:")
+        // so they can never reach the generated tag — isValidEmojiFormat only checks delimiters.
+        if (!VALID_GLYPH_ID.matches(emojiName)) return emoji
+        val glyph = resolveGlyphByName(emojiName) ?: return "<glyph:$emojiName>"
+        val char = reflectGlyphChar(glyph)
+        if (char.isNullOrBlank()) return "<glyph:$emojiName>"
+        val font = reflectGlyphFont(glyph) ?: DEFAULT_GLYPH_FONT
+        return "<font:$font>$char</font>"
+    }
+
+    /**
+     * Looks up a Nexo glyph object by name via FontManager reflection.
+     *
+     * @param name glyph id without colons (e.g. `catsmileysmile`).
+     * @return the glyph object, or null if Nexo/FontManager is unavailable or the lookup fails.
+     */
+    private fun resolveGlyphByName(name: String): Any? {
+        val fontManager = getFontManager() ?: return null
+        return try {
+            fontManager.javaClass.getMethod("glyphFromName", String::class.java).invoke(fontManager, name)
+        } catch (e: ReflectiveOperationException) {
+            logger.debug("glyphFromName failed for '$name': ${e.message}")
+            null
+        } catch (e: IllegalArgumentException) {
+            logger.debug("glyphFromName failed for '$name': ${e.message}")
+            null
+        }
+    }
+
+    /**
+     * Reflectively reads the glyph's unicode char. Tries common accessor names in order;
+     * the value may be a String (e.g. "\uE001"), a single Char, a short String form, or a
+     * collection (Nexo's `getChars()` — the first char is the primary rendering char).
+     */
+    private fun reflectGlyphChar(glyph: Any): String? {
+        for (accessor in listOf("getChars", "getChar", "char", "getCharacter", "character", "getGlyphCode", "glyphCode", "getCode", "code")) {
+            val value = invokeNoArgGetter(glyph, accessor) ?: continue
+            when (value) {
+                is String -> if (value.isNotEmpty()) return value
+                is Char -> return value.toString()
+                is Iterable<*> -> value.firstOrNull { it != null }?.let { return it.toString() }
+                is Array<*> -> value.firstOrNull { it != null }?.let { return it.toString() }
+                else -> {
+                    val s = value.toString()
+                    if (s.isNotEmpty() && s.length <= 2) return s
+                }
+            }
+        }
+        return null
+    }
+
+    /**
+     * Reflectively reads the glyph's font key (e.g. `nexo:default`), or null when no
+     * accessor yields a usable value.
+     */
+    private fun reflectGlyphFont(glyph: Any): String? {
+        for (accessor in listOf("getFont", "font", "getFontName", "fontName", "getFontKey", "fontKey")) {
+            val value = invokeNoArgGetter(glyph, accessor)?.toString()?.trim() ?: continue
+            if (value.isBlank() || value == "null" || value == "minecraft") continue
+            return value
+        }
+        return null
+    }
+
+    /** Invokes a zero-arg getter reflectively, trying public then declared methods. */
+    private fun invokeNoArgGetter(target: Any, name: String): Any? {
+        for (publicFirst in listOf(true, false)) {
+            try {
+                val method = if (publicFirst) {
+                    target.javaClass.getMethod(name)
+                } else {
+                    target.javaClass.getDeclaredMethod(name)
+                }
+                method.trySetAccessible()
+                return method.invoke(target)
+            } catch (e: ReflectiveOperationException) {
+                // try the next accessor variant
+            } catch (e: IllegalArgumentException) {
+                // try the next accessor variant
+            }
+        }
+        return null
     }
     
     /**

--- a/src/main/kotlin/net/lumalyte/lg/infrastructure/services/ProgressionServiceBukkit.kt
+++ b/src/main/kotlin/net/lumalyte/lg/infrastructure/services/ProgressionServiceBukkit.kt
@@ -8,6 +8,7 @@ import net.lumalyte.lg.application.persistence.ProgressionRepository
 import net.lumalyte.lg.application.services.*
 import net.lumalyte.lg.domain.values.ExperienceSource
 import net.lumalyte.lg.domain.values.PerkType
+import net.lumalyte.lg.domain.values.ProgressionCurve
 import net.lumalyte.lg.domain.entities.*
 import net.lumalyte.lg.domain.events.GuildLevelUpEvent
 import org.bukkit.Bukkit
@@ -17,7 +18,6 @@ import java.time.Duration
 import java.time.Instant
 import java.time.temporal.ChronoUnit
 import java.util.UUID
-import kotlin.math.pow
 
 class ProgressionServiceBukkit(
     private val progressionRepository: ProgressionRepository,
@@ -29,6 +29,23 @@ class ProgressionServiceBukkit(
 ) : ProgressionService {
 
     private val logger = LoggerFactory.getLogger(ProgressionServiceBukkit::class.java)
+
+    // Memoized curve, invalidated when the config values change (reload-safe).
+    private var curveCacheKey: String? = null
+    private var curveCache: ProgressionCurve? = null
+
+    /** The config-driven leveling curve — single source of truth for XP math. */
+    private fun curve(): ProgressionCurve {
+        val config = configService.loadConfig().progression
+        val key = "${config.baseXp}|${config.levelExponent}|${config.linearBonusPerLevel}"
+        curveCache?.let { cached ->
+            if (curveCacheKey == key) return cached
+        }
+        val built = ProgressionCurve.from(config)
+        curveCache = built
+        curveCacheKey = key
+        return built
+    }
 
     override fun awardExperience(guildId: UUID, experience: Int, source: ExperienceSource): Int? {
         try {
@@ -45,7 +62,7 @@ class ProgressionServiceBukkit(
 
             // Get or create guild progression
             val progression = progressionRepository.getGuildProgression(guildId)
-                ?: GuildProgression.create(guildId)
+                ?: GuildProgression.create(guildId, getExperienceForNextLevel(1))
 
             val oldLevel = progression.currentLevel
             val newTotalExperience = progression.totalExperience + experience
@@ -100,24 +117,14 @@ class ProgressionServiceBukkit(
         }
     }
 
-    override fun getExperienceForNextLevel(currentLevel: Int): Int {
-        val config = configService.loadConfig().progression
-        
-        // Use the configurable leveling curve
-        val baseXp = config.baseXp
-        val exponent = config.levelExponent
-        val linearBonus = config.linearBonusPerLevel
-        
-        // Calculate XP needed for next level: base * (level^exponent) + (level * linearBonus)
-        val nextLevel = currentLevel + 1
-        return (baseXp * nextLevel.toDouble().pow(exponent) + (nextLevel * linearBonus)).toInt()
-    }
+    override fun getExperienceForNextLevel(currentLevel: Int): Int =
+        curve().experienceForNextLevel(currentLevel)
 
     override fun removeExperience(guildId: UUID, amount: Int, source: ExperienceSource): Int {
         try {
             if (amount <= 0) return getLevelFromExperience(progressionRepository.getGuildProgression(guildId)?.totalExperience ?: 0)
             val progression = progressionRepository.getGuildProgression(guildId)
-                ?: GuildProgression.create(guildId)
+                ?: GuildProgression.create(guildId, getExperienceForNextLevel(1))
 
             val newTotalExperience = (progression.totalExperience - amount).coerceAtLeast(0)
             val newLevel = getLevelFromExperience(newTotalExperience)
@@ -154,7 +161,7 @@ class ProgressionServiceBukkit(
     override fun reduceLevel(guildId: UUID, levels: Int, source: ExperienceSource): Int {
         try {
             val progression = progressionRepository.getGuildProgression(guildId)
-                ?: GuildProgression.create(guildId)
+                ?: GuildProgression.create(guildId, getExperienceForNextLevel(1))
 
             val currentLevel = progression.currentLevel
             val targetLevel = (currentLevel - levels).coerceAtLeast(1)
@@ -191,39 +198,11 @@ class ProgressionServiceBukkit(
         }
     }
 
-    override fun getTotalExperienceForLevel(targetLevel: Int): Int {
-        if (targetLevel <= 1) return 0
-        
-        var totalXp = 0
-        for (level in 1 until targetLevel) {
-            totalXp += getExperienceForNextLevel(level)
-        }
-        return totalXp
-    }
+    override fun getTotalExperienceForLevel(targetLevel: Int): Int =
+        curve().totalExperienceForLevel(targetLevel)
 
-    override fun getLevelFromExperience(totalExperience: Int): Int {
-        if (totalExperience <= 0) return 1
-        
-        var currentLevel = 1
-        var experienceUsed = 0
-        
-        while (true) {
-            val xpNeeded = getExperienceForNextLevel(currentLevel)
-            if (experienceUsed + xpNeeded > totalExperience) {
-                break
-            }
-            experienceUsed += xpNeeded
-            currentLevel++
-            
-            // Safety check to prevent infinite loops
-            if (currentLevel > 100) {
-                logger.warn("Level calculation exceeded maximum level (100) for experience $totalExperience")
-                break
-            }
-        }
-        
-        return currentLevel
-    }
+    override fun getLevelFromExperience(totalExperience: Int): Int =
+        curve().levelFromExperience(totalExperience)
 
     override fun getLevelProgress(totalExperience: Int): Pair<Int, Int> {
         val currentLevel = getLevelFromExperience(totalExperience)
@@ -236,11 +215,8 @@ class ProgressionServiceBukkit(
     /**
      * Gets the experience within the current level (0 to experienceForNextLevel-1).
      */
-    private fun getExperienceInCurrentLevel(totalExperience: Int): Int {
-        val currentLevel = getLevelFromExperience(totalExperience)
-        val totalXpForCurrentLevel = getTotalExperienceForLevel(currentLevel)
-        return totalExperience - totalXpForCurrentLevel
-    }
+    private fun getExperienceInCurrentLevel(totalExperience: Int): Int =
+        curve().experienceInCurrentLevel(totalExperience)
 
     override fun getPerksForLevel(level: Int): List<PerkType> {
         val configs = LevelPerkConfig.getDefaultConfigs(configService.loadConfig().claimsEnabled)

--- a/src/main/kotlin/net/lumalyte/lg/utils/ColorCodeUtils.kt
+++ b/src/main/kotlin/net/lumalyte/lg/utils/ColorCodeUtils.kt
@@ -9,6 +9,9 @@ import net.kyori.adventure.text.serializer.legacy.LegacyComponentSerializer
  */
 object ColorCodeUtils {
 
+    /** Safe glyph id shape — rejects MiniMessage control characters (e.g. `x><reset>`). */
+    private val VALID_GLYPH_ID = Regex("^[a-zA-Z0-9_-]+$")
+
     /**
      * Converts a guild emoji (stored in Discord format, e.g. `:catsmileysmile:`) into
      * the Nexo glyph MiniMessage tag (`<glyph:catsmileysmile>`).
@@ -18,12 +21,16 @@ object ColorCodeUtils {
      * renders in MiniMessage formatters that have glyph support — e.g. Velocitab on the
      * proxy via NexoProxy, and backend chat/scoreboards via Nexo's formatting engine.
      *
-     * Non-`:name:` values pass through unchanged; null or blank return `""`.
+     * Non-`:name:` values pass through unchanged; null or blank return `""`. Emoji names
+     * containing MiniMessage control characters (anything outside `[a-zA-Z0-9_-]`) pass
+     * through unchanged so they can never inject tags into the generated output.
      */
     fun emojiToGlyphTag(emoji: String?): String {
         if (emoji.isNullOrBlank()) return ""
         if (emoji.startsWith(":") && emoji.endsWith(":") && emoji.length > 2) {
-            return "<glyph:${emoji.substring(1, emoji.length - 1)}>"
+            val name = emoji.substring(1, emoji.length - 1)
+            if (!VALID_GLYPH_ID.matches(name)) return emoji
+            return "<glyph:$name>"
         }
         return emoji
     }

--- a/src/test/kotlin/net/lumalyte/lg/di/KoinGraphSmokeTest.kt
+++ b/src/test/kotlin/net/lumalyte/lg/di/KoinGraphSmokeTest.kt
@@ -1,0 +1,134 @@
+package net.lumalyte.lg.di
+
+import io.mockk.every
+import io.mockk.mockk
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import net.kyori.adventure.text.logger.slf4j.ComponentLogger
+import net.lumalyte.lg.LumaGuilds
+import net.lumalyte.lg.infrastructure.persistence.migrations.SQLiteMigrations
+import net.lumalyte.lg.infrastructure.persistence.storage.SQLiteStorage
+import org.bukkit.configuration.file.YamlConfiguration
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.koin.core.annotation.KoinInternalApi
+import org.koin.core.context.GlobalContext
+import org.koin.core.context.startKoin
+import org.koin.core.context.stopKoin
+import org.koin.core.instance.ResolutionContext
+import org.koin.core.parameter.ParametersHolder
+import org.mockbukkit.mockbukkit.MockBukkit
+import java.nio.file.Files
+import java.nio.file.Path
+import java.util.logging.Logger
+
+/**
+ * Boot smoke test: composes the REAL Koin graph — the same `appModule` the server
+ * builds — and force-constructs every registered definition.
+ *
+ * Guards against the v2.1.23 failure mode: a module referenced a type
+ * (`GetClaimAtPosition`) that had no registration. The plugin enabled, cleaned the
+ * database, then crashed with `NoDefinitionFoundException` mid-boot. A class-presence
+ * check in the release workflow would have PASSED the broken jar (the class file was
+ * there; what was missing was the Koin registration). This test catches the real
+ * failure: it resolves every definition eagerly, so any missing registration throws
+ * `InstanceNotFoundException` (Koin 4) immediately.
+ *
+ * Uses MockBukkit for a realistic Bukkit environment and a real in-memory SQLite
+ * storage so the graph is as close to production as possible.
+ *
+ * The instance registry iteration uses `@KoinInternalApi` surfaces (InstanceRegistry,
+ * InstanceFactory) — deliberately, since the whole point is to enumerate every
+ * registered definition regardless of what the public `getAll` overload exposes.
+ */
+@OptIn(KoinInternalApi::class)
+internal class KoinGraphSmokeTest {
+
+    private lateinit var tempDir: Path
+
+    @BeforeEach
+    fun setUp() {
+        MockBukkit.mock()
+        tempDir = Files.createTempDirectory("lg-graph-test")
+    }
+
+    @AfterEach
+    fun tearDown() {
+        stopKoin()
+        MockBukkit.unmock()
+    }
+
+    @Test
+    fun `every definition in the real koin graph resolves`() {
+        val plugin = mockk<LumaGuilds>(relaxed = true)
+        every { plugin.dataFolder } returns tempDir.toFile()
+        every { plugin.config } returns YamlConfiguration()
+        every { plugin.logger } returns Logger.getLogger("LumaGuilds-GraphTest")
+        every { plugin.pluginScope } returns CoroutineScope(Dispatchers.IO)
+
+        val storage = SQLiteStorage(tempDir.toFile())
+
+        // Run DB migrations before composing the graph (same order as production
+        // onEnable: initDatabase → startKoin). The repos preload data at construction
+        // time and need the schema to exist.
+        every { plugin.getComponentLogger() } returns ComponentLogger.logger("LumaGuilds-GraphTest")
+        storage.connection.getConnection().use { conn ->
+            SQLiteMigrations(plugin, conn, claimsEnabled = true).migrate()
+        }
+
+        startKoin {
+            modules(appModule(plugin, storage, claimsEnabled = true))
+        }
+
+        val koin = GlobalContext.get()
+        val rootScope = koin.scopeRegistry.rootScope
+        val factories = koin.instanceRegistry.instances.values.toList()
+
+        assertTrue(factories.isNotEmpty(), "Koin graph registered zero definitions")
+
+        // Force-construct every registered definition by calling its factory.
+        // A definition whose constructor references an unregistered type throws
+        // InstanceNotFoundException (Koin 4) / NoDefinitionFoundException (Koin 3).
+        val failures = mutableListOf<String>()
+        for (factory in factories) {
+            val bean = factory.beanDefinition
+            val context = ResolutionContext(
+                logger = koin.logger,
+                scope = rootScope,
+                clazz = bean.primaryType,
+                qualifier = bean.qualifier,
+                parameters = ParametersHolder()
+            )
+            try {
+                factory.get(context)
+            } catch (e: Throwable) {
+                val name = bean.primaryType.simpleName ?: bean.primaryType.toString()
+                failures.add("$name: ${e::class.simpleName} — ${causeChain(e)}")
+            }
+        }
+
+        assertTrue(
+            failures.isEmpty(),
+            "Koin graph has ${failures.size} unresolvable definition(s):\n" +
+                failures.joinToString("\n")
+        )
+    }
+
+    /** Flattens the root-cause chain into a readable one-liner. */
+    private fun causeChain(t: Throwable): String {
+        val parts = mutableListOf<String>()
+        var current: Throwable? = t
+        var depth = 0
+        while (current != null && depth < 6) {
+            val msg = current.message?.replace('\n', ' ')?.trim()
+            if (!msg.isNullOrEmpty()) {
+                parts.add("${current::class.simpleName}: $msg")
+            }
+            current = current.cause
+            depth++
+        }
+        return parts.joinToString(" ← ")
+    }
+}

--- a/src/test/kotlin/net/lumalyte/lg/di/KoinGraphSmokeTest.kt
+++ b/src/test/kotlin/net/lumalyte/lg/di/KoinGraphSmokeTest.kt
@@ -78,42 +78,47 @@ internal class KoinGraphSmokeTest {
             SQLiteMigrations(plugin, conn, claimsEnabled = true).migrate()
         }
 
-        startKoin {
-            modules(appModule(plugin, storage, claimsEnabled = true))
-        }
-
-        val koin = GlobalContext.get()
-        val rootScope = koin.scopeRegistry.rootScope
-        val factories = koin.instanceRegistry.instances.values.toList()
-
-        assertTrue(factories.isNotEmpty(), "Koin graph registered zero definitions")
-
-        // Force-construct every registered definition by calling its factory.
-        // A definition whose constructor references an unregistered type throws
-        // InstanceNotFoundException (Koin 4) / NoDefinitionFoundException (Koin 3).
-        val failures = mutableListOf<String>()
-        for (factory in factories) {
-            val bean = factory.beanDefinition
-            val context = ResolutionContext(
-                logger = koin.logger,
-                scope = rootScope,
-                clazz = bean.primaryType,
-                qualifier = bean.qualifier,
-                parameters = ParametersHolder()
-            )
-            try {
-                factory.get(context)
-            } catch (e: Throwable) {
-                val name = bean.primaryType.simpleName ?: bean.primaryType.toString()
-                failures.add("$name: ${e::class.simpleName} — ${causeChain(e)}")
+        try {
+            startKoin {
+                modules(appModule(plugin, storage, claimsEnabled = true))
             }
-        }
 
-        assertTrue(
-            failures.isEmpty(),
-            "Koin graph has ${failures.size} unresolvable definition(s):\n" +
-                failures.joinToString("\n")
-        )
+            val koin = GlobalContext.get()
+            val rootScope = koin.scopeRegistry.rootScope
+            val factories = koin.instanceRegistry.instances.values.toList()
+
+            assertTrue(factories.isNotEmpty(), "Koin graph registered zero definitions")
+
+            // Force-construct every registered definition by calling its factory.
+            // A definition whose constructor references an unregistered type throws
+            // InstanceNotFoundException (Koin 4) / NoDefinitionFoundException (Koin 3).
+            val failures = mutableListOf<String>()
+            for (factory in factories) {
+                val bean = factory.beanDefinition
+                val context = ResolutionContext(
+                    logger = koin.logger,
+                    scope = rootScope,
+                    clazz = bean.primaryType,
+                    qualifier = bean.qualifier,
+                    parameters = ParametersHolder()
+                )
+                try {
+                    factory.get(context)
+                } catch (e: Throwable) {
+                    val name = bean.primaryType.simpleName ?: bean.primaryType.toString()
+                    failures.add("$name: ${e::class.simpleName} — ${causeChain(e)}")
+                }
+            }
+
+            assertTrue(
+                failures.isEmpty(),
+                "Koin graph has ${failures.size} unresolvable definition(s):\n" +
+                    failures.joinToString("\n")
+            )
+        } finally {
+            // Close the HikariCP connection pool before the temp directory is deleted
+            storage.connection.close()
+        }
     }
 
     /** Flattens the root-cause chain into a readable one-liner. */

--- a/src/test/kotlin/net/lumalyte/lg/domain/values/ProgressionCurveTest.kt
+++ b/src/test/kotlin/net/lumalyte/lg/domain/values/ProgressionCurveTest.kt
@@ -1,0 +1,55 @@
+package net.lumalyte.lg.domain.values
+
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Test
+
+/**
+ * Tests for [ProgressionCurve] — the single source of truth for guild XP math.
+ *
+ * Anchor values locked from the production DB: every stored
+ * `experience_for_next_level` that was ever written by the service matches this
+ * curve (level 1 -> 2369, level 3 -> 5650, ...).
+ */
+class ProgressionCurveTest {
+
+    private val curve = ProgressionCurve(baseXp = 800.0, exponent = 1.3, linearBonusPerLevel = 200)
+
+    @Test
+    fun `experience for next level matches the service curve`() {
+        // 800 * 2^1.3 + 2*200 = 2369.6 -> 2369 (the value every non-fresh guild stored)
+        assertEquals(2369, curve.experienceForNextLevel(1))
+        // 800 * 4^1.3 + 4*200 = 5650.3 -> 5650
+        assertEquals(5650, curve.experienceForNextLevel(3))
+        // level 0 -> threshold for level 1: 800 * 1^1.3 + 1*200 = 1000
+        assertEquals(1000, curve.experienceForNextLevel(0))
+    }
+
+    @Test
+    fun `cumulative totals`() {
+        assertEquals(0, curve.totalExperienceForLevel(1))
+        assertEquals(2369, curve.totalExperienceForLevel(2))
+        assertEquals(2369 + 3936, curve.totalExperienceForLevel(3)) // 3936 = 800*3^1.3 + 600
+    }
+
+    @Test
+    fun `level from experience`() {
+        assertEquals(1, curve.levelFromExperience(0))
+        assertEquals(1, curve.levelFromExperience(2368))
+        assertEquals(2, curve.levelFromExperience(2369))
+        assertEquals(2, curve.levelFromExperience(5000))
+        assertEquals(3, curve.levelFromExperience(2369 + 3936))
+    }
+
+    @Test
+    fun `experience in current level`() {
+        assertEquals(0, curve.experienceInCurrentLevel(2369))
+        assertEquals(100, curve.experienceInCurrentLevel(2469))
+        assertEquals(2631, curve.experienceInCurrentLevel(5000)) // 5000 - 2369 (start of level 2)
+    }
+
+    @Test
+    fun `caps at level 101 like the service loop`() {
+        assertEquals(101, curve.levelFromExperience(17_518_681)) // prod max total XP
+        assertEquals(101, curve.levelFromExperience(Int.MAX_VALUE / 2))
+    }
+}

--- a/src/test/kotlin/net/lumalyte/lg/infrastructure/persistence/guilds/ProgressionRepositorySQLiteHealTest.kt
+++ b/src/test/kotlin/net/lumalyte/lg/infrastructure/persistence/guilds/ProgressionRepositorySQLiteHealTest.kt
@@ -1,0 +1,47 @@
+package net.lumalyte.lg.infrastructure.persistence.guilds
+
+import net.lumalyte.lg.domain.values.ProgressionCurve
+import org.junit.jupiter.api.Assertions.assertFalse
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+
+/**
+ * Regression: `GuildProgression.create()` hardcoded a different formula than the
+ * service curve, so fresh guilds stored `experience_for_next_level = 1200` while
+ * every guild that had earned XP stored 2369 (level 1). The preload heal rewrites
+ * exactly those rows — only when the row is otherwise internally consistent.
+ */
+class ProgressionRepositorySQLiteHealTest {
+
+    private val curve = ProgressionCurve(baseXp = 800.0, exponent = 1.3, linearBonusPerLevel = 200)
+
+    @Test
+    fun `heals fresh guilds with the hardcoded 1200 value`() {
+        // fresh guild: 0 XP, level 1, 0 this-level, stored 1200 (old create() formula)
+        assertTrue(ProgressionRepositorySQLite.hasStaleNextLevel(0, 1, 0, 1200, curve))
+    }
+
+    @Test
+    fun `does not touch rows already on the curve`() {
+        // fresh guild with the correct curve value
+        assertFalse(ProgressionRepositorySQLite.hasStaleNextLevel(0, 1, 0, 2369, curve))
+    }
+
+    @Test
+    fun `heals stale rows whose totals are consistent`() {
+        // stale next (1200 != 3936 for level 2) AND total == cumulative + this -> heal
+        assertTrue(ProgressionRepositorySQLite.hasStaleNextLevel(2369 + 100, 2, 100, 1200, curve))
+    }
+
+    @Test
+    fun `heals stale-but-otherwise-consistent rows`() {
+        // guild at level 1 with XP, still holding the old hardcoded 1200
+        assertTrue(ProgressionRepositorySQLite.hasStaleNextLevel(500, 1, 500, 1200, curve))
+    }
+
+    @Test
+    fun `never rewrites internally inconsistent rows`() {
+        // total doesn't match cumulative thresholds + this-level -> leave alone
+        assertFalse(ProgressionRepositorySQLite.hasStaleNextLevel(9999, 1, 500, 1200, curve))
+    }
+}

--- a/src/test/kotlin/net/lumalyte/lg/infrastructure/persistence/guilds/RankRepositorySQLiteParseTest.kt
+++ b/src/test/kotlin/net/lumalyte/lg/infrastructure/persistence/guilds/RankRepositorySQLiteParseTest.kt
@@ -1,0 +1,66 @@
+package net.lumalyte.lg.infrastructure.persistence.guilds
+
+import net.lumalyte.lg.domain.entities.RankPermission
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertFalse
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+
+/**
+ * Rank-permission DB parsing — self-healing against enum/DB drift.
+ *
+ * Regression: `EXPORT_BANK_DATA` was removed from [RankPermission] in #90 (CSV export
+ * removal) but remained in live rank rows, crashing plugin enable via
+ * `RankPermission.valueOf` in preload. The parser must skip unknown names instead.
+ */
+class RankRepositorySQLiteParseTest {
+
+    @Test
+    fun `parses known permissions`() {
+        assertEquals(
+            setOf(RankPermission.MANAGE_RANKS, RankPermission.MANAGE_MEMBERS),
+            RankRepositorySQLite.parseRankPermissions("MANAGE_RANKS, MANAGE_MEMBERS")
+        )
+    }
+
+    @Test
+    fun `skips unknown permissions instead of crashing`() {
+        // EXPORT_BANK_DATA no longer exists in the enum — must be dropped, not fatal.
+        assertEquals(
+            setOf(RankPermission.MANAGE_RANKS),
+            RankRepositorySQLite.parseRankPermissions("MANAGE_RANKS,EXPORT_BANK_DATA")
+        )
+    }
+
+    @Test
+    fun `handles null blank and whitespace-only values`() {
+        assertTrue(RankRepositorySQLite.parseRankPermissions(null).isEmpty())
+        assertTrue(RankRepositorySQLite.parseRankPermissions("").isEmpty())
+        assertTrue(RankRepositorySQLite.parseRankPermissions("   ,, ").isEmpty())
+    }
+
+    @Test
+    fun `deduplicates repeated permissions`() {
+        assertEquals(
+            setOf(RankPermission.MANAGE_RANKS),
+            RankRepositorySQLite.parseRankPermissions("MANAGE_RANKS,MANAGE_RANKS")
+        )
+    }
+
+    @Test
+    fun `detects stale rows that need cleanup`() {
+        assertTrue(RankRepositorySQLite.hasStalePermissions("MANAGE_RANKS,EXPORT_BANK_DATA", setOf(RankPermission.MANAGE_RANKS)))
+        assertTrue(RankRepositorySQLite.hasStalePermissions("EXPORT_BANK_DATA", emptySet()))
+        assertTrue(RankRepositorySQLite.hasStalePermissions("EXPORT_BANK_DATA,MANAGE_MEMBERS", setOf(RankPermission.MANAGE_MEMBERS)))
+    }
+
+    @Test
+    fun `does not rewrite clean rows`() {
+        // order and duplicates are not stale
+        assertFalse(RankRepositorySQLite.hasStalePermissions("MANAGE_RANKS", setOf(RankPermission.MANAGE_RANKS)))
+        assertFalse(RankRepositorySQLite.hasStalePermissions("MANAGE_MEMBERS,MANAGE_RANKS", setOf(RankPermission.MANAGE_RANKS, RankPermission.MANAGE_MEMBERS)))
+        assertFalse(RankRepositorySQLite.hasStalePermissions("MANAGE_RANKS,MANAGE_RANKS", setOf(RankPermission.MANAGE_RANKS)))
+        assertFalse(RankRepositorySQLite.hasStalePermissions(null, emptySet()))
+        assertFalse(RankRepositorySQLite.hasStalePermissions("", emptySet()))
+    }
+}

--- a/src/test/kotlin/net/lumalyte/lg/infrastructure/services/NexoEmojiServiceFontTagTest.kt
+++ b/src/test/kotlin/net/lumalyte/lg/infrastructure/services/NexoEmojiServiceFontTagTest.kt
@@ -1,0 +1,55 @@
+package net.lumalyte.lg.infrastructure.services
+
+import io.mockk.mockk
+import net.lumalyte.lg.application.services.ConfigService
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Test
+
+/**
+ * Tests for [NexoEmojiService.emojiToFontTag] — the guild-emoji → raw
+ * `<font:<glyphfont>><char></font>` converter used by
+ * %lumaguilds_guild_emoji_font% (backend MiniMessage consumers: UnlimitedNameTags,
+ * IC-DiscordSRV-Addon playerlist image renderer, Velocitab via PapiProxyBridge).
+ *
+ * Without a running Bukkit server [NexoEmojiService.getFontManager] resolves to null,
+ * so these tests exercise the fallback path (Nexo `<glyph:name>` tag, matching
+ * [net.lumalyte.lg.utils.ColorCodeUtils.emojiToGlyphTag]). The Nexo char/font
+ * extraction itself is integration-only (requires live Nexo classes on a server).
+ */
+class NexoEmojiServiceFontTagTest {
+
+    private val service = NexoEmojiService(mockk<ConfigService>())
+
+    @Test
+    fun `returns empty for null or blank`() {
+        assertEquals("", service.emojiToFontTag(null))
+        assertEquals("", service.emojiToFontTag(""))
+        assertEquals("", service.emojiToFontTag("   "))
+        assertEquals("", service.emojiToFontTag("\t\n"))
+    }
+
+    @Test
+    fun `passes non-discord values through unchanged`() {
+        assertEquals(":weird", service.emojiToFontTag(":weird"))
+        assertEquals("plain", service.emojiToFontTag("plain"))
+        // ":": length 1, doesn't match the :name: guard -> passthrough (same as the glyph-tag converter)
+        assertEquals(":", service.emojiToFontTag(":"))
+    }
+
+    @Test
+    fun `rejects emoji names with MiniMessage control characters`() {
+        // isValidEmojiFormat only checks delimiters; the glyph-id guard must stop
+        // MiniMessage control characters from reaching the generated tag.
+        assertEquals(":x><reset>:", service.emojiToFontTag(":x><reset>:"))
+        assertEquals(":<red>evil</red>:", service.emojiToFontTag(":<red>evil</red>:"))
+        assertEquals(":emoji with spaces:", service.emojiToFontTag(":emoji with spaces:"))
+    }
+
+    @Test
+    fun `falls back to glyph tag when Nexo is unavailable`() {
+        // No Bukkit server in unit tests -> getFontManager() is null -> <glyph:name>
+        assertEquals("<glyph:catsmileysmile>", service.emojiToFontTag(":catsmileysmile:"))
+        assertEquals("<glyph:clown>", service.emojiToFontTag(":clown:"))
+        assertEquals("<glyph:fire>", service.emojiToFontTag(":fire:"))
+    }
+}

--- a/src/test/kotlin/net/lumalyte/lg/utils/ColorCodeUtilsEmojiGlyphTest.kt
+++ b/src/test/kotlin/net/lumalyte/lg/utils/ColorCodeUtilsEmojiGlyphTest.kt
@@ -26,6 +26,15 @@ class ColorCodeUtilsEmojiGlyphTest {
     }
 
     @Test
+    fun `rejects emoji names with MiniMessage control characters`() {
+        // isValidEmojiFormat only checks delimiters; the glyph-id guard must stop
+        // MiniMessage control characters from reaching the generated tag.
+        assertEquals(":x><reset>:", ColorCodeUtils.emojiToGlyphTag(":x><reset>:"))
+        assertEquals(":<red>evil</red>:", ColorCodeUtils.emojiToGlyphTag(":<red>evil</red>:"))
+        assertEquals(":emoji with spaces:", ColorCodeUtils.emojiToGlyphTag(":emoji with spaces:"))
+    }
+
+    @Test
     fun `returns empty for null or blank`() {
         assertEquals("", ColorCodeUtils.emojiToGlyphTag(null))
         assertEquals("", ColorCodeUtils.emojiToGlyphTag(""))

--- a/wiki/docs/admins/placeholderapi.md
+++ b/wiki/docs/admins/placeholderapi.md
@@ -34,6 +34,7 @@ The same variants apply to `guild_display` and `guild_chat_format`.
 | `guild_tag_plain` | Text (plain) | Guild tag with formatting stripped |
 | `guild_emoji` | Text | Guild emoji, converted to Nexo PAPI format (`%nexo_<name>%`) — resolves only where Nexo's PAPI expansion runs (backend) |
 | `guild_emoji_minimessage` | Text | Guild emoji as Nexo glyph tag for MiniMessage formatters (Velocitab via NexoProxy). Matching `:name:` values become `<glyph:name>`; null/blank returns empty; other values pass through unchanged |
+| `guild_emoji_font` | Text | Guild emoji as raw MiniMessage font fragment (`<font:<glyphfont>><char></font>`) — renders in MiniMessage consumers without Nexo glyph-tag support (UnlimitedNameTags, IC-DiscordSRV-Addon playerlist, Velocitab via PapiProxyBridge). Resolves the char/font from Nexo's FontManager; falls back to `<glyph:name>` when Nexo is unavailable |
 | `guild_level` | Integer | Current guild level |
 | `guild_balance` | Integer | Virtual bank balance (coins) |
 | `guild_mode` | Text | `Peaceful` or `Hostile` |


### PR DESCRIPTION
## Summary

Four-landable stack (code + CI guard):

### #97 — `%lumaguilds_guild_emoji_font%` placeholder
Raw glyph character wrapped in `<font:nexo:default>...</font>` for use in PAPI contexts that don't resolve `<glyph:...>` tags natively (e.g. chat channels, scoreboards without MiniMessage double-pass). Tested with Nexo emoji integration.

### #98 — Self-heal rank permission enum drift
Preload no longer crashes when `Rank.kt` permissions enum has entries not in the database, or the DB has stale permissions (like `EXPORT_BANK_DATA` that was removed in #90). Warns+skips unknown values, then actively cleans them from the DB. Tested on real production DB (1.4 GB, 154 stale ranks).

### #99 — Unified guild progression curve
Fresh guilds no longer show a misleading 0→next XP value. ProgressionCurve extracted as a domain value with a single `xpForLevel(level)` formula across the whole range. Backward-compatible — existing guild XP data unchanged.

### CI guard — Koin graph smoke test
Force-resolves every Koin definition in `appModule` at test time. Catches v2.1.23-class release failures where definitions exist in source but Koin registrations are missing. Prevents shipping broken artifacts. Release workflow cleaned up to match.

## Verification
- `./gradlew test` → **BUILD SUCCESSFUL** (all tests pass)
- `./gradlew shadowJar` builds cleanly
- KoinGraphSmokeTest passes (resolves every definition including the compileOnly APIs it touches)
- PR #98 boot-tested on Fuji with real production DB