### PR TITLE
feat: Guild Dashboard with Nexo icon integration

### DIFF
--- a/src/main/kotlin/net/lumalyte/lg/application/services/ProgressionService.kt
+++ b/src/main/kotlin/net/lumalyte/lg/application/services/ProgressionService.kt
@@ -217,6 +217,17 @@ interface ProgressionService {
      * GuildProgression.currentLevel. Returns the number of guild rows updated.
      */
     fun syncGuildLevels(): Int
+
+    /**
+     * Returns the amount of XP earned per source for a guild today.
+     * Used by the progression menu to display daily caps and progress.
+     */
+    fun getDailySourceXp(guildId: UUID): Map<ExperienceSource, Int>
+
+    /**
+     * Gets the daily XP cap for a given experience source.
+     */
+    fun getDailyCap(source: ExperienceSource): Int
 }
 
 /**

--- a/src/main/kotlin/net/lumalyte/lg/infrastructure/services/ProgressionServiceBukkit.kt
+++ b/src/main/kotlin/net/lumalyte/lg/infrastructure/services/ProgressionServiceBukkit.kt
@@ -604,4 +604,40 @@ class ProgressionServiceBukkit(
             PerkType.ALLY_HOME_ACCESS -> "Ally Home Teleportation"
         }
     }
+
+    override fun getDailySourceXp(guildId: UUID): Map<ExperienceSource, Int> {
+        return try {
+            val todayStart = Instant.now().truncatedTo(java.time.temporal.ChronoUnit.DAYS)
+            val transactions = progressionRepository.getExperienceTransactions(guildId, 1000)
+                .filter { it.timestamp >= todayStart }
+                .groupBy { it.source }
+                .mapValues { (_, txns) -> txns.sumOf { it.amount.coerceAtLeast(0) } }
+            ExperienceSource.entries.associateWith { transactions[it] ?: 0 }
+        } catch (e: Exception) {
+            logger.error("Error calculating daily source XP for guild $guildId", e)
+            emptyMap()
+        }
+    }
+
+    override fun getDailyCap(source: ExperienceSource): Int {
+        return when (source) {
+            ExperienceSource.BANK_DEPOSIT -> 1000
+            ExperienceSource.MEMBER_JOINED -> 200
+            ExperienceSource.WAR_WON -> 500
+            ExperienceSource.WAR_LOST -> 200
+            ExperienceSource.PLAYER_KILL -> 1000
+            ExperienceSource.MOB_KILL -> 800
+            ExperienceSource.CROP_BREAK -> 500
+            ExperienceSource.BLOCK_BREAK -> 600
+            ExperienceSource.BLOCK_PLACE -> 600
+            ExperienceSource.CRAFTING -> 400
+            ExperienceSource.SMELTING -> 400
+            ExperienceSource.FISHING -> 300
+            ExperienceSource.ENCHANTING -> 300
+            ExperienceSource.CLAIM_CREATED -> 500
+            ExperienceSource.CLAIM_DESTROYED -> 0
+            ExperienceSource.WEEKLY_ACTIVITY -> 0
+            ExperienceSource.ADMIN_BONUS -> Int.MAX_VALUE
+        }
+    }
 }

--- a/src/main/kotlin/net/lumalyte/lg/interaction/menus/MenuFactory.kt
+++ b/src/main/kotlin/net/lumalyte/lg/interaction/menus/MenuFactory.kt
@@ -346,9 +346,24 @@ class MenuFactory(
             val rankService = org.koin.core.context.GlobalContext.get().get<net.lumalyte.lg.application.services.RankService>()
             val memberService = org.koin.core.context.GlobalContext.get().get<net.lumalyte.lg.application.services.MemberService>()
             val vaultService = org.koin.core.context.GlobalContext.get().get<net.lumalyte.lg.application.services.GuildVaultService>()
-            val progressionService = org.koin.core.context.GlobalContext.get().get<net.lumalyte.lg.application.services.ProgressionService>()
-            val progressionRepository = org.koin.core.context.GlobalContext.get().get<net.lumalyte.lg.application.persistence.ProgressionRepository>()
-            net.lumalyte.lg.interaction.menus.guild.GuildControlPanelMenu(menuNavigator, player, guild, guildService, rankService, memberService, vaultService, this, configService, progressionService, progressionRepository)
+            val menuItemBuilder = org.koin.core.context.GlobalContext.get().get<net.lumalyte.lg.utils.MenuItemBuilder>()
+
+            // Use the new dashboard when Nexo is available, fall back to old panel
+            if (net.lumalyte.lg.utils.NexoItemProvider.isAvailable()) {
+                net.lumalyte.lg.interaction.menus.guild.GuildDashboard(
+                    menuNavigator, player, guild,
+                    guildService, rankService, memberService, vaultService,
+                    this, menuItemBuilder, configService
+                )
+            } else {
+                val progressionService = org.koin.core.context.GlobalContext.get().get<net.lumalyte.lg.application.services.ProgressionService>()
+                val progressionRepository = org.koin.core.context.GlobalContext.get().get<net.lumalyte.lg.application.persistence.ProgressionRepository>()
+                net.lumalyte.lg.interaction.menus.guild.GuildControlPanelMenu(
+                    menuNavigator, player, guild,
+                    guildService, rankService, memberService, vaultService,
+                    this, configService, progressionService, progressionRepository
+                )
+            }
         }
     }
 

--- a/src/main/kotlin/net/lumalyte/lg/interaction/menus/MenuFactory.kt
+++ b/src/main/kotlin/net/lumalyte/lg/interaction/menus/MenuFactory.kt
@@ -352,8 +352,8 @@ class MenuFactory(
             if (net.lumalyte.lg.utils.NexoItemProvider.isAvailable()) {
                 net.lumalyte.lg.interaction.menus.guild.GuildDashboard(
                     menuNavigator, player, guild,
-                    guildService, rankService, memberService, vaultService,
-                    this, menuItemBuilder, configService
+                    guildService, rankService, memberService,
+                    this
                 )
             } else {
                 val progressionService = org.koin.core.context.GlobalContext.get().get<net.lumalyte.lg.application.services.ProgressionService>()

--- a/src/main/kotlin/net/lumalyte/lg/interaction/menus/MenuFactory.kt
+++ b/src/main/kotlin/net/lumalyte/lg/interaction/menus/MenuFactory.kt
@@ -753,6 +753,29 @@ class MenuFactory(
     }
 
     /**
+     * Creates a guild progression menu appropriate for the player's platform
+     */
+    fun createGuildProgressionMenu(
+        menuNavigator: MenuNavigator,
+        player: Player,
+        guild: net.lumalyte.lg.domain.entities.Guild
+    ): Menu {
+        return if (shouldUseBedrockMenus(player)) {
+            net.lumalyte.lg.interaction.menus.bedrock.BedrockGuildProgressionInfoMenu(menuNavigator, player, guild, logger)
+        } else {
+            val guildService = org.koin.core.context.GlobalContext.get().get<net.lumalyte.lg.application.services.GuildService>()
+            val memberService = org.koin.core.context.GlobalContext.get().get<net.lumalyte.lg.application.services.MemberService>()
+            val progressionService = org.koin.core.context.GlobalContext.get().get<net.lumalyte.lg.application.services.ProgressionService>()
+            val menuItemBuilder = org.koin.core.context.GlobalContext.get().get<net.lumalyte.lg.utils.MenuItemBuilder>()
+            net.lumalyte.lg.interaction.menus.guild.GuildProgressionMenu(
+                menuNavigator, player, guild,
+                guildService, memberService, progressionService,
+                this, menuItemBuilder, configService
+            )
+        }
+    }
+
+    /**
      * Creates a guild invite menu appropriate for the player's platform
      */
     fun createGuildInviteMenu(

--- a/src/main/kotlin/net/lumalyte/lg/interaction/menus/guild/EnemiesListMenu.kt
+++ b/src/main/kotlin/net/lumalyte/lg/interaction/menus/guild/EnemiesListMenu.kt
@@ -228,8 +228,10 @@ class EnemiesListMenu(
         val warDetailsGuiItem = GuiItem(warDetailsItem) {
             player.sendMessage("§c=== War with $guildName ===")
             player.sendMessage("§7Started: ${formatDuration(Duration.between(relation.createdAt, Instant.now()))} ago")
-            player.sendMessage("§7")
-            player.sendMessage("§7War details and statistics coming soon!")
+            player.sendMessage("§7Type: §cHostile (${relation.type.name})")
+            if (relation.expiresAt != null) {
+                player.sendMessage("§7Expires: ${formatDuration(Duration.between(Instant.now(), relation.expiresAt))}")
+            }
         }
         pane.addItem(warDetailsGuiItem, 7, 1)
 

--- a/src/main/kotlin/net/lumalyte/lg/interaction/menus/guild/GuildDashboard.kt
+++ b/src/main/kotlin/net/lumalyte/lg/interaction/menus/guild/GuildDashboard.kt
@@ -1,0 +1,184 @@
+package net.lumalyte.lg.interaction.menus.guild
+
+import com.github.stefvanschie.inventoryframework.gui.GuiItem
+import com.github.stefvanschie.inventoryframework.gui.type.ChestGui
+import com.github.stefvanschie.inventoryframework.pane.StaticPane
+import net.lumalyte.lg.application.services.*
+import net.lumalyte.lg.domain.entities.Guild
+import net.lumalyte.lg.interaction.menus.Menu
+import net.lumalyte.lg.interaction.menus.MenuFactory
+import net.lumalyte.lg.interaction.menus.MenuNavigator
+import net.lumalyte.lg.utils.MenuItemBuilder
+import net.lumalyte.lg.utils.NexoItemProvider
+import net.lumalyte.lg.utils.name
+import org.bukkit.Material
+import org.bukkit.entity.Player
+import org.bukkit.inventory.ItemStack
+
+/**
+ * Guild Dashboard — the hub-and-spoke entry point for guild management.
+ *
+ * A 3-row menu with 8 navigation category icons and a guild info display.
+ * Replaces the old 6-row flat control panel.
+ */
+class GuildDashboard(
+    private val menuNavigator: MenuNavigator,
+    private val player: Player,
+    private var guild: Guild,
+    private val guildService: GuildService,
+    private val rankService: RankService,
+    private val memberService: MemberService,
+    private val vaultService: GuildVaultService,
+    private val menuFactory: MenuFactory,
+    private val menuItemBuilder: MenuItemBuilder,
+    private val configService: ConfigService
+) : Menu {
+
+    override fun open() {
+        val playerId = player.uniqueId
+
+        // Security check
+        if (memberService.getMember(playerId, guild.id) == null) {
+            player.sendMessage("§c❌ You cannot access the dashboard for a guild you're not a member of!")
+            menuNavigator.goBack()
+            return
+        }
+
+        // Refresh guild data
+        guild = guildService.getGuild(guild.id) ?: run {
+            player.sendMessage("§c❌ Guild no longer exists.")
+            menuNavigator.goBack()
+            return
+        }
+
+        val gui = ChestGui(3, "§0§8⚔ §7${guild.name}")
+        val pane = StaticPane(0, 0, 9, 3)
+        gui.setOnTopClick { e -> e.isCancelled = true }
+        gui.setOnBottomClick { e ->
+            val click = e.click
+            if (click == org.bukkit.event.inventory.ClickType.SHIFT_LEFT ||
+                click == org.bukkit.event.inventory.ClickType.SHIFT_RIGHT
+            ) e.isCancelled = true
+        }
+        gui.addPane(pane)
+
+        // Fill background first (nav buttons overwrite their slots)
+        fillBackground(pane)
+
+        // Guild info display at top center
+        addGuildInfoDisplay(pane, 4, 0)
+
+        // Row 1 (y=1): Information, Members, Ranks, Economy
+        addNavButton(pane, 0, 1, "lg_nav_info", Material.KNOWLEDGE_BOOK, "§9Information",
+            "§7Guild details, statistics,", "§7and performance metrics") {
+            menuNavigator.openMenu(menuFactory.createGuildInfoMenu(menuNavigator, player, guild))
+        }
+
+        addNavButton(pane, 2, 1, "lg_nav_members", Material.PLAYER_HEAD, "§bMembers",
+            "§7Member list, management,", "§7invite, kick, and promote") {
+            menuNavigator.openMenu(menuFactory.createGuildMemberManagementMenu(menuNavigator, player, guild))
+        }
+
+        addNavButton(pane, 4, 1, "lg_nav_ranks", Material.IRON_SWORD, "§6Ranks",
+            "§7Create, edit, and manage", "§7guild ranks and permissions") {
+            menuNavigator.openMenu(menuFactory.createGuildRankManagementMenu(menuNavigator, player, guild))
+        }
+
+        addNavButton(pane, 6, 1, "lg_nav_economy", Material.GOLD_BLOCK, "§6Economy",
+            "§7Bank, vault, budget,", "§7and transaction history") {
+            menuNavigator.openMenu(menuFactory.createGuildBankMenu(menuNavigator, player, guild))
+        }
+
+        // Row 2 (y=2): Settings, Progression, Diplomacy, Warfare
+        addNavButton(pane, 0, 2, "lg_nav_settings", Material.COMMAND_BLOCK, "§eSettings",
+            "§7Guild name, tag, emoji,", "§7home, mode, and more") {
+            menuNavigator.openMenu(menuFactory.createGuildSettingsMenu(menuNavigator, player, guild))
+        }
+
+        addNavButton(pane, 2, 2, "lg_nav_progression", Material.EXPERIENCE_BOTTLE, "§aProgression",
+            "§7Guild leveling, XP,", "§7and unlocked perks") {
+            menuNavigator.openMenu(menuFactory.createGuildStatisticsMenu(menuNavigator, player, guild))
+        }
+
+        addNavButton(pane, 4, 2, "lg_nav_diplomacy", Material.BOOK, "§dDiplomacy",
+            "§7Alliances, enemies,", "§7truces, and relations") {
+            menuNavigator.openMenu(menuFactory.createGuildRelationsMenu(menuNavigator, player, guild))
+        }
+
+        addNavButton(pane, 6, 2, "lg_nav_warfare", Material.DIAMOND_SWORD, "§4War & Party",
+            "§7Declare war, manage", "§7parties, and conflicts") {
+            menuNavigator.openMenu(menuFactory.createGuildWarManagementMenu(menuNavigator, player, guild))
+        }
+
+        gui.show(player)
+    }
+
+    /**
+     * Fills all slots with the 3-row background texture.
+     * Nav buttons are added after this, so they overwrite their positions.
+     */
+    private fun fillBackground(pane: StaticPane) {
+        val bgItem = NexoItemProvider.getItemStack("lg_bg_3_row")
+            ?: ItemStack.of(Material.GRAY_STAINED_GLASS_PANE).name(" ")
+
+        for (x in 0..8) {
+            for (y in 0..2) {
+                pane.addItem(GuiItem(bgItem.clone()) { it.isCancelled = true }, x, y)
+            }
+        }
+    }
+
+    /**
+     * Creates a navigation category button with Nexo icon + fallback.
+     */
+    private fun addNavButton(
+        pane: StaticPane,
+        x: Int,
+        y: Int,
+        nexoId: String,
+        fallbackMaterial: Material,
+        displayName: String,
+        vararg loreLines: String,
+        action: () -> Unit
+    ) {
+        val item = NexoItemProvider.getItemStackOrFallback(nexoId) {
+            ItemStack.of(fallbackMaterial).name(displayName)
+        }
+
+        val meta = item.itemMeta ?: return
+        meta.setDisplayName(displayName)
+        val lore = java.util.ArrayList<String>()
+        for (line in loreLines) lore.add(line)
+        meta.lore = lore
+        item.itemMeta = meta
+
+        pane.addItem(GuiItem(item) { action() }, x, y)
+    }
+
+    /**
+     * Guild identity display at the top center: name, emoji, member count, balance.
+     */
+    private fun addGuildInfoDisplay(pane: StaticPane, x: Int, y: Int) {
+        val emoji = guildService.getEmoji(guild.id)
+        val memberCount = memberService.getMemberCount(guild.id)
+        val rankCount = rankService.listRanks(guild.id).size
+
+        val displayName = if (emoji != null) "$emoji ${guild.name}" else guild.name
+
+        val item = ItemStack.of(Material.BELL)
+            .name("§f⚔ §7$displayName")
+        val lore = java.util.ArrayList<String>().apply {
+            add("§7Members: §f$memberCount")
+            add("§7Ranks: §f$rankCount")
+            add("§7Balance: §6$${guild.bankBalance}")
+            add("")
+            add("§7Select a category below")
+            add("§7to manage your guild")
+        }
+        val meta = item.itemMeta ?: return
+        meta.lore = lore
+        item.itemMeta = meta
+
+        pane.addItem(GuiItem(item) { it.isCancelled = true }, x, y)
+    }
+}

--- a/src/main/kotlin/net/lumalyte/lg/interaction/menus/guild/GuildDashboard.kt
+++ b/src/main/kotlin/net/lumalyte/lg/interaction/menus/guild/GuildDashboard.kt
@@ -97,7 +97,7 @@ class GuildDashboard(
 
         addNavButton(pane, 2, 2, "lg_nav_progression", Material.EXPERIENCE_BOTTLE, "§aProgression",
             "§7Guild leveling, XP,", "§7and unlocked perks") {
-            menuNavigator.openMenu(menuFactory.createGuildStatisticsMenu(menuNavigator, player, guild))
+            menuNavigator.openMenu(menuFactory.createGuildProgressionMenu(menuNavigator, player, guild))
         }
 
         addNavButton(pane, 4, 2, "lg_nav_diplomacy", Material.BOOK, "§dDiplomacy",

--- a/src/main/kotlin/net/lumalyte/lg/interaction/menus/guild/GuildDashboard.kt
+++ b/src/main/kotlin/net/lumalyte/lg/interaction/menus/guild/GuildDashboard.kt
@@ -8,7 +8,6 @@ import net.lumalyte.lg.domain.entities.Guild
 import net.lumalyte.lg.interaction.menus.Menu
 import net.lumalyte.lg.interaction.menus.MenuFactory
 import net.lumalyte.lg.interaction.menus.MenuNavigator
-import net.lumalyte.lg.utils.MenuItemBuilder
 import net.lumalyte.lg.utils.NexoItemProvider
 import net.lumalyte.lg.utils.name
 import org.bukkit.Material
@@ -28,10 +27,7 @@ class GuildDashboard(
     private val guildService: GuildService,
     private val rankService: RankService,
     private val memberService: MemberService,
-    private val vaultService: GuildVaultService,
-    private val menuFactory: MenuFactory,
-    private val menuItemBuilder: MenuItemBuilder,
-    private val configService: ConfigService
+    private val menuFactory: MenuFactory
 ) : Menu {
 
     override fun open() {

--- a/src/main/kotlin/net/lumalyte/lg/interaction/menus/guild/GuildDisbandConfirmationMenu.kt
+++ b/src/main/kotlin/net/lumalyte/lg/interaction/menus/guild/GuildDisbandConfirmationMenu.kt
@@ -57,6 +57,7 @@ class GuildDisbandConfirmationMenu(
                 player.closeInventory()
             } else {
                 player.sendMessage("§cFailed to disband guild. You may not be the owner.")
+                player.playSound(player.location, Sound.ENTITY_VILLAGER_NO, 1.0f, 1.0f)
             }
         }, 3, 2)
 

--- a/src/main/kotlin/net/lumalyte/lg/interaction/menus/guild/GuildDisbandConfirmationMenu.kt
+++ b/src/main/kotlin/net/lumalyte/lg/interaction/menus/guild/GuildDisbandConfirmationMenu.kt
@@ -55,6 +55,7 @@ class GuildDisbandConfirmationMenu(
                 player.sendMessage("§c❌ Guild §f${guild.name} §chas been disbanded.")
                 player.playSound(player.location, Sound.ENTITY_ENDER_DRAGON_GROWL, 1.0f, 1.0f)
                 player.closeInventory()
+                menuNavigator.clearMenuStack()
             } else {
                 player.sendMessage("§cFailed to disband guild. You may not be the owner.")
                 player.playSound(player.location, Sound.ENTITY_VILLAGER_NO, 1.0f, 1.0f)

--- a/src/main/kotlin/net/lumalyte/lg/interaction/menus/guild/GuildDisbandConfirmationMenu.kt
+++ b/src/main/kotlin/net/lumalyte/lg/interaction/menus/guild/GuildDisbandConfirmationMenu.kt
@@ -1,21 +1,74 @@
 package net.lumalyte.lg.interaction.menus.guild
 
+import com.github.stefvanschie.inventoryframework.gui.GuiItem
+import com.github.stefvanschie.inventoryframework.gui.type.ChestGui
+import com.github.stefvanschie.inventoryframework.pane.StaticPane
+import net.lumalyte.lg.application.services.GuildService
 import net.lumalyte.lg.domain.entities.Guild
 import net.lumalyte.lg.interaction.menus.Menu
 import net.lumalyte.lg.interaction.menus.MenuNavigator
-import net.lumalyte.lg.interaction.menus.MenuFactory
+import net.lumalyte.lg.utils.lore
+import net.lumalyte.lg.utils.name
+import org.bukkit.Material
+import org.bukkit.Sound
 import org.bukkit.entity.Player
+import org.bukkit.event.inventory.ClickType
+import org.bukkit.inventory.ItemStack
 import org.koin.core.component.KoinComponent
 import org.koin.core.component.inject
 
-class GuildDisbandConfirmationMenu(private val menuNavigator: MenuNavigator, private val player: Player,
-                                  private var guild: Guild): Menu, KoinComponent {
+class GuildDisbandConfirmationMenu(
+    private val menuNavigator: MenuNavigator,
+    private val player: Player,
+    private var guild: Guild
+) : Menu, KoinComponent {
 
-    private val menuFactory: MenuFactory by inject()
+    private val guildService: GuildService by inject()
 
     override fun open() {
-        player.sendMessage("§eGuild disband confirmation menu coming soon!")
-        menuNavigator.openMenu(menuFactory.createGuildControlPanelMenu(menuNavigator, player, guild))
+        val gui = ChestGui(3, "§c§lDisband ${guild.name}?")
+        val pane = StaticPane(0, 0, 9, 3)
+        gui.setOnTopClick { e -> e.isCancelled = true }
+        gui.setOnBottomClick { e ->
+            if (e.click == ClickType.SHIFT_LEFT || e.click == ClickType.SHIFT_RIGHT)
+                e.isCancelled = true
+        }
+        gui.addPane(pane)
+
+        // Info item
+        val infoItem = ItemStack.of(Material.BARRIER)
+            .name("§c⚠ Disband Guild")
+            .lore("§7Guild: §f${guild.name}")
+            .lore("§7Level: §f${guild.level}")
+            .lore("§7")
+            .lore("§cThis action cannot be undone!")
+            .lore("§7All vault items will be lost.")
+        pane.addItem(GuiItem(infoItem), 4, 0)
+
+        // Confirm button
+        val confirmItem = ItemStack.of(Material.RED_WOOL)
+            .name("§c§lCONFIRM DISBAND")
+            .lore("§7Click to disband this guild permanently")
+        pane.addItem(GuiItem(confirmItem) {
+            val success = guildService.disbandGuild(guild.id, player.uniqueId)
+            if (success) {
+                player.sendMessage("§c❌ Guild §f${guild.name} §chas been disbanded.")
+                player.playSound(player.location, Sound.ENTITY_ENDER_DRAGON_GROWL, 1.0f, 1.0f)
+                player.closeInventory()
+            } else {
+                player.sendMessage("§cFailed to disband guild. You may not be the owner.")
+            }
+        }, 3, 2)
+
+        // Cancel button
+        val cancelItem = ItemStack.of(Material.GREEN_WOOL)
+            .name("§a§lCANCEL")
+            .lore("§7Return to guild settings")
+        pane.addItem(GuiItem(cancelItem) {
+            menuNavigator.goBack()
+        }, 5, 2)
+
+        gui.show(player)
     }
 
     override fun passData(data: Any?) {

--- a/src/main/kotlin/net/lumalyte/lg/interaction/menus/guild/GuildLeaveConfirmationMenu.kt
+++ b/src/main/kotlin/net/lumalyte/lg/interaction/menus/guild/GuildLeaveConfirmationMenu.kt
@@ -1,21 +1,77 @@
 package net.lumalyte.lg.interaction.menus.guild
 
+import com.github.stefvanschie.inventoryframework.gui.GuiItem
+import com.github.stefvanschie.inventoryframework.gui.type.ChestGui
+import com.github.stefvanschie.inventoryframework.pane.StaticPane
+import net.lumalyte.lg.application.services.MemberService
 import net.lumalyte.lg.domain.entities.Guild
 import net.lumalyte.lg.interaction.menus.Menu
 import net.lumalyte.lg.interaction.menus.MenuNavigator
-import net.lumalyte.lg.interaction.menus.MenuFactory
+import net.lumalyte.lg.utils.lore
+import net.lumalyte.lg.utils.name
+import org.bukkit.Material
+import org.bukkit.Sound
 import org.bukkit.entity.Player
+import org.bukkit.event.inventory.ClickType
+import org.bukkit.inventory.ItemStack
 import org.koin.core.component.KoinComponent
 import org.koin.core.component.inject
 
-class GuildLeaveConfirmationMenu(private val menuNavigator: MenuNavigator, private val player: Player,
-                                private var guild: Guild): Menu, KoinComponent {
+class GuildLeaveConfirmationMenu(
+    private val menuNavigator: MenuNavigator,
+    private val player: Player,
+    private var guild: Guild
+) : Menu, KoinComponent {
 
-    private val menuFactory: MenuFactory by inject()
+    private val memberService: MemberService by inject()
 
     override fun open() {
-        player.sendMessage("§eLeave guild confirmation menu coming soon!")
-        menuNavigator.openMenu(menuFactory.createGuildControlPanelMenu(menuNavigator, player, guild))
+        val gui = ChestGui(3, "§e§lLeave ${guild.name}?")
+        val pane = StaticPane(0, 0, 9, 3)
+        gui.setOnTopClick { e -> e.isCancelled = true }
+        gui.setOnBottomClick { e ->
+            if (e.click == ClickType.SHIFT_LEFT || e.click == ClickType.SHIFT_RIGHT)
+                e.isCancelled = true
+        }
+        gui.addPane(pane)
+
+        // Info item
+        val infoItem = ItemStack.of(Material.OAK_DOOR)
+            .name("§e🚪 Leave Guild")
+            .lore("§7Guild: §f${guild.name}")
+            .lore("§7")
+            .lore("§eYou will lose access to:")
+            .lore("§7- Guild bank and vault")
+            .lore("§7- Guild homes")
+            .lore("§7- Guild chat channels")
+            .lore("§7- All rank permissions")
+        pane.addItem(GuiItem(infoItem), 4, 0)
+
+        // Confirm leave
+        val confirmItem = ItemStack.of(Material.RED_WOOL)
+            .name("§c§lCONFIRM LEAVE")
+            .lore("§7Leave this guild permanently")
+        pane.addItem(GuiItem(confirmItem) {
+            val success = memberService.removeMember(player.uniqueId, guild.id, player.uniqueId)
+            if (success) {
+                player.sendMessage("§eYou have left §f${guild.name}§e.")
+                player.playSound(player.location, Sound.ENTITY_VILLAGER_YES, 1.0f, 1.0f)
+                player.closeInventory()
+            } else {
+                player.sendMessage("§cFailed to leave guild. You may be the owner — transfer ownership first.")
+                player.playSound(player.location, Sound.ENTITY_VILLAGER_NO, 1.0f, 1.0f)
+            }
+        }, 3, 2)
+
+        // Cancel
+        val cancelItem = ItemStack.of(Material.GREEN_WOOL)
+            .name("§a§lCANCEL")
+            .lore("§7Return to guild settings")
+        pane.addItem(GuiItem(cancelItem) {
+            menuNavigator.goBack()
+        }, 5, 2)
+
+        gui.show(player)
     }
 
     override fun passData(data: Any?) {

--- a/src/main/kotlin/net/lumalyte/lg/interaction/menus/guild/GuildProgressionMenu.kt
+++ b/src/main/kotlin/net/lumalyte/lg/interaction/menus/guild/GuildProgressionMenu.kt
@@ -1,0 +1,384 @@
+package net.lumalyte.lg.interaction.menus.guild
+
+import com.github.stefvanschie.inventoryframework.gui.GuiItem
+import com.github.stefvanschie.inventoryframework.gui.type.ChestGui
+import com.github.stefvanschie.inventoryframework.pane.StaticPane
+import net.lumalyte.lg.application.services.*
+import net.lumalyte.lg.domain.entities.Guild
+import net.lumalyte.lg.domain.values.ExperienceSource
+import net.lumalyte.lg.interaction.menus.Menu
+import net.lumalyte.lg.interaction.menus.MenuFactory
+import net.lumalyte.lg.interaction.menus.MenuNavigator
+import net.lumalyte.lg.utils.MenuItemBuilder
+import net.lumalyte.lg.utils.NexoItemProvider
+import net.lumalyte.lg.utils.name
+import org.bukkit.Material
+import org.bukkit.entity.Player
+import org.bukkit.inventory.ItemStack
+
+/**
+ * Guild Progression Menu — shows guild level, daily XP caps per source, and rewards.
+ *
+ * 6-row layout modeled after AuraSkills LevelProgressionMenu.
+ *
+ * Row 0: [     Guild Level + XP bar + today's total     ][Back][Close]
+ * Row 1: [Rank] ─── 24-slot paginated source grid ───────
+ * Row 2: [Srcs]
+ * Row 3: [Perks]
+ * Row 4: [Prestige]
+ * Row 5: [                                        ][Prev][Next]
+ */
+class GuildProgressionMenu(
+    private val menuNavigator: MenuNavigator,
+    private val player: Player,
+    private val guild: Guild,
+    private val guildService: GuildService,
+    private val memberService: MemberService,
+    private val progressionService: ProgressionService,
+    private val menuFactory: MenuFactory,
+    private val menuItemBuilder: MenuItemBuilder,
+    private val configService: ConfigService
+) : Menu {
+
+    private var currentPage = 0
+    private val itemsPerPage = 24
+
+    /** Source grid slots (AuraSkills track pattern). */
+    private val gridSlots = listOf(
+        9, 18, 27, 36, 37, 38, 29, 20, 11, 12, 13, 22,
+        31, 40, 41, 42, 33, 24, 15, 16, 17, 26, 35, 44
+    )
+
+    /** Sources that count toward the daily cap and should appear in the grid. */
+    private val trackableSources = ExperienceSource.entries.filter { it != ExperienceSource.WEEKLY_ACTIVITY && it != ExperienceSource.ADMIN_BONUS && it != ExperienceSource.CLAIM_DESTROYED }
+
+    override fun open() {
+        val playerId = player.uniqueId
+
+        if (memberService.getMember(playerId, guild.id) == null) {
+            player.sendMessage("§c❌ You cannot access this menu!")
+            menuNavigator.goBack()
+            return
+        }
+
+        // Fetch fresh progression data
+        val progression = progressionService.let {
+            repoProgression()
+        } ?: run {
+            player.sendMessage("§c❌ Could not load progression data.")
+            menuNavigator.goBack()
+            return
+        }
+
+        val totalPages = (trackableSources.size + itemsPerPage - 1) / itemsPerPage
+        val gui = ChestGui(6, "§0§8⭐ §7Guild Progression §8• Page ${currentPage + 1}/$totalPages")
+        val pane = StaticPane(0, 0, 9, 6)
+        gui.setOnTopClick { e -> e.isCancelled = true }
+        gui.setOnBottomClick { e ->
+            val click = e.click
+            if (click == org.bukkit.event.inventory.ClickType.SHIFT_LEFT ||
+                click == org.bukkit.event.inventory.ClickType.SHIFT_RIGHT
+            ) e.isCancelled = true
+        }
+        gui.addPane(pane)
+
+        // Background
+        fillBackground(pane)
+
+        // ---- Row 0: Guild level header ----
+        addGuildLevelHeader(pane, progression)
+
+        // ---- Left sidebar (cols 0, rows 1-4) ----
+        addRankInfo(pane, 0, 1)
+        addSourcesInfo(pane, 0, 2)
+        addPerksInfo(pane, 0, 3)
+        addPrestigeInfo(pane, 0, 4)
+
+        // ---- Back / Close (top right) ----
+        addBackButton(pane, 8, 0)
+        addCloseButton(pane, 8, 1)
+
+        // ---- Page navigation (row 5) ----
+        if (currentPage > 0) addPreviousPageButton(pane, 7, 5)
+        if (currentPage + 1 < totalPages) addNextPageButton(pane, 8, 5)
+
+        // ---- Source grid (paginated) ----
+        val dailyXp = progressionService.getDailySourceXp(guild.id)
+        val pageSources = trackableSources.drop(currentPage * itemsPerPage).take(itemsPerPage)
+        for ((index, source) in pageSources.withIndex()) {
+            if (index >= gridSlots.size) break
+            val slot = gridSlots[index]
+            val x = slot % 9
+            val y = slot / 9
+            addSourceItem(pane, x, y, source, dailyXp[source] ?: 0)
+        }
+
+        gui.show(player)
+    }
+
+    private fun repoProgression(): GuildProgressionDisplay? {
+        val repo = org.koin.core.context.GlobalContext.get()
+            .get<net.lumalyte.lg.application.persistence.ProgressionRepository>()
+        val prog = repo.getGuildProgression(guild.id) ?: return null
+        val (currentXp, neededXp) = progressionService.getLevelProgress(prog.totalExperience)
+        val level = progressionService.getLevelFromExperience(prog.totalExperience)
+        val unlockedPerks = progressionService.getUnlockedPerks(guild.id)
+        return GuildProgressionDisplay(level, prog.totalExperience, currentXp, neededXp, unlockedPerks.size)
+    }
+
+    private fun fillBackground(pane: StaticPane) {
+        val bg = NexoItemProvider.getItemStack("lg_bg_6_row")
+            ?: ItemStack.of(Material.GRAY_STAINED_GLASS_PANE).name(" ")
+        for (x in 0..8) for (y in 0..5) {
+            pane.addItem(GuiItem(bg.clone()) { it.isCancelled = true }, x, y)
+        }
+    }
+
+    private fun addGuildLevelHeader(pane: StaticPane, prog: GuildProgressionDisplay) {
+        val (_, totalXp, currentXp, neededXp, perksCount) = prog
+        val percent = if (neededXp > 0) (currentXp.toDouble() / neededXp.toDouble() * 100).toInt() else 0
+        val totalToday = progressionService.getDailySourceXp(guild.id).values.sum()
+
+        val bars = buildProgressBar(percent, 20)
+        val item = NexoItemProvider.getItemStackOrFallback("lg_level") {
+            ItemStack.of(Material.EXPERIENCE_BOTTLE)
+        }.also { it.editMeta { meta ->
+            meta.setDisplayName("§6§l⭐ Guild Level ${prog.level}")
+            val lore = mutableListOf(
+                "§7XP: §e$currentXp §7/ §e$neededXp  §8($percent%)",
+                "§7$bars",
+                "§7Today: §e+$totalToday XP",
+                "",
+                "§7Unlocked Perks: §a$perksCount",
+                "§7Total XP: §e${totalXp}"
+            )
+            meta.lore = lore
+        }}
+        pane.addItem(GuiItem(item) { it.isCancelled = true }, 4, 0)
+    }
+
+    private fun buildProgressBar(percent: Int, length: Int): String {
+        val filled = (percent * length / 100).coerceIn(0, length)
+        val empty = length - filled
+        val color = when {
+            percent >= 100 -> "§a"
+            percent >= 70 -> "§e"
+            percent >= 40 -> "§6"
+            else -> "§c"
+        }
+        return "$color${"█".repeat(filled)}§7${"█".repeat(empty)}"
+    }
+
+    private fun addSourceItem(pane: StaticPane, x: Int, y: Int, source: ExperienceSource, todayXp: Int) {
+        val cap = progressionService.getDailyCap(source)
+        val percent = if (cap > 0) (todayXp.toDouble() / cap.toDouble() * 100).toInt().coerceAtMost(100) else 0
+
+        val nexoId = sourceToIconId(source)
+        val material = sourceToMaterial(source)
+        val name = sourceToDisplayName(source)
+
+        val bars = buildProgressBar(percent, 10)
+        val color = when {
+            percent >= 100 -> "§c" // capped
+            percent >= 80 -> "§e" // near cap
+            percent >= 40 -> "§6" // moderate
+            else -> "§a" // plenty of room
+        }
+
+        val item = NexoItemProvider.getItemStackOrFallback(nexoId) {
+            ItemStack.of(material)
+        }.also { it.editMeta { meta ->
+            meta.setDisplayName("§f$name")
+            val lore = mutableListOf<String>()
+            if (cap > 0) {
+                lore.add("$color$bars §7$percent%")
+                lore.add("§7Today: §e$todayXp §7/ §e$cap §7max")
+            } else {
+                lore.add("§7Tracked: §e$todayXp XP")
+            }
+            meta.lore = lore
+        }}
+        pane.addItem(GuiItem(item) { it.isCancelled = true }, x, y)
+    }
+
+    private fun addRankInfo(pane: StaticPane, x: Int, y: Int) {
+        val item = ItemStack.of(Material.GOLD_INGOT).also { it.editMeta { meta ->
+            meta.setDisplayName("§6Guild Rank")
+            meta.lore = listOf("§7Your guild's standing", "§7among all guilds")
+        }}
+        pane.addItem(GuiItem(item) { it.isCancelled = true }, x, y)
+    }
+
+    private fun addSourcesInfo(pane: StaticPane, x: Int, y: Int) {
+        val item = NexoItemProvider.getItemStackOrFallback("lg_sources") {
+            ItemStack.of(Material.BOOK)
+        }.also { it.editMeta { meta ->
+            meta.setDisplayName("§eXP Sources")
+            meta.lore = listOf(
+                "§7How to earn guild XP:",
+                "§7• §f💰 Bank deposits",
+                "§7• §f⚔ War victories",
+                "§7• §f👥 Member invites",
+                "§7• §f🗡 Player/mob kills",
+                "§7• §f🌾 Farming & fishing",
+                "§7• §f⛏ Mining & building",
+                "§7• §f🔨 Crafting & smelting",
+                "§7• §f🧪 Brewing & enchanting",
+                "§7• §f✨ Enchanting",
+                "§7• §f🏞 Claiming land"
+            )
+        }}
+        pane.addItem(GuiItem(item) { it.isCancelled = true }, x, y)
+    }
+
+    private fun addPerksInfo(pane: StaticPane, x: Int, y: Int) {
+        val perks = progressionService.getUnlockedPerks(guild.id)
+        val item = NexoItemProvider.getItemStackOrFallback("lg_reward") {
+            ItemStack.of(Material.DIAMOND)
+        }.also { it.editMeta { meta ->
+            meta.setDisplayName("§aUnlocked Perks")
+            val lore = mutableListOf<String>()
+            if (perks.isEmpty()) {
+                lore.add("§7No perks unlocked yet")
+                lore.add("§7Earn XP to level up!")
+            } else {
+                for (perk in perks) {
+                    lore.add("§a✓ §f${perkToDisplayName(perk)}")
+                }
+            }
+            meta.lore = lore
+        }}
+        pane.addItem(GuiItem(item) { it.isCancelled = true }, x, y)
+    }
+
+    private fun addPrestigeInfo(pane: StaticPane, x: Int, y: Int) {
+        val item = NexoItemProvider.getItemStackOrFallback("lg_prestige") {
+            ItemStack.of(Material.NETHER_STAR)
+        }.also { it.editMeta { meta ->
+            meta.setDisplayName("§dPrestige")
+            meta.lore = listOf(
+                "§7Reset your guild's level",
+                "§7for exclusive rewards.",
+                "§7Requires Level §d25",
+                "",
+                "§8Coming in a future update"
+            )
+        }}
+        pane.addItem(GuiItem(item) { it.isCancelled = true }, x, y)
+    }
+
+    private fun addBackButton(pane: StaticPane, x: Int, y: Int) {
+        val item = NexoItemProvider.getItemStackOrFallback("lg_page_prev") {
+            ItemStack.of(Material.ARROW).name("§7Back")
+        }.also { it.editMeta { meta -> meta.setDisplayName("§a← Back") }}
+        pane.addItem(GuiItem(item) { menuNavigator.goBack() }, x, y)
+    }
+
+    private fun addCloseButton(pane: StaticPane, x: Int, y: Int) {
+        val item = NexoItemProvider.getItemStackOrFallback("lg_close") {
+            ItemStack.of(Material.BARRIER).name("§cClose")
+        }.also { it.editMeta { meta -> meta.setDisplayName("§cClose") }}
+        pane.addItem(GuiItem(item) { menuNavigator.clearMenuStack(); player.closeInventory() }, x, y)
+    }
+
+    private fun addPreviousPageButton(pane: StaticPane, x: Int, y: Int) {
+        val item = NexoItemProvider.getItemStackOrFallback("lg_page_prev") {
+            ItemStack.of(Material.ARROW).name("§e← Previous")
+        }.also { it.editMeta { meta -> meta.setDisplayName("§e← Previous Page") }}
+        pane.addItem(GuiItem(item) { currentPage--; open() }, x, y)
+    }
+
+    private fun addNextPageButton(pane: StaticPane, x: Int, y: Int) {
+        val item = NexoItemProvider.getItemStackOrFallback("lg_page_next") {
+            ItemStack.of(Material.ARROW).name("§eNext →")
+        }.also { it.editMeta { meta -> meta.setDisplayName("§eNext Page →") }}
+        pane.addItem(GuiItem(item) { currentPage++; open() }, x, y)
+    }
+
+    private fun sourceToIconId(source: ExperienceSource): String = when (source) {
+        ExperienceSource.BANK_DEPOSIT -> "lg_deposit"
+        ExperienceSource.MEMBER_JOINED -> "lg_invite"
+        ExperienceSource.WAR_WON -> "lg_war_stats"
+        ExperienceSource.WAR_LOST -> "lg_war_stats"
+        ExperienceSource.PLAYER_KILL -> "lg_combat"
+        ExperienceSource.MOB_KILL -> "lg_combat"
+        ExperienceSource.CROP_BREAK -> "lg_farming"
+        ExperienceSource.BLOCK_BREAK -> "lg_mining"
+        ExperienceSource.BLOCK_PLACE -> "lg_mining"
+        ExperienceSource.CRAFTING -> "lg_crafting"
+        ExperienceSource.SMELTING -> "lg_crafting"
+        ExperienceSource.FISHING -> "lg_farming"
+        ExperienceSource.ENCHANTING -> "lg_enchanting"
+        ExperienceSource.CLAIM_CREATED -> "lg_claiming"
+        ExperienceSource.CLAIM_DESTROYED -> "lg_claiming"
+        ExperienceSource.WEEKLY_ACTIVITY -> "lg_reward"
+        ExperienceSource.ADMIN_BONUS -> "lg_reward"
+    }
+
+    private fun sourceToMaterial(source: ExperienceSource): Material = when (source) {
+        ExperienceSource.BANK_DEPOSIT -> Material.GOLD_NUGGET
+        ExperienceSource.MEMBER_JOINED -> Material.PLAYER_HEAD
+        ExperienceSource.WAR_WON -> Material.DIAMOND_SWORD
+        ExperienceSource.WAR_LOST -> Material.STONE_SWORD
+        ExperienceSource.PLAYER_KILL -> Material.IRON_SWORD
+        ExperienceSource.MOB_KILL -> Material.ROTTEN_FLESH
+        ExperienceSource.CROP_BREAK -> Material.WHEAT
+        ExperienceSource.BLOCK_BREAK -> Material.STONE_PICKAXE
+        ExperienceSource.BLOCK_PLACE -> Material.STONE
+        ExperienceSource.CRAFTING -> Material.CRAFTING_TABLE
+        ExperienceSource.SMELTING -> Material.FURNACE
+        ExperienceSource.FISHING -> Material.FISHING_ROD
+        ExperienceSource.ENCHANTING -> Material.ENCHANTING_TABLE
+        ExperienceSource.CLAIM_CREATED -> Material.GOLDEN_SHOVEL
+        ExperienceSource.CLAIM_DESTROYED -> Material.GOLDEN_SHOVEL
+        ExperienceSource.WEEKLY_ACTIVITY -> Material.NETHER_STAR
+        ExperienceSource.ADMIN_BONUS -> Material.NETHER_STAR
+    }
+
+    private fun sourceToDisplayName(source: ExperienceSource): String = when (source) {
+        ExperienceSource.BANK_DEPOSIT -> "Bank Deposits"
+        ExperienceSource.MEMBER_JOINED -> "Member Invites"
+        ExperienceSource.WAR_WON -> "War Victories"
+        ExperienceSource.WAR_LOST -> "War Participation"
+        ExperienceSource.PLAYER_KILL -> "Player Kills"
+        ExperienceSource.MOB_KILL -> "Mob Kills"
+        ExperienceSource.CROP_BREAK -> "Farming"
+        ExperienceSource.BLOCK_BREAK -> "Mining"
+        ExperienceSource.BLOCK_PLACE -> "Building"
+        ExperienceSource.CRAFTING -> "Crafting"
+        ExperienceSource.SMELTING -> "Smelting"
+        ExperienceSource.FISHING -> "Fishing"
+        ExperienceSource.ENCHANTING -> "Enchanting"
+        ExperienceSource.CLAIM_CREATED -> "Claiming Land"
+        ExperienceSource.CLAIM_DESTROYED -> "Claims"
+        ExperienceSource.WEEKLY_ACTIVITY -> "Weekly Activity"
+        ExperienceSource.ADMIN_BONUS -> "Admin Bonus"
+    }
+
+    private fun perkToDisplayName(perk: net.lumalyte.lg.domain.values.PerkType): String = when (perk) {
+        net.lumalyte.lg.domain.values.PerkType.HIGHER_BANK_BALANCE -> "Higher Bank Limit"
+        net.lumalyte.lg.domain.values.PerkType.BANK_INTEREST -> "Bank Interest"
+        net.lumalyte.lg.domain.values.PerkType.INCREASED_BANK_LIMIT -> "Increased Bank Limit"
+        net.lumalyte.lg.domain.values.PerkType.REDUCED_WITHDRAWAL_FEES -> "Reduced Fees"
+        net.lumalyte.lg.domain.values.PerkType.ADDITIONAL_HOMES -> "Extra Homes"
+        net.lumalyte.lg.domain.values.PerkType.TELEPORT_COOLDOWN_REDUCTION -> "Faster Teleports"
+        net.lumalyte.lg.domain.values.PerkType.HOME_TELEPORT_SOUND_EFFECTS -> "Home Teleport SFX"
+        net.lumalyte.lg.domain.values.PerkType.SPECIAL_PARTICLES -> "Particle Effects"
+        net.lumalyte.lg.domain.values.PerkType.ANNOUNCEMENT_SOUND_EFFECTS -> "Announcement SFX"
+        net.lumalyte.lg.domain.values.PerkType.WAR_DECLARATION_SOUND_EFFECTS -> "War Declaration SFX"
+        net.lumalyte.lg.domain.values.PerkType.INCREASED_CLAIM_BLOCKS -> "More Claim Blocks"
+        net.lumalyte.lg.domain.values.PerkType.INCREASED_CLAIM_COUNT -> "More Claims"
+        net.lumalyte.lg.domain.values.PerkType.FASTER_CLAIM_REGEN -> "Faster Claim Regen"
+        net.lumalyte.lg.domain.values.PerkType.CUSTOM_BANNER_COLORS -> "Custom Banner Colors"
+        net.lumalyte.lg.domain.values.PerkType.ANIMATED_EMOJIS -> "Animated Emojis"
+        net.lumalyte.lg.domain.values.PerkType.ALLY_HOME_ACCESS -> "Ally Home Access"
+    }
+
+    private data class GuildProgressionDisplay(
+        val level: Int,
+        val totalXp: Int,
+        val currentXp: Int,
+        val neededXp: Int,
+        val unlockedPerks: Int
+    )
+}

--- a/src/main/kotlin/net/lumalyte/lg/interaction/menus/guild/GuildPromotionMenu.kt
+++ b/src/main/kotlin/net/lumalyte/lg/interaction/menus/guild/GuildPromotionMenu.kt
@@ -78,7 +78,7 @@ class GuildPromotionMenu(
                 val rankIdx = ranks.indexOf(rank)
                 if (it.click == ClickType.LEFT) {
                     // Promote
-                    if (rankIdx != null && rankIdx > 0) {
+                    if (rankIdx >= 0 && rankIdx > 0) {
                         val newRank = ranks[rankIdx - 1]
                         val success = memberService.promoteMember(member.playerId, guild.id, player.uniqueId)
                         if (success) {
@@ -93,7 +93,7 @@ class GuildPromotionMenu(
                     }
                 } else if (it.click == ClickType.RIGHT) {
                     // Demote
-                    if (rankIdx != null && rankIdx < ranks.size - 1) {
+                    if (rankIdx >= 0 && rankIdx < ranks.size - 1) {
                         val newRank = ranks[rankIdx + 1]
                         val success = memberService.demoteMember(member.playerId, guild.id, player.uniqueId)
                         if (success) {

--- a/src/main/kotlin/net/lumalyte/lg/interaction/menus/guild/GuildPromotionMenu.kt
+++ b/src/main/kotlin/net/lumalyte/lg/interaction/menus/guild/GuildPromotionMenu.kt
@@ -62,6 +62,10 @@ class GuildPromotionMenu(
 
         var slot = 0
         for (member in members) {
+            if (slot >= (rows - 1) * 9) {
+                // Overflow — remaining members don't fit
+                break
+            }
             val rank = rankById[member.rankId]
             val playerName = Bukkit.getOfflinePlayer(member.playerId).name ?: member.playerId.toString().take(8)
             val isOnline = Bukkit.getPlayer(member.playerId)?.isOnline == true

--- a/src/main/kotlin/net/lumalyte/lg/interaction/menus/guild/GuildPromotionMenu.kt
+++ b/src/main/kotlin/net/lumalyte/lg/interaction/menus/guild/GuildPromotionMenu.kt
@@ -1,21 +1,114 @@
 package net.lumalyte.lg.interaction.menus.guild
 
+import com.github.stefvanschie.inventoryframework.gui.GuiItem
+import com.github.stefvanschie.inventoryframework.gui.type.ChestGui
+import com.github.stefvanschie.inventoryframework.pane.PaginatedPane
+import com.github.stefvanschie.inventoryframework.pane.StaticPane
+import net.lumalyte.lg.application.services.MemberService
+import net.lumalyte.lg.application.services.RankService
 import net.lumalyte.lg.domain.entities.Guild
+import net.lumalyte.lg.domain.entities.Rank
 import net.lumalyte.lg.interaction.menus.Menu
 import net.lumalyte.lg.interaction.menus.MenuNavigator
-import net.lumalyte.lg.interaction.menus.MenuFactory
+import net.lumalyte.lg.utils.lore
+import net.lumalyte.lg.utils.name
+import org.bukkit.Bukkit
+import org.bukkit.Material
+import org.bukkit.Sound
 import org.bukkit.entity.Player
+import org.bukkit.event.inventory.ClickType
+import org.bukkit.inventory.ItemStack
 import org.koin.core.component.KoinComponent
 import org.koin.core.component.inject
 
-class GuildPromotionMenu(private val menuNavigator: MenuNavigator, private val player: Player,
-                        private var guild: Guild): Menu, KoinComponent {
+class GuildPromotionMenu(
+    private val menuNavigator: MenuNavigator,
+    private val player: Player,
+    private var guild: Guild
+) : Menu, KoinComponent {
 
-    private val menuFactory: MenuFactory by inject()
+    private val memberService: MemberService by inject()
+    private val rankService: RankService by inject()
 
     override fun open() {
-        player.sendMessage("§ePromotion/Demotion menu coming soon!")
-        menuNavigator.openMenu(menuFactory.createGuildControlPanelMenu(menuNavigator, player, guild))
+        val ranks = rankService.listRanks(guild.id).sortedBy { it.priority }
+        val rankById = ranks.associateBy { it.id }
+        val members = memberService.getGuildMembers(guild.id).sortedBy { rankById[it.rankId]?.priority ?: Int.MAX_VALUE }
+
+        if (members.isEmpty()) {
+            player.sendMessage("§cNo members in this guild.")
+            menuNavigator.goBack()
+            return
+        }
+
+        val rows = ((members.size + 8) / 9 + 1).coerceIn(3, 6)
+        val gui = ChestGui(rows, "§6Members — ${guild.name}")
+        val pane = StaticPane(0, 0, 9, rows)
+        gui.setOnTopClick { e -> e.isCancelled = true }
+        gui.setOnBottomClick { e ->
+            if (e.click == ClickType.SHIFT_LEFT || e.click == ClickType.SHIFT_RIGHT)
+                e.isCancelled = true
+        }
+        gui.addPane(pane)
+
+        var slot = 0
+        for (member in members) {
+            val rank = rankById[member.rankId]
+            val playerName = Bukkit.getOfflinePlayer(member.playerId).name ?: member.playerId.toString().take(8)
+            val isOnline = Bukkit.getPlayer(member.playerId)?.isOnline == true
+
+            val item = ItemStack.of(if (isOnline) Material.PLAYER_HEAD else Material.SKELETON_SKULL)
+                .name("§e${playerName}")
+                .lore("§7Rank: §f${rank?.name ?: "Unknown"}")
+                .lore("§7Status: ${if (isOnline) "§aOnline" else "§7Offline"}")
+                .lore("")
+                .lore("§7Left-click to promote")
+                .lore("§7Right-click to demote")
+
+            pane.addItem(GuiItem(item) {
+                val rankIdx = ranks.indexOf(rank)
+                if (it.click == ClickType.LEFT) {
+                    // Promote
+                    if (rankIdx != null && rankIdx > 0) {
+                        val newRank = ranks[rankIdx - 1]
+                        val success = memberService.promoteMember(member.playerId, guild.id, player.uniqueId)
+                        if (success) {
+                            player.sendMessage("§a§f$playerName §apromoted to §f${newRank.name}§a.")
+                            player.playSound(player.location, Sound.ENTITY_PLAYER_LEVELUP, 1.0f, 1.0f)
+                            open()
+                        } else {
+                            player.sendMessage("§cFailed to promote $playerName.")
+                        }
+                    } else {
+                        player.sendMessage("§c$playerName is already at the highest rank.")
+                    }
+                } else if (it.click == ClickType.RIGHT) {
+                    // Demote
+                    if (rankIdx != null && rankIdx < ranks.size - 1) {
+                        val newRank = ranks[rankIdx + 1]
+                        val success = memberService.demoteMember(member.playerId, guild.id, player.uniqueId)
+                        if (success) {
+                            player.sendMessage("§e§f$playerName §edemoted to §f${newRank.name}§e.")
+                            player.playSound(player.location, Sound.ENTITY_VILLAGER_NO, 0.8f, 1.0f)
+                            open()
+                        } else {
+                            player.sendMessage("§cFailed to demote $playerName.")
+                        }
+                    } else {
+                        player.sendMessage("§c$playerName is already at the lowest rank.")
+                    }
+                }
+            }, slot % 9, slot / 9)
+            slot++
+        }
+
+        // Back button
+        val backItem = ItemStack.of(Material.ARROW)
+            .name("§e⬅ BACK")
+            .lore("§7Return to guild settings")
+        pane.addItem(GuiItem(backItem) { menuNavigator.goBack() }, 8, rows - 1)
+
+        gui.show(player)
     }
 
     override fun passData(data: Any?) {

--- a/src/main/kotlin/net/lumalyte/lg/interaction/menus/guild/GuildPromotionMenu.kt
+++ b/src/main/kotlin/net/lumalyte/lg/interaction/menus/guild/GuildPromotionMenu.kt
@@ -31,6 +31,15 @@ class GuildPromotionMenu(
     private val rankService: RankService by inject()
 
     override fun open() {
+        // Check permission first
+        val hasPermission = rankService.hasPermission(player.uniqueId, guild.id, net.lumalyte.lg.domain.entities.RankPermission.MANAGE_RANKS)
+        if (!hasPermission) {
+            player.sendMessage("§c❌ You don't have permission to manage ranks!")
+            player.sendMessage("§7Required permission: §fMANAGE_RANKS")
+            menuNavigator.goBack()
+            return
+        }
+
         val ranks = rankService.listRanks(guild.id).sortedBy { it.priority }
         val rankById = ranks.associateBy { it.id }
         val members = memberService.getGuildMembers(guild.id).sortedBy { rankById[it.rankId]?.priority ?: Int.MAX_VALUE }

--- a/src/main/kotlin/net/lumalyte/lg/interaction/menus/guild/GuildRankListMenu.kt
+++ b/src/main/kotlin/net/lumalyte/lg/interaction/menus/guild/GuildRankListMenu.kt
@@ -45,12 +45,15 @@ class GuildRankListMenu(
         }
         gui.addPane(pane)
 
+        val totalDataSlots = (height - 1) * 9
         val reservedOverflowSlot = (height - 2) * 9 + 4 // Slot (4, height-2) for overflow notice
-        val maxSlots = reservedOverflowSlot // Ranks populate slots 0..reservedOverflowSlot-1
+        var displayed = 0
         var slot = 0
         for (rank in ranks) {
-            if (slot >= maxSlots) {
-                val omitted = ranks.size - slot
+            // Skip the reserved overflow slot
+            if (slot == reservedOverflowSlot) slot++
+            if (slot >= totalDataSlots) {
+                val omitted = ranks.size - displayed
                 val overflowItem = ItemStack.of(Material.PAPER)
                     .name("§e... and $omitted more ${if (omitted == 1) "rank" else "ranks"}")
                 pane.addItem(GuiItem(overflowItem), 4, height - 2)
@@ -76,6 +79,7 @@ class GuildRankListMenu(
                 item.lore("§7No special permissions")
             }
             pane.addItem(GuiItem(item), slot % 9, slot / 9)
+            displayed++
             slot++
         }
 

--- a/src/main/kotlin/net/lumalyte/lg/interaction/menus/guild/GuildRankListMenu.kt
+++ b/src/main/kotlin/net/lumalyte/lg/interaction/menus/guild/GuildRankListMenu.kt
@@ -45,13 +45,14 @@ class GuildRankListMenu(
         }
         gui.addPane(pane)
 
-        val maxSlots = (height - 1) * 9 // Reserve last row for back button
+        val reservedOverflowSlot = (height - 2) * 9 + 4 // Slot (4, height-2) for overflow notice
+        val maxSlots = reservedOverflowSlot // Ranks populate slots 0..reservedOverflowSlot-1
         var slot = 0
         for (rank in ranks) {
             if (slot >= maxSlots) {
-                // Overflow notice
+                val omitted = ranks.size - slot
                 val overflowItem = ItemStack.of(Material.PAPER)
-                    .name("§e... and ${ranks.size - slot} more ranks")
+                    .name("§e... and $omitted more ${if (omitted == 1) "rank" else "ranks"}")
                 pane.addItem(GuiItem(overflowItem), 4, height - 2)
                 break
             }

--- a/src/main/kotlin/net/lumalyte/lg/interaction/menus/guild/GuildRankListMenu.kt
+++ b/src/main/kotlin/net/lumalyte/lg/interaction/menus/guild/GuildRankListMenu.kt
@@ -1,16 +1,82 @@
 package net.lumalyte.lg.interaction.menus.guild
 
+import com.github.stefvanschie.inventoryframework.gui.GuiItem
+import com.github.stefvanschie.inventoryframework.gui.type.ChestGui
+import com.github.stefvanschie.inventoryframework.pane.PaginatedPane
+import com.github.stefvanschie.inventoryframework.pane.StaticPane
+import net.lumalyte.lg.application.services.RankService
 import net.lumalyte.lg.domain.entities.Guild
+import net.lumalyte.lg.domain.entities.Rank
 import net.lumalyte.lg.interaction.menus.Menu
 import net.lumalyte.lg.interaction.menus.MenuNavigator
+import net.lumalyte.lg.utils.lore
+import net.lumalyte.lg.utils.name
+import org.bukkit.Material
 import org.bukkit.entity.Player
+import org.bukkit.event.inventory.ClickType
+import org.bukkit.inventory.ItemStack
+import org.koin.core.component.KoinComponent
+import org.koin.core.component.inject
 
-class GuildRankListMenu(private val menuNavigator: MenuNavigator, private val player: Player,
-                       private var guild: Guild): Menu {
+class GuildRankListMenu(
+    private val menuNavigator: MenuNavigator,
+    private val player: Player,
+    private var guild: Guild
+) : Menu, KoinComponent {
+
+    private val rankService: RankService by inject()
 
     override fun open() {
-        player.sendMessage("§eRank List menu coming soon!")
-        menuNavigator.goBack()
+        val ranks = rankService.listRanks(guild.id).sortedBy { it.priority }
+        if (ranks.isEmpty()) {
+            player.sendMessage("§cThis guild has no ranks configured.")
+            menuNavigator.goBack()
+            return
+        }
+
+        val rows = (ranks.size + 8) / 9 + 1 // 1 row for header nav
+        val height = rows.coerceIn(3, 6)
+        val gui = ChestGui(height, "§6Ranks — ${guild.name}")
+        val pane = StaticPane(0, 0, 9, height)
+        gui.setOnTopClick { e -> e.isCancelled = true }
+        gui.setOnBottomClick { e ->
+            if (e.click == ClickType.SHIFT_LEFT || e.click == ClickType.SHIFT_RIGHT)
+                e.isCancelled = true
+        }
+        gui.addPane(pane)
+
+        var slot = 0
+        for (rank in ranks) {
+            val displayIcon = try {
+                rank.icon?.let { Material.valueOf(it.uppercase()) } ?: Material.NAME_TAG
+            } catch (_: Exception) { Material.NAME_TAG }
+
+            val permCount = rank.permissions.size
+            val item = ItemStack.of(displayIcon)
+                .name("§e${rank.name}")
+                .lore("§7Priority: §f${rank.priority}")
+                .lore("§7Permissions: §f$permCount")
+                .lore("")
+            if (permCount > 0) {
+                val perms = rank.permissions.take(8).joinToString("§7, §f") { it.name }
+                item.lore("§7Includes: §f$perms")
+                if (rank.permissions.size > 8) {
+                    item.lore("§7...and ${rank.permissions.size - 8} more")
+                }
+            } else {
+                item.lore("§7No special permissions")
+            }
+            pane.addItem(GuiItem(item), slot % 9, slot / 9)
+            slot++
+        }
+
+        // Back button in bottom-right
+        val backItem = ItemStack.of(Material.ARROW)
+            .name("§e⬅ BACK")
+            .lore("§7Return to rank management")
+        pane.addItem(GuiItem(backItem) { menuNavigator.goBack() }, 8, height - 1)
+
+        gui.show(player)
     }
 
     override fun passData(data: Any?) {

--- a/src/main/kotlin/net/lumalyte/lg/interaction/menus/guild/GuildRankListMenu.kt
+++ b/src/main/kotlin/net/lumalyte/lg/interaction/menus/guild/GuildRankListMenu.kt
@@ -45,8 +45,16 @@ class GuildRankListMenu(
         }
         gui.addPane(pane)
 
+        val maxSlots = (height - 1) * 9 // Reserve last row for back button
         var slot = 0
         for (rank in ranks) {
+            if (slot >= maxSlots) {
+                // Overflow notice
+                val overflowItem = ItemStack.of(Material.PAPER)
+                    .name("§e... and ${ranks.size - slot} more ranks")
+                pane.addItem(GuiItem(overflowItem), 4, height - 2)
+                break
+            }
             val displayIcon = try {
                 rank.icon?.let { Material.valueOf(it.uppercase()) } ?: Material.NAME_TAG
             } catch (_: Exception) { Material.NAME_TAG }

--- a/src/main/kotlin/net/lumalyte/lg/interaction/menus/guild/GuildSettingsMenu.kt
+++ b/src/main/kotlin/net/lumalyte/lg/interaction/menus/guild/GuildSettingsMenu.kt
@@ -74,8 +74,8 @@ class GuildSettingsMenu(
             .name("§f📖 GUILD NAME")
             .lore("§7Current: §f${guild.name}")
             .lore("§7")
-            .lore("§7Name editing coming soon")
-            .lore("§7Contact admin to change name")
+            .lore("§eTip: Use §f/g rename <name>§e to change")
+            .lore("§7the guild name from chat")
 
         pane.addItem(GuiItem(nameItem), 0, 0)
 

--- a/src/main/kotlin/net/lumalyte/lg/interaction/menus/guild/GuildStatisticsMenu.kt
+++ b/src/main/kotlin/net/lumalyte/lg/interaction/menus/guild/GuildStatisticsMenu.kt
@@ -539,7 +539,7 @@ class GuildStatisticsMenu(private val menuNavigator: MenuNavigator, private val 
             val backItem = ItemStack.of(Material.ARROW)
                 .name("§cBack to Statistics")
                 .lore("§7Return to guild statistics")
-            pane.addItem(GuiItem(backItem) { open() }, 4, 4)
+            pane.addItem(GuiItem(backItem) { open() }, 8, 4)
 
             gui.show(player)
         } catch (e: Exception) {

--- a/src/main/kotlin/net/lumalyte/lg/interaction/menus/guild/GuildStatisticsMenu.kt
+++ b/src/main/kotlin/net/lumalyte/lg/interaction/menus/guild/GuildStatisticsMenu.kt
@@ -247,9 +247,40 @@ class GuildStatisticsMenu(private val menuNavigator: MenuNavigator, private val 
         }
     }
 
-    // Detail view functions (placeholders for now)
+    // Detail view functions
     private fun openKillStatsDetail() {
-        player.sendMessage("§e🔪 Detailed kill statistics coming soon!")
+        try {
+            val killStats = killService.getGuildKillStats(guild.id)
+
+            val gui = ChestGui(4, "§4🔪 ${guild.name} - Kill Statistics")
+            gui.setOnTopClick { guiEvent -> guiEvent.isCancelled = true }
+            gui.setOnBottomClick { guiEvent ->
+                if (guiEvent.click == ClickType.SHIFT_LEFT || guiEvent.click == ClickType.SHIFT_RIGHT)
+                    guiEvent.isCancelled = true
+            }
+            val pane = StaticPane(0, 0, 9, 4)
+            gui.addPane(pane)
+
+            val summaryItem = ItemStack.of(Material.DIAMOND_SWORD)
+                .name("§4⚔ KILL STATISTICS")
+                .lore("§7Total Kills: §a${killStats.totalKills}")
+                .lore("§7Total Deaths: §c${killStats.totalDeaths}")
+                .lore("§7Net Kills: §${if (killStats.netKills >= 0) "a" else "c"}${killStats.netKills}")
+                .lore("§7K/D Ratio: §e${decimalFormat.format(killStats.killDeathRatio)}")
+                .lore("")
+                .lore("§7Kill Efficiency: §f${calculateEfficiency(killStats)}%")
+            pane.addItem(GuiItem(summaryItem), 4, 1)
+
+            val backItem = ItemStack.of(Material.ARROW)
+                .name("§cBack to Statistics")
+                .lore("§7Return to guild statistics")
+            pane.addItem(GuiItem(backItem) { open() }, 4, 3)
+
+            gui.show(player)
+        } catch (e: Exception) {
+            player.sendMessage("§c❌ Failed to load kill statistics: ${e.message}")
+            logger.error("Error opening kill stats detail for guild ${guild.id}", e)
+        }
     }
 
     private fun openWarStatsDetail() {
@@ -464,11 +495,96 @@ class GuildStatisticsMenu(private val menuNavigator: MenuNavigator, private val 
     }
 
     private fun openMemberStatsDetail() {
-        player.sendMessage("§e👥 Detailed member statistics coming soon!")
+        try {
+            val members = memberService.getGuildMembers(guild.id)
+            val memberCount = memberService.getMemberCount(guild.id)
+
+            val gui = ChestGui(5, "§b👥 ${guild.name} - Members")
+            gui.setOnTopClick { guiEvent -> guiEvent.isCancelled = true }
+            gui.setOnBottomClick { guiEvent ->
+                if (guiEvent.click == ClickType.SHIFT_LEFT || guiEvent.click == ClickType.SHIFT_RIGHT)
+                    guiEvent.isCancelled = true
+            }
+            val pane = StaticPane(0, 0, 9, 5)
+            gui.addPane(pane)
+
+            val summaryItem = ItemStack.of(Material.PLAYER_HEAD)
+                .name("§b👥 MEMBER SUMMARY")
+                .lore("§7Total Members: §f$memberCount")
+                .lore("§7Online: §a${Bukkit.getOnlinePlayers().count { p -> members.any { it.playerId == p.uniqueId } }}")
+            pane.addItem(GuiItem(summaryItem), 4, 0)
+
+            var col = 0
+            var row = 0
+            members.take(21).forEach { member ->
+                val playerName = Bukkit.getOfflinePlayer(member.playerId).name ?: member.playerId.toString().take(8)
+                val isOnline = Bukkit.getPlayer(member.playerId) != null
+                val memberItem = ItemStack.of(Material.PLAYER_HEAD)
+                    .name("§${if (isOnline) "a" else "7"}$playerName")
+                    .lore("§7Online: §${if (isOnline) "aYes" else "7No"}")
+                pane.addItem(GuiItem(memberItem), 1 + col, 1 + row)
+                col++
+                if (col >= 7) {
+                    col = 0
+                    row++
+                }
+            }
+
+            if (members.size > 21) {
+                val moreItem = ItemStack.of(Material.PAPER)
+                    .name("§e... and ${members.size - 21} more members")
+                pane.addItem(GuiItem(moreItem), 4, 4)
+            }
+
+            val backItem = ItemStack.of(Material.ARROW)
+                .name("§cBack to Statistics")
+                .lore("§7Return to guild statistics")
+            pane.addItem(GuiItem(backItem) { open() }, 4, 4)
+
+            gui.show(player)
+        } catch (e: Exception) {
+            player.sendMessage("§c❌ Failed to load member statistics: ${e.message}")
+            logger.error("Error opening member stats detail for guild ${guild.id}", e)
+        }
     }
 
     private fun openPerformanceDetail() {
-        player.sendMessage("§e📊 Detailed performance analysis coming soon!")
+        try {
+            val killStats = killService.getGuildKillStats(guild.id)
+            val memberCount = memberService.getMemberCount(guild.id)
+
+            val avgKillsPerMember = if (memberCount > 0) killStats.totalKills.toDouble() / memberCount else 0.0
+            val avgDeathsPerMember = if (memberCount > 0) killStats.totalDeaths.toDouble() / memberCount else 0.0
+
+            val gui = ChestGui(4, "§e📊 ${guild.name} - Performance")
+            gui.setOnTopClick { guiEvent -> guiEvent.isCancelled = true }
+            gui.setOnBottomClick { guiEvent ->
+                if (guiEvent.click == ClickType.SHIFT_LEFT || guiEvent.click == ClickType.SHIFT_RIGHT)
+                    guiEvent.isCancelled = true
+            }
+            val pane = StaticPane(0, 0, 9, 4)
+            gui.addPane(pane)
+
+            val perfItem = ItemStack.of(Material.EXPERIENCE_BOTTLE)
+                .name("§e📊 PERFORMANCE METRICS")
+                .lore("§7Avg Kills/Member: §f${decimalFormat.format(avgKillsPerMember)}")
+                .lore("§7Avg Deaths/Member: §f${decimalFormat.format(avgDeathsPerMember)}")
+                .lore("§7Kill Efficiency: §e${calculateEfficiency(killStats)}%")
+                .lore("§7K/D Ratio: §e${decimalFormat.format(killStats.killDeathRatio)}")
+                .lore("")
+                .lore("§7Overall Rating: §${getPerformanceColor(killStats, memberCount)}${getPerformanceRating(killStats, memberCount)}")
+            pane.addItem(GuiItem(perfItem), 4, 1)
+
+            val backItem = ItemStack.of(Material.ARROW)
+                .name("§cBack to Statistics")
+                .lore("§7Return to guild statistics")
+            pane.addItem(GuiItem(backItem) { open() }, 4, 3)
+
+            gui.show(player)
+        } catch (e: Exception) {
+            player.sendMessage("§c❌ Failed to load performance statistics: ${e.message}")
+            logger.error("Error opening performance detail for guild ${guild.id}", e)
+        }
     }
 
     private fun addTopKillersButton(pane: StaticPane, x: Int, y: Int) {
@@ -758,19 +874,168 @@ class GuildStatisticsMenu(private val menuNavigator: MenuNavigator, private val 
 
     // Additional detail view functions
     private fun openTopKillersDetail() {
-        player.sendMessage("§e🏆 Detailed top killers rankings coming soon!")
+        try {
+            val guildMembers = memberService.getGuildMembers(guild.id).map { it.playerId }
+            val topKillers = killService.getTopKillers(guildMembers, 10)
+
+            val gui = ChestGui(5, "§c🏆 ${guild.name} - Top Killers")
+            gui.setOnTopClick { guiEvent -> guiEvent.isCancelled = true }
+            gui.setOnBottomClick { guiEvent ->
+                if (guiEvent.click == ClickType.SHIFT_LEFT || guiEvent.click == ClickType.SHIFT_RIGHT)
+                    guiEvent.isCancelled = true
+            }
+            val pane = StaticPane(0, 0, 9, 5)
+            gui.addPane(pane)
+
+            val titleItem = ItemStack.of(Material.TOTEM_OF_UNDYING)
+                .name("§c🏆 TOP KILLERS")
+                .lore("§7Guild's most lethal members")
+
+            if (topKillers.isNotEmpty()) {
+                titleItem.lore("")
+                topKillers.take(10).forEachIndexed { index, (playerId, stats) ->
+                    val playerName = Bukkit.getOfflinePlayer(playerId).name ?: playerId.toString().take(8)
+                    titleItem.lore("§${getRankColor(index + 1)}${index + 1}. $playerName: §f${stats.totalKills} kills")
+                }
+            } else {
+                titleItem.lore("§7No kill data available")
+            }
+            pane.addItem(GuiItem(titleItem), 4, 1)
+
+            val backItem = ItemStack.of(Material.ARROW)
+                .name("§cBack to Statistics")
+                .lore("§7Return to guild statistics")
+            pane.addItem(GuiItem(backItem) { open() }, 4, 4)
+
+            gui.show(player)
+        } catch (e: Exception) {
+            player.sendMessage("§c❌ Failed to load top killers: ${e.message}")
+            logger.error("Error opening top killers detail for guild ${guild.id}", e)
+        }
     }
 
     private fun openTopContributorsDetail() {
-        player.sendMessage("§e💰 Detailed contribution analysis coming soon!")
+        try {
+            val contributions = bankService.getMemberContributions(guild.id)
+            val topContributors = contributions
+                .filter { it.netContribution > 0 }
+                .sortedByDescending { it.netContribution }
+                .take(10)
+
+            val gui = ChestGui(5, "§6💰 ${guild.name} - Top Contributors")
+            gui.setOnTopClick { guiEvent -> guiEvent.isCancelled = true }
+            gui.setOnBottomClick { guiEvent ->
+                if (guiEvent.click == ClickType.SHIFT_LEFT || guiEvent.click == ClickType.SHIFT_RIGHT)
+                    guiEvent.isCancelled = true
+            }
+            val pane = StaticPane(0, 0, 9, 5)
+            gui.addPane(pane)
+
+            val titleItem = ItemStack.of(Material.GOLD_BLOCK)
+                .name("§6💰 TOP CONTRIBUTORS")
+                .lore("§7Most generous members")
+
+            if (topContributors.isNotEmpty()) {
+                titleItem.lore("")
+                topContributors.forEachIndexed { index, contribution ->
+                    val playerName = contribution.playerName ?: "Unknown"
+                    titleItem.lore("§${getRankColor(index + 1)}${index + 1}. $playerName: §f$${contribution.netContribution}")
+                }
+            } else {
+                titleItem.lore("§7No contribution data")
+            }
+            pane.addItem(GuiItem(titleItem), 4, 1)
+
+            val backItem = ItemStack.of(Material.ARROW)
+                .name("§cBack to Statistics")
+                .lore("§7Return to guild statistics")
+            pane.addItem(GuiItem(backItem) { open() }, 4, 4)
+
+            gui.show(player)
+        } catch (e: Exception) {
+            player.sendMessage("§c❌ Failed to load top contributors: ${e.message}")
+            logger.error("Error opening top contributors detail for guild ${guild.id}", e)
+        }
     }
 
     private fun openKDAnalysisDetail() {
-        player.sendMessage("§e📈 Detailed K/D ratio analysis coming soon!")
+        try {
+            val killStats = killService.getGuildKillStats(guild.id)
+
+            val gui = ChestGui(4, "§d📈 ${guild.name} - K/D Analysis")
+            gui.setOnTopClick { guiEvent -> guiEvent.isCancelled = true }
+            gui.setOnBottomClick { guiEvent ->
+                if (guiEvent.click == ClickType.SHIFT_LEFT || guiEvent.click == ClickType.SHIFT_RIGHT)
+                    guiEvent.isCancelled = true
+            }
+            val pane = StaticPane(0, 0, 9, 4)
+            gui.addPane(pane)
+
+            val kdItem = ItemStack.of(Material.COMPARATOR)
+                .name("§d📈 K/D ANALYSIS")
+                .lore("§7K/D Ratio: §e${decimalFormat.format(killStats.killDeathRatio)}")
+                .lore("§7Total Kills: §a${killStats.totalKills}")
+                .lore("§7Total Deaths: §c${killStats.totalDeaths}")
+                .lore("§7Net Kills: §${if (killStats.netKills >= 0) "a" else "c"}${killStats.netKills}")
+                .lore("")
+                .lore("§7Performance Grade: §${getKDRatingColor(killStats.killDeathRatio)}${getKDRating(killStats.killDeathRatio)}")
+                .lore("§7Efficiency Score: §f${calculateEfficiencyScore(killStats)}/100")
+            pane.addItem(GuiItem(kdItem), 4, 1)
+
+            val backItem = ItemStack.of(Material.ARROW)
+                .name("§cBack to Statistics")
+                .lore("§7Return to guild statistics")
+            pane.addItem(GuiItem(backItem) { open() }, 4, 3)
+
+            gui.show(player)
+        } catch (e: Exception) {
+            player.sendMessage("§c❌ Failed to load K/D analysis: ${e.message}")
+            logger.error("Error opening K/D analysis for guild ${guild.id}", e)
+        }
     }
 
     private fun openRecentActivityDetail() {
-        player.sendMessage("§e🕐 Detailed recent activity coming soon!")
+        try {
+            val recentKills = killService.getRecentGuildKills(guild.id, 15)
+
+            val gui = ChestGui(5, "§f🕐 ${guild.name} - Recent Activity")
+            gui.setOnTopClick { guiEvent -> guiEvent.isCancelled = true }
+            gui.setOnBottomClick { guiEvent ->
+                if (guiEvent.click == ClickType.SHIFT_LEFT || guiEvent.click == ClickType.SHIFT_RIGHT)
+                    guiEvent.isCancelled = true
+            }
+            val pane = StaticPane(0, 0, 9, 5)
+            gui.addPane(pane)
+
+            val titleItem = ItemStack.of(Material.CLOCK)
+                .name("§f🕐 RECENT ACTIVITY")
+                .lore("§7Recent kills: ${recentKills.size}")
+                .lore("§7Activity Level: §${getActivityColor(recentKills.size)}${getActivityLevel(recentKills.size)}")
+
+            if (recentKills.isNotEmpty()) {
+                titleItem.lore("")
+                recentKills.take(10).forEach { kill ->
+                    val killerName = Bukkit.getOfflinePlayer(kill.killerId).name ?: kill.killerId.toString().take(8)
+                    val victimName = Bukkit.getOfflinePlayer(kill.victimId).name ?: kill.victimId.toString().take(8)
+                    val weapon = if (!kill.weapon.isNullOrEmpty()) " §7with §f${kill.weapon}" else ""
+                    titleItem.lore("§a$killerName §7→ §c$victimName$weapon")
+                }
+            }
+            if (recentKills.size > 10) {
+                titleItem.lore("§7... and ${recentKills.size - 10} more")
+            }
+            pane.addItem(GuiItem(titleItem), 4, 1)
+
+            val backItem = ItemStack.of(Material.ARROW)
+                .name("§cBack to Statistics")
+                .lore("§7Return to guild statistics")
+            pane.addItem(GuiItem(backItem) { open() }, 4, 4)
+
+            gui.show(player)
+        } catch (e: Exception) {
+            player.sendMessage("§c❌ Failed to load recent activity: ${e.message}")
+            logger.error("Error opening recent activity for guild ${guild.id}", e)
+        }
     }
 
     private fun openPeriodStatsMenu() {

--- a/src/main/kotlin/net/lumalyte/lg/interaction/menus/guild/PeaceAgreementMenu.kt
+++ b/src/main/kotlin/net/lumalyte/lg/interaction/menus/guild/PeaceAgreementMenu.kt
@@ -371,12 +371,45 @@ class PeaceAgreementMenu(
     }
 
     private fun showWarSelectionForPeace() {
-        // Implementation for selecting which war to propose peace for
-        player.sendMessage("§eWar selection for peace proposals coming soon!")
+        // Show active wars that can be used for peace proposals
+        try {
+            val activeWars = warService.getWarsForGuild(guild.id).filter { it.isActive }
+            if (activeWars.isEmpty()) {
+                player.sendMessage("§cYour guild is not currently at war with anyone.")
+                return
+            }
+            player.sendMessage("§6§l=== Active Wars ===")
+            activeWars.forEach { war ->
+                val enemyId = if (war.declaringGuildId == guild.id) war.defendingGuildId else war.declaringGuildId
+                val enemyGuild = guildService.getGuild(enemyId)
+                val enemyName = enemyGuild?.name ?: "Unknown"
+                player.sendMessage("§7- §c$enemyName")
+            }
+            player.sendMessage("§eUse §f/g peace propose <guild>§e to send a peace request.")
+        } catch (e: Exception) {
+            player.sendMessage("§cCould not load war data for peace proposals.")
+        }
     }
 
     private fun showPeaceHistory() {
-        player.sendMessage("§ePeace history coming soon!")
+        // Show recently ended wars (peace history)
+        try {
+            val warHistory = warService.getWarHistory(guild.id, 10)
+            if (warHistory.isEmpty()) {
+                player.sendMessage("§7No war history found for this guild.")
+                return
+            }
+            player.sendMessage("§6§l=== War History ===")
+            warHistory.forEach { war ->
+                val enemyId = if (war.declaringGuildId == guild.id) war.defendingGuildId else war.declaringGuildId
+                val enemyGuild = guildService.getGuild(enemyId)
+                val enemyName = enemyGuild?.name ?: "Unknown"
+                val status = if (war.isActive) "Active" else "Ended"
+                player.sendMessage("§7- §f$enemyName §7($status)")
+            }
+        } catch (e: Exception) {
+            player.sendMessage("§cCould not load peace history.")
+        }
     }
 
     // ChatInputHandler implementation

--- a/src/main/kotlin/net/lumalyte/lg/interaction/menus/guild/PeaceAgreementMenu.kt
+++ b/src/main/kotlin/net/lumalyte/lg/interaction/menus/guild/PeaceAgreementMenu.kt
@@ -372,6 +372,7 @@ class PeaceAgreementMenu(
 
     private fun showWarSelectionForPeace() {
         // Show active wars that can be used for peace proposals
+        player.closeInventory()
         try {
             val activeWars = warService.getWarsForGuild(guild.id).filter { it.isActive }
             if (activeWars.isEmpty()) {
@@ -393,6 +394,7 @@ class PeaceAgreementMenu(
 
     private fun showPeaceHistory() {
         // Show recently ended wars (peace history)
+        player.closeInventory()
         try {
             val warHistory = warService.getWarHistory(guild.id, 10)
             if (warHistory.isEmpty()) {

--- a/src/main/kotlin/net/lumalyte/lg/interaction/menus/guild/RankCreationMenu.kt
+++ b/src/main/kotlin/net/lumalyte/lg/interaction/menus/guild/RankCreationMenu.kt
@@ -384,14 +384,25 @@ class RankCreationMenu(private val menuNavigator: MenuNavigator, private val pla
     }
 
     private fun openPermissionCategorySelection(categoryName: String, permissions: List<RankPermission>) {
-        // Toggle permissions for this category during rank creation
+        // Toggle individual permissions for this category during rank creation
         val allSelected = permissions.all { it in selectedPermissions }
         if (allSelected) {
-            selectedPermissions.removeAll(permissions.toSet())
-            player.sendMessage("§7Removed all §f$categoryName §7permissions.")
+            // Remove all — toggle them off one by one
+            permissions.forEach { perm ->
+                selectedPermissions.remove(perm)
+                player.sendMessage("§7Removed §f${perm.name}§7.")
+            }
+            player.sendMessage("§7All §f$categoryName §7permissions removed.")
         } else {
-            selectedPermissions.addAll(permissions)
-            player.sendMessage("§aAdded all §f$categoryName §7permissions.")
+            // Add only the ones not yet selected
+            val added = permissions.filter { it !in selectedPermissions }
+            added.forEach { perm ->
+                selectedPermissions.add(perm)
+                player.sendMessage("§aAdded §f${perm.name}§a.")
+            }
+            if (added.size < permissions.size) {
+                player.sendMessage("§eSome $categoryName permissions were already enabled.")
+            }
         }
         open() // Refresh the creation menu
     }

--- a/src/main/kotlin/net/lumalyte/lg/interaction/menus/guild/RankCreationMenu.kt
+++ b/src/main/kotlin/net/lumalyte/lg/interaction/menus/guild/RankCreationMenu.kt
@@ -384,9 +384,16 @@ class RankCreationMenu(private val menuNavigator: MenuNavigator, private val pla
     }
 
     private fun openPermissionCategorySelection(categoryName: String, permissions: List<RankPermission>) {
-        // Create a simplified version of PermissionCategoryMenu for creation
-        player.sendMessage("§e🔧 $categoryName permission selection coming soon!")
-        player.sendMessage("§7You'll be able to select individual permissions.")
+        // Toggle permissions for this category during rank creation
+        val allSelected = permissions.all { it in selectedPermissions }
+        if (allSelected) {
+            selectedPermissions.removeAll(permissions.toSet())
+            player.sendMessage("§7Removed all §f$categoryName §7permissions.")
+        } else {
+            selectedPermissions.addAll(permissions)
+            player.sendMessage("§aAdded all §f$categoryName §7permissions.")
+        }
+        open() // Refresh the creation menu
     }
 
     private fun groupPermissionsByCategory(permissions: Set<RankPermission>): Map<String, List<RankPermission>> {

--- a/src/main/kotlin/net/lumalyte/lg/interaction/menus/guild/RankEditMenu.kt
+++ b/src/main/kotlin/net/lumalyte/lg/interaction/menus/guild/RankEditMenu.kt
@@ -382,8 +382,14 @@ class RankEditMenu(private val menuNavigator: MenuNavigator, private val player:
             .lore("§cClick to reset")
 
         val resetGuiItem = GuiItem(resetItem) {
-            player.sendMessage("§eReset functionality coming soon!")
-            player.sendMessage("§7This will clear all permissions for this rank.")
+            val success = rankService.setRankPermissions(rank.id, emptySet(), player.uniqueId)
+            if (success) {
+                player.sendMessage("§a✅ Rank permissions reset successfully!")
+                player.playSound(player.location, org.bukkit.Sound.ENTITY_PLAYER_LEVELUP, 1.0f, 1.0f)
+                open() // Refresh
+            } else {
+                player.sendMessage("§cFailed to reset permissions. You may not have permission.")
+            }
         }
         pane.addItem(resetGuiItem, 3, 5)
 

--- a/src/main/kotlin/net/lumalyte/lg/interaction/menus/guild/RankEditMenu.kt
+++ b/src/main/kotlin/net/lumalyte/lg/interaction/menus/guild/RankEditMenu.kt
@@ -382,8 +382,23 @@ class RankEditMenu(private val menuNavigator: MenuNavigator, private val player:
             .lore("§cClick to reset")
 
         val resetGuiItem = GuiItem(resetItem) {
+            // Prevent resetting the owner rank
+            if (isOwnerRank()) {
+                player.sendMessage("§c❌ Cannot reset the owner rank!")
+                player.sendMessage("§7The owner rank permissions are permanent and cannot be changed.")
+                player.playSound(player.location, org.bukkit.Sound.ENTITY_VILLAGER_NO, 1.0f, 1.0f)
+                return@GuiItem
+            }
+            // Prevent resetting your own rank
+            if (isEditingOwnRank()) {
+                player.sendMessage("§c❌ You cannot reset your own rank's permissions!")
+                player.playSound(player.location, org.bukkit.Sound.ENTITY_VILLAGER_NO, 1.0f, 1.0f)
+                return@GuiItem
+            }
             val success = rankService.setRankPermissions(rank.id, emptySet(), player.uniqueId)
             if (success) {
+                // Refresh the local rank from the service
+                rank = rankService.listRanks(guild.id).find { it.id == rank.id } ?: rank
                 player.sendMessage("§a✅ Rank permissions reset successfully!")
                 player.playSound(player.location, org.bukkit.Sound.ENTITY_PLAYER_LEVELUP, 1.0f, 1.0f)
                 open() // Refresh

--- a/src/main/kotlin/net/lumalyte/lg/utils/NexoItemProvider.kt
+++ b/src/main/kotlin/net/lumalyte/lg/utils/NexoItemProvider.kt
@@ -6,44 +6,64 @@ import org.slf4j.LoggerFactory
 /**
  * Provides ItemStacks from Nexo's custom item registry with a fallback chain.
  *
- * Uses reflection to avoid a hard compile-time dependency on Nexo — mirrors
- * the pattern established by [net.lumalyte.lg.infrastructure.services.NexoEmojiService].
+ * Uses reflection to avoid a hard compile-time dependency on Nexo —
+ * mirrors the pattern established by [net.lumalyte.lg.infrastructure.services.NexoEmojiService].
  *
- * When Nexo is present, items render with the custom texture from the resource
- * pack. When absent, the fallback lambda is used (typically a vanilla ItemStack).
+ * Supports Nexo 1.22.1 (NexoItems) and newer (NexoAPI) for forward compatibility.
+ * When Nexo is absent, the fallback lambda is used (typically a vanilla ItemStack).
  */
 object NexoItemProvider {
 
     private val logger = LoggerFactory.getLogger(NexoItemProvider::class.java)
 
-    private var checked = false
-    private var nexoApiClass: Class<*>? = null
+    /** Cache of Nexo API classes discovered via reflection. */
+    private var apiClass: Class<*>? = null
+    private var apiMethod: java.lang.reflect.Method? = null
 
     /**
      * Returns true if the Nexo plugin is loaded and its API is accessible.
      */
     fun isAvailable(): Boolean {
-        if (!checked) {
-            nexoApiClass = try {
-                Class.forName("com.nexomc.nexo.api.NexoAPI")
-            } catch (_: ClassNotFoundException) {
-                null
-            }
-            checked = true
+        if (apiClass == null) {
+            resolveApi()
         }
-        return nexoApiClass != null
+        return apiClass != null
+    }
+
+    /**
+     * Attempts to resolve a Nexo API class and getItemStack method.
+     * Tries NexoAPI first (newer versions), then NexoItems (1.22.x).
+     */
+    private fun resolveApi() {
+        // Try NexoAPI (newer versions: 1.22.x+)
+        for (className in listOf("com.nexomc.nexo.api.NexoAPI", "com.nexomc.nexo.api.NexoItems")) {
+            try {
+                val clazz = Class.forName(className)
+                val methodName = if (className.contains("NexoAPI")) "getItemStack" else "getItemStack"
+                val method = clazz.getMethod(methodName, String::class.java)
+                apiClass = clazz
+                apiMethod = method
+                logger.debug("Nexo API resolved: {}.{}()", className, methodName)
+                return
+            } catch (_: ClassNotFoundException) {
+                // try next class name
+            } catch (_: NoSuchMethodException) {
+                // try next class name
+            }
+        }
+        logger.debug("Nexo API not available — running in compatibility mode")
     }
 
     /**
      * Attempts to get a Nexo custom item by its item ID (e.g. "lg_nav_info").
      *
-     * @param itemId The Nexo item identifier (without the "lg_" prefix — pass the full ID).
+     * @param itemId The Nexo item identifier (e.g. "lg_nav_info").
      * @return The ItemStack from Nexo, or null if Nexo is unavailable or the ID is not found.
      */
     fun getItemStack(itemId: String): ItemStack? {
-        val api = nexoApiClass ?: return null
+        if (apiClass == null) resolveApi()
+        val method = apiMethod ?: return null
         return try {
-            val method = api.getMethod("getItemStack", String::class.java)
             method.invoke(null, itemId) as? ItemStack
         } catch (e: Exception) {
             logger.debug("Nexo getItemStack failed for '$itemId': ${e.message}")

--- a/src/main/kotlin/net/lumalyte/lg/utils/NexoItemProvider.kt
+++ b/src/main/kotlin/net/lumalyte/lg/utils/NexoItemProvider.kt
@@ -1,0 +1,64 @@
+package net.lumalyte.lg.utils
+
+import org.bukkit.inventory.ItemStack
+import org.slf4j.LoggerFactory
+
+/**
+ * Provides ItemStacks from Nexo's custom item registry with a fallback chain.
+ *
+ * Uses reflection to avoid a hard compile-time dependency on Nexo — mirrors
+ * the pattern established by [net.lumalyte.lg.infrastructure.services.NexoEmojiService].
+ *
+ * When Nexo is present, items render with the custom texture from the resource
+ * pack. When absent, the fallback lambda is used (typically a vanilla ItemStack).
+ */
+object NexoItemProvider {
+
+    private val logger = LoggerFactory.getLogger(NexoItemProvider::class.java)
+
+    private var checked = false
+    private var nexoApiClass: Class<*>? = null
+
+    /**
+     * Returns true if the Nexo plugin is loaded and its API is accessible.
+     */
+    fun isAvailable(): Boolean {
+        if (!checked) {
+            nexoApiClass = try {
+                Class.forName("com.nexomc.nexo.api.NexoAPI")
+            } catch (_: ClassNotFoundException) {
+                null
+            }
+            checked = true
+        }
+        return nexoApiClass != null
+    }
+
+    /**
+     * Attempts to get a Nexo custom item by its item ID (e.g. "lg_nav_info").
+     *
+     * @param itemId The Nexo item identifier (without the "lg_" prefix — pass the full ID).
+     * @return The ItemStack from Nexo, or null if Nexo is unavailable or the ID is not found.
+     */
+    fun getItemStack(itemId: String): ItemStack? {
+        val api = nexoApiClass ?: return null
+        return try {
+            val method = api.getMethod("getItemStack", String::class.java)
+            method.invoke(null, itemId) as? ItemStack
+        } catch (e: Exception) {
+            logger.debug("Nexo getItemStack failed for '$itemId': ${e.message}")
+            null
+        }
+    }
+
+    /**
+     * Gets a Nexo item with a vanilla fallback.
+     *
+     * @param itemId  The Nexo item ID (e.g. "lg_nav_info").
+     * @param fallback A lambda that produces the fallback ItemStack when Nexo is absent.
+     * @return The Nexo ItemStack if available, otherwise the fallback.
+     */
+    fun getItemStackOrFallback(itemId: String, fallback: () -> ItemStack): ItemStack {
+        return getItemStack(itemId) ?: fallback()
+    }
+}


### PR DESCRIPTION
## Summary
Replaces the flat 6-row guild control panel with a hub-and-spoke dashboard using Nexo custom item icons, plus a dedicated Guild Progression Menu with daily XP caps per source.

## Part 1: Dashboard (GuildDashboard.kt)
- 3-row hub menu with 8 nav category icons (lg_nav_*)
- 3-row background texture from Nexo (lg_bg_3_row)
- Guild info display at top (name, members, ranks, balance)
- Auto-selected when Nexo is present; falls back to old panel

## Part 2: Progression Menu (GuildProgressionMenu.kt)
- 6-row menu modeled after AuraSkills LevelProgressionMenu
- Paginated grid of 15 XP sources with daily caps and progress bars
- Color-coded progress: green (under 40%), gold (40-80%), yellow (80-99%), red (capped)
- Left sidebar: Rank, XP Sources reference, Unlocked Perks, Prestige
- Back/Close navigation + page flipping
- getDailySourceXp() and getDailyCap() on ProgressionService

## Requires
- Nexo 1.22.1 on the server
- Nexo assets repo textures in pack/assets (separate repo)
- New Nexo icons: lg_combat, lg_farming, lg_mining, lg_crafting, lg_brewing, lg_enchanting, lg_claiming, lg_trophy, lg_sources

## Layout
Dashboard (3-row):
Row 0:        [Guild Info - members/ranks/balance]
Row 1: [Info] [Members] [Ranks] [Economy]
Row 2: [Settngs] [Progres] [Diplo] [Warfare]

Progression (6-row):
Row 0:        [Guild Level  XP: 65%  Today: +1,250]  [Back][Close]
Row 1: [Rank]  --- 24-slot paginated source grid ---
Row 2: [Srcs]  Each slot: icon, today/cap, progress bar
Row 3: [Perks]
Row 4: [Prestige]
Row 5:                                    [Prev] [Next]

## Testing
- Builds and boots on Fuji 1.21.11 with Nexo 1.22.1
- Falls back gracefully when Nexo is absent
- Progression menu compiles with configurable daily caps