### PR TITLE
fix: add visible title text above background glyph; calibrate shift to -8

### DIFF
--- a/src/main/kotlin/net/lumalyte/lg/interaction/menus/guild/AllianceRequestMenu.kt
+++ b/src/main/kotlin/net/lumalyte/lg/interaction/menus/guild/AllianceRequestMenu.kt
@@ -48,7 +48,7 @@ class AllianceRequestMenu(
             return
         }
 
-        val gui = ChestGui(6, MenuTitleBuilder.build(guild.guiTheme, 6))
+        val gui = ChestGui(6, MenuTitleBuilder.build(guild.guiTheme, 6, "§6Request Alliance"))
         val pane = StaticPane(0, 0, 9, 6)
         gui.setOnTopClick { guiEvent -> guiEvent.isCancelled = true }
         gui.setOnBottomClick { guiEvent ->

--- a/src/main/kotlin/net/lumalyte/lg/interaction/menus/guild/AlliesListMenu.kt
+++ b/src/main/kotlin/net/lumalyte/lg/interaction/menus/guild/AlliesListMenu.kt
@@ -45,7 +45,7 @@ class AlliesListMenu(
     private val itemsPerPage = 28 // 4 rows x 7 columns
 
     override fun open() {
-        val gui = ChestGui(6, MenuTitleBuilder.build(guild.guiTheme, 6))
+        val gui = ChestGui(6, MenuTitleBuilder.build(guild.guiTheme, 6, "§aAllied Guilds"))
         val pane = StaticPane(0, 0, 9, 6)
         gui.setOnTopClick { guiEvent -> guiEvent.isCancelled = true }
         gui.setOnBottomClick { guiEvent ->
@@ -154,7 +154,7 @@ class AlliesListMenu(
         val guildName = otherGuild?.name ?: "Unknown Guild"
 
         // Create actions menu
-        val gui = ChestGui(3, MenuTitleBuilder.build(guild.guiTheme, 3))
+        val gui = ChestGui(3, MenuTitleBuilder.build(guild.guiTheme, 3, "§a$guildName"))
         val pane = StaticPane(0, 0, 9, 3)
         gui.setOnTopClick { guiEvent -> guiEvent.isCancelled = true }
         gui.setOnBottomClick { guiEvent ->
@@ -212,7 +212,7 @@ class AlliesListMenu(
 
     private fun openBreakConfirmMenu(relation: Relation, guildName: String) {
         // Create confirmation menu
-        val gui = ChestGui(3, MenuTitleBuilder.build(guild.guiTheme, 3))
+        val gui = ChestGui(3, MenuTitleBuilder.build(guild.guiTheme, 3, "§cBreak Alliance?"))
         val pane = StaticPane(0, 0, 9, 3)
         gui.setOnTopClick { guiEvent -> guiEvent.isCancelled = true }
         gui.setOnBottomClick { guiEvent ->

--- a/src/main/kotlin/net/lumalyte/lg/interaction/menus/guild/AllyHomeAccessMenu.kt
+++ b/src/main/kotlin/net/lumalyte/lg/interaction/menus/guild/AllyHomeAccessMenu.kt
@@ -51,7 +51,7 @@ class AllyHomeAccessMenu(
             }
         val allowed = current.allyHomeAllowedGuilds.toMutableSet()
 
-        val gui = ChestGui(4, MenuTitleBuilder.build(guild.guiTheme, 4))
+        val gui = ChestGui(4, MenuTitleBuilder.build(guild.guiTheme, 4, "§6Ally-home Access"))
         val pane = StaticPane(0, 0, 9, 4)
         gui.setOnTopClick { it.isCancelled = true }
         gui.setOnBottomClick {

--- a/src/main/kotlin/net/lumalyte/lg/interaction/menus/guild/DescriptionEditorMenu.kt
+++ b/src/main/kotlin/net/lumalyte/lg/interaction/menus/guild/DescriptionEditorMenu.kt
@@ -52,7 +52,7 @@ class DescriptionEditorMenu(private val menuNavigator: MenuNavigator, private va
         // Validate current input
         validationError = validateDescription(inputDescription)
 
-        val gui = ChestGui(4, MenuTitleBuilder.build(guild.guiTheme, 4))
+        val gui = ChestGui(4, MenuTitleBuilder.build(guild.guiTheme, 4, "§6Edit Guild Description"))
         val pane = StaticPane(0, 0, 9, 4)
         gui.setOnTopClick { guiEvent -> guiEvent.isCancelled = true }
         gui.setOnBottomClick { guiEvent ->

--- a/src/main/kotlin/net/lumalyte/lg/interaction/menus/guild/EnemiesListMenu.kt
+++ b/src/main/kotlin/net/lumalyte/lg/interaction/menus/guild/EnemiesListMenu.kt
@@ -45,7 +45,7 @@ class EnemiesListMenu(
     private val itemsPerPage = 28 // 4 rows x 7 columns
 
     override fun open() {
-        val gui = ChestGui(6, MenuTitleBuilder.build(guild.guiTheme, 6))
+        val gui = ChestGui(6, MenuTitleBuilder.build(guild.guiTheme, 6, "§cEnemy Guilds"))
         val pane = StaticPane(0, 0, 9, 6)
         gui.setOnTopClick { guiEvent -> guiEvent.isCancelled = true }
         gui.setOnBottomClick { guiEvent ->
@@ -154,7 +154,7 @@ class EnemiesListMenu(
         val guildName = otherGuild?.name ?: "Unknown Guild"
 
         // Create actions menu
-        val gui = ChestGui(3, MenuTitleBuilder.build(guild.guiTheme, 3))
+        val gui = ChestGui(3, MenuTitleBuilder.build(guild.guiTheme, 3, "§cEnemy Guilds"))
         val pane = StaticPane(0, 0, 9, 3)
         gui.setOnTopClick { guiEvent -> guiEvent.isCancelled = true }
         gui.setOnBottomClick { guiEvent ->

--- a/src/main/kotlin/net/lumalyte/lg/interaction/menus/guild/EnemyDeclarationMenu.kt
+++ b/src/main/kotlin/net/lumalyte/lg/interaction/menus/guild/EnemyDeclarationMenu.kt
@@ -48,7 +48,7 @@ class EnemyDeclarationMenu(
             return
         }
 
-        val gui = ChestGui(6, MenuTitleBuilder.build(guild.guiTheme, 6))
+        val gui = ChestGui(6, MenuTitleBuilder.build(guild.guiTheme, 6, "§cDeclare Enemy"))
         val pane = StaticPane(0, 0, 9, 6)
         gui.setOnTopClick { guiEvent -> guiEvent.isCancelled = true }
         gui.setOnBottomClick { guiEvent ->
@@ -147,7 +147,7 @@ class EnemyDeclarationMenu(
     }
 
     private fun openConfirmation(targetGuild: Guild) {
-        val gui = ChestGui(3, MenuTitleBuilder.build(guild.guiTheme, 3))
+        val gui = ChestGui(3, MenuTitleBuilder.build(guild.guiTheme, 3, "§cDeclare Enemy"))
         val pane = StaticPane(0, 0, 9, 3)
         gui.setOnTopClick { guiEvent -> guiEvent.isCancelled = true }
         gui.setOnBottomClick { guiEvent ->

--- a/src/main/kotlin/net/lumalyte/lg/interaction/menus/guild/GuildBankAutomationMenu.kt
+++ b/src/main/kotlin/net/lumalyte/lg/interaction/menus/guild/GuildBankAutomationMenu.kt
@@ -127,7 +127,7 @@ class GuildBankAutomationMenu(
      * Initialize the GUI structure
      */
     private fun initializeGui() {
-        gui = ChestGui(5, MenuTitleBuilder.build(guild.guiTheme, 5))
+        gui = ChestGui(5, MenuTitleBuilder.build(guild.guiTheme, 5, "Automation & Rewards - ${guild.name}"))
         gui.setOnGlobalClick { event -> event.isCancelled = true }
 
         // Create main navigation pane

--- a/src/main/kotlin/net/lumalyte/lg/interaction/menus/guild/GuildBankBudgetMenu.kt
+++ b/src/main/kotlin/net/lumalyte/lg/interaction/menus/guild/GuildBankBudgetMenu.kt
@@ -139,7 +139,7 @@ class GuildBankBudgetMenu(
      * Initialize the GUI structure
      */
     private fun initializeGui() {
-        gui = ChestGui(5, MenuTitleBuilder.build(guild.guiTheme, 5))
+        gui = ChestGui(5, MenuTitleBuilder.build(guild.guiTheme, 5, "Budget Management - ${guild.name}"))
         gui.setOnGlobalClick { event -> event.isCancelled = true }
 
         // Create main navigation pane

--- a/src/main/kotlin/net/lumalyte/lg/interaction/menus/guild/GuildBankMenu.kt
+++ b/src/main/kotlin/net/lumalyte/lg/interaction/menus/guild/GuildBankMenu.kt
@@ -122,7 +122,7 @@ class GuildBankMenu(
      * Initialize the GUI structure
      */
     private fun initializeGui() {
-        gui = ChestGui(6, MenuTitleBuilder.build(guild.guiTheme, 6))
+        gui = ChestGui(6, MenuTitleBuilder.build(guild.guiTheme, 6, getLocalizedTitle()))
         gui.setOnGlobalClick { event -> event.isCancelled = true }
 
         // Create main pane for balance and quick actions

--- a/src/main/kotlin/net/lumalyte/lg/interaction/menus/guild/GuildBankSecurityMenu.kt
+++ b/src/main/kotlin/net/lumalyte/lg/interaction/menus/guild/GuildBankSecurityMenu.kt
@@ -209,7 +209,7 @@ class GuildBankSecurityMenu(
      * Initialize the GUI structure
      */
     private fun initializeGui() {
-        gui = ChestGui(5, MenuTitleBuilder.build(guild.guiTheme, 5))
+        gui = ChestGui(5, MenuTitleBuilder.build(guild.guiTheme, 5, "Security & Audit - ${guild.name}"))
         gui.setOnGlobalClick { event -> event.isCancelled = true }
 
         // Create main navigation pane

--- a/src/main/kotlin/net/lumalyte/lg/interaction/menus/guild/GuildBankStatisticsMenu.kt
+++ b/src/main/kotlin/net/lumalyte/lg/interaction/menus/guild/GuildBankStatisticsMenu.kt
@@ -87,7 +87,7 @@ class GuildBankStatisticsMenu(
      * Initialize the GUI structure
      */
     private fun initializeGui() {
-        gui = ChestGui(6, MenuTitleBuilder.build(guild.guiTheme, 6))
+        gui = ChestGui(6, MenuTitleBuilder.build(guild.guiTheme, 6, getLocalizedString(LocalizationKeys.MENU_BANK_STATS_TITLE, guild.name)))
         gui.setOnGlobalClick { event -> event.isCancelled = true }
 
         // Create main navigation pane

--- a/src/main/kotlin/net/lumalyte/lg/interaction/menus/guild/GuildBankTransactionHistoryMenu.kt
+++ b/src/main/kotlin/net/lumalyte/lg/interaction/menus/guild/GuildBankTransactionHistoryMenu.kt
@@ -94,7 +94,7 @@ class GuildBankTransactionHistoryMenu(
      * Initialize the GUI structure
      */
     private fun initializeGui() {
-        gui = ChestGui(6, MenuTitleBuilder.build(guild.guiTheme, 6))
+        gui = ChestGui(6, MenuTitleBuilder.build(guild.guiTheme, 6, getLocalizedString(LocalizationKeys.MENU_BANK_HISTORY_TITLE, guild.name)))
         gui.setOnGlobalClick { event -> event.isCancelled = true }
 
         // Create main pane for navigation and filters
@@ -379,7 +379,7 @@ class GuildBankTransactionHistoryMenu(
         }
         val sortedMembers = members.sortedBy { memberNames[it.playerId]?.lowercase() }
 
-        val memberGui = ChestGui(6, MenuTitleBuilder.build(guild.guiTheme, 6))
+        val memberGui = ChestGui(6, MenuTitleBuilder.build(guild.guiTheme, 6, getLocalizedString(LocalizationKeys.MENU_BANK_HISTORY_TITLE, guild.name)))
         memberGui.setOnGlobalClick { event -> event.isCancelled = true }
 
         val memberPane = PaginatedPane(0, 0, 9, 5)

--- a/src/main/kotlin/net/lumalyte/lg/interaction/menus/guild/GuildBannerMenu.kt
+++ b/src/main/kotlin/net/lumalyte/lg/interaction/menus/guild/GuildBannerMenu.kt
@@ -50,7 +50,7 @@ class GuildBannerMenu(private val menuNavigator: MenuNavigator, private val play
         activeMenus.remove(player.uniqueId)
 
         // Create a 3x9 GUI for banner selection
-        val gui = ChestGui(3, MenuTitleBuilder.build(guild.guiTheme, 3))
+        val gui = ChestGui(3, MenuTitleBuilder.build(guild.guiTheme, 3, "§6Guild Banner - ${guild.name}"))
         val pane = StaticPane(0, 0, 9, 3)
         gui.setOnTopClick { guiEvent ->
             // Allow clicks on the banner placement slot (slot 11)

--- a/src/main/kotlin/net/lumalyte/lg/interaction/menus/guild/GuildControlPanelMenu.kt
+++ b/src/main/kotlin/net/lumalyte/lg/interaction/menus/guild/GuildControlPanelMenu.kt
@@ -44,7 +44,7 @@ class GuildControlPanelMenu(
             return
         }
 
-        val gui = ChestGui(6, MenuTitleBuilder.build(guild.guiTheme, 6))
+        val gui = ChestGui(6, MenuTitleBuilder.build(guild.guiTheme, 6, "§6Guild Control Panel - ${guild.name}"))
         val pane = StaticPane(0, 0, 9, 6)
         gui.setOnTopClick { guiEvent -> guiEvent.isCancelled = true }
         gui.setOnBottomClick { guiEvent -> if (guiEvent.click == ClickType.SHIFT_LEFT ||

--- a/src/main/kotlin/net/lumalyte/lg/interaction/menus/guild/GuildDashboard.kt
+++ b/src/main/kotlin/net/lumalyte/lg/interaction/menus/guild/GuildDashboard.kt
@@ -49,7 +49,7 @@ class GuildDashboard(
             return
         }
 
-        val gui = ChestGui(3, MenuTitleBuilder.build(guild.guiTheme, 3))
+        val gui = ChestGui(3, MenuTitleBuilder.build(guild.guiTheme, 3, "§0§8⚔ §7${guild.name}"))
         val pane = StaticPane(0, 0, 9, 3)
         gui.setOnTopClick { e -> e.isCancelled = true }
         gui.setOnBottomClick { e ->

--- a/src/main/kotlin/net/lumalyte/lg/interaction/menus/guild/GuildDisbandConfirmationMenu.kt
+++ b/src/main/kotlin/net/lumalyte/lg/interaction/menus/guild/GuildDisbandConfirmationMenu.kt
@@ -36,7 +36,7 @@ class GuildDisbandConfirmationMenu(
             return
         }
 
-        val gui = ChestGui(3, MenuTitleBuilder.build(guild.guiTheme, 3))
+        val gui = ChestGui(3, MenuTitleBuilder.build(guild.guiTheme, 3, "§c§lDisband ${guild.name}?"))
         val pane = StaticPane(0, 0, 9, 3)
         gui.setOnTopClick { e -> e.isCancelled = true }
         gui.setOnBottomClick { e ->

--- a/src/main/kotlin/net/lumalyte/lg/interaction/menus/guild/GuildEmojiMenu.kt
+++ b/src/main/kotlin/net/lumalyte/lg/interaction/menus/guild/GuildEmojiMenu.kt
@@ -77,7 +77,7 @@ class GuildEmojiMenu(private val menuNavigator: MenuNavigator, private val playe
         }
         println("[LumaGuilds] GuildEmojiMenu: Final validation result: ${validationError ?: "VALID"}")
 
-        val gui = ChestGui(3, MenuTitleBuilder.build(guild.guiTheme, 3))
+        val gui = ChestGui(3, MenuTitleBuilder.build(guild.guiTheme, 3, "§6Guild Emoji - ${guild.name}"))
         val pane = StaticPane(0, 0, 9, 3)
         gui.setOnTopClick { guiEvent -> guiEvent.isCancelled = true }
         gui.setOnBottomClick { guiEvent -> if (guiEvent.click == ClickType.SHIFT_LEFT ||
@@ -477,7 +477,7 @@ class EmojiSelectionMenu(
         val totalPages = (unlockedEmojis.size + itemsPerPage - 1) / itemsPerPage
 
         // Create double chest GUI (6 rows x 9 columns = 54 slots)
-        val gui = ChestGui(6, MenuTitleBuilder.build(guild.guiTheme, 6))
+        val gui = ChestGui(6, MenuTitleBuilder.build(guild.guiTheme, 6, "§6Select Emoji - Page ${currentPage + 1}/$totalPages"))
         val pane = StaticPane(0, 0, 9, 6)
         gui.setOnTopClick { guiEvent -> guiEvent.isCancelled = true }
         gui.setOnBottomClick { guiEvent ->

--- a/src/main/kotlin/net/lumalyte/lg/interaction/menus/guild/GuildHomeMenu.kt
+++ b/src/main/kotlin/net/lumalyte/lg/interaction/menus/guild/GuildHomeMenu.kt
@@ -34,7 +34,7 @@ class GuildHomeMenu(private val menuNavigator: MenuNavigator, private val player
     private val rankService: net.lumalyte.lg.application.services.RankService by inject()
 
     override fun open() {
-        val gui = ChestGui(6, MenuTitleBuilder.build(guild.guiTheme, 6))
+        val gui = ChestGui(6, MenuTitleBuilder.build(guild.guiTheme, 6, "§6Guild Homes - ${guild.name}"))
         val pane = StaticPane(0, 0, 9, 6)
         gui.setOnTopClick { guiEvent -> guiEvent.isCancelled = true }
         gui.setOnBottomClick { guiEvent ->
@@ -273,7 +273,7 @@ class GuildHomeMenu(private val menuNavigator: MenuNavigator, private val player
             return
         }
 
-        val gui = ChestGui(4, MenuTitleBuilder.build(guild.guiTheme, 4))
+        val gui = ChestGui(4, MenuTitleBuilder.build(guild.guiTheme, 4, "§cRemove Guild Homes"))
         val pane = StaticPane(0, 0, 9, 4)
 
         // Prevent moving items in the top or bottom inventory (same as main menu)

--- a/src/main/kotlin/net/lumalyte/lg/interaction/menus/guild/GuildInfoMenu.kt
+++ b/src/main/kotlin/net/lumalyte/lg/interaction/menus/guild/GuildInfoMenu.kt
@@ -41,7 +41,7 @@ class GuildInfoMenu(private val menuNavigator: MenuNavigator, private val player
     private val menuFactory: net.lumalyte.lg.interaction.menus.MenuFactory by inject()
 
     override fun open() {
-        val gui = ChestGui(6, MenuTitleBuilder.build(guild.guiTheme, 6))
+        val gui = ChestGui(6, MenuTitleBuilder.build(guild.guiTheme, 6, "§6Guild Info - ${guild.name}"))
         val pane = StaticPane(0, 0, 9, 6)
         gui.setOnTopClick { guiEvent -> guiEvent.isCancelled = true }
         gui.setOnBottomClick { guiEvent ->

--- a/src/main/kotlin/net/lumalyte/lg/interaction/menus/guild/GuildInviteConfirmationMenu.kt
+++ b/src/main/kotlin/net/lumalyte/lg/interaction/menus/guild/GuildInviteConfirmationMenu.kt
@@ -32,7 +32,7 @@ class GuildInviteConfirmationMenu(private val menuNavigator: MenuNavigator, priv
 
     override fun open() {
         // Create 3x9 chest GUI
-        val gui = ChestGui(3, MenuTitleBuilder.build(guild.guiTheme, 3))
+        val gui = ChestGui(3, MenuTitleBuilder.build(guild.guiTheme, 3, "§6Confirm Invite - ${guild.name}"))
         val pane = StaticPane(0, 0, 9, 3)
         gui.setOnTopClick { guiEvent -> guiEvent.isCancelled = true }
         gui.setOnBottomClick { guiEvent ->

--- a/src/main/kotlin/net/lumalyte/lg/interaction/menus/guild/GuildInviteMenu.kt
+++ b/src/main/kotlin/net/lumalyte/lg/interaction/menus/guild/GuildInviteMenu.kt
@@ -36,7 +36,7 @@ class GuildInviteMenu(private val menuNavigator: MenuNavigator, private val play
 
     override fun open() {
         // Create 3x9 chest GUI
-        val gui = ChestGui(3, MenuTitleBuilder.build(guild.guiTheme, 3))
+        val gui = ChestGui(3, MenuTitleBuilder.build(guild.guiTheme, 3, "§6Invite Player - ${guild.name}"))
         val pane = StaticPane(0, 0, 9, 3)
         gui.setOnTopClick { guiEvent -> guiEvent.isCancelled = true }
         gui.setOnBottomClick { guiEvent ->

--- a/src/main/kotlin/net/lumalyte/lg/interaction/menus/guild/GuildKickConfirmationMenu.kt
+++ b/src/main/kotlin/net/lumalyte/lg/interaction/menus/guild/GuildKickConfirmationMenu.kt
@@ -33,7 +33,7 @@ class GuildKickConfirmationMenu(private val menuNavigator: MenuNavigator, privat
 
     override fun open() {
         // Create 3x9 chest GUI
-        val gui = ChestGui(3, MenuTitleBuilder.build(guild.guiTheme, 3))
+        val gui = ChestGui(3, MenuTitleBuilder.build(guild.guiTheme, 3, "§6Confirm Kick - ${guild.name}"))
         val pane = StaticPane(0, 0, 9, 3)
         gui.setOnTopClick { guiEvent -> guiEvent.isCancelled = true }
         gui.setOnBottomClick { guiEvent ->

--- a/src/main/kotlin/net/lumalyte/lg/interaction/menus/guild/GuildKickMenu.kt
+++ b/src/main/kotlin/net/lumalyte/lg/interaction/menus/guild/GuildKickMenu.kt
@@ -38,7 +38,7 @@ class GuildKickMenu(private val menuNavigator: MenuNavigator, private val player
 
     override fun open() {
         // Create 6x9 double chest GUI
-        val gui = ChestGui(6, MenuTitleBuilder.build(guild.guiTheme, 6))
+        val gui = ChestGui(6, MenuTitleBuilder.build(guild.guiTheme, 6, "§6Kick Member - ${guild.name}"))
         val pane = StaticPane(0, 0, 9, 6)
         gui.setOnTopClick { guiEvent -> guiEvent.isCancelled = true }
         gui.setOnBottomClick { guiEvent ->

--- a/src/main/kotlin/net/lumalyte/lg/interaction/menus/guild/GuildLeaveConfirmationMenu.kt
+++ b/src/main/kotlin/net/lumalyte/lg/interaction/menus/guild/GuildLeaveConfirmationMenu.kt
@@ -28,7 +28,7 @@ class GuildLeaveConfirmationMenu(
     private val memberService: MemberService by inject()
 
     override fun open() {
-        val gui = ChestGui(3, MenuTitleBuilder.build(guild.guiTheme, 3))
+        val gui = ChestGui(3, MenuTitleBuilder.build(guild.guiTheme, 3, "§e§lLeave ${guild.name}?"))
         val pane = StaticPane(0, 0, 9, 3)
         gui.setOnTopClick { e -> e.isCancelled = true }
         gui.setOnBottomClick { e ->

--- a/src/main/kotlin/net/lumalyte/lg/interaction/menus/guild/GuildMemberContributionsMenu.kt
+++ b/src/main/kotlin/net/lumalyte/lg/interaction/menus/guild/GuildMemberContributionsMenu.kt
@@ -71,7 +71,7 @@ class GuildMemberContributionsMenu(
      * Initialize the GUI structure
      */
     private fun initializeGui() {
-        gui = ChestGui(6, MenuTitleBuilder.build(guild.guiTheme, 6))
+        gui = ChestGui(6, MenuTitleBuilder.build(guild.guiTheme, 6, "§6${guild.name} - Member Contributions"))
         gui.setOnGlobalClick { event -> event.isCancelled = true }
 
         // Create main pane for navigation

--- a/src/main/kotlin/net/lumalyte/lg/interaction/menus/guild/GuildMemberListMenu.kt
+++ b/src/main/kotlin/net/lumalyte/lg/interaction/menus/guild/GuildMemberListMenu.kt
@@ -31,7 +31,7 @@ class GuildMemberListMenu(private val menuNavigator: MenuNavigator, private val 
     private val rankService: RankService by inject()
 
     override fun open() {
-        val gui = ChestGui(6, MenuTitleBuilder.build(guild.guiTheme, 6))
+        val gui = ChestGui(6, MenuTitleBuilder.build(guild.guiTheme, 6, "§6${guild.name} - Members"))
         gui.setOnTopClick { it.isCancelled = true }
         gui.setOnBottomClick { event ->
             if (event.click == ClickType.SHIFT_LEFT || event.click == ClickType.SHIFT_RIGHT) {

--- a/src/main/kotlin/net/lumalyte/lg/interaction/menus/guild/GuildMemberManagementMenu.kt
+++ b/src/main/kotlin/net/lumalyte/lg/interaction/menus/guild/GuildMemberManagementMenu.kt
@@ -39,7 +39,7 @@ class GuildMemberManagementMenu(private val menuNavigator: MenuNavigator, privat
 
     override fun open() {
         // Create 6x9 double chest GUI
-        val gui = ChestGui(6, MenuTitleBuilder.build(guild.guiTheme, 6))
+        val gui = ChestGui(6, MenuTitleBuilder.build(guild.guiTheme, 6, "§6Member Management - ${guild.name}"))
         val pane = StaticPane(0, 0, 9, 6)
         gui.setOnTopClick { guiEvent -> guiEvent.isCancelled = true }
         gui.setOnBottomClick { guiEvent ->

--- a/src/main/kotlin/net/lumalyte/lg/interaction/menus/guild/GuildMemberRankConfirmationMenu.kt
+++ b/src/main/kotlin/net/lumalyte/lg/interaction/menus/guild/GuildMemberRankConfirmationMenu.kt
@@ -41,7 +41,7 @@ class GuildMemberRankConfirmationMenu(
     private val logger = LoggerFactory.getLogger(GuildMemberRankConfirmationMenu::class.java)
 
     override fun open() {
-        val gui = ChestGui(3, MenuTitleBuilder.build(guild.guiTheme, 3))
+        val gui = ChestGui(3, MenuTitleBuilder.build(guild.guiTheme, 3, "§6Confirm Rank Change"))
         val pane = StaticPane(0, 0, 9, 3)
         gui.setOnTopClick { guiEvent -> guiEvent.isCancelled = true }
         gui.setOnBottomClick { guiEvent ->

--- a/src/main/kotlin/net/lumalyte/lg/interaction/menus/guild/GuildMemberRankMenu.kt
+++ b/src/main/kotlin/net/lumalyte/lg/interaction/menus/guild/GuildMemberRankMenu.kt
@@ -44,7 +44,7 @@ class GuildMemberRankMenu(
     private val ranksPerPage = 9 // 3 columns × 3 rows (rows 1-3)
 
     override fun open() {
-        val gui = ChestGui(5, MenuTitleBuilder.build(guild.guiTheme, 5))
+        val gui = ChestGui(5, MenuTitleBuilder.build(guild.guiTheme, 5, "§6Rank Management"))
         val pane = StaticPane(0, 0, 9, 5)
         gui.setOnTopClick { guiEvent -> guiEvent.isCancelled = true }
         gui.setOnBottomClick { guiEvent ->

--- a/src/main/kotlin/net/lumalyte/lg/interaction/menus/guild/GuildModeMenu.kt
+++ b/src/main/kotlin/net/lumalyte/lg/interaction/menus/guild/GuildModeMenu.kt
@@ -42,7 +42,7 @@ class GuildModeMenu(private val menuNavigator: MenuNavigator, private val player
             return
         }
 
-        val gui = ChestGui(3, MenuTitleBuilder.build(guild.guiTheme, 3))
+        val gui = ChestGui(3, MenuTitleBuilder.build(guild.guiTheme, 3, "§6Change Guild Mode"))
         val pane = StaticPane(0, 0, 9, 3)
         gui.setOnTopClick { guiEvent -> guiEvent.isCancelled = true }
         gui.setOnBottomClick { guiEvent ->
@@ -62,7 +62,7 @@ class GuildModeMenu(private val menuNavigator: MenuNavigator, private val player
     }
 
     private fun showDisabledModeMenu() {
-        val gui = ChestGui(3, MenuTitleBuilder.build(guild.guiTheme, 3))
+        val gui = ChestGui(3, MenuTitleBuilder.build(guild.guiTheme, 3, "§6Change Guild Mode"))
         val pane = StaticPane(0, 0, 9, 3)
         gui.setOnTopClick { guiEvent -> guiEvent.isCancelled = true }
         gui.setOnBottomClick { guiEvent ->

--- a/src/main/kotlin/net/lumalyte/lg/interaction/menus/guild/GuildPartyManagementMenu.kt
+++ b/src/main/kotlin/net/lumalyte/lg/interaction/menus/guild/GuildPartyManagementMenu.kt
@@ -42,7 +42,7 @@ class GuildPartyManagementMenu(private val menuNavigator: MenuNavigator, private
             return
         }
 
-        val gui = ChestGui(6, MenuTitleBuilder.build(guild.guiTheme, 6))
+        val gui = ChestGui(6, MenuTitleBuilder.build(guild.guiTheme, 6, "§6Party Management - ${guild.name}"))
         val pane = StaticPane(0, 0, 9, 6)
         gui.setOnTopClick { guiEvent -> guiEvent.isCancelled = true }
         gui.setOnBottomClick { guiEvent ->
@@ -267,7 +267,7 @@ class GuildPartyManagementMenu(private val menuNavigator: MenuNavigator, private
         }
 
         // Create incoming requests menu
-        val gui = ChestGui(6, MenuTitleBuilder.build(guild.guiTheme, 6))
+        val gui = ChestGui(6, MenuTitleBuilder.build(guild.guiTheme, 6, "§6Party Management - ${guild.name}"))
         val pane = StaticPane(0, 0, 9, 6)
         gui.setOnTopClick { guiEvent -> guiEvent.isCancelled = true }
         gui.setOnBottomClick { guiEvent ->
@@ -350,7 +350,7 @@ class GuildPartyManagementMenu(private val menuNavigator: MenuNavigator, private
         }
 
         // Create outgoing requests menu
-        val gui = ChestGui(6, MenuTitleBuilder.build(guild.guiTheme, 6))
+        val gui = ChestGui(6, MenuTitleBuilder.build(guild.guiTheme, 6, "§6Party Management - ${guild.name}"))
         val pane = StaticPane(0, 0, 9, 6)
         gui.setOnTopClick { guiEvent -> guiEvent.isCancelled = true }
         gui.setOnBottomClick { guiEvent ->

--- a/src/main/kotlin/net/lumalyte/lg/interaction/menus/guild/GuildProgressionMenu.kt
+++ b/src/main/kotlin/net/lumalyte/lg/interaction/menus/guild/GuildProgressionMenu.kt
@@ -73,7 +73,7 @@ class GuildProgressionMenu(
         }
 
         val totalPages = (trackableSources.size + itemsPerPage - 1) / itemsPerPage
-        val gui = ChestGui(6, MenuTitleBuilder.build(guild.guiTheme, 6))
+        val gui = ChestGui(6, MenuTitleBuilder.build(guild.guiTheme, 6, "§0§8⭐ §7Guild Progression §8• Page ${currentPage + 1}/$totalPages"))
         val pane = StaticPane(0, 0, 9, 6)
         gui.setOnTopClick { e -> e.isCancelled = true }
         gui.setOnBottomClick { e ->

--- a/src/main/kotlin/net/lumalyte/lg/interaction/menus/guild/GuildPromotionMenu.kt
+++ b/src/main/kotlin/net/lumalyte/lg/interaction/menus/guild/GuildPromotionMenu.kt
@@ -54,7 +54,7 @@ class GuildPromotionMenu(
             return
         }
 
-        val gui = ChestGui(6, MenuTitleBuilder.build(guild.guiTheme, 6))
+        val gui = ChestGui(6, MenuTitleBuilder.build(guild.guiTheme, 6, "§6Members — ${guild.name}"))
         gui.setOnTopClick { e -> e.isCancelled = true }
         gui.setOnBottomClick { e ->
             if (e.click == ClickType.SHIFT_LEFT || e.click == ClickType.SHIFT_RIGHT)

--- a/src/main/kotlin/net/lumalyte/lg/interaction/menus/guild/GuildRankManagementMenu.kt
+++ b/src/main/kotlin/net/lumalyte/lg/interaction/menus/guild/GuildRankManagementMenu.kt
@@ -44,7 +44,7 @@ class GuildRankManagementMenu(private val menuNavigator: MenuNavigator, private 
             return
         }
 
-        val gui = ChestGui(5, MenuTitleBuilder.build(guild.guiTheme, 5))
+        val gui = ChestGui(5, MenuTitleBuilder.build(guild.guiTheme, 5, "§6Rank Management - ${guild.name}"))
         val pane = StaticPane(0, 0, 9, 5)
         gui.setOnTopClick { guiEvent -> guiEvent.isCancelled = true }
         gui.setOnBottomClick { guiEvent -> if (guiEvent.click == ClickType.SHIFT_LEFT ||

--- a/src/main/kotlin/net/lumalyte/lg/interaction/menus/guild/GuildRelationsMenu.kt
+++ b/src/main/kotlin/net/lumalyte/lg/interaction/menus/guild/GuildRelationsMenu.kt
@@ -30,7 +30,7 @@ class GuildRelationsMenu(private val menuNavigator: MenuNavigator, private val p
     private val menuFactory: net.lumalyte.lg.interaction.menus.MenuFactory by inject()
 
     override fun open() {
-        val gui = ChestGui(6, MenuTitleBuilder.build(guild.guiTheme, 6))
+        val gui = ChestGui(6, MenuTitleBuilder.build(guild.guiTheme, 6, "§bDiplomatic Relations - ${guild.name}"))
         val pane = StaticPane(0, 0, 9, 6)
         gui.setOnTopClick { guiEvent -> guiEvent.isCancelled = true }
         gui.setOnBottomClick { guiEvent ->

--- a/src/main/kotlin/net/lumalyte/lg/interaction/menus/guild/GuildSelectionMenu.kt
+++ b/src/main/kotlin/net/lumalyte/lg/interaction/menus/guild/GuildSelectionMenu.kt
@@ -39,7 +39,7 @@ class GuildSelectionMenu(
     private val itemsPerPage = 45 // 9x5 grid
 
     override fun open() {
-        val gui = ChestGui(6, MenuTitleBuilder.build(GuiTheme.NEUTRAL, 6))
+        val gui = ChestGui(6, MenuTitleBuilder.build(GuiTheme.NEUTRAL, 6, "§6Select Guilds to Invite"))
         val pane = StaticPane(0, 0, 9, 6)
         gui.setOnTopClick { guiEvent -> guiEvent.isCancelled = true }
         gui.setOnBottomClick { guiEvent ->

--- a/src/main/kotlin/net/lumalyte/lg/interaction/menus/guild/GuildSettingsMenu.kt
+++ b/src/main/kotlin/net/lumalyte/lg/interaction/menus/guild/GuildSettingsMenu.kt
@@ -48,7 +48,7 @@ class GuildSettingsMenu(
         guild = guildService.getGuild(guild.id) ?: guild
 
         // Create 6x9 double chest GUI
-        val gui = ChestGui(6, MenuTitleBuilder.build(guild.guiTheme, 6))
+        val gui = ChestGui(6, MenuTitleBuilder.build(guild.guiTheme, 6, "§6Guild Settings - ${guild.name}"))
         val pane = StaticPane(0, 0, 9, 6)
         gui.setOnTopClick { guiEvent -> guiEvent.isCancelled = true }
         gui.setOnBottomClick { guiEvent ->
@@ -497,7 +497,7 @@ class GuildSettingsMenu(
      * with the new theme applied.
      */
     private fun openThemeSelector() {
-        val gui = ChestGui(1, MenuTitleBuilder.build(guild.guiTheme, 1))
+        val gui = ChestGui(1, MenuTitleBuilder.build(guild.guiTheme, 1, "§6Guild Settings - ${guild.name}"))
         val pane = StaticPane(0, 0, 9, 1)
         gui.setOnGlobalClick { it.isCancelled = true }
         gui.addPane(pane)

--- a/src/main/kotlin/net/lumalyte/lg/interaction/menus/guild/GuildStatisticsMenu.kt
+++ b/src/main/kotlin/net/lumalyte/lg/interaction/menus/guild/GuildStatisticsMenu.kt
@@ -43,7 +43,7 @@ class GuildStatisticsMenu(private val menuNavigator: MenuNavigator, private val 
     private val decimalFormat = DecimalFormat("#.##")
 
     override fun open() {
-        val gui = ChestGui(6, MenuTitleBuilder.build(guild.guiTheme, 6))
+        val gui = ChestGui(6, MenuTitleBuilder.build(guild.guiTheme, 6, "§6${guild.name} - Statistics"))
         gui.setOnTopClick { guiEvent -> guiEvent.isCancelled = true }
         gui.setOnBottomClick { guiEvent ->
             if (guiEvent.click == ClickType.SHIFT_LEFT || guiEvent.click == ClickType.SHIFT_RIGHT)
@@ -254,7 +254,7 @@ class GuildStatisticsMenu(private val menuNavigator: MenuNavigator, private val 
         try {
             val killStats = killService.getGuildKillStats(guild.id)
 
-            val gui = ChestGui(4, MenuTitleBuilder.build(guild.guiTheme, 4))
+            val gui = ChestGui(4, MenuTitleBuilder.build(guild.guiTheme, 4, "§6${guild.name} - Statistics"))
             gui.setOnTopClick { guiEvent -> guiEvent.isCancelled = true }
             gui.setOnBottomClick { guiEvent ->
                 if (guiEvent.click == ClickType.SHIFT_LEFT || guiEvent.click == ClickType.SHIFT_RIGHT)
@@ -290,7 +290,7 @@ class GuildStatisticsMenu(private val menuNavigator: MenuNavigator, private val 
             val activeWars = warService.getWarsForGuild(guild.id).filter { it.isActive }
             val warHistory = warService.getWarHistory(guild.id, 20)
 
-            val gui = ChestGui(6, MenuTitleBuilder.build(guild.guiTheme, 6))
+            val gui = ChestGui(6, MenuTitleBuilder.build(guild.guiTheme, 6, "§6${guild.name} - Statistics"))
             val pane = StaticPane(0, 0, 9, 6)
             gui.setOnTopClick { guiEvent -> guiEvent.isCancelled = true }
             gui.setOnBottomClick { guiEvent ->
@@ -501,7 +501,7 @@ class GuildStatisticsMenu(private val menuNavigator: MenuNavigator, private val 
             val members = memberService.getGuildMembers(guild.id)
             val memberCount = memberService.getMemberCount(guild.id)
 
-            val gui = ChestGui(5, MenuTitleBuilder.build(guild.guiTheme, 5))
+            val gui = ChestGui(5, MenuTitleBuilder.build(guild.guiTheme, 5, "§6${guild.name} - Statistics"))
             gui.setOnTopClick { guiEvent -> guiEvent.isCancelled = true }
             gui.setOnBottomClick { guiEvent ->
                 if (guiEvent.click == ClickType.SHIFT_LEFT || guiEvent.click == ClickType.SHIFT_RIGHT)
@@ -558,7 +558,7 @@ class GuildStatisticsMenu(private val menuNavigator: MenuNavigator, private val 
             val avgKillsPerMember = if (memberCount > 0) killStats.totalKills.toDouble() / memberCount else 0.0
             val avgDeathsPerMember = if (memberCount > 0) killStats.totalDeaths.toDouble() / memberCount else 0.0
 
-            val gui = ChestGui(4, MenuTitleBuilder.build(guild.guiTheme, 4))
+            val gui = ChestGui(4, MenuTitleBuilder.build(guild.guiTheme, 4, "§6${guild.name} - Statistics"))
             gui.setOnTopClick { guiEvent -> guiEvent.isCancelled = true }
             gui.setOnBottomClick { guiEvent ->
                 if (guiEvent.click == ClickType.SHIFT_LEFT || guiEvent.click == ClickType.SHIFT_RIGHT)
@@ -880,7 +880,7 @@ class GuildStatisticsMenu(private val menuNavigator: MenuNavigator, private val 
             val guildMembers = memberService.getGuildMembers(guild.id).map { it.playerId }
             val topKillers = killService.getTopKillers(guildMembers, 10)
 
-            val gui = ChestGui(5, MenuTitleBuilder.build(guild.guiTheme, 5))
+            val gui = ChestGui(5, MenuTitleBuilder.build(guild.guiTheme, 5, "§6${guild.name} - Statistics"))
             gui.setOnTopClick { guiEvent -> guiEvent.isCancelled = true }
             gui.setOnBottomClick { guiEvent ->
                 if (guiEvent.click == ClickType.SHIFT_LEFT || guiEvent.click == ClickType.SHIFT_RIGHT)
@@ -924,7 +924,7 @@ class GuildStatisticsMenu(private val menuNavigator: MenuNavigator, private val 
                 .sortedByDescending { it.netContribution }
                 .take(10)
 
-            val gui = ChestGui(5, MenuTitleBuilder.build(guild.guiTheme, 5))
+            val gui = ChestGui(5, MenuTitleBuilder.build(guild.guiTheme, 5, "§6${guild.name} - Statistics"))
             gui.setOnTopClick { guiEvent -> guiEvent.isCancelled = true }
             gui.setOnBottomClick { guiEvent ->
                 if (guiEvent.click == ClickType.SHIFT_LEFT || guiEvent.click == ClickType.SHIFT_RIGHT)
@@ -964,7 +964,7 @@ class GuildStatisticsMenu(private val menuNavigator: MenuNavigator, private val 
         try {
             val killStats = killService.getGuildKillStats(guild.id)
 
-            val gui = ChestGui(4, MenuTitleBuilder.build(guild.guiTheme, 4))
+            val gui = ChestGui(4, MenuTitleBuilder.build(guild.guiTheme, 4, "§6${guild.name} - Statistics"))
             gui.setOnTopClick { guiEvent -> guiEvent.isCancelled = true }
             gui.setOnBottomClick { guiEvent ->
                 if (guiEvent.click == ClickType.SHIFT_LEFT || guiEvent.click == ClickType.SHIFT_RIGHT)
@@ -1000,7 +1000,7 @@ class GuildStatisticsMenu(private val menuNavigator: MenuNavigator, private val 
         try {
             val recentKills = killService.getRecentGuildKills(guild.id, 15)
 
-            val gui = ChestGui(5, MenuTitleBuilder.build(guild.guiTheme, 5))
+            val gui = ChestGui(5, MenuTitleBuilder.build(guild.guiTheme, 5, "§6${guild.name} - Statistics"))
             gui.setOnTopClick { guiEvent -> guiEvent.isCancelled = true }
             gui.setOnBottomClick { guiEvent ->
                 if (guiEvent.click == ClickType.SHIFT_LEFT || guiEvent.click == ClickType.SHIFT_RIGHT)

--- a/src/main/kotlin/net/lumalyte/lg/interaction/menus/guild/GuildStrikePenaltyConfirmMenu.kt
+++ b/src/main/kotlin/net/lumalyte/lg/interaction/menus/guild/GuildStrikePenaltyConfirmMenu.kt
@@ -39,7 +39,7 @@ class GuildStrikePenaltyConfirmMenu(
     private val menuFactory: net.lumalyte.lg.interaction.menus.MenuFactory by inject()
 
     override fun open() {
-        val gui = ChestGui(3, MenuTitleBuilder.build(guild.guiTheme, 3))
+        val gui = ChestGui(3, MenuTitleBuilder.build(guild.guiTheme, 3, "§4§lConfirm - ${penaltyType.name.replace('_', ' ')}"))
         val pane = StaticPane(0, 0, 9, 3)
         gui.setOnTopClick { event -> event.isCancelled = true }
         gui.setOnBottomClick { event ->

--- a/src/main/kotlin/net/lumalyte/lg/interaction/menus/guild/GuildStrikePenaltyMenu.kt
+++ b/src/main/kotlin/net/lumalyte/lg/interaction/menus/guild/GuildStrikePenaltyMenu.kt
@@ -39,7 +39,7 @@ class GuildStrikePenaltyMenu(
     private val penaltyService: PenaltyService by inject()
 
     override fun open() {
-        val gui = ChestGui(6, MenuTitleBuilder.build(guild.guiTheme, 6))
+        val gui = ChestGui(6, MenuTitleBuilder.build(guild.guiTheme, 6, "§4§lPenalties - ${GuildResolver.displayName(guild)}"))
         val pane = StaticPane(0, 0, 9, 6)
         gui.setOnTopClick { event -> event.isCancelled = true }
         gui.setOnBottomClick { event ->

--- a/src/main/kotlin/net/lumalyte/lg/interaction/menus/guild/GuildWarAcceptanceMenu.kt
+++ b/src/main/kotlin/net/lumalyte/lg/interaction/menus/guild/GuildWarAcceptanceMenu.kt
@@ -58,7 +58,7 @@ class GuildWarAcceptanceMenu(
             return
         }
 
-        val gui = ChestGui(5, MenuTitleBuilder.build(guild.guiTheme, 5))
+        val gui = ChestGui(5, MenuTitleBuilder.build(guild.guiTheme, 5, "§4⚔ War Declaration - ${guild.name}"))
         val pane = StaticPane(0, 0, 9, 5)
         gui.setOnTopClick { guiEvent -> guiEvent.isCancelled = true }
         gui.setOnBottomClick { guiEvent ->

--- a/src/main/kotlin/net/lumalyte/lg/interaction/menus/guild/GuildWarDeclarationMenu.kt
+++ b/src/main/kotlin/net/lumalyte/lg/interaction/menus/guild/GuildWarDeclarationMenu.kt
@@ -77,7 +77,7 @@ class GuildWarDeclarationMenu(
             return
         }
 
-        val gui = ChestGui(6, MenuTitleBuilder.build(guild.guiTheme, 6))
+        val gui = ChestGui(6, MenuTitleBuilder.build(guild.guiTheme, 6, "§4⚔ Declare War - ${guild.name}"))
         val pane = StaticPane(0, 0, 9, 6)
         gui.setOnTopClick { guiEvent -> guiEvent.isCancelled = true }
         gui.setOnBottomClick { guiEvent ->

--- a/src/main/kotlin/net/lumalyte/lg/interaction/menus/guild/GuildWarManagementMenu.kt
+++ b/src/main/kotlin/net/lumalyte/lg/interaction/menus/guild/GuildWarManagementMenu.kt
@@ -29,7 +29,7 @@ class GuildWarManagementMenu(private val menuNavigator: MenuNavigator, private v
     private val menuFactory: net.lumalyte.lg.interaction.menus.MenuFactory by inject()
 
     override fun open() {
-        val gui = ChestGui(6, MenuTitleBuilder.build(guild.guiTheme, 6))
+        val gui = ChestGui(6, MenuTitleBuilder.build(guild.guiTheme, 6, "§4War Management - ${guild.name}"))
         val pane = StaticPane(0, 0, 9, 6)
         gui.setOnTopClick { guiEvent -> guiEvent.isCancelled = true }
         gui.setOnBottomClick { guiEvent ->

--- a/src/main/kotlin/net/lumalyte/lg/interaction/menus/guild/HomeAccessMenu.kt
+++ b/src/main/kotlin/net/lumalyte/lg/interaction/menus/guild/HomeAccessMenu.kt
@@ -46,7 +46,7 @@ class HomeAccessMenu(
             return
         }
 
-        val gui = ChestGui(4, MenuTitleBuilder.build(guild.guiTheme, 4))
+        val gui = ChestGui(4, MenuTitleBuilder.build(guild.guiTheme, 4, "§6Access: $homeName"))
         val pane = StaticPane(0, 0, 9, 4)
         gui.setOnTopClick { it.isCancelled = true }
         gui.setOnBottomClick {

--- a/src/main/kotlin/net/lumalyte/lg/interaction/menus/guild/IncomingRequestsMenu.kt
+++ b/src/main/kotlin/net/lumalyte/lg/interaction/menus/guild/IncomingRequestsMenu.kt
@@ -43,7 +43,7 @@ class IncomingRequestsMenu(
     private val itemsPerPage = 28 // 4 rows x 7 columns
 
     override fun open() {
-        val gui = ChestGui(6, MenuTitleBuilder.build(guild.guiTheme, 6))
+        val gui = ChestGui(6, MenuTitleBuilder.build(guild.guiTheme, 6, "§6Incoming Relation Requests"))
         val pane = StaticPane(0, 0, 9, 6)
         gui.setOnTopClick { guiEvent -> guiEvent.isCancelled = true }
         gui.setOnBottomClick { guiEvent ->
@@ -153,7 +153,7 @@ class IncomingRequestsMenu(
 
     private fun openRequestActionMenu(relation: Relation) {
         // Create a small menu with accept/reject options
-        val gui = ChestGui(3, MenuTitleBuilder.build(guild.guiTheme, 3))
+        val gui = ChestGui(3, MenuTitleBuilder.build(guild.guiTheme, 3, "§6Incoming Relation Requests"))
         val pane = StaticPane(0, 0, 9, 3)
         gui.setOnTopClick { guiEvent -> guiEvent.isCancelled = true }
         gui.setOnBottomClick { guiEvent ->

--- a/src/main/kotlin/net/lumalyte/lg/interaction/menus/guild/JoinRequirementsMenu.kt
+++ b/src/main/kotlin/net/lumalyte/lg/interaction/menus/guild/JoinRequirementsMenu.kt
@@ -41,7 +41,7 @@ class JoinRequirementsMenu(
     private val menuFactory: net.lumalyte.lg.interaction.menus.MenuFactory by inject()
 
     override fun open() {
-        val gui = ChestGui(3, MenuTitleBuilder.build(guild.guiTheme, 3))
+        val gui = ChestGui(3, MenuTitleBuilder.build(guild.guiTheme, 3, "Join ${guild.name}"))
         val pane = StaticPane(0, 0, 9, 3)
         gui.setOnTopClick { guiEvent -> guiEvent.isCancelled = true }
         gui.setOnBottomClick { guiEvent ->

--- a/src/main/kotlin/net/lumalyte/lg/interaction/menus/guild/LfgBrowserMenu.kt
+++ b/src/main/kotlin/net/lumalyte/lg/interaction/menus/guild/LfgBrowserMenu.kt
@@ -37,7 +37,7 @@ class LfgBrowserMenu(
     private val menuFactory: net.lumalyte.lg.interaction.menus.MenuFactory by inject()
 
     override fun open() {
-        val gui = ChestGui(6, MenuTitleBuilder.build(GuiTheme.NEUTRAL, 6))
+        val gui = ChestGui(6, MenuTitleBuilder.build(GuiTheme.NEUTRAL, 6, "Guild Browser - Looking For Guild"))
         gui.setOnTopClick { guiEvent -> guiEvent.isCancelled = true }
         gui.setOnBottomClick { guiEvent ->
             if (guiEvent.click == org.bukkit.event.inventory.ClickType.SHIFT_LEFT ||

--- a/src/main/kotlin/net/lumalyte/lg/interaction/menus/guild/OutgoingRequestsMenu.kt
+++ b/src/main/kotlin/net/lumalyte/lg/interaction/menus/guild/OutgoingRequestsMenu.kt
@@ -43,7 +43,7 @@ class OutgoingRequestsMenu(
     private val itemsPerPage = 28 // 4 rows x 7 columns
 
     override fun open() {
-        val gui = ChestGui(6, MenuTitleBuilder.build(guild.guiTheme, 6))
+        val gui = ChestGui(6, MenuTitleBuilder.build(guild.guiTheme, 6, "§6Outgoing Relation Requests"))
         val pane = StaticPane(0, 0, 9, 6)
         gui.setOnTopClick { guiEvent -> guiEvent.isCancelled = true }
         gui.setOnBottomClick { guiEvent ->
@@ -154,7 +154,7 @@ class OutgoingRequestsMenu(
 
     private fun openCancelConfirmMenu(relation: Relation) {
         // Create a small menu with confirm cancel
-        val gui = ChestGui(3, MenuTitleBuilder.build(guild.guiTheme, 3))
+        val gui = ChestGui(3, MenuTitleBuilder.build(guild.guiTheme, 3, "§6Cancel Request?"))
         val pane = StaticPane(0, 0, 9, 3)
         gui.setOnTopClick { guiEvent -> guiEvent.isCancelled = true }
         gui.setOnBottomClick { guiEvent ->

--- a/src/main/kotlin/net/lumalyte/lg/interaction/menus/guild/PartyCreationMenu.kt
+++ b/src/main/kotlin/net/lumalyte/lg/interaction/menus/guild/PartyCreationMenu.kt
@@ -56,7 +56,7 @@ class PartyCreationMenu(
             return
         }
 
-        val gui = ChestGui(6, MenuTitleBuilder.build(guild.guiTheme, 6))
+        val gui = ChestGui(6, MenuTitleBuilder.build(guild.guiTheme, 6, "§6Create New Party - ${guild.name}"))
         val pane = StaticPane(0, 0, 9, 6)
         gui.setOnTopClick { guiEvent -> guiEvent.isCancelled = true }
         gui.setOnBottomClick { guiEvent ->

--- a/src/main/kotlin/net/lumalyte/lg/interaction/menus/guild/PartyModerationMenu.kt
+++ b/src/main/kotlin/net/lumalyte/lg/interaction/menus/guild/PartyModerationMenu.kt
@@ -53,7 +53,7 @@ class PartyModerationMenu(
             return
         }
 
-        val gui = ChestGui(6, MenuTitleBuilder.build(guild.guiTheme, 6))
+        val gui = ChestGui(6, MenuTitleBuilder.build(guild.guiTheme, 6, "§6Moderate: ${party.name ?: "Channel"}"))
         val pane = StaticPane(0, 0, 9, 6)
         gui.setOnTopClick { guiEvent -> guiEvent.isCancelled = true }
         gui.setOnBottomClick { guiEvent ->

--- a/src/main/kotlin/net/lumalyte/lg/interaction/menus/guild/PeaceAgreementMenu.kt
+++ b/src/main/kotlin/net/lumalyte/lg/interaction/menus/guild/PeaceAgreementMenu.kt
@@ -57,7 +57,7 @@ class PeaceAgreementMenu(
             return
         }
 
-        val gui = ChestGui(6, MenuTitleBuilder.build(guild.guiTheme, 6))
+        val gui = ChestGui(6, MenuTitleBuilder.build(guild.guiTheme, 6, "§6Peace Agreements - ${guild.name}"))
         val pane = StaticPane(0, 0, 9, 6)
         gui.setOnTopClick { guiEvent -> guiEvent.isCancelled = true }
         gui.setOnBottomClick { guiEvent ->
@@ -223,7 +223,7 @@ class PeaceAgreementMenu(
             offeringExp = 0
         }
 
-        val gui = ChestGui(4, MenuTitleBuilder.build(guild.guiTheme, 4))
+        val gui = ChestGui(4, MenuTitleBuilder.build(guild.guiTheme, 4, "§6Peace Agreements - ${guild.name}"))
         val pane = StaticPane(0, 0, 9, 4)
         gui.setOnTopClick { guiEvent -> guiEvent.isCancelled = true }
         gui.setOnBottomClick { guiEvent ->

--- a/src/main/kotlin/net/lumalyte/lg/interaction/menus/guild/PermissionCategoryMenu.kt
+++ b/src/main/kotlin/net/lumalyte/lg/interaction/menus/guild/PermissionCategoryMenu.kt
@@ -46,7 +46,7 @@ class PermissionCategoryMenu(private val menuNavigator: MenuNavigator, private v
             return
         }
 
-        val gui = ChestGui(6, MenuTitleBuilder.build(guild.guiTheme, 6))
+        val gui = ChestGui(6, MenuTitleBuilder.build(guild.guiTheme, 6, "§6$categoryName - ${rank.name}"))
         val pane = StaticPane(0, 0, 9, 6)
         gui.setOnTopClick { guiEvent -> guiEvent.isCancelled = true }
         gui.setOnBottomClick { guiEvent ->

--- a/src/main/kotlin/net/lumalyte/lg/interaction/menus/guild/PlayerModerationMenu.kt
+++ b/src/main/kotlin/net/lumalyte/lg/interaction/menus/guild/PlayerModerationMenu.kt
@@ -51,7 +51,7 @@ class PlayerModerationMenu(
         }
 
         val targetName = Bukkit.getOfflinePlayer(targetPlayerId).name ?: "Unknown Player"
-        val gui = ChestGui(3, MenuTitleBuilder.build(guild.guiTheme, 3))
+        val gui = ChestGui(3, MenuTitleBuilder.build(guild.guiTheme, 3, "§6Moderate: $targetName"))
         val pane = StaticPane(0, 0, 9, 3)
         gui.setOnTopClick { guiEvent -> guiEvent.isCancelled = true }
         gui.setOnBottomClick { guiEvent ->

--- a/src/main/kotlin/net/lumalyte/lg/interaction/menus/guild/RankCreationMenu.kt
+++ b/src/main/kotlin/net/lumalyte/lg/interaction/menus/guild/RankCreationMenu.kt
@@ -53,7 +53,7 @@ class RankCreationMenu(private val menuNavigator: MenuNavigator, private val pla
             return
         }
 
-        val gui = ChestGui(6, MenuTitleBuilder.build(guild.guiTheme, 6))
+        val gui = ChestGui(6, MenuTitleBuilder.build(guild.guiTheme, 6, "§6Create New Rank - ${guild.name}"))
         val pane = StaticPane(0, 0, 9, 6)
         gui.setOnTopClick { guiEvent -> guiEvent.isCancelled = true }
         gui.setOnBottomClick { guiEvent ->

--- a/src/main/kotlin/net/lumalyte/lg/interaction/menus/guild/RankEditMenu.kt
+++ b/src/main/kotlin/net/lumalyte/lg/interaction/menus/guild/RankEditMenu.kt
@@ -147,7 +147,7 @@ class RankEditMenu(private val menuNavigator: MenuNavigator, private val player:
             return
         }
 
-        val gui = ChestGui(6, MenuTitleBuilder.build(guild.guiTheme, 6))
+        val gui = ChestGui(6, MenuTitleBuilder.build(guild.guiTheme, 6, "§6Edit Rank: ${rank.name}"))
         val pane = StaticPane(0, 0, 9, 6)
         gui.setOnTopClick { guiEvent -> guiEvent.isCancelled = true }
         gui.setOnBottomClick { guiEvent ->

--- a/src/main/kotlin/net/lumalyte/lg/interaction/menus/guild/TagEditorMenu.kt
+++ b/src/main/kotlin/net/lumalyte/lg/interaction/menus/guild/TagEditorMenu.kt
@@ -71,7 +71,7 @@ class TagEditorMenu(private val menuNavigator: MenuNavigator, private val player
         }
 
         // Create 3x9 chest GUI
-        val gui = ChestGui(3, MenuTitleBuilder.build(guild.guiTheme, 3))
+        val gui = ChestGui(3, MenuTitleBuilder.build(guild.guiTheme, 3, "§6Tag Editor - ${guild.name}"))
         val pane = StaticPane(0, 0, 9, 3)
         gui.setOnTopClick { guiEvent -> guiEvent.isCancelled = true }
         gui.setOnBottomClick { guiEvent ->

--- a/src/main/kotlin/net/lumalyte/lg/interaction/menus/guild/TruceRequestMenu.kt
+++ b/src/main/kotlin/net/lumalyte/lg/interaction/menus/guild/TruceRequestMenu.kt
@@ -49,7 +49,7 @@ class TruceRequestMenu(
             return
         }
 
-        val gui = ChestGui(6, MenuTitleBuilder.build(guild.guiTheme, 6))
+        val gui = ChestGui(6, MenuTitleBuilder.build(guild.guiTheme, 6, "§eRequest Truce"))
         val pane = StaticPane(0, 0, 9, 6)
         gui.setOnTopClick { guiEvent -> guiEvent.isCancelled = true }
         gui.setOnBottomClick { guiEvent ->
@@ -147,7 +147,7 @@ class TruceRequestMenu(
     }
 
     private fun openDurationSelection(targetGuild: Guild) {
-        val gui = ChestGui(3, MenuTitleBuilder.build(guild.guiTheme, 3))
+        val gui = ChestGui(3, MenuTitleBuilder.build(guild.guiTheme, 3, "§eSelect Truce Duration"))
         val pane = StaticPane(0, 0, 9, 3)
         gui.setOnTopClick { guiEvent -> guiEvent.isCancelled = true }
         gui.setOnBottomClick { guiEvent ->

--- a/src/main/kotlin/net/lumalyte/lg/interaction/menus/guild/WarGuildSelectionMenu.kt
+++ b/src/main/kotlin/net/lumalyte/lg/interaction/menus/guild/WarGuildSelectionMenu.kt
@@ -38,7 +38,7 @@ class WarGuildSelectionMenu(
         val totalPages = (availableGuilds.size + GUILDS_PER_PAGE - 1) / GUILDS_PER_PAGE
         val actualPage = currentPage.coerceIn(0, (totalPages - 1).coerceAtLeast(0))
 
-        val gui = ChestGui(6, MenuTitleBuilder.build(GuiTheme.NEUTRAL, 6))
+        val gui = ChestGui(6, MenuTitleBuilder.build(GuiTheme.NEUTRAL, 6, "§4⚔ Select War Target (${actualPage + 1}/$totalPages)"))
         val pane = StaticPane(0, 0, 9, 6)
         gui.setOnTopClick { it.isCancelled = true }
         gui.setOnBottomClick { if (it.click == ClickType.SHIFT_LEFT || it.click == ClickType.SHIFT_RIGHT) it.isCancelled = true }

--- a/src/main/kotlin/net/lumalyte/lg/interaction/menus/guild/WarObjectivesSelectionMenu.kt
+++ b/src/main/kotlin/net/lumalyte/lg/interaction/menus/guild/WarObjectivesSelectionMenu.kt
@@ -34,7 +34,7 @@ class WarObjectivesSelectionMenu(
     override fun open() {
         val claimsEnabled = configService.loadConfig().claimsEnabled
 
-        val gui = ChestGui(5, MenuTitleBuilder.build(GuiTheme.NEUTRAL, 5))
+        val gui = ChestGui(5, MenuTitleBuilder.build(GuiTheme.NEUTRAL, 5, "§6⚔ War Objectives"))
         val pane = StaticPane(0, 0, 9, 5)
         gui.setOnTopClick { it.isCancelled = true }
         gui.setOnBottomClick { if (it.click == ClickType.SHIFT_LEFT || it.click == ClickType.SHIFT_RIGHT) it.isCancelled = true }

--- a/src/main/kotlin/net/lumalyte/lg/utils/MenuTitleBuilder.kt
+++ b/src/main/kotlin/net/lumalyte/lg/utils/MenuTitleBuilder.kt
@@ -6,41 +6,52 @@ package net.lumalyte.lg.utils
  *
  * The themed PNGs have their artwork at canvas origin (0,0) within
  * a 256x256 transparent canvas. The content measures 176 pixels
- * wide x rowHeight tall (e.g. 168 px for 3 rows).
+ * wide x rowHeight tall.
  *
- * To align this artwork with the native Minecraft inventory window
- * (also 176 px wide):
+ * Title component structure:
  *
- *   shift:20  moves the cursor right by 20 pixels so the 176-wide
- *             artwork starts at column 0 of the window.
+ *   <shift:-7>                    calibrated horizontal offset
+ *   <glyph:guild_bg_<theme>_<R>>  background overlay (advances cursor ~256px)
+ *   <shift:-241>                  rewind cursor back to ~8px from default start
+ *   §f<title>                     visible title text in the top bar
  *
- *   ascent: 12  must be set on each glyph in the Nexo resource pack
- *               (the font baseline is ~12 px from the window top).
+ * The rewind value of -241 is calculated as:
+ *   want D + 8 (title margin) - (D - 7 + 256) = -241
+ *   where D = default cursor start, 256 = glyph texture width
  *
  * DO NOT use the neutral theme as a positioning reference — its
  * assets are oversized and are being corrected separately.
  *
  * Glyph naming: guild_bg_<theme>_<rows>_row
- * e.g. guild_bg_neutral_3_row, guild_bg_emberstone_4_row
  */
 object MenuTitleBuilder {
 
-    /** Horizontal prefix that places the glyph at the window origin. */
-    private const val GLYPH_PREFIX: String = "<shift:-7>"
+    /** Calibrated horizontal offset placing the glyph at the window origin. */
+    private const val HORIZONTAL_OFFSET: String = "<shift:-8>"
+
+    /** Rewind past the 256-pixel glyph advance + advance to title margin. */
+    private const val REWIND_TO_TITLE: String = "<shift:-241>"
 
     /**
      * Returns a ChestGui title string that renders a Nexo font-glyph
-     * background overlay for the given theme and row count.
+     * background with an optional visible title in the top bar.
      *
-     * Result: <shift:-8><glyph:guild_bg_<theme>_<rows>_row>
+     * Result:
+     *   <shift:-7><glyph:guild_bg_<theme>_<R>_row><shift:-241>§f<title>
      *
      * @param theme  GUI background theme (default: NEUTRAL)
      * @param rows   Inventory row count (3-6)
+     * @param title  Optional visible title text (default: empty = no title)
      * @return       Title string for the ChestGui constructor.
      */
-    fun build(theme: GuiTheme = GuiTheme.NEUTRAL, rows: Int): String {
+    fun build(theme: GuiTheme = GuiTheme.NEUTRAL, rows: Int, title: String = ""): String {
         val themeKey = theme.name.lowercase()
         val glyphName = "guild_bg_${themeKey}_${rows}_row"
-        return "${GLYPH_PREFIX}<glyph:${glyphName}>"
+        val prefix = "${HORIZONTAL_OFFSET}<glyph:${glyphName}>"
+        return if (title.isNotEmpty()) {
+            "${prefix}${REWIND_TO_TITLE}§f${title}"
+        } else {
+            prefix
+        }
     }
 }

--- a/src/test/kotlin/net/lumalyte/lg/utils/MenuTitleBuilderTest.kt
+++ b/src/test/kotlin/net/lumalyte/lg/utils/MenuTitleBuilderTest.kt
@@ -14,6 +14,8 @@ import org.junit.jupiter.params.provider.CsvSource
  * - Positioning prefix is deterministic and independent of slots/contents
  * - The prefix is identical for every theme and row count
  * - The glyph name correctly reflects the row count
+ * - Visible title text appears after the rewind shift when supplied
+ * - No-title path still produces a clean background-only string
  */
 class MenuTitleBuilderTest {
 
@@ -66,11 +68,11 @@ class MenuTitleBuilderTest {
     // ---------------------------------------------------------------
 
     @Test
-    fun `positioning prefix is always shift -7`() {
+    fun `positioning prefix is always shift -8`() {
         val title = MenuTitleBuilder.build(GuiTheme.NEUTRAL, 3)
         assertTrue(
-            title.startsWith("<shift:-7>"),
-            "Expected title '$title' to start with '<shift:-7>'"
+            title.startsWith("<shift:-8>"),
+            "Expected title '$title' to start with '<shift:-8>'"
         )
     }
 
@@ -114,13 +116,77 @@ class MenuTitleBuilderTest {
     }
 
     // ---------------------------------------------------------------
-    // 5. No stray shift characters after the glyph
+    // 5. No-title path produces background-only string
     // ---------------------------------------------------------------
 
     @Test
-    fun `no content after the glyph tag`() {
+    fun `no stray content after the glyph tag when no title`() {
         val title = MenuTitleBuilder.build(GuiTheme.EMBERSTONE, 6)
-        assertTrue(title.endsWith("<glyph:guild_bg_emberstone_6_row>"), 
-            "Expected title to end with the glyph tag, got: '$title'")
+        assertTrue(title.endsWith("<glyph:guild_bg_emberstone_6_row>"),
+            "Expected title to end with glyph tag, got: '$title'")
+    }
+
+    // ---------------------------------------------------------------
+    // 6. Visible title text after rewind
+    // ---------------------------------------------------------------
+
+    @Test
+    fun `title text appears after rewind shift`() {
+        val title = MenuTitleBuilder.build(GuiTheme.NEUTRAL, 3, "⚔ My Guild")
+        val expectedEnd = "<shift:-241>§f⚔ My Guild"
+        assertTrue(
+            title.endsWith(expectedEnd),
+            "Expected title '$title' to end with '$expectedEnd'"
+        )
+    }
+
+    @Test
+    fun `title is prefixed with white color code`() {
+        val title = MenuTitleBuilder.build(rows = 5, title = "Test Menu")
+        assertTrue(
+            title.contains("§fTest Menu"),
+            "Expected title '$title' to contain '§fTest Menu'"
+        )
+    }
+
+    @Test
+    fun `background glyph appears before rewind and title`() {
+        val title = MenuTitleBuilder.build(GuiTheme.MOSSBOUND, 4, "Info")
+        val glyphIdx = title.indexOf("<glyph:guild_bg_mossbound_4_row>")
+        val rewindIdx = title.indexOf("<shift:-241>")
+        val textIdx = title.indexOf("§fInfo")
+        assertTrue(glyphIdx >= 0, "Glyph must be present")
+        assertTrue(rewindIdx > glyphIdx, "Rewind shift must come after glyph (got idx $rewindIdx vs $glyphIdx)")
+        assertTrue(textIdx > rewindIdx, "Title text must come after rewind shift (got idx $textIdx vs $rewindIdx)")
+    }
+
+    @Test
+    fun `title is preserved for dynamic content`() {
+        val guildName = "Enthusia"
+        val page = 1
+        val total = 3
+        val title = MenuTitleBuilder.build(GuiTheme.EMBERSTONE, 6, "§6Info - ${guildName} §8• Page ${page}/${total}")
+        assertTrue(title.contains("§f§6Info - Enthusia §8• Page 1/3"),
+            "Dynamic title not preserved, got: '$title'")
+    }
+
+    // ---------------------------------------------------------------
+    // 7. Representative 3-row and 6-row menus
+    // ---------------------------------------------------------------
+
+    @Test
+    fun `three row menu with title`() {
+        val title = MenuTitleBuilder.build(GuiTheme.NEUTRAL, 3, "⚔ Dashboard")
+        assertTrue(title.startsWith("<shift:-8>"), "3-row must start with shift:-8")
+        assertTrue(title.contains("<glyph:guild_bg_neutral_3_row>"), "3-row must use 3_row glyph")
+        assertTrue(title.contains("§f⚔ Dashboard"), "Title text must be present")
+    }
+
+    @Test
+    fun `six row menu with title`() {
+        val title = MenuTitleBuilder.build(GuiTheme.CARVED_SLATE, 6, "Member Management")
+        assertTrue(title.startsWith("<shift:-8>"), "6-row must start with shift:-8")
+        assertTrue(title.contains("<glyph:guild_bg_carved_slate_6_row>"), "6-row must use 6_row glyph")
+        assertTrue(title.contains("§fMember Management"), "Title text must be present")
     }
 }


### PR DESCRIPTION
## Summary

Restores visible menu title text that was lost when glyph backgrounds replaced filler items, and calibrates horizontal offset from -7 to -8.

## Title component structure

`<shift:-8><glyph:guild_bg_<theme>_<R>_row><shift:-241>§f<title>`

1. `shift:-8` — calibrated horizontal offset (was -7, shifted 1 logical pixel right)
2. `glyph:...` — background overlay (advances cursor ~256px)
3. `shift:-241` — rewind cursor past glyph advance to ~8px from window edge
4. `§f<title>` — visible white title text in the top bar

All 49 guild menus now pass their original title text (e.g. "Settings", "Dashboard", "Member Management") as the title parameter.

## Vertical offset (not in this PR)
Codex will change `ascent: 12` → `ascent: 14` in the Nexo glyph definitions.

## Tests
17 MenuTitleBuilder tests cover shift:-8, rewind structure, title presence, 3/6-row menus, dynamic titles.
`clean test shadowJar` — BUILD SUCCESSFUL.