### PR TITLE
fix: reduce cursor rewind ~80px (shift:-239 -> shift:-161) to center title in header bar

### DIFF
--- a/pr_body.txt
+++ b/pr_body.txt
@@ -1,0 +1,6 @@
+**Changes:** `MenuTitleBuilder.kt`
+
+- `HORIZONTAL_OFFSET`: `<shift:-8>` -> `<shift:-9>` (1px left)
+- `REWIND_TO_TITLE`: `<shift:-241>` -> `<shift:-239>` (math consistency with new offset)
+
+No other files, no PNGs, no ascent changes. All 49 guild menus pick this up automatically.

--- a/src/main/kotlin/net/lumalyte/lg/utils/MenuTitleBuilder.kt
+++ b/src/main/kotlin/net/lumalyte/lg/utils/MenuTitleBuilder.kt
@@ -12,11 +12,11 @@ package net.lumalyte.lg.utils
  *
  *   <shift:-9>                    calibrated horizontal offset
  *   <glyph:guild_bg_<theme>_<R>>  background overlay (advances cursor ~256px)
- *   <shift:-239>                  rewind cursor back to ~8px from default start
+ *   <shift:-161>                  rewind ~80px less — title lands at ~x=86
  *   §f<title>                     visible title text in the top bar
  *
- * The rewind value of -239 is calculated as:
- *   want D + 8 (title margin) - (D - 9 + 256) = -239
+ * The rewind value of -161 advances the cursor ~80px into the title bar:
+ *   D - 9 + 256 - 161 = D + 86
  *   where D = default cursor start, 256 = glyph texture width
  *
  * DO NOT use the neutral theme as a positioning reference — its
@@ -29,15 +29,15 @@ object MenuTitleBuilder {
     /** Calibrated horizontal offset placing the glyph at the window origin. */
     private const val HORIZONTAL_OFFSET: String = "<shift:-9>"
 
-    /** Rewind past the 256-pixel glyph advance + advance to title margin. */
-    private const val REWIND_TO_TITLE: String = "<shift:-239>"
+    /** Rewind past the 256-pixel glyph advance, landing title ~86px from default start. */
+    private const val REWIND_TO_TITLE: String = "<shift:-161>"
 
     /**
      * Returns a ChestGui title string that renders a Nexo font-glyph
      * background with an optional visible title in the top bar.
      *
      * Result:
-     *   <shift:-9><glyph:guild_bg_<theme>_<R>_row><shift:-239>§f<title>
+     *   <shift:-9><glyph:guild_bg_<theme>_<R>_row><shift:-161>§f<title>
      *
      * @param theme  GUI background theme (default: NEUTRAL)
      * @param rows   Inventory row count (3-6)

--- a/src/test/kotlin/net/lumalyte/lg/utils/MenuTitleBuilderTest.kt
+++ b/src/test/kotlin/net/lumalyte/lg/utils/MenuTitleBuilderTest.kt
@@ -133,7 +133,7 @@ class MenuTitleBuilderTest {
     @Test
     fun `title text appears after rewind shift`() {
         val title = MenuTitleBuilder.build(GuiTheme.NEUTRAL, 3, "⚔ My Guild")
-        val expectedEnd = "<shift:-239>§f⚔ My Guild"
+        val expectedEnd = "<shift:-161>§f⚔ My Guild"
         assertTrue(
             title.endsWith(expectedEnd),
             "Expected title '$title' to end with '$expectedEnd'"
@@ -153,7 +153,7 @@ class MenuTitleBuilderTest {
     fun `background glyph appears before rewind and title`() {
         val title = MenuTitleBuilder.build(GuiTheme.MOSSBOUND, 4, "Info")
         val glyphIdx = title.indexOf("<glyph:guild_bg_mossbound_4_row>")
-        val rewindIdx = title.indexOf("<shift:-239>")
+        val rewindIdx = title.indexOf("<shift:-161>")
         val textIdx = title.indexOf("§fInfo")
         assertTrue(glyphIdx >= 0, "Glyph must be present")
         assertTrue(rewindIdx > glyphIdx, "Rewind shift must come after glyph (got idx $rewindIdx vs $glyphIdx)")


### PR DESCRIPTION
Title was rendering ~80px too far left (at x=8 instead of ~x=86 in the header bar).

Moves the dynamic title text ~80px right by reducing the cursor rewind:
`<shift:-239>` -> `<shift:-161>`

Effect: `D - 9 + 256 - 161 = D + 86` — title lands in the central header bar.

Background positioning (shift:-9) and all PNGs are untouched.