### PR TITLE
PR-12: allow guild emoji removal

### DIFF
--- a/docs/tasks.md
+++ b/docs/tasks.md
@@ -329,11 +329,11 @@ PR grouping: tasks under each `## PR-n` header ship together in one pull request
   - References: REQ-046
   - Evidence: `/g balance` renders the unified live vault-gold balance; `/g baltop` overlays buffered in-memory balances onto persisted rows before ranking; the `@guilds` completion contract returns every guild name. Focused regression tests and the clean repository suite are GREEN.
   - Files: `infrastructure/vault/VaultInventoryManager.kt`, `VaultLeaderboardConsistencyTest`, `GuildBalanceCommandContractTest`, existing `CommandLocalizationTest`
-- [ ] **LG-1103** Guild emoji removal — emoji can be cleared once set
+- [x] **LG-1103** Guild emoji removal — emoji can be cleared once set
   - Tag: `TDD`
   - References: REQ-047
-  - Evidence:
-  - Files: emoji menu/service
+  - Evidence: Java Clear now persists `null` immediately through the existing permission-checked `GuildService.setEmoji` path, matching the Bedrock blank-input behavior; `GuildEmojiClearTest` reproduces the prior state-reset bug and is GREEN; full clean suite is GREEN (661 tests).
+  - Files: `interaction/menus/guild/GuildEmojiMenu.kt`, `GuildEmojiClearTest.kt`
 - [ ] **LG-1104** Custom guild emojis via config — guild-name → Nexo permission grant for all members
   - Tag: `TDD`
   - References: REQ-048

--- a/src/main/kotlin/net/lumalyte/lg/interaction/menus/guild/GuildEmojiMenu.kt
+++ b/src/main/kotlin/net/lumalyte/lg/interaction/menus/guild/GuildEmojiMenu.kt
@@ -283,15 +283,16 @@ class GuildEmojiMenu(private val menuNavigator: MenuNavigator, private val playe
 
         val guiItem = GuiItem(clearItem) {
             println("[LumaGuilds] GuildEmojiMenu: Clear button clicked")
-            println("[LumaGuilds] GuildEmojiMenu: Setting inputEmoji to null")
-
-            inputEmoji = null
-            validationError = null
-
-            player.sendMessage(lang.msg("menu.guild_emoji.feedback.cleared"))
-
-            // Refresh the menu to show updated state
-            open()
+            val success = guildService.setEmoji(guild.id, null, player.uniqueId)
+            if (success) {
+                currentEmoji = null
+                inputEmoji = null
+                validationError = null
+                player.sendMessage(lang.msg("menu.guild_emoji.feedback.cleared"))
+                open()
+            } else {
+                player.sendMessage(lang.msg("menu.guild_emoji.feedback.save_failed"))
+            }
         }
         pane.addItem(guiItem, x, y)
     }

--- a/src/test/kotlin/net/lumalyte/lg/interaction/menus/guild/GuildEmojiClearTest.kt
+++ b/src/test/kotlin/net/lumalyte/lg/interaction/menus/guild/GuildEmojiClearTest.kt
@@ -1,0 +1,92 @@
+package net.lumalyte.lg.interaction.menus.guild
+
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.mockkStatic
+import io.mockk.unmockkStatic
+import net.badgersmc.nexus.i18n.LangService
+import net.kyori.adventure.text.Component
+import net.lumalyte.lg.application.services.GuildService
+import net.lumalyte.lg.domain.entities.Guild
+import net.lumalyte.lg.infrastructure.services.NexoEmojiService
+import net.lumalyte.lg.interaction.listeners.ChatInputListener
+import net.lumalyte.lg.interaction.menus.MenuFactory
+import net.lumalyte.lg.interaction.menus.MenuNavigator
+import net.lumalyte.lg.utils.MenuItemBuilder
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.koin.core.context.startKoin
+import org.koin.core.context.stopKoin
+import org.koin.dsl.module
+import org.mockbukkit.mockbukkit.MockBukkit
+import org.mockbukkit.mockbukkit.ServerMock
+import org.bukkit.plugin.java.JavaPlugin
+import java.time.Instant
+import java.util.UUID
+import kotlin.test.assertNull
+
+class GuildEmojiClearTest {
+    private lateinit var server: ServerMock
+
+    @BeforeEach
+    fun setUp() {
+        server = MockBukkit.mock()
+        val plugin = MockBukkit.createMockPlugin()
+        mockkStatic(JavaPlugin::class)
+        every { JavaPlugin.getProvidingPlugin(any()) } returns plugin
+        stopKoin()
+    }
+
+    @AfterEach
+    fun tearDown() {
+        stopKoin()
+        unmockkStatic(JavaPlugin::class)
+        MockBukkit.unmock()
+    }
+
+    @Test
+    fun `Java clear button persists removal immediately`() {
+        val guildId = UUID.randomUUID()
+        var storedEmoji: String? = ":enthusia:"
+        val guildService = mockk<GuildService>(relaxed = true) {
+            every { getEmoji(guildId) } answers { storedEmoji }
+            every { setEmoji(guildId, null, any()) } answers {
+                storedEmoji = null
+                true
+            }
+        }
+        val lang = mockk<LangService> {
+            every { msg(any(), *anyVararg()) } returns Component.text("localized")
+            every { raw(any()) } returns "localized"
+        }
+        val nexoEmojiService = mockk<NexoEmojiService>(relaxed = true)
+
+        startKoin {
+            modules(module {
+                single<GuildService> { guildService }
+                single<LangService> { lang }
+                single<NexoEmojiService> { nexoEmojiService }
+                single<ChatInputListener> { mockk(relaxed = true) }
+                single<MenuFactory> { mockk(relaxed = true) }
+                single<MenuItemBuilder> { mockk(relaxed = true) }
+            })
+        }
+
+        val player = server.addPlayer()
+        val guild = Guild(id = guildId, name = "Clearable", emoji = storedEmoji, createdAt = Instant.EPOCH)
+        val menu = GuildEmojiMenu(mockk<MenuNavigator>(relaxed = true), player, guild)
+        val pane = com.github.stefvanschie.inventoryframework.pane.StaticPane(9, 3)
+        val addClearButton = GuildEmojiMenu::class.java.getDeclaredMethod(
+            "addClearButton",
+            com.github.stefvanschie.inventoryframework.pane.StaticPane::class.java,
+            Int::class.javaPrimitiveType,
+            Int::class.javaPrimitiveType,
+        ).apply { isAccessible = true }
+
+        addClearButton.invoke(menu, pane, 4, 2)
+        pane.items.single().callAction(mockk(relaxed = true))
+
+        assertNull(storedEmoji)
+    }
+}


### PR DESCRIPTION
## Summary

- complete LG-1103 / REQ-047
- persist Java guild emoji removal immediately through the existing permission-checked service path
- match the existing Bedrock blank-input clear behavior
- keep localized success and failure feedback

## Verification

- gradlew clean test: 661 tests, 0 failures, 0 errors
- regression test reproduced the prior state-reset bug before the fix
- independent review: no Critical or Important findings; ready to merge
- git diff --check