### PR TITLE
fix: use lg_filler instead of lg_bg_3_row for dashboard filler slots

### DIFF
--- a/src/main/kotlin/net/lumalyte/lg/interaction/menus/guild/GuildDashboard.kt
+++ b/src/main/kotlin/net/lumalyte/lg/interaction/menus/guild/GuildDashboard.kt
@@ -30,6 +30,11 @@ class GuildDashboard(
     private val menuFactory: MenuFactory
 ) : Menu {
 
+    companion object {
+        /** Nexo item ID for inventory filler slots (not a background overlay). */
+        const val FILLER_NEXO_ID = "lg_filler"
+    }
+
     override fun open() {
         val playerId = player.uniqueId
 
@@ -114,7 +119,7 @@ class GuildDashboard(
      * Nav buttons are added after this, so they overwrite their positions.
      */
     private fun fillBackground(pane: StaticPane) {
-        val bgItem = NexoItemProvider.getItemStack("lg_bg_3_row")
+        val bgItem = NexoItemProvider.getItemStack(FILLER_NEXO_ID)
             ?: ItemStack.of(Material.GRAY_STAINED_GLASS_PANE).name(" ")
 
         for (x in 0..8) {

--- a/src/test/kotlin/net/lumalyte/lg/interaction/menus/guild/GuildDashboardFillerItemTest.kt
+++ b/src/test/kotlin/net/lumalyte/lg/interaction/menus/guild/GuildDashboardFillerItemTest.kt
@@ -1,0 +1,75 @@
+package net.lumalyte.lg.interaction.menus.guild
+
+import org.junit.jupiter.api.Assertions.assertNotNull
+import org.junit.jupiter.api.Test
+import java.lang.reflect.Modifier
+
+/**
+ * Verifies that GuildDashboard uses the correct Nexo item ID for filler slots.
+ *
+ * The filler must be a dedicated `lg_filler` item, NOT a background overlay
+ * (`lg_bg_*`). Background overlays are full-menu textures intended for the
+ * resource pack overlay system, not for individual inventory slots.
+ */
+internal class GuildDashboardFillerItemTest {
+
+    private fun findConstantValue(): String? {
+        // Look for a static String field with FILLER in its name
+        for (field in GuildDashboard::class.java.declaredFields) {
+            if (Modifier.isStatic(field.modifiers) &&
+                Modifier.isPublic(field.modifiers) &&
+                field.type == String::class.java &&
+                field.name.uppercase().contains("FILLER")
+            ) {
+                field.isAccessible = true
+                return field.get(null) as? String
+            }
+        }
+        // Also check companion object if it exists
+        for (inner in GuildDashboard::class.java.declaredClasses) {
+            if (inner.simpleName == "Companion") {
+                for (field in inner.declaredFields) {
+                    if (Modifier.isPublic(field.modifiers) &&
+                        field.type == String::class.java &&
+                        field.name.uppercase().contains("FILLER")
+                    ) {
+                        field.isAccessible = true
+                        return field.get(null) as? String
+                    }
+                }
+            }
+        }
+        return null
+    }
+
+    @Test
+    fun `GuildDashboard declares a FILLER_NEXO_ID constant`() {
+        val value = findConstantValue()
+        assertNotNull(value) {
+            "GuildDashboard must declare a public static String constant with 'FILLER' in its name " +
+            "(e.g. FILLER_NEXO_ID or FILLER_ITEM_ID) set to \"lg_filler\"."
+        }
+    }
+
+    @Test
+    fun `filler Nexo item ID is "lg_filler"`() {
+        val value = findConstantValue()
+        assertNotNull(value) {
+            "GuildDashboard must declare a public static filler constant."
+        }
+        assert(value == "lg_filler") {
+            "Expected filler Nexo item ID to be \"lg_filler\", but got \"$value\". " +
+            "Background overlay IDs (lg_bg_*) are not valid filler items."
+        }
+    }
+
+    @Test
+    fun `filler Nexo item ID is not a background overlay ID`() {
+        val value = findConstantValue()
+        if (value != null) {
+            assert(!value.startsWith("lg_bg_")) {
+                "Filler item ID must not be a background overlay ID. Got: \"$value\" (starts with lg_bg_)."
+            }
+        }
+    }
+}


### PR DESCRIPTION
GuildDashboard.fillBackground() was using the full-menu background overlay item lg_bg_3_row as the filler for all 27 inventory slots. Background overlays (lg_bg_*) are intended for resource pack overlay rendering, not for individual slot items.

Fix:
- Extract FILLER_NEXO_ID companion constant (value: "lg_filler")
- fillBackground() now requests lg_filler from NexoItemProvider
- Falls back to GRAY_STAINED_GLASS_PANE when Nexo is unavailable

TDD: 3 tests written first (RED), then minimal code change (GREEN). All 370+ tests pass, shadowJar builds clean.