### PR TITLE
PR-11: keep guild balance leaderboards current

### DIFF
--- a/docs/tasks.md
+++ b/docs/tasks.md
@@ -324,11 +324,11 @@ PR grouping: tasks under each `## PR-n` header ship together in one pull request
   - References: operator backlog (bugs channel `<#1421662495923372194>`)
   - Evidence:
   - Files: TBD — bug list must be pasted into this doc before tracking
-- [ ] **LG-1102** Economy commands fix: `/g balance` + `/g baltop` correct data; `/g balance` tab-completes all guild names
+- [x] **LG-1102** Economy commands fix: `/g balance` + `/g baltop` correct data; `/g balance` tab-completes all guild names
   - Tag: `TDD`
   - References: REQ-046
-  - Evidence:
-  - Files: guild balance/baltop commands, tab-completion provider
+  - Evidence: `/g balance` renders the unified live vault-gold balance; `/g baltop` overlays buffered in-memory balances onto persisted rows before ranking; the `@guilds` completion contract returns every guild name. Focused regression tests and the clean repository suite are GREEN.
+  - Files: `infrastructure/vault/VaultInventoryManager.kt`, `VaultLeaderboardConsistencyTest`, `GuildBalanceCommandContractTest`, existing `CommandLocalizationTest`
 - [ ] **LG-1103** Guild emoji removal — emoji can be cleared once set
   - Tag: `TDD`
   - References: REQ-047

--- a/src/main/kotlin/net/lumalyte/lg/infrastructure/services/BankServiceBukkit.kt
+++ b/src/main/kotlin/net/lumalyte/lg/infrastructure/services/BankServiceBukkit.kt
@@ -78,16 +78,6 @@ class BankServiceBukkit(
     // Vault Economy integration
     private var economy: Economy? = null
 
-    // --- Balance leaderboard cache ---
-    // The underlying repository already keeps balances in memory, so this cache only amortizes the
-    // sort. It is invalidated immediately whenever a balance changes (deposit/withdraw/deduct), and
-    // also carries a short TTL as a safety net against any balance path that bypasses this service.
-    private val balanceLeaderboardLock = Any()
-    @Volatile private var cachedTopBalances: List<Pair<UUID, Int>> = emptyList()
-    @Volatile private var balanceLeaderboardExpiresAtMs: Long = 0L
-    private val balanceLeaderboardTtlMs = 30_000L
-    private val balanceLeaderboardCacheSize = 100
-
     init {
         setupEconomy()
     }
@@ -287,7 +277,6 @@ class BankServiceBukkit(
             }
 
             // SUCCESS: player debited and guild balance credited
-            invalidateBalanceLeaderboard()
             val newBalance = creditedBalance.toInt()
             recordAudit(BankAudit(
                 transactionId = transaction.id,
@@ -471,7 +460,6 @@ class BankServiceBukkit(
             }
 
             // SUCCESS: guild balance debited and player paid
-            invalidateBalanceLeaderboard()
             val newBalance = debitedBalance.toInt()
             recordAudit(BankAudit(
                 transactionId = transaction.id,
@@ -512,23 +500,8 @@ class BankServiceBukkit(
 
     override fun getTopBalances(limit: Int): List<Pair<UUID, Int>> {
         if (limit <= 0) return emptyList()
-        // Cache the largest requested page so callers asking for a smaller N reuse it.
-        val cacheSize = maxOf(limit, balanceLeaderboardCacheSize)
-        val now = System.currentTimeMillis()
-        synchronized(balanceLeaderboardLock) {
-            if (now >= balanceLeaderboardExpiresAtMs || cachedTopBalances.size < limit) {
-                // Ranked by store B (vault gold balance), the unified source of truth.
-                cachedTopBalances = vaultInventoryManager.getTopGoldBalances(cacheSize)
-                    .map { (id, balance) -> id to balance.toInt() }
-                balanceLeaderboardExpiresAtMs = now + balanceLeaderboardTtlMs
-            }
-            return cachedTopBalances.take(limit)
-        }
-    }
-
-    /** Invalidates the cached balance leaderboard so the next read reflects the change. */
-    private fun invalidateBalanceLeaderboard() {
-        balanceLeaderboardExpiresAtMs = 0L
+        return vaultInventoryManager.getTopGoldBalances(limit)
+            .map { (id, balance) -> id to balance.toInt() }
     }
 
     override fun getPlayerBalance(playerId: UUID): Int {
@@ -750,7 +723,6 @@ class BankServiceBukkit(
                 logger.warn("Failed to record deduction history for guild $guildId (balance already updated)", e)
             }
 
-            invalidateBalanceLeaderboard()
             return true
         } catch (e: SQLException) {
             logger.error("Database error processing guild bank deduction for guild $guildId", e)
@@ -787,7 +759,6 @@ class BankServiceBukkit(
                 logger.warn("Failed to record credit history for guild $guildId (balance already updated)", e)
             }
 
-            invalidateBalanceLeaderboard()
             return true
         } catch (e: SQLException) {
             logger.error("Database error processing guild bank credit for guild $guildId", e)

--- a/src/main/kotlin/net/lumalyte/lg/infrastructure/vault/VaultInventoryManager.kt
+++ b/src/main/kotlin/net/lumalyte/lg/infrastructure/vault/VaultInventoryManager.kt
@@ -305,11 +305,12 @@ class VaultInventoryManager(
     fun getTopGoldBalances(limit: Int): List<Pair<UUID, Long>> {
         if (limit <= 0) return emptyList()
 
-        val candidateLimit = (limit.toLong() + vaultCache.size)
+        val loadedBalances = vaultCache.entries.map { (guildId, vault) -> guildId to vault.getGold() }
+        val candidateLimit = (limit.toLong() + loadedBalances.size)
             .coerceAtMost(Int.MAX_VALUE.toLong())
             .toInt()
         val balances = vaultRepository.getTopGoldBalances(candidateLimit).toMap().toMutableMap()
-        vaultCache.forEach { (guildId, vault) -> balances[guildId] = vault.getGold() }
+        loadedBalances.forEach { (guildId, balance) -> balances[guildId] = balance }
 
         return balances.entries
             .sortedWith(compareByDescending<Map.Entry<UUID, Long>> { it.value }.thenBy { it.key })

--- a/src/main/kotlin/net/lumalyte/lg/infrastructure/vault/VaultInventoryManager.kt
+++ b/src/main/kotlin/net/lumalyte/lg/infrastructure/vault/VaultInventoryManager.kt
@@ -303,7 +303,18 @@ class VaultInventoryManager(
      * @return A list of (guildId, balance) pairs ordered by balance descending.
      */
     fun getTopGoldBalances(limit: Int): List<Pair<UUID, Long>> {
-        return vaultRepository.getTopGoldBalances(limit)
+        if (limit <= 0) return emptyList()
+
+        val candidateLimit = (limit.toLong() + vaultCache.size)
+            .coerceAtMost(Int.MAX_VALUE.toLong())
+            .toInt()
+        val balances = vaultRepository.getTopGoldBalances(candidateLimit).toMap().toMutableMap()
+        vaultCache.forEach { (guildId, vault) -> balances[guildId] = vault.getGold() }
+
+        return balances.entries
+            .sortedWith(compareByDescending<Map.Entry<UUID, Long>> { it.value }.thenBy { it.key })
+            .take(limit)
+            .map { it.key to it.value }
     }
 
     /**

--- a/src/test/kotlin/net/lumalyte/lg/infrastructure/services/BankLeaderboardFreshnessTest.kt
+++ b/src/test/kotlin/net/lumalyte/lg/infrastructure/services/BankLeaderboardFreshnessTest.kt
@@ -1,0 +1,58 @@
+package net.lumalyte.lg.infrastructure.services
+
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.mockkStatic
+import io.mockk.unmockkStatic
+import net.lumalyte.lg.application.persistence.BankRepository
+import net.lumalyte.lg.application.persistence.GuildRepository
+import net.lumalyte.lg.application.persistence.MemberRepository
+import net.lumalyte.lg.application.persistence.ProgressionRepository
+import net.lumalyte.lg.application.persistence.RankRepository
+import net.lumalyte.lg.application.services.ConfigService
+import net.lumalyte.lg.application.services.GuildService
+import net.lumalyte.lg.infrastructure.vault.VaultInventoryManager
+import org.bukkit.Bukkit
+import org.bukkit.Server
+import org.bukkit.plugin.PluginManager
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.Test
+import java.util.UUID
+import kotlin.test.assertEquals
+
+class BankLeaderboardFreshnessTest {
+    @AfterEach
+    fun tearDown() = unmockkStatic(Bukkit::class)
+
+    @Test
+    fun `leaderboard reads the manager on every request`() {
+        mockkStatic(Bukkit::class)
+        val server = mockk<Server>()
+        val pluginManager = mockk<PluginManager>()
+        every { Bukkit.getServer() } returns server
+        every { server.pluginManager } returns pluginManager
+        every { pluginManager.getPlugin("Vault") } returns null
+
+        val firstGuild = UUID.randomUUID()
+        val secondGuild = UUID.randomUUID()
+        val vaultManager = mockk<VaultInventoryManager>()
+        every { vaultManager.getTopGoldBalances(any()) } returnsMany listOf(
+            listOf(firstGuild to 1_000L, secondGuild to 500L),
+            listOf(secondGuild to 1_500L, firstGuild to 1_000L)
+        )
+        val service = BankServiceBukkit(
+            mockk<BankRepository>(relaxed = true),
+            mockk<MemberRepository>(relaxed = true),
+            mockk<RankRepository>(relaxed = true),
+            mockk<ProgressionRepository>(relaxed = true),
+            mockk<ProgressionConfigService>(relaxed = true),
+            mockk<ConfigService>(relaxed = true),
+            mockk<GuildRepository>(relaxed = true),
+            mockk<GuildService>(relaxed = true),
+            vaultManager
+        )
+
+        assertEquals(listOf(firstGuild to 1_000, secondGuild to 500), service.getTopBalances(2))
+        assertEquals(listOf(secondGuild to 1_500, firstGuild to 1_000), service.getTopBalances(2))
+    }
+}

--- a/src/test/kotlin/net/lumalyte/lg/infrastructure/vault/VaultLeaderboardConsistencyTest.kt
+++ b/src/test/kotlin/net/lumalyte/lg/infrastructure/vault/VaultLeaderboardConsistencyTest.kt
@@ -1,0 +1,56 @@
+package net.lumalyte.lg.infrastructure.vault
+
+import io.mockk.every
+import io.mockk.mockk
+import net.lumalyte.lg.application.persistence.GuildVaultRepository
+import net.lumalyte.lg.config.VaultConfig
+import org.junit.jupiter.api.Test
+import java.util.UUID
+import kotlin.test.assertEquals
+
+class VaultLeaderboardConsistencyTest {
+    @Test
+    fun `leaderboard overlays buffered in-memory balances before ranking`() {
+        val changedGuild = UUID.randomUUID()
+        val persistedLeader = UUID.randomUUID()
+        val repository = mockk<GuildVaultRepository>(relaxed = true)
+        every { repository.getVaultInventory(any()) } returns emptyMap()
+        every { repository.getGoldBalance(changedGuild) } returns 100L
+        every { repository.getTopGoldBalances(any()) } returns listOf(
+            persistedLeader to 500L,
+            changedGuild to 100L
+        )
+        val manager = VaultInventoryManager(repository, vaultConfig = mockk<VaultConfig>(relaxed = true))
+
+        manager.setGoldBalance(changedGuild, 1_000L)
+
+        assertEquals(
+            listOf(changedGuild to 1_000L, persistedLeader to 500L),
+            manager.getTopGoldBalances(10)
+        )
+    }
+
+    @Test
+    fun `leaderboard backfills persisted candidates when a loaded balance falls`() {
+        val changedGuild = UUID.randomUUID()
+        val secondGuild = UUID.randomUUID()
+        val thirdGuild = UUID.randomUUID()
+        val persisted = listOf(
+            changedGuild to 1_000L,
+            secondGuild to 900L,
+            thirdGuild to 800L
+        )
+        val repository = mockk<GuildVaultRepository>(relaxed = true)
+        every { repository.getVaultInventory(any()) } returns emptyMap()
+        every { repository.getGoldBalance(changedGuild) } returns 1_000L
+        every { repository.getTopGoldBalances(any()) } answers { persisted.take(firstArg()) }
+        val manager = VaultInventoryManager(repository, vaultConfig = mockk<VaultConfig>(relaxed = true))
+
+        manager.setGoldBalance(changedGuild, 100L)
+
+        assertEquals(
+            listOf(secondGuild to 900L, thirdGuild to 800L),
+            manager.getTopGoldBalances(2)
+        )
+    }
+}

--- a/src/test/kotlin/net/lumalyte/lg/infrastructure/vault/VaultLeaderboardConsistencyTest.kt
+++ b/src/test/kotlin/net/lumalyte/lg/infrastructure/vault/VaultLeaderboardConsistencyTest.kt
@@ -53,4 +53,30 @@ class VaultLeaderboardConsistencyTest {
             manager.getTopGoldBalances(2)
         )
     }
+
+    @Test
+    fun `leaderboard does not mix a later cache load into an earlier candidate snapshot`() {
+        val concurrentlyLoadedGuild = UUID.randomUUID()
+        val secondGuild = UUID.randomUUID()
+        val thirdGuild = UUID.randomUUID()
+        val persisted = listOf(
+            concurrentlyLoadedGuild to 1_000L,
+            secondGuild to 900L,
+            thirdGuild to 800L
+        )
+        val repository = mockk<GuildVaultRepository>(relaxed = true)
+        every { repository.getVaultInventory(any()) } returns emptyMap()
+        every { repository.getGoldBalance(concurrentlyLoadedGuild) } returns 1_000L
+        lateinit var manager: VaultInventoryManager
+        every { repository.getTopGoldBalances(any()) } answers {
+            manager.setGoldBalance(concurrentlyLoadedGuild, 100L)
+            persisted.take(firstArg())
+        }
+        manager = VaultInventoryManager(repository, vaultConfig = mockk<VaultConfig>(relaxed = true))
+
+        assertEquals(
+            listOf(concurrentlyLoadedGuild to 1_000L, secondGuild to 900L),
+            manager.getTopGoldBalances(2)
+        )
+    }
 }

--- a/src/test/kotlin/net/lumalyte/lg/interaction/commands/GuildBalanceCommandContractTest.kt
+++ b/src/test/kotlin/net/lumalyte/lg/interaction/commands/GuildBalanceCommandContractTest.kt
@@ -1,0 +1,34 @@
+package net.lumalyte.lg.interaction.commands
+
+import co.aikar.commands.annotation.CommandCompletion
+import io.mockk.every
+import io.mockk.mockk
+import net.lumalyte.lg.application.services.GuildService
+import net.lumalyte.lg.domain.entities.Guild
+import net.lumalyte.lg.utils.GuildResolver
+import org.junit.jupiter.api.Test
+import java.time.Instant
+import java.util.UUID
+import kotlin.test.assertEquals
+
+class GuildBalanceCommandContractTest {
+    @Test
+    fun `balance command completes every guild name`() {
+        val guildService = mockk<GuildService>()
+        every { guildService.getAllGuilds() } returns setOf(
+            guild("Zephyr"),
+            guild("Badgers"),
+            guild("Aurora")
+        )
+        val balanceMethod = GuildCommand::class.java.declaredMethods.single { it.name == "onBalance" }
+
+        assertEquals("@guilds", balanceMethod.getAnnotation(CommandCompletion::class.java).value)
+        assertEquals(listOf("Aurora", "Badgers", "Zephyr"), GuildResolver.suggestions(guildService))
+    }
+
+    private fun guild(name: String): Guild = Guild(
+        id = UUID.randomUUID(),
+        name = name,
+        createdAt = Instant.EPOCH
+    )
+}


### PR DESCRIPTION
## Summary

- complete LG-1102 / REQ-046 coverage for guild balance commands and all-guild completion
- rank /g baltop from live in-memory vault balances instead of stale persisted values
- remove the redundant 30-second bank leaderboard cache so direct vault mutations are immediately visible
- snapshot loaded balances before repository lookup and fetch enough persisted candidates to backfill downward balance changes

## Verification

- ./gradlew clean test — 660 tests, 0 failures, 0 errors
- git diff --check`n- independent final review: no Critical or Important findings; ready to merge