### PR TITLE
fix: suppress unchecked cast in PlaytimeActivityServiceBukkit

### DIFF
--- a/src/main/kotlin/net/lumalyte/lg/infrastructure/services/PlaytimeActivityServiceBukkit.kt
+++ b/src/main/kotlin/net/lumalyte/lg/infrastructure/services/PlaytimeActivityServiceBukkit.kt
@@ -22,7 +22,8 @@ class PlaytimeActivityServiceBukkit : PlaytimeActivityService {
 
     override fun isXpBlocked(player: Player): Boolean {
         val service = try {
-            Bukkit.getServicesManager().load(PlaytimeService::class.java)
+            @Suppress("UNCHECKED_CAST")
+            Bukkit.getServicesManager().load(PlaytimeService::class.java) as? PlaytimeService
         } catch (e: Throwable) {
             null // PlayTime absent — never block XP
         } ?: return false


### PR DESCRIPTION
Paper's ServicesManager.load() produces a generic signature mismatch on newer Paper builds. The Kotlin compiler rejects it with: 

> Argument type mismatch: actual type is 'java.lang.Class<T>', but '@NotNull() java.lang.Class<T!>' was expected.

Fix: add @Suppress(UNCHECKED_CAST) and null-safe cast to PlaytimeService.

This is what's blocking the release workflow.