### PR TITLE
feat: PR-11 backlog — guild balance, emoji clearing, emoji grants (#1102 #1103 #1104)

### DIFF
--- a/src/main/kotlin/net/lumalyte/lg/LumaGuilds.kt
+++ b/src/main/kotlin/net/lumalyte/lg/LumaGuilds.kt
@@ -972,6 +972,11 @@ class LumaGuilds : JavaPlugin() {
         val guildDisbandedListener = get().get<net.lumalyte.lg.infrastructure.listeners.GuildDisbandedListener>()
         server.pluginManager.registerEvents(guildDisbandedListener, this)
 
+        // Register emoji grant listener and grant permissions for all configured guilds
+        val emojiGrantListener = get().get<net.lumalyte.lg.infrastructure.listeners.GuildEmojiGrantListener>()
+        server.pluginManager.registerEvents(emojiGrantListener, this)
+        get().get<net.lumalyte.lg.infrastructure.services.GuildEmojiGrantService>().grantAll()
+
         // Clean up RoseChat channels when guild status changes.
         // LumaGuilds can enable BEFORE RoseChat despite `depend: [RoseChat]`
         // (observed on the Fuji test server: RoseChat enabled ~4 minutes later),

--- a/src/main/kotlin/net/lumalyte/lg/config/MainConfig.kt
+++ b/src/main/kotlin/net/lumalyte/lg/config/MainConfig.kt
@@ -145,8 +145,11 @@ data class GuildConfig(
     var peaceAgreementSystemEnabled: Boolean = false, // If true, replaces default war ending with peace agreements
     var dailyWarExpCost: Int = 10, // EXP lost per day during war
     var dailyWarMoneyCost: Int = 100, // Money lost per day during war (virtual currency)
-    var warFarmingCooldownHours: Int = 24 // Hours before guild can earn EXP after war ends
+    var warFarmingCooldownHours: Int = 24, // Hours before guild can earn EXP after war ends
     // NOTE: Physical currency war costs are configured in vault.physical_daily_war_cost
+
+    // Emoji Grants — map guild names to emoji permission nodes
+    var emojiGrants: Map<String, String> = emptyMap()
 )
 
 data class BankConfig(

--- a/src/main/kotlin/net/lumalyte/lg/di/Modules.kt
+++ b/src/main/kotlin/net/lumalyte/lg/di/Modules.kt
@@ -504,6 +504,12 @@ fun socialModule() = module {
     single<net.lumalyte.lg.infrastructure.listeners.GuildDisbandedListener> {
         net.lumalyte.lg.infrastructure.listeners.GuildDisbandedListener(get(), get())
     }
+    single<net.lumalyte.lg.infrastructure.services.GuildEmojiGrantService> {
+        net.lumalyte.lg.infrastructure.services.GuildEmojiGrantService(get(), get(), get(), get())
+    }
+    single<net.lumalyte.lg.infrastructure.listeners.GuildEmojiGrantListener> {
+        net.lumalyte.lg.infrastructure.listeners.GuildEmojiGrantListener(get())
+    }
     single<net.lumalyte.lg.infrastructure.listeners.RoseChatCleanupListener> {
         net.lumalyte.lg.infrastructure.listeners.RoseChatCleanupListener(get(), get(), get(), get())
     }

--- a/src/main/kotlin/net/lumalyte/lg/infrastructure/listeners/GuildEmojiGrantListener.kt
+++ b/src/main/kotlin/net/lumalyte/lg/infrastructure/listeners/GuildEmojiGrantListener.kt
@@ -37,13 +37,18 @@ class GuildEmojiGrantListener(
         }
     }
 
+    /**
+     * Revokes emoji permissions for all former members when a guild is disbanded.
+     * Resolves the permission from the disanded guild's name because the guild
+     * record is already deleted from the repository by the time this fires.
+     */
     @EventHandler(priority = EventPriority.MONITOR)
     fun onGuildDisbanded(event: GuildDisbandedEvent) {
         try {
-            val permission = emojiGrantService.resolveEmojiGrant(event.guild.id)
+            val permission = emojiGrantService.resolveEmojiGrantByName(event.guild.name)
             if (permission != null) {
                 for (memberId in event.memberIds) {
-                    emojiGrantService.revokeForPlayer(memberId, event.guild.id)
+                    emojiGrantService.revokePermission(memberId, permission)
                 }
             }
         } catch (e: Exception) {

--- a/src/main/kotlin/net/lumalyte/lg/infrastructure/listeners/GuildEmojiGrantListener.kt
+++ b/src/main/kotlin/net/lumalyte/lg/infrastructure/listeners/GuildEmojiGrantListener.kt
@@ -1,0 +1,53 @@
+package net.lumalyte.lg.infrastructure.listeners
+
+import net.lumalyte.lg.infrastructure.services.GuildEmojiGrantService
+import net.lumalyte.lg.domain.events.GuildMemberJoinEvent
+import net.lumalyte.lg.domain.events.GuildMemberRemovedEvent
+import net.lumalyte.lg.domain.events.GuildDisbandedEvent
+import org.bukkit.event.EventHandler
+import org.bukkit.event.EventPriority
+import org.bukkit.event.Listener
+import org.slf4j.LoggerFactory
+
+/**
+ * Listens for guild membership changes and grants/revokes emoji permissions
+ * according to the [guild.emoji_grants] config.
+ */
+class GuildEmojiGrantListener(
+    private val emojiGrantService: GuildEmojiGrantService
+) : Listener {
+
+    private val logger = LoggerFactory.getLogger(GuildEmojiGrantListener::class.java)
+
+    @EventHandler(priority = EventPriority.MONITOR)
+    fun onGuildMemberJoin(event: GuildMemberJoinEvent) {
+        try {
+            emojiGrantService.grantForPlayer(event.playerId, event.guildId)
+        } catch (e: Exception) {
+            logger.warn("Failed to grant emoji permission on join: ${e.message}")
+        }
+    }
+
+    @EventHandler(priority = EventPriority.MONITOR)
+    fun onGuildMemberRemoved(event: GuildMemberRemovedEvent) {
+        try {
+            emojiGrantService.revokeForPlayer(event.playerId, event.guildId)
+        } catch (e: Exception) {
+            logger.warn("Failed to revoke emoji permission on leave: ${e.message}")
+        }
+    }
+
+    @EventHandler(priority = EventPriority.MONITOR)
+    fun onGuildDisbanded(event: GuildDisbandedEvent) {
+        try {
+            val permission = emojiGrantService.resolveEmojiGrant(event.guild.id)
+            if (permission != null) {
+                for (memberId in event.memberIds) {
+                    emojiGrantService.revokeForPlayer(memberId, event.guild.id)
+                }
+            }
+        } catch (e: Exception) {
+            logger.warn("Failed to revoke emoji permissions on disband: ${e.message}")
+        }
+    }
+}

--- a/src/main/kotlin/net/lumalyte/lg/infrastructure/services/ConfigServiceBukkit.kt
+++ b/src/main/kotlin/net/lumalyte/lg/infrastructure/services/ConfigServiceBukkit.kt
@@ -123,7 +123,8 @@ class ConfigServiceBukkit(private val config: FileConfiguration): ConfigService 
             dailyWarExpCost = config.getInt("guild.daily_war_exp_cost", 10),
             dailyWarMoneyCost = config.getInt("guild.daily_war_money_cost", 100),
             warFarmingCooldownHours = config.getInt("guild.war_farming_cooldown_hours", 24),
-            nameFilter = loadNameFilterConfig()
+            nameFilter = loadNameFilterConfig(),
+            emojiGrants = loadEmojiGrantsConfig()
         )
     }
 
@@ -138,6 +139,18 @@ class ConfigServiceBukkit(private val config: FileConfiguration): ConfigService 
                 collapseRepeats = config.getBoolean("guild.name_filter.normalization.collapse_repeats", true)
             )
         )
+    }
+
+    private fun loadEmojiGrantsConfig(): Map<String, String> {
+        val section = config.getConfigurationSection("guild.emoji_grants") ?: return emptyMap()
+        val result = mutableMapOf<String, String>()
+        for (key in section.getKeys(false)) {
+            val value = section.getString(key) ?: continue
+            if (value.isNotBlank()) {
+                result[key.lowercase()] = value
+            }
+        }
+        return result
     }
     
     private fun loadBankConfig(): BankConfig {

--- a/src/main/kotlin/net/lumalyte/lg/infrastructure/services/GuildEmojiGrantService.kt
+++ b/src/main/kotlin/net/lumalyte/lg/infrastructure/services/GuildEmojiGrantService.kt
@@ -26,13 +26,22 @@ class GuildEmojiGrantService(
     private val logger = LoggerFactory.getLogger(GuildEmojiGrantService::class.java)
 
     /**
-     * Returns the emoji permission node configured for a guild, or null if none.
-     * Guild name matching is case-insensitive.
+     * Returns the emoji permission node configured for a guild by its ID.
+     * Loads the guild from the repository; returns null if the guild no longer exists.
      */
     fun resolveEmojiGrant(guildId: UUID): String? {
         val guild = guildService.getGuild(guildId) ?: return null
+        return resolveEmojiGrantByName(guild.name)
+    }
+
+    /**
+     * Returns the emoji permission node configured for a guild by its name.
+     * Case-insensitive matching. Does not require the guild to exist in the repository,
+     * so it can be called after a guild has been deleted (e.g. on disband).
+     */
+    fun resolveEmojiGrantByName(guildName: String): String? {
         val grants = configService.loadConfig().guild.emojiGrants
-        return grants[guild.name.lowercase()]
+        return grants[guildName.lowercase()]
     }
 
     /**
@@ -92,15 +101,23 @@ class GuildEmojiGrantService(
         revokePermission(playerId, permission)
     }
 
-    private fun grantPermission(playerId: UUID, permission: String) {
-        Bukkit.getScheduler().runTaskAsynchronously(plugin, Runnable {
+    /**
+     * Grants a raw permission node to a player via LuckPerms console command.
+     * Runs on the server's main thread because Bukkit.dispatchCommand is not thread-safe.
+     */
+    fun grantPermission(playerId: UUID, permission: String) {
+        Bukkit.getScheduler().runTask(plugin, Runnable {
             val cmd = "lp user $playerId permission set $permission true"
             Bukkit.dispatchCommand(Bukkit.getConsoleSender(), cmd)
         })
     }
 
-    private fun revokePermission(playerId: UUID, permission: String) {
-        Bukkit.getScheduler().runTaskAsynchronously(plugin, Runnable {
+    /**
+     * Revokes a raw permission node from a player via LuckPerms console command.
+     * Runs on the server's main thread because Bukkit.dispatchCommand is not thread-safe.
+     */
+    fun revokePermission(playerId: UUID, permission: String) {
+        Bukkit.getScheduler().runTask(plugin, Runnable {
             val cmd = "lp user $playerId permission unset $permission"
             Bukkit.dispatchCommand(Bukkit.getConsoleSender(), cmd)
         })

--- a/src/main/kotlin/net/lumalyte/lg/infrastructure/services/GuildEmojiGrantService.kt
+++ b/src/main/kotlin/net/lumalyte/lg/infrastructure/services/GuildEmojiGrantService.kt
@@ -1,0 +1,108 @@
+package net.lumalyte.lg.infrastructure.services
+
+import net.lumalyte.lg.application.services.GuildService
+import net.lumalyte.lg.application.services.MemberService
+import net.lumalyte.lg.application.services.ConfigService
+import org.bukkit.Bukkit
+import org.bukkit.plugin.Plugin
+import org.slf4j.LoggerFactory
+import java.util.UUID
+
+/**
+ * Manages automatic emoji permission grants for guild members based on
+ * the [guild.emoji_grants] config section.
+ *
+ * When a guild name is mapped to a permission node, all current and future
+ * members of that guild are granted the permission via LuckPerms console
+ * commands. The permission is revoked when a member leaves or the guild is
+ * disbanded.
+ */
+class GuildEmojiGrantService(
+    private val guildService: GuildService,
+    private val memberService: MemberService,
+    private val configService: ConfigService,
+    private val plugin: Plugin
+) {
+    private val logger = LoggerFactory.getLogger(GuildEmojiGrantService::class.java)
+
+    /**
+     * Returns the emoji permission node configured for a guild, or null if none.
+     * Guild name matching is case-insensitive.
+     */
+    fun resolveEmojiGrant(guildId: UUID): String? {
+        val guild = guildService.getGuild(guildId) ?: return null
+        val grants = configService.loadConfig().guild.emojiGrants
+        return grants[guild.name.lowercase()]
+    }
+
+    /**
+     * Grants emoji permissions to all current members of every guild that
+     * has a configured emoji grant. Called on plugin enable.
+     */
+    fun grantAll() {
+        val grants = configService.loadConfig().guild.emojiGrants
+        if (grants.isEmpty()) return
+
+        val allGuilds = guildService.getAllGuilds()
+        for (guild in allGuilds) {
+            val permission = grants[guild.name.lowercase()] ?: continue
+            val members = memberService.getGuildMembers(guild.id)
+            for (member in members) {
+                grantPermission(member.playerId, permission)
+            }
+        }
+        logger.info("Processed emoji grants for ${allGuilds.count { grants.containsKey(it.name.lowercase()) }} guild(s)")
+    }
+
+    /**
+     * Grants the configured emoji permission to all current members of a guild.
+     */
+    fun grantForGuild(guildId: UUID) {
+        val permission = resolveEmojiGrant(guildId) ?: return
+        val members = memberService.getGuildMembers(guildId)
+        for (member in members) {
+            grantPermission(member.playerId, permission)
+        }
+    }
+
+    /**
+     * Revokes the configured emoji permission from all current members of a guild.
+     */
+    fun revokeForGuild(guildId: UUID) {
+        val permission = resolveEmojiGrant(guildId) ?: return
+        val members = memberService.getGuildMembers(guildId)
+        for (member in members) {
+            revokePermission(member.playerId, permission)
+        }
+    }
+
+    /**
+     * Grants the configured emoji permission to a specific player for their guild.
+     */
+    fun grantForPlayer(playerId: UUID, guildId: UUID) {
+        val permission = resolveEmojiGrant(guildId) ?: return
+        grantPermission(playerId, permission)
+    }
+
+    /**
+     * Revokes the configured emoji permission from a specific player for their guild.
+     */
+    fun revokeForPlayer(playerId: UUID, guildId: UUID) {
+        val permission = resolveEmojiGrant(guildId) ?: return
+        revokePermission(playerId, permission)
+    }
+
+    private fun grantPermission(playerId: UUID, permission: String) {
+        Bukkit.getScheduler().runTaskAsynchronously(plugin, Runnable {
+            val cmd = "lp user $playerId permission set $permission true"
+            Bukkit.dispatchCommand(Bukkit.getConsoleSender(), cmd)
+        })
+    }
+
+    private fun revokePermission(playerId: UUID, permission: String) {
+        Bukkit.getScheduler().runTaskAsynchronously(plugin, Runnable {
+            val cmd = "lp user $playerId permission unset $permission"
+            Bukkit.dispatchCommand(Bukkit.getConsoleSender(), cmd)
+        })
+    }
+}

--- a/src/main/kotlin/net/lumalyte/lg/interaction/commands/GuildCommand.kt
+++ b/src/main/kotlin/net/lumalyte/lg/interaction/commands/GuildCommand.kt
@@ -54,6 +54,7 @@ class GuildCommand : BaseCommand(), KoinComponent {
     private val teleportationService: net.lumalyte.lg.infrastructure.services.TeleportationService by inject()
     private val bannermanListeners: net.lumalyte.lg.infrastructure.bukkit.bannerman.BannermanListeners by inject()
     private val strikeService: net.lumalyte.lg.application.services.StrikeService by inject()
+    private val bankService: net.lumalyte.lg.application.services.BankService by inject()
 
     private val lastHomeTeleport = mutableMapOf<java.util.UUID, Long>()
 
@@ -732,6 +733,19 @@ class GuildCommand : BaseCommand(), KoinComponent {
         if (emoji == null) {
             val menuNavigator = MenuNavigator(player)
             menuNavigator.openMenu(menuFactory.createGuildEmojiMenu(menuNavigator, player, guild))
+            return
+        }
+
+        // Clear the emoji if the player passes "clear", "none", or "remove"
+        val clearKeywords = setOf("clear", "none", "remove")
+        if (emoji.lowercase() in clearKeywords) {
+            val success = guildService.setEmoji(guild.id, null, playerId)
+            if (success) {
+                player.sendMessage("§a✅ Guild emoji cleared successfully!")
+                player.playSound(player.location, org.bukkit.Sound.ENTITY_PLAYER_LEVELUP, 1.0f, 1.0f)
+            } else {
+                player.sendMessage("§c❌ Failed to clear emoji. Please try again.")
+            }
             return
         }
 
@@ -2464,6 +2478,55 @@ class GuildCommand : BaseCommand(), KoinComponent {
             player.sendMessage("§c✗ Failed to send peace request.")
             player.sendMessage("§7There may already be a pending request.")
             player.playSound(player.location, org.bukkit.Sound.ENTITY_VILLAGER_NO, 1.0f, 1.0f)
+        }
+    }
+
+    @Subcommand("balance|bal")
+    @CommandPermission("lumaguilds.guild.bal")
+    @CommandCompletion("@guilds")
+    fun onBalance(player: Player, @Optional guildName: String?) {
+        val playerId = player.uniqueId
+
+        // Resolve which guild to show
+        val guild = if (guildName != null) {
+            guildService.getGuildByName(guildName)
+        } else {
+            val guilds = guildService.getPlayerGuilds(playerId)
+            if (guilds.isEmpty()) {
+                player.sendMessage("§cYou are not in a guild.")
+                return
+            }
+            guilds.first()
+        }
+
+        if (guild == null) {
+            player.sendMessage("§cNo guild named '$guildName' found.")
+            return
+        }
+
+        val balance = bankService.getBalance(guild.id)
+        val formatted = java.text.NumberFormat.getIntegerInstance().format(balance.toLong())
+        player.sendMessage("§8[§6LumaGuilds§8] §e${guild.name}§7's balance: §6$$formatted")
+    }
+
+    @Subcommand("baltop")
+    @CommandPermission("lumaguilds.guild.baltop")
+    fun onBaltop(player: Player) {
+        val top = bankService.getTopBalances(15)
+        if (top.isEmpty()) {
+            player.sendMessage("§cNo guild balance data available.")
+            return
+        }
+
+        val nameById = guildService.getAllGuilds().associateBy { it.id }
+        player.sendMessage("§8[§6LumaGuilds§8] §fTop Guilds by Balance")
+        player.sendMessage("§7━━━━━━━━━━━━━━━━━━━━")
+        var index = 0
+        for ((guildId, balance) in top) {
+            val guild = nameById[guildId]
+            val label = guild?.name ?: guildId.toString().take(8)
+            val formatted = java.text.NumberFormat.getIntegerInstance().format(balance.toLong())
+            player.sendMessage("§7${++index}. §e$label §8— §6$$formatted")
         }
     }
 

--- a/src/main/kotlin/net/lumalyte/lg/interaction/commands/GuildCommand.kt
+++ b/src/main/kotlin/net/lumalyte/lg/interaction/commands/GuildCommand.kt
@@ -715,6 +715,7 @@ class GuildCommand : BaseCommand(), KoinComponent {
         val playerRank = rankService.getPlayerRank(playerId, guild.id)
         val hasEmojiPermission = playerRank?.permissions?.any { permission ->
             permission in setOf(
+                RankPermission.MANAGE_EMOJI,
                 RankPermission.MANAGE_BANNER,
                 RankPermission.MANAGE_MEMBERS,
                 RankPermission.MANAGE_CLAIMS

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -419,6 +419,15 @@ combat:
   war_win_experience: 500       # XP gained for winning a war
   war_lose_experience: 100      # XP gained for losing a war (participation)
 
+  # Emoji Grants — map guild names to Nexo emoji permission nodes
+  # Members of the listed guild are automatically granted the permission to use
+  # the corresponding emoji in chat. Format: "Guild Name: lumaguilds.emoji.<name>"
+  # Example:
+  #   emoji_grants:
+  #     "MyGuild": "lumaguilds.emoji.crown"
+  #     "AwesomeGuild": "lumaguilds.emoji.star"
+  emoji_grants: {}
+
 # =====================================
 # Chat System Configuration
 # =====================================

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -161,6 +161,15 @@ guild:
       leet_map: true
       collapse_repeats: true
 
+  # Emoji Grants — map guild names to Nexo emoji permission nodes
+  # Members of the listed guild are automatically granted the permission to use
+  # the corresponding emoji in chat.
+  # Example:
+  #   emoji_grants:
+  #     MyGuild: lumaguilds.emoji.crown
+  #     AwesomeGuild: lumaguilds.emoji.star
+  emoji_grants: {}
+
 # =====================================
 # Guild Vault Configuration
 # =====================================
@@ -419,14 +428,6 @@ combat:
   war_win_experience: 500       # XP gained for winning a war
   war_lose_experience: 100      # XP gained for losing a war (participation)
 
-  # Emoji Grants — map guild names to Nexo emoji permission nodes
-  # Members of the listed guild are automatically granted the permission to use
-  # the corresponding emoji in chat. Format: "Guild Name: lumaguilds.emoji.<name>"
-  # Example:
-  #   emoji_grants:
-  #     "MyGuild": "lumaguilds.emoji.crown"
-  #     "AwesomeGuild": "lumaguilds.emoji.star"
-  emoji_grants: {}
 
 # =====================================
 # Chat System Configuration

--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -109,6 +109,12 @@ permissions:
   lumaguilds.guild.bannerman:
     description: Toggle guild bannerman rendering (banner on members' backs)
     default: true
+  lumaguilds.guild.bal:
+    description: View guild bank balance
+    default: true
+  lumaguilds.guild.baltop:
+    description: View guild balance leaderboard
+    default: true
   lumaguilds.guild.create:
     description: Create new guilds
     default: true

--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -109,12 +109,6 @@ permissions:
   lumaguilds.guild.bannerman:
     description: Toggle guild bannerman rendering (banner on members' backs)
     default: true
-  lumaguilds.guild.bal:
-    description: View guild bank balance
-    default: true
-  lumaguilds.guild.baltop:
-    description: View guild balance leaderboard
-    default: true
   lumaguilds.guild.create:
     description: Create new guilds
     default: true


### PR DESCRIPTION
### PR-11 — Backlog: immediate fixes (operator, Fain)

**LG-1102 — `/g balance` + `/g baltop`** ✅
- New `@Subcommand("balance|bal")` shows guild bank balance; optional guild name arg with tab completion
- New `@Subcommand("baltop")` shows top 15 guilds by balance
- Declared `lumaguilds.guild.bal` and `lumaguilds.guild.baltop` in plugin.yml

**LG-1103 — Emoji clearing** ✅
- `/g emoji clear` / `none` / `remove` clears the guild emoji (was previously impossible via command)

**LG-1104 — Custom guild emoji grants** ✅
- Config section `guild.emoji_grants` maps guild names → emoji permission nodes
- `GuildEmojiGrantService` grants/revokes via LuckPerms console commands (async)
- `GuildEmojiGrantListener` hooks join/leave/disband events for lifecycle management
- `grantAll()` on startup handles existing members

**Usage:**
```yaml
guild:
  emoji_grants:
    MyGuild: lumaguilds.emoji.crown
```
All members of `MyGuild` get the `:crown:` emoji unlocked automatically. Grants on join, revokes on leave/disband.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Fixes
- Dispatch LuckPerms commands on the Bukkit main thread.
- Resolve emoji grants by guild name during disband events.

## Features
- Add `/g balance`, `/g bal`, and `/g baltop` with permissions and tab completion.
- Add `/g emoji clear`, `/g emoji none`, and `/g emoji remove` with `MANAGE_EMOJI` authorization.
- Configure guild emoji grants through `guild.emoji_grants` and apply them on startup, join, leave, and disband events.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->