### PR TITLE
fix(menu): restore Statistics dashboard navigation

### DIFF
--- a/docs/requirements.md
+++ b/docs/requirements.md
@@ -360,3 +360,9 @@ Legend: **Ubiquitous.** / **Event-driven.** / **State-driven.** / **Unwanted.**
 
 ### REQ-079
 **Optional feature.** WHERE PlaceholderAPI is installed THE SYSTEM SHALL expose read-only timer, quest-definition, guild-progress, completion, reward, and weekly-bonus placeholders with documented safe fallbacks for missing players, guilds, quests, and active weeks; placeholder evaluation SHALL NOT generate, reset, claim, reward, or otherwise mutate quest state.
+
+### REQ-087
+**Event-driven.** WHEN a guild member opens the main Guild Dashboard THEN THE SYSTEM SHALL show a Statistics navigation item in the bottom-right slot directly below Economy, and activating it SHALL open the guild statistics menu.
+
+### REQ-088
+**Ubiquitous.** THE SYSTEM SHALL render every Java inventory-menu item name and lore component with italic decoration explicitly disabled at every component depth while preserving colors and all other intentional text decorations.

--- a/docs/tasks.md
+++ b/docs/tasks.md
@@ -232,6 +232,18 @@ PR grouping: tasks under each `## PR-n` header ship together in one pull request
   - Evidence:
   - Files: `GuildSettingsMenu.kt:77`, `EnemiesListMenu.kt:232`, `PeaceAgreementMenu.kt:375,379`, `GuildBankStatisticsMenu.kt:410,417`, `GuildStatisticsMenu.kt:158`
 
+- [x] **LG-807** Wire Statistics into the Guild Dashboard bottom-right slot
+  - Tag: `TDD`
+  - References: REQ-032, REQ-087
+  - Evidence: RED/GREEN dashboard slot regression; locale/menu contract tests; 627-test full suite; shaded JAR boot-verified locally
+  - Files: `GuildDashboard.kt`, `lang/en_US.yml`, dashboard navigation test
+
+- [x] **LG-1709** Enforce non-italic text across all Java inventory menus
+  - Tag: `TDD`
+  - References: REQ-088
+  - Evidence: recursive decoration regression; Java-menu localization contract; 627-test full suite; visually approved in local testing
+  - Files: GUI component styler, ItemStack text extensions, styling/localization tests
+
 ---
 
 ## PR-8b — Bedrock & misc UX

--- a/src/main/kotlin/net/lumalyte/lg/infrastructure/i18n/GuiTextStyler.kt
+++ b/src/main/kotlin/net/lumalyte/lg/infrastructure/i18n/GuiTextStyler.kt
@@ -3,6 +3,7 @@ package net.lumalyte.lg.infrastructure.i18n
 import net.kyori.adventure.text.Component
 import net.kyori.adventure.text.TextComponent
 import net.kyori.adventure.text.format.ShadowColor
+import net.lumalyte.lg.utils.nonItalic
 
 /** Surface-aware typography for translated inventory text. */
 object GuiTextStyler {
@@ -16,7 +17,7 @@ object GuiTextStyler {
     private val blackShadow = ShadowColor.shadowColor(0xFF000000.toInt())
 
     fun style(component: Component, protectedText: Set<String> = emptySet()): Component =
-        shadow(smallCaps(component, protectedText))
+        shadow(smallCaps(component, protectedText)).nonItalic()
 
     fun shadow(component: Component): Component = component.shadowColor(blackShadow)
 

--- a/src/main/kotlin/net/lumalyte/lg/interaction/menus/guild/GuildDashboard.kt
+++ b/src/main/kotlin/net/lumalyte/lg/interaction/menus/guild/GuildDashboard.kt
@@ -110,7 +110,7 @@ class GuildDashboard(
             menuNavigator.openMenu(menuFactory.createGuildBankMenu(menuNavigator, player, guild))
         }
 
-        // Row 2 (y=2): Settings, Progression, Diplomacy, Warfare
+        // Row 2 (y=2): Settings, Progression, Diplomacy, Warfare, Statistics
         addNavButton(pane, 0, 2, "lg_nav_settings", Material.COMMAND_BLOCK,
             lang.gui("menu.dashboard.item.settings.name"),
             lang.gui("menu.dashboard.item.settings.lore.line_1"),
@@ -137,6 +137,13 @@ class GuildDashboard(
             lang.gui("menu.dashboard.item.warfare.lore.line_1"),
             lang.gui("menu.dashboard.item.warfare.lore.line_2")) {
             menuNavigator.openMenu(menuFactory.createGuildWarManagementMenu(menuNavigator, player, guild))
+        }
+
+        addNavButton(pane, 8, 2, "lg_nav_statistics", Material.BOOKSHELF,
+            lang.gui("menu.dashboard.item.statistics.name"),
+            lang.gui("menu.dashboard.item.statistics.lore.line_1"),
+            lang.gui("menu.dashboard.item.statistics.lore.line_2")) {
+            menuNavigator.openMenu(menuFactory.createGuildStatisticsMenu(menuNavigator, player, guild))
         }
 
         gui.show(player)

--- a/src/main/kotlin/net/lumalyte/lg/utils/ComponentExtensions.kt
+++ b/src/main/kotlin/net/lumalyte/lg/utils/ComponentExtensions.kt
@@ -1,0 +1,10 @@
+package net.lumalyte.lg.utils
+
+import net.kyori.adventure.text.Component
+import net.kyori.adventure.text.format.TextDecoration
+
+/** Removes Minecraft's default italic item styling from a complete component tree. */
+fun Component.nonItalic(): Component {
+    val normalized = decoration(TextDecoration.ITALIC, TextDecoration.State.FALSE)
+    return normalized.children(normalized.children().map(Component::nonItalic))
+}

--- a/src/main/kotlin/net/lumalyte/lg/utils/ItemStackExtensions.kt
+++ b/src/main/kotlin/net/lumalyte/lg/utils/ItemStackExtensions.kt
@@ -27,7 +27,7 @@ fun ItemStack.amount(amount: Int): ItemStack {
 fun ItemStack.name(name: String): ItemStack {
     val meta = itemMeta ?: Bukkit.getItemFactory().getItemMeta(type) ?: return this
     // Create component and explicitly disable italic formatting to override Minecraft's default italic lore
-    val component = Component.text(name).decorationIfAbsent(TextDecoration.ITALIC, TextDecoration.State.FALSE)
+    val component = Component.text(name).nonItalic()
     meta.itemName(component)
     // Hide all item attributes and metadata in menus
     meta.addItemFlags(
@@ -45,7 +45,7 @@ fun ItemStack.name(name: String): ItemStack {
 
 fun ItemStack.name(name: Component): ItemStack {
     val meta = itemMeta ?: Bukkit.getItemFactory().getItemMeta(type) ?: return this
-    meta.itemName(name.decorationIfAbsent(TextDecoration.ITALIC, TextDecoration.State.FALSE))
+    meta.itemName(name.nonItalic())
     meta.addItemFlags(
         ItemFlag.HIDE_ATTRIBUTES,
         ItemFlag.HIDE_ENCHANTS,
@@ -66,7 +66,7 @@ fun ItemStack.lore(text: String): ItemStack {
         lore = ArrayList()
     }
     // Create component and explicitly disable italic formatting to override Minecraft's default italic lore
-    val component = text.c().decorationIfAbsent(TextDecoration.ITALIC, TextDecoration.State.FALSE)
+    val component = text.c().nonItalic()
     lore.add(component)
     meta.lore(lore)
     itemMeta = meta
@@ -76,7 +76,7 @@ fun ItemStack.lore(text: String): ItemStack {
 fun ItemStack.lore(text: Component): ItemStack {
     val meta = itemMeta ?: Bukkit.getItemFactory().getItemMeta(type) ?: return this
     val lore = meta.lore()?.toMutableList() ?: mutableListOf()
-    lore += text.decorationIfAbsent(TextDecoration.ITALIC, TextDecoration.State.FALSE)
+    lore += text.nonItalic()
     meta.lore(lore)
     itemMeta = meta
     return this
@@ -94,7 +94,7 @@ fun ItemStack.lore(text: List<*>): ItemStack {
             is Component -> line
             is String -> line.c()
             else -> Component.text(line.toString())
-        }.decorationIfAbsent(TextDecoration.ITALIC, TextDecoration.State.FALSE)
+        }.nonItalic()
     }
     meta.lore(componentLore)
     itemMeta = meta
@@ -190,8 +190,7 @@ fun ItemStack.setStringMeta(key: String, value: String): ItemStack {
 }
 
 private fun String.c(): Component {
-    return LegacyComponentSerializer.legacyAmpersand().deserialize(this)
-        .decorationIfAbsent(TextDecoration.ITALIC, TextDecoration.State.FALSE)
+    return LegacyComponentSerializer.legacyAmpersand().deserialize(this).nonItalic()
 }
 
 /**

--- a/src/main/resources/lang/en_US.yml
+++ b/src/main/resources/lang/en_US.yml
@@ -2863,6 +2863,11 @@ menu:
           line_1: '<gray>Guild name, tag, emoji,'
           line_2: '<gray>home, mode, and more'
         name: '<yellow>Settings'
+      statistics:
+        lore:
+          line_1: '<gray>Performance, rivalries,'
+          line_2: '<gray>achievements, and trends'
+        name: '<green>Statistics'
       warfare:
         lore:
           line_1: '<gray>Declare war, manage'

--- a/src/test/kotlin/net/lumalyte/lg/infrastructure/i18n/GuiTextStylerTest.kt
+++ b/src/test/kotlin/net/lumalyte/lg/infrastructure/i18n/GuiTextStylerTest.kt
@@ -2,6 +2,7 @@ package net.lumalyte.lg.infrastructure.i18n
 
 import net.kyori.adventure.text.Component
 import net.kyori.adventure.text.format.NamedTextColor
+import net.kyori.adventure.text.format.TextDecoration
 import net.kyori.adventure.text.serializer.plain.PlainTextComponentSerializer
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Assertions.assertNull
@@ -37,5 +38,19 @@ class GuiTextStylerTest {
 
         assertEquals("ʀᴀɴᴋ 10", plain.serialize(converted))
         assertNull(converted.shadowColor())
+    }
+
+    @Test
+    fun `menu styling disables italics at every component depth while preserving other decoration`() {
+        val translated = Component.text("Parent")
+            .decorate(TextDecoration.ITALIC)
+            .append(Component.text("Child", NamedTextColor.GOLD).decorate(TextDecoration.ITALIC, TextDecoration.BOLD))
+
+        val styled = GuiTextStyler.style(translated)
+
+        assertEquals(TextDecoration.State.FALSE, styled.decoration(TextDecoration.ITALIC))
+        assertEquals(TextDecoration.State.FALSE, styled.children().single().decoration(TextDecoration.ITALIC))
+        assertEquals(TextDecoration.State.TRUE, styled.children().single().decoration(TextDecoration.BOLD))
+        assertEquals(NamedTextColor.GOLD, styled.children().single().color())
     }
 }

--- a/src/test/kotlin/net/lumalyte/lg/interaction/menus/guild/GuildDashboardFillerItemTest.kt
+++ b/src/test/kotlin/net/lumalyte/lg/interaction/menus/guild/GuildDashboardFillerItemTest.kt
@@ -2,6 +2,8 @@ package net.lumalyte.lg.interaction.menus.guild
 
 import org.junit.jupiter.api.Test
 import java.lang.reflect.Modifier
+import java.nio.file.Path
+import kotlin.test.assertTrue
 
 /**
  * Verifies that GuildDashboard does not add filler items to inventory slots.
@@ -39,9 +41,9 @@ internal class GuildDashboardFillerItemTest {
     }
 
     @Test
-    fun `GuildDashboard declares exactly 9 positioned items`() {
-        // The dashboard's open() method places 9 items into the pane:
-        // 8 nav buttons + 1 guild info display.
+    fun `GuildDashboard declares exactly 11 positioned items`() {
+        // The dashboard's open() method places 11 items into the pane:
+        // 10 nav buttons + 1 guild info display.
         // No filler items should occupy any slots.
         // Verify by checking the method count of addNavButton calls
         val source = javaClass.getResourceAsStream("/net/lumalyte/lg/interaction/menus/guild/GuildDashboard.kt")
@@ -49,5 +51,16 @@ internal class GuildDashboardFillerItemTest {
         // If we can't read the source, the test is vacuously true
         // (the important thing is the method doesn't exist, tested above)
         assert(true)
+    }
+
+    @Test
+    fun `GuildDashboard wires statistics below economy in the bottom right slot`() {
+        val source = Path.of(System.getProperty("user.dir"))
+            .resolve("src/main/kotlin/net/lumalyte/lg/interaction/menus/guild/GuildDashboard.kt")
+            .toFile()
+            .readText()
+
+        assertTrue(source.contains("addNavButton(pane, 8, 2, \"lg_nav_statistics\""))
+        assertTrue(source.contains("menuFactory.createGuildStatisticsMenu(menuNavigator, player, guild)"))
     }
 }


### PR DESCRIPTION
## Summary
- add Statistics to the Guild Dashboard bottom-right slot below Economy
- open the completed Guild Statistics menu from the dashboard
- enforce non-italic item names and lore across Java inventory menus
- document and test both UI contracts

## Verification
- ./gradlew clean test shadowJar --no-daemon -Dkotlin.compiler.execution.strategy=in-process
- 627 tests, 0 failures, 0 errors
- shaded JAR deployed and boot-verified on the local Leaf 1.21.11 lobby

## Manual testing
- Statistics item appears at dashboard slot (8,2), directly below Economy
- clicking Statistics opens the guild Statistics menu
- Weekly Quests and Guild Control Panel text render without italics