### PR TITLE
fix: calibrate horizontal glyph offset to shift:-7

### DIFF
--- a/src/main/kotlin/net/lumalyte/lg/utils/MenuTitleBuilder.kt
+++ b/src/main/kotlin/net/lumalyte/lg/utils/MenuTitleBuilder.kt
@@ -26,7 +26,7 @@ package net.lumalyte.lg.utils
 object MenuTitleBuilder {
 
     /** Horizontal prefix that places the glyph at the window origin. */
-    private const val GLYPH_PREFIX: String = "<shift:6>"
+    private const val GLYPH_PREFIX: String = "<shift:-7>"
 
     /**
      * Returns a ChestGui title string that renders a Nexo font-glyph

--- a/src/test/kotlin/net/lumalyte/lg/utils/MenuTitleBuilderTest.kt
+++ b/src/test/kotlin/net/lumalyte/lg/utils/MenuTitleBuilderTest.kt
@@ -66,11 +66,11 @@ class MenuTitleBuilderTest {
     // ---------------------------------------------------------------
 
     @Test
-    fun `positioning prefix is always shift 6`() {
+    fun `positioning prefix is always shift -7`() {
         val title = MenuTitleBuilder.build(GuiTheme.NEUTRAL, 3)
         assertTrue(
-            title.startsWith("<shift:6>"),
-            "Expected title '$title' to start with '<shift:6>'"
+            title.startsWith("<shift:-7>"),
+            "Expected title '$title' to start with '<shift:-7>'"
         )
     }
 


### PR DESCRIPTION
## Summary

Iterative calibration of horizontal glyph offset based on in-game screenshots at GUI scale 2.

| Shift | Result |
|-------|--------|
| `-37` | 56px too far left (original) |
| `-8`  | 56px still too far left |
| `+20` | 56px too far right |
| `+6`  | 26px too far right |
| **`-7`** | **calibrated midpoint** |

## Tests
7 MenuTitleBuilder tests pass, `clean test shadowJar` — BUILD SUCCESSFUL.

## Still needed (Nexo config)
All 24 themed glyph definitions in `enthusia.yml` must use `ascent: 12` (was 37).