### PR TITLE
feat: reconcile guild emoji permission grants

### DIFF
--- a/docs/EMOJI_PERMISSIONS.md
+++ b/docs/EMOJI_PERMISSIONS.md
@@ -53,7 +53,7 @@ guild:
     explorers: "nexo.emoji.compass"
 ```
 
-LumaGuilds reconciles these grants at startup, on `/lg reload`, and when a guild is created, renamed, disbanded, joined, or left. Guild names and permission nodes are normalized to lowercase. Invalid permission nodes are rejected during config loading.
+LumaGuilds reconciles these grants at startup, on `/lumaguilds reload`, and when a guild is created, renamed, disbanded, joined, or left. Guild names and permission nodes are normalized to lowercase. Invalid permission nodes are rejected during config loading.
 
 Only grants recorded in LumaGuilds' `guild_emoji_grants_applied` ownership ledger are revoked. Permissions granted manually, through groups, or by another plugin are never removed by this feature. Changing a mapping from permission A to B revokes the recorded A grant before granting B; removing a mapping revokes its recorded grants on the next reconciliation.
 

--- a/docs/EMOJI_PERMISSIONS.md
+++ b/docs/EMOJI_PERMISSIONS.md
@@ -42,6 +42,21 @@ Where:
 
 ## Granting Permissions
 
+### Automatic Guild Grants
+
+Map normalized guild names to LuckPerms permission nodes under `guild.emoji_grants`:
+
+```yaml
+guild:
+  emoji_grants:
+    builders: "nexo.emoji.hammer"
+    explorers: "nexo.emoji.compass"
+```
+
+LumaGuilds reconciles these grants at startup, on `/lg reload`, and when a guild is created, renamed, disbanded, joined, or left. Guild names and permission nodes are normalized to lowercase. Invalid permission nodes are rejected during config loading.
+
+Only grants recorded in LumaGuilds' `guild_emoji_grants_applied` ownership ledger are revoked. Permissions granted manually, through groups, or by another plugin are never removed by this feature. Changing a mapping from permission A to B revokes the recorded A grant before granting B; removing a mapping revokes its recorded grants on the next reconciliation.
+
 ### Grant All Emojis
 ```yaml
 # In your permissions plugin (LuckPerms, etc.)
@@ -175,5 +190,4 @@ chat:
 
 ---
 
-*Last updated: December 15, 2025*
-*Plugin Version: 0.5.3*
+*Last updated: August 27, 2026*

--- a/docs/superpowers/plans/2026-08-26-guild-emoji-grant-reconciliation.md
+++ b/docs/superpowers/plans/2026-08-26-guild-emoji-grant-reconciliation.md
@@ -1,0 +1,383 @@
+# Guild Emoji Grant Reconciliation Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make configured guild emoji permissions grant and revoke correctly across startup, reload, membership changes, rename, disband, and restart without touching permissions LumaGuilds does not own.
+
+**Architecture:** Persist every LumaGuilds-owned grant in a SQLite ledger behind an application repository port. A Bukkit-free application reconciler compares desired membership/config state with that ledger and applies ordered revoke/grant operations through a permission gateway; infrastructure adapters provide SQLite, LuckPerms command dispatch, config access, and Bukkit lifecycle events.
+
+**Tech Stack:** Kotlin 2.2, Paper 1.21.11, SQLite via Aikar IDB, Koin 4.0.2, MockBukkit 4.107.0, JUnit 5, MockK
+
+**Spec:** `docs/superpowers/specs/2026-08-26-guild-emoji-grant-reconciliation-design.md`
+
+## Global Constraints
+
+- Follow SPEAR for every behavior: requirement → failing test → minimal code → layer check → refactor and re-run.
+- Domain imports no Bukkit, LuckPerms, SQL, Koin, Adventure, or config types.
+- Guild names are matched case-insensitively with `Locale.ROOT`.
+- Permission nodes are trimmed, lowercase, and match `[a-z0-9][a-z0-9_.-]*`.
+- Each `(playerId, guildId)` has at most one LumaGuilds-owned permission.
+- Never revoke an unrecorded permission.
+- Replace A with B in order: revoke A, delete A's ledger row, grant B, record B.
+- A failed revoke retains A; a failed grant records nothing.
+- No admin command, GUI, Nexo glyph creation, or multi-permission mapping is included.
+
+---
+
+## File Map
+
+New production files:
+
+- `domain/entities/EmojiPermissionGrant.kt` — immutable owned grant.
+- `application/persistence/EmojiGrantRepository.kt` — ownership ledger port.
+- `application/services/EmojiPermissionGateway.kt` — external side-effect port.
+- `application/services/GuildEmojiGrantReconciler.kt` — reconciliation algorithm.
+- `infrastructure/persistence/guilds/EmojiGrantRepositorySQLite.kt` — SQLite ledger.
+- `infrastructure/services/LuckPermsEmojiPermissionGateway.kt` — Bukkit command adapter.
+- `api/events/GuildRenamedEvent.kt` — committed rename event.
+
+Modified production files:
+
+- `ConfigServiceBukkit.kt`, `config.yml` — mapping validation and operator copy.
+- `GuildEmojiGrantService.kt` — config-aware façade.
+- `GuildEmojiGrantListener.kt` — lifecycle routing.
+- `GuildServiceBukkit.kt` — rename event emission.
+- `LumaGuildsCommand.kt`, `LumaGuilds.kt`, `Modules.kt` — reload/startup/DI wiring.
+- `docs/EMOJI_PERMISSIONS.md`, `docs/tasks.md` — operator and SPEAR evidence.
+
+---
+
+### Task 1: Persist LumaGuilds-owned grants
+
+**Files:**
+- Create: `src/main/kotlin/net/lumalyte/lg/domain/entities/EmojiPermissionGrant.kt`
+- Create: `src/main/kotlin/net/lumalyte/lg/application/persistence/EmojiGrantRepository.kt`
+- Create: `src/main/kotlin/net/lumalyte/lg/infrastructure/persistence/guilds/EmojiGrantRepositorySQLite.kt`
+- Create: `src/test/kotlin/net/lumalyte/lg/infrastructure/persistence/guilds/EmojiGrantRepositorySQLiteTest.kt`
+
+**Interfaces:**
+- Produces: `EmojiPermissionGrant(playerId: UUID, guildId: UUID, permission: String)`.
+- Produces: `getAll`, `getForGuild`, `getForPlayerAndGuild`, `upsert`, and `delete` ledger operations.
+- Consumes: `Storage<Database>` and `VirtualThreadSQLiteStorage`.
+
+- [ ] **Step 1: Write the failing repository tests**
+
+Use `@TempDir` and real SQLite. Add these literal behaviors:
+
+```kotlin
+@Test
+fun `owned grant survives repository restart`() {
+    val grant = EmojiPermissionGrant(playerId, guildId, "enthusia.emoji.badger")
+    assertTrue(repository.upsert(grant))
+    val secondStorage = VirtualThreadSQLiteStorage(tempDir.toFile())
+    try {
+        assertEquals(
+            grant,
+            EmojiGrantRepositorySQLite(secondStorage)
+                .getForPlayerAndGuild(playerId, guildId),
+        )
+    } finally {
+        secondStorage.connection.close()
+    }
+}
+
+@Test
+fun `upsert replaces one memberships permission`() {
+    repository.upsert(EmojiPermissionGrant(playerId, guildId, "enthusia.emoji.old"))
+    repository.upsert(EmojiPermissionGrant(playerId, guildId, "enthusia.emoji.new"))
+    assertEquals("enthusia.emoji.new", repository.getForPlayerAndGuild(playerId, guildId)?.permission)
+    assertEquals(1, repository.getAll().size)
+}
+
+@Test
+fun `delete preserves other guild members`() {
+    repository.upsert(EmojiPermissionGrant(playerId, guildId, "enthusia.emoji.badger"))
+    repository.upsert(EmojiPermissionGrant(otherPlayerId, guildId, "enthusia.emoji.badger"))
+    assertTrue(repository.delete(playerId, guildId))
+    assertNull(repository.getForPlayerAndGuild(playerId, guildId))
+    assertNotNull(repository.getForPlayerAndGuild(otherPlayerId, guildId))
+}
+```
+
+- [ ] **Step 2: Run RED**
+
+Run `./gradlew test --tests net.lumalyte.lg.infrastructure.persistence.guilds.EmojiGrantRepositorySQLiteTest`.
+
+Expected: compilation fails because the entity, port, and adapter do not exist.
+
+- [ ] **Step 3: Add the domain value and port**
+
+```kotlin
+data class EmojiPermissionGrant(
+    val playerId: UUID,
+    val guildId: UUID,
+    val permission: String,
+)
+
+interface EmojiGrantRepository {
+    fun getAll(): List<EmojiPermissionGrant>
+    fun getForGuild(guildId: UUID): List<EmojiPermissionGrant>
+    fun getForPlayerAndGuild(playerId: UUID, guildId: UUID): EmojiPermissionGrant?
+    fun upsert(grant: EmojiPermissionGrant): Boolean
+    fun delete(playerId: UUID, guildId: UUID): Boolean
+}
+```
+
+- [ ] **Step 4: Add the SQLite adapter**
+
+Create `guild_emoji_grants_applied(player_id TEXT, guild_id TEXT, permission TEXT, PRIMARY KEY(player_id, guild_id))` and an index on `guild_id`. Preload a map keyed by `playerId to guildId`. Use parameterized `INSERT OR REPLACE` and `DELETE`; mutate the cache only after a successful database write. Throw `DatabaseOperationException` for schema/preload failure and return `false` with logging for mutation failure.
+
+- [ ] **Step 5: Run GREEN and layer checks**
+
+Run `./gradlew test --tests net.lumalyte.lg.infrastructure.persistence.guilds.EmojiGrantRepositorySQLiteTest --tests net.lumalyte.lg.architecture.LayerRulesTest`.
+
+- [ ] **Step 6: Commit**
+
+```text
+feat(emoji): persist managed grants
+```
+
+---
+
+### Task 2: Validate the config mapping
+
+**Files:**
+- Modify: `src/main/kotlin/net/lumalyte/lg/infrastructure/services/ConfigServiceBukkit.kt`
+- Modify: `src/main/resources/config.yml`
+- Modify: `src/test/kotlin/net/lumalyte/lg/config/ConfigLoaderConsistencyTest.kt`
+
+**Interfaces:**
+- Produces: normalized `MainConfig.guild.emojiGrants: Map<String, String>`.
+- Consumes: existing `loadEmojiGrantsConfig()`.
+
+- [ ] **Step 1: Add failing loader cases**
+
+```kotlin
+config.set("guild.emoji_grants.Badgers", "  Enthusia.Emoji.Badger  ")
+config.set("guild.emoji_grants.Blank", "   ")
+config.set("guild.emoji_grants.Injected", "permission true\nlp user attacker permission set * true")
+
+val grants = service.loadConfig().guild.emojiGrants
+assertEquals("enthusia.emoji.badger", grants["badgers"])
+assertFalse(grants.containsKey("blank"))
+assertFalse(grants.containsKey("injected"))
+```
+
+- [ ] **Step 2: Run RED**
+
+Run `./gradlew test --tests net.lumalyte.lg.config.ConfigLoaderConsistencyTest`.
+
+Expected: mixed-case values are not normalized and the injected value is accepted.
+
+- [ ] **Step 3: Implement minimal validation**
+
+In `loadEmojiGrantsConfig`, trim and lowercase keys/values using `Locale.ROOT`; accept only values matching `Regex("^[a-z0-9][a-z0-9_.-]*$")`. Ignore blank/invalid entries and log their guild key without logging executable text. Let the last duplicate normalized guild key win and log the collision.
+
+- [ ] **Step 4: Update `config.yml` comments**
+
+Document exact validation, case-insensitive names, one node per guild, and that `/lumaguilds reload` applies changes.
+
+- [ ] **Step 5: Run GREEN**
+
+Run `./gradlew test --tests net.lumalyte.lg.config.ConfigLoaderConsistencyTest --tests net.lumalyte.lg.infrastructure.i18n.LocaleContractTest`.
+
+- [ ] **Step 6: Commit**
+
+```text
+fix(config): validate emoji grants
+```
+
+---
+
+### Task 3: Build the reconciliation engine
+
+**Files:**
+- Create: `src/main/kotlin/net/lumalyte/lg/application/services/EmojiPermissionGateway.kt`
+- Create: `src/main/kotlin/net/lumalyte/lg/application/services/GuildEmojiGrantReconciler.kt`
+- Create: `src/test/kotlin/net/lumalyte/lg/application/services/GuildEmojiGrantReconcilerTest.kt`
+
+**Interfaces:**
+- Consumes: `GuildService`, `MemberService`, `EmojiGrantRepository`.
+- Produces: `EmojiPermissionGateway.grant(UUID, String): Boolean` and `revoke(UUID, String): Boolean`.
+- Produces: `EmojiGrantReconciliationResult(granted: Int, revoked: Int, failed: Int)` with `successful = failed == 0`.
+- Produces: `reconcileAll(Map<String, String>)`, `reconcileMembership`, `removeMembership`, `reconcileGuild`, and `removeGuild`.
+
+- [ ] **Step 1: Write RED initial-state tests using real fakes**
+
+The in-memory gateway records ordered strings; the in-memory ledger stores real `EmojiPermissionGrant` values.
+
+```kotlin
+@Test
+fun `initial mapping grants every current member and records ownership`() {
+    val result = reconciler.reconcileAll(mapOf("badgers" to "enthusia.emoji.badger"))
+    assertEquals(setOf(playerOne, playerTwo), ledger.getForGuild(guildId).map { it.playerId }.toSet())
+    assertEquals(2, result.granted)
+    assertEquals(0, result.failed)
+}
+
+@Test
+fun `unrecorded matching permission is never revoked`() {
+    gateway.externallyOwned += playerOne to "enthusia.emoji.badger"
+    reconciler.reconcileAll(emptyMap())
+    assertEquals(emptyList<String>(), gateway.operations)
+}
+```
+
+- [ ] **Step 2: Run RED**
+
+Run `./gradlew test --tests net.lumalyte.lg.application.services.GuildEmojiGrantReconcilerTest`.
+
+Expected: compilation fails because the gateway, result, and reconciler do not exist.
+
+- [ ] **Step 3: Implement desired-state addition/removal**
+
+Build desired entries from current guilds and members with normalized guild names. Compare only against repository rows. Revoke recorded entries absent from desired; grant desired entries absent from recorded. Continue after per-player failures and return exact counters. Serialize all public operations with one `ReentrantLock`.
+
+- [ ] **Step 4: Add RED replacement tests**
+
+```kotlin
+@Test
+fun `replacement revokes A before granting B`() {
+    ledger.upsert(EmojiPermissionGrant(playerOne, guildId, "enthusia.emoji.a"))
+    reconciler.reconcileAll(mapOf("badgers" to "enthusia.emoji.b"))
+    assertEquals(
+        listOf("revoke:$playerOne:enthusia.emoji.a", "grant:$playerOne:enthusia.emoji.b"),
+        gateway.operations,
+    )
+    assertEquals("enthusia.emoji.b", ledger.getForPlayerAndGuild(playerOne, guildId)?.permission)
+}
+
+@Test
+fun `config removal revokes and deletes ownership`() {
+    ledger.upsert(EmojiPermissionGrant(playerOne, guildId, "enthusia.emoji.badger"))
+    reconciler.reconcileAll(emptyMap())
+    assertNull(ledger.getForPlayerAndGuild(playerOne, guildId))
+}
+```
+
+- [ ] **Step 5: Run RED, then implement ordered replacement**
+
+For a differing pair: revoke recorded permission; on success delete its row; grant desired permission; on success upsert desired. If ledger upsert fails after a grant, immediately compensate with a revoke. Do not add background retries.
+
+- [ ] **Step 6: Add RED failure/retry tests**
+
+Prove revoke failure retains A, grant failure leaves no B row, ledger-upsert failure triggers compensating revoke, and a second reconciliation retries retained work.
+
+- [ ] **Step 7: Implement only those failure paths and run GREEN**
+
+Run `./gradlew test --tests net.lumalyte.lg.application.services.GuildEmojiGrantReconcilerTest --tests net.lumalyte.lg.architecture.LayerRulesTest`.
+
+- [ ] **Step 8: Add RED narrow lifecycle tests**
+
+Prove `reconcileMembership` grants on join; `removeMembership` revokes from the ledger without config; `reconcileGuild` replaces permissions for every current member and removes former-member rows; `removeGuild` revokes ledger rows after the guild record is gone.
+
+- [ ] **Step 9: Reuse the single-entry transition to implement lifecycle methods, then run GREEN**
+
+Do not duplicate replacement logic. Callers pass a resolved permission or `null`; the application reconciler never loads Bukkit config.
+
+- [ ] **Step 10: Commit**
+
+```text
+feat(emoji): reconcile managed grants
+```
+
+---
+
+### Task 4: Wire Bukkit lifecycle and permission dispatch
+
+**Files:**
+- Create: `src/main/kotlin/net/lumalyte/lg/infrastructure/services/LuckPermsEmojiPermissionGateway.kt`
+- Create: `src/main/kotlin/net/lumalyte/lg/api/events/GuildRenamedEvent.kt`
+- Create: `src/test/kotlin/net/lumalyte/lg/infrastructure/services/LuckPermsEmojiPermissionGatewayTest.kt`
+- Create: `src/test/kotlin/net/lumalyte/lg/infrastructure/listeners/GuildEmojiGrantListenerTest.kt`
+- Create: `src/test/kotlin/net/lumalyte/lg/api/events/GuildRenamedEventTest.kt`
+- Modify: `GuildEmojiGrantService.kt`, `GuildEmojiGrantListener.kt`, `GuildServiceBukkit.kt`, `LumaGuildsCommand.kt`, `Modules.kt`, and `LumaGuilds.kt`.
+- Modify: `GuildEventApiContractTest.kt` and `KoinGraphSmokeTest.kt`.
+
+**Interfaces:**
+- Consumes: Tasks 1–3 repository, gateway port, and reconciler.
+- Produces: config-aware façade methods `reconcileAll`, `onMemberJoined`, `onMemberRemoved`, `onGuildCreated`, `onGuildRenamed`, and `onGuildDisbanded`.
+- Produces: `GuildRenamedEvent(guildId: UUID, oldName: String, newName: String)`.
+
+- [ ] **Step 1: Write RED gateway safety tests**
+
+Using MockBukkit command capture, assert exact valid commands:
+
+```text
+lp user <uuid> permission set enthusia.emoji.badger true
+lp user <uuid> permission unset enthusia.emoji.badger
+```
+
+Invalid nodes return false and dispatch nothing.
+
+- [ ] **Step 2: Implement gateway and run GREEN**
+
+Dispatch directly when `Bukkit.isPrimaryThread()`. Off-thread, submit to the scheduler and wait at most five seconds for the Boolean result; timeout/interruption returns false. Validate UUID and permission before constructing commands.
+
+- [ ] **Step 3: Write RED façade/listener tests**
+
+Assert join resolves the current mapping and reconciles one membership; removal calls `removeMembership` without config; creation reconciles the guild; rename resolves the new name and calls `reconcileGuild`; disband calls `removeGuild`; global reload passes the freshly loaded map to `reconcileAll`.
+
+- [ ] **Step 4: Replace ad-hoc grant/revoke code with the façade**
+
+Delete direct command construction from `GuildEmojiGrantService`. Keep all config lookup in this infrastructure façade and route every listener event to one narrow reconciler method.
+
+- [ ] **Step 5: Write RED rename-event tests**
+
+Add the event to `GuildEventApiContractTest`. Prove `renameGuild` emits exactly once after successful repository update and never on validation, permission, collision, or repository failure.
+
+- [ ] **Step 6: Implement `GuildRenamedEvent` and emission**
+
+Follow the existing `GuildCreatedEvent` HandlerList structure. Carry literal old/new names and guild ID.
+
+- [ ] **Step 7: Wire Koin, startup, and reload**
+
+Bind `EmojiGrantRepository`, `EmojiPermissionGateway`, `GuildEmojiGrantReconciler`, façade, and listener. Replace startup `grantAll()` with `reconcileAll()`. After `reloadConfig()` and `initConfig()`, invoke reconciliation and report/log an unsuccessful result.
+
+- [ ] **Step 8: Run focused integration GREEN**
+
+Run `./gradlew test --tests net.lumalyte.lg.infrastructure.services.LuckPermsEmojiPermissionGatewayTest --tests net.lumalyte.lg.infrastructure.listeners.GuildEmojiGrantListenerTest --tests net.lumalyte.lg.api.events.GuildRenamedEventTest --tests net.lumalyte.lg.api.events.GuildEventApiContractTest --tests net.lumalyte.lg.di.KoinGraphSmokeTest`.
+
+- [ ] **Step 9: Commit**
+
+```text
+feat(emoji): wire grant reconciliation
+```
+
+---
+
+### Task 5: Documentation, evidence, and final gates
+
+**Files:**
+- Modify: `docs/EMOJI_PERMISSIONS.md`
+- Modify: `docs/tasks.md`
+
+- [ ] **Step 1: Update operator documentation**
+
+Document exact YAML, validation, case-insensitive matching, startup/reload reconciliation, join/leave/rename/disband behavior, mapping removal, A→B replacement, and the difference between displayed emoji selection (LG-1103) and permission ownership (LG-1104).
+
+- [ ] **Step 2: Run the focused acceptance suite**
+
+Run all new repository, reconciler, gateway, listener, rename-event, config, architecture, and Koin tests in one Gradle invocation. Expected: zero failures/errors.
+
+- [ ] **Step 3: Run the complete clean suite**
+
+Run `./gradlew clean test`. Record the exact test/failure/error counts from XML.
+
+- [ ] **Step 4: Complete SPEAR tracking**
+
+Change LG-1104 from `[~]` to `[x]`. Record the exact count and name the reconciler, ledger, gateway, lifecycle integration, config validation, and regression tests.
+
+- [ ] **Step 5: Verify the diff**
+
+Run `git diff --check`, `git status --short`, and `git diff --stat origin/main...HEAD`. Expected: no whitespace errors and only LG-1104 files.
+
+- [ ] **Step 6: Commit documentation**
+
+```text
+docs(emoji): document managed grants
+```
+
+- [ ] **Step 7: Request independent review**
+
+Review `origin/main...HEAD`. Resolve every Critical and Important finding through a new red-green cycle, then rerun `./gradlew clean test` after the final code change.

--- a/docs/superpowers/specs/2026-08-26-guild-emoji-grant-reconciliation-design.md
+++ b/docs/superpowers/specs/2026-08-26-guild-emoji-grant-reconciliation-design.md
@@ -1,0 +1,203 @@
+# Guild Emoji Grant Reconciliation Design
+
+**Task:** LG-1104  
+**Requirement:** REQ-048  
+**Status:** Proposed
+
+## Purpose
+
+Operators can map a guild name to one Nexo-compatible permission node in
+`guild.emoji_grants`. LumaGuilds must grant that permission to every current
+member and must remove only the permissions it previously granted when the
+membership, guild name, or configuration changes.
+
+The current implementation grants on startup and member join, but derives
+revocation solely from the current config. After a mapping is removed or
+replaced, the old permission is no longer discoverable. A restart loses the
+last in-memory configuration entirely. This design adds durable ownership and
+one reconciliation path for every lifecycle trigger.
+
+## Operator Contract
+
+```yaml
+guild:
+  emoji_grants:
+    Badgers: enthusia.emoji.badger
+    Dragons: enthusia.emoji.dragon
+```
+
+- Guild-name matching is case-insensitive.
+- Each guild name maps to at most one permission node.
+- Permission nodes are trimmed, normalized to lowercase, and accepted only
+  when they match `[a-z0-9][a-z0-9_.-]*`.
+- Invalid or blank mappings are ignored and logged. Any formerly owned grant
+  for that mapping becomes obsolete and is revoked during reconciliation.
+- The configured permission must be the permission Nexo/chat actually checks.
+  LumaGuilds does not invent a second parallel permission.
+- Configuration remains the only operator-facing mutation mechanism. This
+  task does not add an admin command.
+
+## Architecture
+
+### Domain
+
+No Bukkit, LuckPerms, SQL, or configuration types enter `domain/**`.
+
+`EmojiPermissionGrant` is a small domain value containing:
+
+- `playerId: UUID`
+- `guildId: UUID`
+- `permission: String`
+
+Its identity is `(playerId, guildId)` because the current config permits one
+managed permission per guild. The permission is the replaceable value.
+
+### Application ports
+
+`EmojiGrantRepository` owns the durable record of grants made by LumaGuilds:
+
+- `getAll(): List<EmojiPermissionGrant>`
+- `getForGuild(guildId): List<EmojiPermissionGrant>`
+- `getForPlayerAndGuild(playerId, guildId): EmojiPermissionGrant?`
+- `upsert(grant): Boolean`
+- `delete(playerId, guildId): Boolean`
+
+`EmojiPermissionGateway` owns the external permission side effect:
+
+- `grant(playerId, permission): Boolean`
+- `revoke(playerId, permission): Boolean`
+
+The gateway is the only component allowed to communicate with the permissions
+plugin. Tests use an in-memory gateway; production initially retains the
+existing LuckPerms command integration behind this port.
+
+### Infrastructure
+
+`EmojiGrantRepositorySQLite` creates and accesses:
+
+```sql
+CREATE TABLE IF NOT EXISTS guild_emoji_grants_applied (
+    player_id TEXT NOT NULL,
+    guild_id TEXT NOT NULL,
+    permission TEXT NOT NULL,
+    PRIMARY KEY (player_id, guild_id)
+);
+CREATE INDEX IF NOT EXISTS idx_guild_emoji_grants_guild
+    ON guild_emoji_grants_applied(guild_id);
+```
+
+`LuckPermsEmojiPermissionGateway` wraps the current console-command behavior.
+UUID and permission values are validated before command construction. Calls
+return the dispatch result. All callers enter through Bukkit's primary thread;
+the gateway schedules onto that thread only when necessary.
+
+`GuildEmojiGrantService` becomes the reconciliation coordinator. It depends on
+guild/member read services, the validated config mapping, the ownership
+repository, and the permission gateway. It does not directly construct or
+dispatch console commands.
+
+## Reconciliation Algorithm
+
+Global reconciliation computes a desired map keyed by `(playerId, guildId)`:
+
+1. Read every current guild.
+2. Resolve its normalized name in the validated config mapping.
+3. If mapped, pair every current member with the configured permission.
+4. Read every recorded grant owned by LumaGuilds.
+5. Revoke recorded entries that are absent from desired or whose permission
+   differs.
+6. Grant desired entries that are absent from recorded or whose permission
+   differs.
+
+Replacement from A to B is ordered: revoke A and retain its ledger row until
+the revoke succeeds; then grant B and replace the ledger row only after the
+grant succeeds. This prevents the old permission from being forgotten and
+ensures a failed operation can be retried on the next reconciliation.
+
+If a grant succeeds but the ledger write fails, the service immediately
+attempts a compensating revoke and reports failure. If a revoke succeeds but
+ledger deletion fails, the stale row remains and the next reconciliation
+performs an idempotent revoke again.
+
+The service serializes reconciliation calls with one lock so startup, reload,
+and lifecycle events cannot interleave two replacements for the same entry.
+
+## Lifecycle Triggers
+
+- **Plugin enable:** run global reconciliation after repositories and services
+  are ready.
+- **Config reload:** run global reconciliation after `reloadConfig()` and
+  `initConfig()` so removals and replacements are observed immediately.
+- **Member join:** reconcile the `(player, guild)` pair and grant the current
+  mapping if one exists.
+- **Member leave/kick:** revoke and delete the recorded `(player, guild)` grant
+  directly. This does not depend on event ordering or the current config.
+- **Guild create:** reconcile the new guild so its owner receives a preconfigured
+  name mapping.
+- **Guild rename:** after the rename commits, reconcile every member of that
+  guild. Old-name grants are recorded in the ledger and are therefore revoked
+  before a new-name grant is applied.
+- **Guild disband:** revoke and delete every recorded grant for the guild. This
+  uses the ledger and remains valid after the guild row is deleted.
+
+A new `GuildRenamedEvent` carries the guild ID, old name, and new name and fires
+only after repository update succeeds. Existing join, removal, creation, and
+disband events remain the other lifecycle boundaries.
+
+## Failure Handling
+
+- One failed player operation does not stop reconciliation for other players.
+- Failed external operations remain represented by their prior ledger state and
+  are logged with player, guild, permission, and operation.
+- Repository failures are logged and return an unsuccessful reconciliation
+  result; no success is claimed to the reload caller.
+- Plugin disable performs no revocation. The ledger and external grants are
+  intentionally durable across restarts and are reconciled on the next enable.
+- LumaGuilds never revokes an unrecorded permission, even if it matches a
+  configured node. Operator- or group-owned grants therefore remain untouched.
+
+## Testing Strategy
+
+SPEAR red-green cycles cover:
+
+1. Initial mapping grants every current guild member and records ownership.
+2. A later member join receives and records the grant.
+3. Leave/kick revokes only that membership's recorded grant.
+4. Guild disband revokes all recorded grants after the guild is gone.
+5. Guild rename revokes the old-name permission and grants the new-name mapping.
+6. Config removal revokes and deletes prior grants.
+7. Config replacement A to B revokes A before granting B.
+8. Restart recovery reconciles persisted ledger rows against current config.
+9. Unrecorded matching permissions are never revoked.
+10. Revoke failure retains the old ledger row for retry.
+11. Grant failure does not create a ledger row.
+12. Config loading normalizes names/nodes and rejects invalid nodes.
+13. Architecture tests preserve domain/application/infrastructure boundaries.
+
+Focused service tests use real in-memory repository and gateway fakes so they
+assert state and ordered side effects rather than mock existence. SQLite tests
+prove schema persistence and restart behavior. Listener tests prove events call
+the correct narrow reconciliation entry points.
+
+## Scope Boundaries
+
+Included:
+
+- Durable ownership tracking.
+- Startup, reload, membership, rename, creation, and disband reconciliation.
+- Validation and documentation of `guild.emoji_grants`.
+- Replacement of direct permission commands with a gateway adapter.
+
+Excluded:
+
+- Creating or editing Nexo glyphs.
+- Choosing the guild's displayed emoji (LG-1103).
+- Multiple automatic emoji permissions per guild.
+- An in-game admin command or GUI for mapping changes.
+- General-purpose LuckPerms synchronization outside guild emoji grants.
+
+## Acceptance
+
+LG-1104 is complete when all REQ-048 lifecycle cases pass, stale owned grants
+are recoverable across restart, unowned permissions are preserved, the full
+test suite is green, and `docs/tasks.md` contains concrete evidence and files.

--- a/docs/tasks.md
+++ b/docs/tasks.md
@@ -334,7 +334,7 @@ PR grouping: tasks under each `## PR-n` header ship together in one pull request
   - References: REQ-047
   - Evidence: Java Clear now persists `null` immediately through the existing permission-checked `GuildService.setEmoji` path, matching the Bedrock blank-input behavior; `GuildEmojiClearTest` reproduces the prior state-reset bug and is GREEN; full clean suite is GREEN (661 tests).
   - Files: `interaction/menus/guild/GuildEmojiMenu.kt`, `GuildEmojiClearTest.kt`
-- [ ] **LG-1104** Custom guild emojis via config — guild-name → Nexo permission grant for all members
+- [~] **LG-1104** Custom guild emojis via config — guild-name → Nexo permission grant for all members
   - Tag: `TDD`
   - References: REQ-048
   - Evidence:

--- a/docs/tasks.md
+++ b/docs/tasks.md
@@ -334,11 +334,11 @@ PR grouping: tasks under each `## PR-n` header ship together in one pull request
   - References: REQ-047
   - Evidence: Java Clear now persists `null` immediately through the existing permission-checked `GuildService.setEmoji` path, matching the Bedrock blank-input behavior; `GuildEmojiClearTest` reproduces the prior state-reset bug and is GREEN; full clean suite is GREEN (661 tests).
   - Files: `interaction/menus/guild/GuildEmojiMenu.kt`, `GuildEmojiClearTest.kt`
-- [~] **LG-1104** Custom guild emojis via config — guild-name → Nexo permission grant for all members
+- [x] **LG-1104** Custom guild emojis via config — guild-name → Nexo permission grant for all members
   - Tag: `TDD`
   - References: REQ-048
-  - Evidence:
-  - Files: config section, `NexoEmojiService` (↳ LG-902 reflection cleanup)
+  - Evidence: SQLite ownership-ledger restart coverage; config normalization/injection rejection; reconciliation tests cover grant, leave, shared-node ownership, disband, rename, config removal, A→B replacement, and partial failures; LuckPerms gateway tests assert exact console commands; event, architecture, Koin graph, and full clean suite GREEN (682 tests).
+  - Files: `EmojiPermissionGrant`, `EmojiGrantRepository`, `EmojiGrantRepositorySQLite`, `GuildEmojiGrantReconciler`, `LuckPermsEmojiPermissionGateway`, `GuildEmojiGrantService`, `GuildEmojiGrantListener`, `GuildRenamedEvent`, config loader, startup/reload wiring, `EMOJI_PERMISSIONS.md`
   - Notes: lifecycle reconciliation — revoke on config-removal, guild rename/disband, member leave, and mapping change (A→B revokes A, grants B); tests cover grant, revoke, rename, config-removal, and value replacement
   - Harvest: `CustomEmojiCommand` + `setEmojiAdmin()` from closed PR #7 (superseded) — rebuild admin-command flow against current rank/permission model
 

--- a/docs/tasks.md
+++ b/docs/tasks.md
@@ -337,7 +337,7 @@ PR grouping: tasks under each `## PR-n` header ship together in one pull request
 - [x] **LG-1104** Custom guild emojis via config — guild-name → Nexo permission grant for all members
   - Tag: `TDD`
   - References: REQ-048
-  - Evidence: SQLite ownership-ledger restart coverage; config normalization/injection rejection; reconciliation tests cover grant, leave, shared-node ownership, disband, rename, config removal, A→B replacement, and partial failures; LuckPerms gateway tests assert exact console commands; event, architecture, Koin graph, and full clean suite GREEN (682 tests).
+  - Evidence: SQLite ownership-ledger restart and malformed-row coverage; config normalization/injection/length rejection; reconciliation tests cover grant, leave, shared-node ownership, disband, rename, config removal, A→B replacement, and partial failures; LuckPerms gateway tests assert exact console commands; event, architecture, Koin graph, and full clean suite GREEN (685 tests).
   - Files: `EmojiPermissionGrant`, `EmojiGrantRepository`, `EmojiGrantRepositorySQLite`, `GuildEmojiGrantReconciler`, `LuckPermsEmojiPermissionGateway`, `GuildEmojiGrantService`, `GuildEmojiGrantListener`, `GuildRenamedEvent`, config loader, startup/reload wiring, `EMOJI_PERMISSIONS.md`
   - Notes: lifecycle reconciliation — revoke on config-removal, guild rename/disband, member leave, and mapping change (A→B revokes A, grants B); tests cover grant, revoke, rename, config-removal, and value replacement
   - Harvest: `CustomEmojiCommand` + `setEmojiAdmin()` from closed PR #7 (superseded) — rebuild admin-command flow against current rank/permission model

--- a/src/main/kotlin/net/lumalyte/lg/LumaGuilds.kt
+++ b/src/main/kotlin/net/lumalyte/lg/LumaGuilds.kt
@@ -967,10 +967,13 @@ class LumaGuilds : JavaPlugin() {
         val guildDisbandedListener = get().get<net.lumalyte.lg.infrastructure.listeners.GuildDisbandedListener>()
         server.pluginManager.registerEvents(guildDisbandedListener, this)
 
-        // Register emoji grant listener and grant permissions for all configured guilds
+        // Register emoji grant listener and reconcile all plugin-managed permissions.
         val emojiGrantListener = get().get<net.lumalyte.lg.infrastructure.listeners.GuildEmojiGrantListener>()
         server.pluginManager.registerEvents(emojiGrantListener, this)
-        get().get<net.lumalyte.lg.infrastructure.services.GuildEmojiGrantService>().grantAll()
+        val emojiResult = get().get<net.lumalyte.lg.infrastructure.services.GuildEmojiGrantService>().reconcileAll()
+        if (!emojiResult.successful) {
+            logger.warning("Emoji permission reconciliation completed with ${emojiResult.failed} failure(s)")
+        }
 
         // Clean up RoseChat channels when guild status changes.
         // LumaGuilds can enable BEFORE RoseChat despite `depend: [RoseChat]`

--- a/src/main/kotlin/net/lumalyte/lg/api/events/GuildRenamedEvent.kt
+++ b/src/main/kotlin/net/lumalyte/lg/api/events/GuildRenamedEvent.kt
@@ -1,0 +1,18 @@
+package net.lumalyte.lg.api.events
+
+import net.lumalyte.lg.domain.entities.Guild
+import org.bukkit.event.Event
+import org.bukkit.event.HandlerList
+import java.util.UUID
+
+class GuildRenamedEvent(
+    val oldGuild: Guild,
+    val guild: Guild,
+    val actorId: UUID,
+) : Event() {
+    companion object {
+        private val HANDLERS = HandlerList()
+        @JvmStatic fun getHandlerList(): HandlerList = HANDLERS
+    }
+    override fun getHandlers(): HandlerList = HANDLERS
+}

--- a/src/main/kotlin/net/lumalyte/lg/api/events/GuildRenamedEvent.kt
+++ b/src/main/kotlin/net/lumalyte/lg/api/events/GuildRenamedEvent.kt
@@ -1,14 +1,13 @@
 package net.lumalyte.lg.api.events
 
-import net.lumalyte.lg.domain.entities.Guild
 import org.bukkit.event.Event
 import org.bukkit.event.HandlerList
 import java.util.UUID
 
 class GuildRenamedEvent(
-    val oldGuild: Guild,
-    val guild: Guild,
-    val actorId: UUID,
+    val guildId: UUID,
+    val oldName: String,
+    val newName: String,
 ) : Event() {
     companion object {
         private val HANDLERS = HandlerList()

--- a/src/main/kotlin/net/lumalyte/lg/application/persistence/EmojiGrantRepository.kt
+++ b/src/main/kotlin/net/lumalyte/lg/application/persistence/EmojiGrantRepository.kt
@@ -1,0 +1,12 @@
+package net.lumalyte.lg.application.persistence
+
+import net.lumalyte.lg.domain.entities.EmojiPermissionGrant
+import java.util.UUID
+
+interface EmojiGrantRepository {
+    fun getAll(): List<EmojiPermissionGrant>
+    fun getForGuild(guildId: UUID): List<EmojiPermissionGrant>
+    fun getForPlayerAndGuild(playerId: UUID, guildId: UUID): EmojiPermissionGrant?
+    fun upsert(grant: EmojiPermissionGrant): Boolean
+    fun delete(playerId: UUID, guildId: UUID): Boolean
+}

--- a/src/main/kotlin/net/lumalyte/lg/application/services/EmojiPermissionGateway.kt
+++ b/src/main/kotlin/net/lumalyte/lg/application/services/EmojiPermissionGateway.kt
@@ -1,0 +1,8 @@
+package net.lumalyte.lg.application.services
+
+import java.util.UUID
+
+interface EmojiPermissionGateway {
+    fun grant(playerId: UUID, permission: String): Boolean
+    fun revoke(playerId: UUID, permission: String): Boolean
+}

--- a/src/main/kotlin/net/lumalyte/lg/application/services/GuildEmojiGrantReconciler.kt
+++ b/src/main/kotlin/net/lumalyte/lg/application/services/GuildEmojiGrantReconciler.kt
@@ -1,0 +1,117 @@
+package net.lumalyte.lg.application.services
+
+import net.lumalyte.lg.application.persistence.EmojiGrantRepository
+import net.lumalyte.lg.domain.entities.EmojiPermissionGrant
+import java.util.Locale
+import java.util.UUID
+import java.util.concurrent.locks.ReentrantLock
+import kotlin.concurrent.withLock
+
+data class EmojiGrantReconciliationResult(
+    val granted: Int = 0,
+    val revoked: Int = 0,
+    val failed: Int = 0,
+) {
+    val successful: Boolean get() = failed == 0
+
+    operator fun plus(other: EmojiGrantReconciliationResult) = EmojiGrantReconciliationResult(
+        granted = granted + other.granted,
+        revoked = revoked + other.revoked,
+        failed = failed + other.failed,
+    )
+}
+
+class GuildEmojiGrantReconciler(
+    private val guildService: GuildService,
+    private val memberService: MemberService,
+    private val repository: EmojiGrantRepository,
+    private val gateway: EmojiPermissionGateway,
+) {
+    private val lock = ReentrantLock()
+
+    fun reconcileAll(mappings: Map<String, String>): EmojiGrantReconciliationResult = lock.withLock {
+        val desired = buildMap<Pair<UUID, UUID>, EmojiPermissionGrant> {
+            guildService.getAllGuilds().forEach { guild ->
+                val permission = mappings[guild.name.lowercase(Locale.ROOT)] ?: return@forEach
+                memberService.getGuildMembers(guild.id).forEach { member ->
+                    put(member.playerId to guild.id, EmojiPermissionGrant(member.playerId, guild.id, permission))
+                }
+            }
+        }
+        reconcileDesired(desired, repository.getAll())
+    }
+
+    fun reconcileMembership(
+        playerId: UUID,
+        guildId: UUID,
+        permission: String?,
+    ): EmojiGrantReconciliationResult = lock.withLock {
+        val desired = permission?.let { EmojiPermissionGrant(playerId, guildId, it) }
+        reconcileDesired(
+            desired = listOfNotNull(desired).associateBy { it.playerId to it.guildId },
+            recordedGrants = listOfNotNull(repository.getForPlayerAndGuild(playerId, guildId)),
+        )
+    }
+
+    fun removeMembership(playerId: UUID, guildId: UUID): EmojiGrantReconciliationResult = lock.withLock {
+        reconcileDesired(
+            desired = emptyMap(),
+            recordedGrants = listOfNotNull(repository.getForPlayerAndGuild(playerId, guildId)),
+        )
+    }
+
+    fun reconcileGuild(guildId: UUID, permission: String?): EmojiGrantReconciliationResult = lock.withLock {
+        val desired = if (permission == null) {
+            emptyMap()
+        } else {
+            memberService.getGuildMembers(guildId).associate { member ->
+                (member.playerId to guildId) to EmojiPermissionGrant(member.playerId, guildId, permission)
+            }
+        }
+        reconcileDesired(desired, repository.getForGuild(guildId))
+    }
+
+    fun removeGuild(guildId: UUID): EmojiGrantReconciliationResult = lock.withLock {
+        reconcileDesired(emptyMap(), repository.getForGuild(guildId))
+    }
+
+    private fun reconcileDesired(
+        desired: Map<Pair<UUID, UUID>, EmojiPermissionGrant>,
+        recordedGrants: List<EmojiPermissionGrant>,
+    ): EmojiGrantReconciliationResult {
+        val recorded = recordedGrants.associateBy { it.playerId to it.guildId }
+        var result = EmojiGrantReconciliationResult()
+
+        recorded.filterKeys { it !in desired }.values.forEach { grant ->
+            result += revokeAndDelete(grant)
+        }
+        recorded.keys.intersect(desired.keys).forEach { key ->
+            val oldGrant = recorded.getValue(key)
+            val newGrant = desired.getValue(key)
+            if (oldGrant.permission != newGrant.permission) {
+                val revoked = revokeAndDelete(oldGrant)
+                result += revoked
+                if (revoked.successful) result += grantAndRecord(newGrant)
+            }
+        }
+        desired.filterKeys { it !in recorded }.values.forEach { grant ->
+            result += grantAndRecord(grant)
+        }
+        return result
+    }
+
+    private fun grantAndRecord(grant: EmojiPermissionGrant): EmojiGrantReconciliationResult {
+        if (!gateway.grant(grant.playerId, grant.permission)) return EmojiGrantReconciliationResult(failed = 1)
+        if (!repository.upsert(grant)) {
+            gateway.revoke(grant.playerId, grant.permission)
+            return EmojiGrantReconciliationResult(failed = 1)
+        }
+        return EmojiGrantReconciliationResult(granted = 1)
+    }
+
+    private fun revokeAndDelete(grant: EmojiPermissionGrant): EmojiGrantReconciliationResult {
+        if (!gateway.revoke(grant.playerId, grant.permission)) return EmojiGrantReconciliationResult(failed = 1)
+        if (!repository.delete(grant.playerId, grant.guildId)) return EmojiGrantReconciliationResult(failed = 1)
+        return EmojiGrantReconciliationResult(revoked = 1)
+    }
+}

--- a/src/main/kotlin/net/lumalyte/lg/application/services/GuildEmojiGrantReconciler.kt
+++ b/src/main/kotlin/net/lumalyte/lg/application/services/GuildEmojiGrantReconciler.kt
@@ -110,8 +110,15 @@ class GuildEmojiGrantReconciler(
     }
 
     private fun revokeAndDelete(grant: EmojiPermissionGrant): EmojiGrantReconciliationResult {
-        if (!gateway.revoke(grant.playerId, grant.permission)) return EmojiGrantReconciliationResult(failed = 1)
+        val anotherOwnedGrantRequiresPermission = repository.getAll().any {
+            it.playerId == grant.playerId &&
+                it.permission == grant.permission &&
+                it.guildId != grant.guildId
+        }
+        if (!anotherOwnedGrantRequiresPermission && !gateway.revoke(grant.playerId, grant.permission)) {
+            return EmojiGrantReconciliationResult(failed = 1)
+        }
         if (!repository.delete(grant.playerId, grant.guildId)) return EmojiGrantReconciliationResult(failed = 1)
-        return EmojiGrantReconciliationResult(revoked = 1)
+        return EmojiGrantReconciliationResult(revoked = if (anotherOwnedGrantRequiresPermission) 0 else 1)
     }
 }

--- a/src/main/kotlin/net/lumalyte/lg/application/services/GuildEmojiGrantReconciler.kt
+++ b/src/main/kotlin/net/lumalyte/lg/application/services/GuildEmojiGrantReconciler.kt
@@ -32,7 +32,7 @@ class GuildEmojiGrantReconciler(
     fun reconcileAll(mappings: Map<String, String>): EmojiGrantReconciliationResult = lock.withLock {
         val desired = buildMap<Pair<UUID, UUID>, EmojiPermissionGrant> {
             guildService.getAllGuilds().forEach { guild ->
-                val permission = mappings[guild.name.lowercase(Locale.ROOT)] ?: return@forEach
+                val permission = mappings[guild.name.trim().lowercase(Locale.ROOT)] ?: return@forEach
                 memberService.getGuildMembers(guild.id).forEach { member ->
                     put(member.playerId to guild.id, EmojiPermissionGrant(member.playerId, guild.id, permission))
                 }

--- a/src/main/kotlin/net/lumalyte/lg/di/Modules.kt
+++ b/src/main/kotlin/net/lumalyte/lg/di/Modules.kt
@@ -504,7 +504,16 @@ fun socialModule() = module {
         net.lumalyte.lg.infrastructure.listeners.GuildDisbandedListener(get(), get(), get())
     }
     single<net.lumalyte.lg.infrastructure.services.GuildEmojiGrantService> {
-        net.lumalyte.lg.infrastructure.services.GuildEmojiGrantService(get(), get(), get(), get())
+        net.lumalyte.lg.infrastructure.services.GuildEmojiGrantService(get(), get(), get())
+    }
+    single<net.lumalyte.lg.application.persistence.EmojiGrantRepository> {
+        net.lumalyte.lg.infrastructure.persistence.guilds.EmojiGrantRepositorySQLite(get())
+    }
+    single<net.lumalyte.lg.application.services.EmojiPermissionGateway> {
+        net.lumalyte.lg.infrastructure.services.LuckPermsEmojiPermissionGateway(get())
+    }
+    single {
+        net.lumalyte.lg.application.services.GuildEmojiGrantReconciler(get(), get(), get(), get())
     }
     single<net.lumalyte.lg.infrastructure.listeners.GuildEmojiGrantListener> {
         net.lumalyte.lg.infrastructure.listeners.GuildEmojiGrantListener(get())

--- a/src/main/kotlin/net/lumalyte/lg/di/Modules.kt
+++ b/src/main/kotlin/net/lumalyte/lg/di/Modules.kt
@@ -246,7 +246,7 @@ fun coreModule(plugin: LumaGuilds, storage: Storage<*>) = module {
     single<Storage<Database>> { storage as Storage<Database> }
 
     // Core services
-    single<ConfigService> { ConfigServiceBukkit(get()) }
+    single<ConfigService> { ConfigServiceBukkit { get<LumaGuilds>().config } }
     single { get<ConfigService>().loadConfig() }
     single<PlayerMetadataService> { PlayerMetadataServiceVault(get(), get()) }
 
@@ -510,7 +510,7 @@ fun socialModule() = module {
         net.lumalyte.lg.infrastructure.persistence.guilds.EmojiGrantRepositorySQLite(get())
     }
     single<net.lumalyte.lg.application.services.EmojiPermissionGateway> {
-        net.lumalyte.lg.infrastructure.services.LuckPermsEmojiPermissionGateway(get())
+        net.lumalyte.lg.infrastructure.services.LuckPermsEmojiPermissionGateway()
     }
     single {
         net.lumalyte.lg.application.services.GuildEmojiGrantReconciler(get(), get(), get(), get())

--- a/src/main/kotlin/net/lumalyte/lg/domain/entities/EmojiPermissionGrant.kt
+++ b/src/main/kotlin/net/lumalyte/lg/domain/entities/EmojiPermissionGrant.kt
@@ -1,0 +1,9 @@
+package net.lumalyte.lg.domain.entities
+
+import java.util.UUID
+
+data class EmojiPermissionGrant(
+    val playerId: UUID,
+    val guildId: UUID,
+    val permission: String,
+)

--- a/src/main/kotlin/net/lumalyte/lg/domain/entities/EmojiPermissionGrant.kt
+++ b/src/main/kotlin/net/lumalyte/lg/domain/entities/EmojiPermissionGrant.kt
@@ -2,6 +2,8 @@ package net.lumalyte.lg.domain.entities
 
 import java.util.UUID
 
+const val MAX_EMOJI_PERMISSION_LENGTH = 255
+
 data class EmojiPermissionGrant(
     val playerId: UUID,
     val guildId: UUID,

--- a/src/main/kotlin/net/lumalyte/lg/infrastructure/listeners/GuildEmojiGrantListener.kt
+++ b/src/main/kotlin/net/lumalyte/lg/infrastructure/listeners/GuildEmojiGrantListener.kt
@@ -10,6 +10,7 @@ import org.bukkit.event.EventHandler
 import org.bukkit.event.EventPriority
 import org.bukkit.event.Listener
 import org.slf4j.LoggerFactory
+import net.lumalyte.lg.application.services.EmojiGrantReconciliationResult
 
 /**
  * Listens for guild membership changes and grants/revokes emoji permissions
@@ -23,46 +24,41 @@ class GuildEmojiGrantListener(
 
     @EventHandler(priority = EventPriority.MONITOR)
     fun onGuildMemberJoin(event: GuildMemberJoinEvent) {
-        try {
+        reconcile("member join player=${event.playerId} guild=${event.guildId}") {
             emojiGrantService.reconcileMember(event.playerId, event.guildId)
-        } catch (e: Exception) {
-            logger.warn("Failed to grant emoji permission on join: ${e.message}")
         }
     }
 
     @EventHandler(priority = EventPriority.MONITOR)
     fun onGuildMemberRemoved(event: GuildMemberRemovedEvent) {
-        try {
+        reconcile("member removal player=${event.playerId} guild=${event.guildId}") {
             emojiGrantService.removeMember(event.playerId, event.guildId)
-        } catch (e: Exception) {
-            logger.warn("Failed to revoke emoji permission on leave: ${e.message}")
         }
     }
 
     @EventHandler(priority = EventPriority.MONITOR)
     fun onGuildCreated(event: GuildCreatedEvent) {
-        reconcile("create") { emojiGrantService.reconcileGuild(event.guild.id) }
+        reconcile("guild create guild=${event.guild.id}") { emojiGrantService.reconcileGuild(event.guild.id) }
     }
 
     @EventHandler(priority = EventPriority.MONITOR)
     fun onGuildRenamed(event: GuildRenamedEvent) {
-        reconcile("rename") { emojiGrantService.reconcileGuild(event.guild.id) }
+        reconcile("guild rename guild=${event.guild.id}") { emojiGrantService.reconcileGuild(event.guild.id) }
     }
 
     @EventHandler(priority = EventPriority.MONITOR)
     fun onGuildDisbanded(event: GuildDisbandedEvent) {
-        try {
-            emojiGrantService.removeGuild(event.guild.id)
-        } catch (e: Exception) {
-            logger.warn("Failed to revoke emoji permissions on disband: ${e.message}")
-        }
+        reconcile("guild disband guild=${event.guild.id}") { emojiGrantService.removeGuild(event.guild.id) }
     }
 
-    private fun reconcile(operation: String, action: () -> Unit) {
+    private fun reconcile(operation: String, action: () -> EmojiGrantReconciliationResult) {
         try {
-            action()
+            val result = action()
+            if (!result.successful) {
+                logger.warn("Emoji permission reconciliation failed for $operation: ${result.failed} operation(s) will retry on global reconciliation")
+            }
         } catch (e: Exception) {
-            logger.warn("Failed to reconcile emoji permissions on guild $operation: ${e.message}")
+            logger.warn("Failed to reconcile emoji permissions for $operation: ${e.message}")
         }
     }
 }

--- a/src/main/kotlin/net/lumalyte/lg/infrastructure/listeners/GuildEmojiGrantListener.kt
+++ b/src/main/kotlin/net/lumalyte/lg/infrastructure/listeners/GuildEmojiGrantListener.kt
@@ -43,7 +43,7 @@ class GuildEmojiGrantListener(
 
     @EventHandler(priority = EventPriority.MONITOR)
     fun onGuildRenamed(event: GuildRenamedEvent) {
-        reconcile("guild rename guild=${event.guild.id}") { emojiGrantService.reconcileGuild(event.guild.id) }
+        reconcile("guild rename guild=${event.guildId}") { emojiGrantService.reconcileGuild(event.guildId) }
     }
 
     @EventHandler(priority = EventPriority.MONITOR)

--- a/src/main/kotlin/net/lumalyte/lg/infrastructure/listeners/GuildEmojiGrantListener.kt
+++ b/src/main/kotlin/net/lumalyte/lg/infrastructure/listeners/GuildEmojiGrantListener.kt
@@ -4,6 +4,8 @@ import net.lumalyte.lg.infrastructure.services.GuildEmojiGrantService
 import net.lumalyte.lg.api.events.GuildMemberJoinEvent
 import net.lumalyte.lg.api.events.GuildMemberRemovedEvent
 import net.lumalyte.lg.api.events.GuildDisbandedEvent
+import net.lumalyte.lg.api.events.GuildCreatedEvent
+import net.lumalyte.lg.api.events.GuildRenamedEvent
 import org.bukkit.event.EventHandler
 import org.bukkit.event.EventPriority
 import org.bukkit.event.Listener
@@ -22,7 +24,7 @@ class GuildEmojiGrantListener(
     @EventHandler(priority = EventPriority.MONITOR)
     fun onGuildMemberJoin(event: GuildMemberJoinEvent) {
         try {
-            emojiGrantService.grantForPlayer(event.playerId, event.guildId)
+            emojiGrantService.reconcileMember(event.playerId, event.guildId)
         } catch (e: Exception) {
             logger.warn("Failed to grant emoji permission on join: ${e.message}")
         }
@@ -31,28 +33,36 @@ class GuildEmojiGrantListener(
     @EventHandler(priority = EventPriority.MONITOR)
     fun onGuildMemberRemoved(event: GuildMemberRemovedEvent) {
         try {
-            emojiGrantService.revokeForPlayer(event.playerId, event.guildId)
+            emojiGrantService.removeMember(event.playerId, event.guildId)
         } catch (e: Exception) {
             logger.warn("Failed to revoke emoji permission on leave: ${e.message}")
         }
     }
 
-    /**
-     * Revokes emoji permissions for all former members when a guild is disbanded.
-     * Resolves the permission from the disanded guild's name because the guild
-     * record is already deleted from the repository by the time this fires.
-     */
+    @EventHandler(priority = EventPriority.MONITOR)
+    fun onGuildCreated(event: GuildCreatedEvent) {
+        reconcile("create") { emojiGrantService.reconcileGuild(event.guild.id) }
+    }
+
+    @EventHandler(priority = EventPriority.MONITOR)
+    fun onGuildRenamed(event: GuildRenamedEvent) {
+        reconcile("rename") { emojiGrantService.reconcileGuild(event.guild.id) }
+    }
+
     @EventHandler(priority = EventPriority.MONITOR)
     fun onGuildDisbanded(event: GuildDisbandedEvent) {
         try {
-            val permission = emojiGrantService.resolveEmojiGrantByName(event.guild.name)
-            if (permission != null) {
-                for (memberId in event.memberIds) {
-                    emojiGrantService.revokePermission(memberId, permission)
-                }
-            }
+            emojiGrantService.removeGuild(event.guild.id)
         } catch (e: Exception) {
             logger.warn("Failed to revoke emoji permissions on disband: ${e.message}")
+        }
+    }
+
+    private fun reconcile(operation: String, action: () -> Unit) {
+        try {
+            action()
+        } catch (e: Exception) {
+            logger.warn("Failed to reconcile emoji permissions on guild $operation: ${e.message}")
         }
     }
 }

--- a/src/main/kotlin/net/lumalyte/lg/infrastructure/persistence/guilds/EmojiGrantRepositorySQLite.kt
+++ b/src/main/kotlin/net/lumalyte/lg/infrastructure/persistence/guilds/EmojiGrantRepositorySQLite.kt
@@ -14,6 +14,18 @@ class EmojiGrantRepositorySQLite(
 ) : EmojiGrantRepository {
     private val logger = LoggerFactory.getLogger(EmojiGrantRepositorySQLite::class.java)
     private val grants = mutableMapOf<Pair<UUID, UUID>, EmojiPermissionGrant>()
+    private val upsertSql = if (storage.javaClass.simpleName.contains("MariaDB")) {
+        """
+            INSERT INTO guild_emoji_grants_applied (player_id, guild_id, permission)
+            VALUES (?, ?, ?)
+            ON DUPLICATE KEY UPDATE permission = VALUES(permission)
+        """.trimIndent()
+    } else {
+        """
+            INSERT OR REPLACE INTO guild_emoji_grants_applied (player_id, guild_id, permission)
+            VALUES (?, ?, ?)
+        """.trimIndent()
+    }
 
     init {
         createTable()
@@ -29,13 +41,9 @@ class EmojiGrantRepositorySQLite(
         grants[playerId to guildId]
 
     override fun upsert(grant: EmojiPermissionGrant): Boolean {
-        val sql = """
-            INSERT OR REPLACE INTO guild_emoji_grants_applied (player_id, guild_id, permission)
-            VALUES (?, ?, ?)
-        """.trimIndent()
         return try {
             val changed = storage.connection.executeUpdate(
-                sql,
+                upsertSql,
                 grant.playerId.toString(),
                 grant.guildId.toString(),
                 grant.permission,
@@ -62,7 +70,18 @@ class EmojiGrantRepositorySQLite(
 
     private fun createTable() {
         try {
-            storage.connection.executeUpdate(
+            val isMariaDb = storage.javaClass.simpleName.contains("MariaDB")
+            val createSql = if (isMariaDb) {
+                """
+                CREATE TABLE IF NOT EXISTS guild_emoji_grants_applied (
+                    player_id VARCHAR(36) NOT NULL,
+                    guild_id VARCHAR(36) NOT NULL,
+                    permission VARCHAR(255) NOT NULL,
+                    PRIMARY KEY (player_id, guild_id),
+                    INDEX idx_guild_emoji_grants_guild (guild_id)
+                )
+                """.trimIndent()
+            } else {
                 """
                 CREATE TABLE IF NOT EXISTS guild_emoji_grants_applied (
                     player_id TEXT NOT NULL,
@@ -70,11 +89,14 @@ class EmojiGrantRepositorySQLite(
                     permission TEXT NOT NULL,
                     PRIMARY KEY (player_id, guild_id)
                 )
-                """.trimIndent(),
-            )
-            storage.connection.executeUpdate(
-                "CREATE INDEX IF NOT EXISTS idx_guild_emoji_grants_guild ON guild_emoji_grants_applied(guild_id)",
-            )
+                """.trimIndent()
+            }
+            storage.connection.executeUpdate(createSql)
+            if (!isMariaDb) {
+                storage.connection.executeUpdate(
+                    "CREATE INDEX IF NOT EXISTS idx_guild_emoji_grants_guild ON guild_emoji_grants_applied(guild_id)",
+                )
+            }
         } catch (exception: SQLException) {
             throw DatabaseOperationException("Failed to create emoji grant ledger", exception)
         }

--- a/src/main/kotlin/net/lumalyte/lg/infrastructure/persistence/guilds/EmojiGrantRepositorySQLite.kt
+++ b/src/main/kotlin/net/lumalyte/lg/infrastructure/persistence/guilds/EmojiGrantRepositorySQLite.kt
@@ -1,0 +1,99 @@
+package net.lumalyte.lg.infrastructure.persistence.guilds
+
+import co.aikar.idb.Database
+import net.lumalyte.lg.application.errors.DatabaseOperationException
+import net.lumalyte.lg.application.persistence.EmojiGrantRepository
+import net.lumalyte.lg.domain.entities.EmojiPermissionGrant
+import net.lumalyte.lg.infrastructure.persistence.storage.Storage
+import org.slf4j.LoggerFactory
+import java.sql.SQLException
+import java.util.UUID
+
+class EmojiGrantRepositorySQLite(
+    private val storage: Storage<Database>,
+) : EmojiGrantRepository {
+    private val logger = LoggerFactory.getLogger(EmojiGrantRepositorySQLite::class.java)
+    private val grants = mutableMapOf<Pair<UUID, UUID>, EmojiPermissionGrant>()
+
+    init {
+        createTable()
+        preload()
+    }
+
+    override fun getAll(): List<EmojiPermissionGrant> = grants.values.toList()
+
+    override fun getForGuild(guildId: UUID): List<EmojiPermissionGrant> =
+        grants.values.filter { it.guildId == guildId }
+
+    override fun getForPlayerAndGuild(playerId: UUID, guildId: UUID): EmojiPermissionGrant? =
+        grants[playerId to guildId]
+
+    override fun upsert(grant: EmojiPermissionGrant): Boolean {
+        val sql = """
+            INSERT OR REPLACE INTO guild_emoji_grants_applied (player_id, guild_id, permission)
+            VALUES (?, ?, ?)
+        """.trimIndent()
+        return try {
+            val changed = storage.connection.executeUpdate(
+                sql,
+                grant.playerId.toString(),
+                grant.guildId.toString(),
+                grant.permission,
+            ) > 0
+            if (changed) grants[grant.playerId to grant.guildId] = grant
+            changed
+        } catch (exception: SQLException) {
+            logger.error("Failed to persist emoji grant for player ${grant.playerId} in guild ${grant.guildId}", exception)
+            false
+        }
+    }
+
+    override fun delete(playerId: UUID, guildId: UUID): Boolean {
+        val sql = "DELETE FROM guild_emoji_grants_applied WHERE player_id = ? AND guild_id = ?"
+        return try {
+            storage.connection.executeUpdate(sql, playerId.toString(), guildId.toString())
+            grants.remove(playerId to guildId)
+            true
+        } catch (exception: SQLException) {
+            logger.error("Failed to delete emoji grant for player $playerId in guild $guildId", exception)
+            false
+        }
+    }
+
+    private fun createTable() {
+        try {
+            storage.connection.executeUpdate(
+                """
+                CREATE TABLE IF NOT EXISTS guild_emoji_grants_applied (
+                    player_id TEXT NOT NULL,
+                    guild_id TEXT NOT NULL,
+                    permission TEXT NOT NULL,
+                    PRIMARY KEY (player_id, guild_id)
+                )
+                """.trimIndent(),
+            )
+            storage.connection.executeUpdate(
+                "CREATE INDEX IF NOT EXISTS idx_guild_emoji_grants_guild ON guild_emoji_grants_applied(guild_id)",
+            )
+        } catch (exception: SQLException) {
+            throw DatabaseOperationException("Failed to create emoji grant ledger", exception)
+        }
+    }
+
+    private fun preload() {
+        try {
+            storage.connection.getResults(
+                "SELECT player_id, guild_id, permission FROM guild_emoji_grants_applied",
+            ).forEach { row ->
+                val grant = EmojiPermissionGrant(
+                    playerId = UUID.fromString(row.getString("player_id")),
+                    guildId = UUID.fromString(row.getString("guild_id")),
+                    permission = row.getString("permission"),
+                )
+                grants[grant.playerId to grant.guildId] = grant
+            }
+        } catch (exception: SQLException) {
+            throw DatabaseOperationException("Failed to preload emoji grant ledger", exception)
+        }
+    }
+}

--- a/src/main/kotlin/net/lumalyte/lg/infrastructure/persistence/guilds/EmojiGrantRepositorySQLite.kt
+++ b/src/main/kotlin/net/lumalyte/lg/infrastructure/persistence/guilds/EmojiGrantRepositorySQLite.kt
@@ -4,6 +4,7 @@ import co.aikar.idb.Database
 import net.lumalyte.lg.application.errors.DatabaseOperationException
 import net.lumalyte.lg.application.persistence.EmojiGrantRepository
 import net.lumalyte.lg.domain.entities.EmojiPermissionGrant
+import net.lumalyte.lg.domain.entities.MAX_EMOJI_PERMISSION_LENGTH
 import net.lumalyte.lg.infrastructure.persistence.storage.Storage
 import org.slf4j.LoggerFactory
 import java.sql.SQLException
@@ -76,7 +77,7 @@ class EmojiGrantRepositorySQLite(
                 CREATE TABLE IF NOT EXISTS guild_emoji_grants_applied (
                     player_id VARCHAR(36) NOT NULL,
                     guild_id VARCHAR(36) NOT NULL,
-                    permission VARCHAR(255) NOT NULL,
+                    permission VARCHAR($MAX_EMOJI_PERMISSION_LENGTH) NOT NULL,
                     PRIMARY KEY (player_id, guild_id),
                     INDEX idx_guild_emoji_grants_guild (guild_id)
                 )
@@ -115,6 +116,8 @@ class EmojiGrantRepositorySQLite(
                 grants[grant.playerId to grant.guildId] = grant
             }
         } catch (exception: SQLException) {
+            throw DatabaseOperationException("Failed to preload emoji grant ledger", exception)
+        } catch (exception: IllegalArgumentException) {
             throw DatabaseOperationException("Failed to preload emoji grant ledger", exception)
         }
     }

--- a/src/main/kotlin/net/lumalyte/lg/infrastructure/services/ConfigServiceBukkit.kt
+++ b/src/main/kotlin/net/lumalyte/lg/infrastructure/services/ConfigServiceBukkit.kt
@@ -3,8 +3,12 @@ package net.lumalyte.lg.infrastructure.services
 import net.lumalyte.lg.application.services.ConfigService
 import net.lumalyte.lg.config.*
 import org.bukkit.configuration.file.FileConfiguration
+import org.slf4j.LoggerFactory
+import java.util.Locale
 
 class ConfigServiceBukkit(private val config: FileConfiguration): ConfigService {
+    private val logger = LoggerFactory.getLogger(ConfigServiceBukkit::class.java)
+
     override fun loadConfig(): MainConfig {
         return MainConfig(
             databaseType = config.getString("database_type", "sqlite") ?: "sqlite",
@@ -145,12 +149,22 @@ class ConfigServiceBukkit(private val config: FileConfiguration): ConfigService 
         val section = config.getConfigurationSection("guild.emoji_grants") ?: return emptyMap()
         val result = mutableMapOf<String, String>()
         for (key in section.getKeys(false)) {
-            val value = section.getString(key) ?: continue
-            if (value.isNotBlank()) {
-                result[key.lowercase()] = value
+            val normalizedKey = key.trim().lowercase(Locale.ROOT)
+            val normalizedValue = section.getString(key)?.trim()?.lowercase(Locale.ROOT) ?: continue
+            if (normalizedKey.isBlank() || normalizedValue.isBlank()) continue
+            if (!PERMISSION_NODE.matches(normalizedValue)) {
+                logger.warn("Ignoring invalid guild emoji permission mapping for '$key'")
+                continue
+            }
+            if (result.put(normalizedKey, normalizedValue) != null) {
+                logger.warn("Duplicate guild emoji mapping after normalization for '$key'; using the last value")
             }
         }
         return result
+    }
+
+    companion object {
+        private val PERMISSION_NODE = Regex("^[a-z0-9][a-z0-9_.-]*$")
     }
     
     private fun loadBankConfig(): BankConfig {

--- a/src/main/kotlin/net/lumalyte/lg/infrastructure/services/ConfigServiceBukkit.kt
+++ b/src/main/kotlin/net/lumalyte/lg/infrastructure/services/ConfigServiceBukkit.kt
@@ -6,7 +6,10 @@ import org.bukkit.configuration.file.FileConfiguration
 import org.slf4j.LoggerFactory
 import java.util.Locale
 
-class ConfigServiceBukkit(private val config: FileConfiguration): ConfigService {
+class ConfigServiceBukkit(private val configProvider: () -> FileConfiguration): ConfigService {
+    constructor(config: FileConfiguration) : this({ config })
+
+    private val config: FileConfiguration get() = configProvider()
     private val logger = LoggerFactory.getLogger(ConfigServiceBukkit::class.java)
 
     override fun loadConfig(): MainConfig {

--- a/src/main/kotlin/net/lumalyte/lg/infrastructure/services/ConfigServiceBukkit.kt
+++ b/src/main/kotlin/net/lumalyte/lg/infrastructure/services/ConfigServiceBukkit.kt
@@ -2,6 +2,7 @@ package net.lumalyte.lg.infrastructure.services
 
 import net.lumalyte.lg.application.services.ConfigService
 import net.lumalyte.lg.config.*
+import net.lumalyte.lg.domain.entities.MAX_EMOJI_PERMISSION_LENGTH
 import org.bukkit.configuration.file.FileConfiguration
 import org.slf4j.LoggerFactory
 import java.util.Locale
@@ -155,7 +156,7 @@ class ConfigServiceBukkit(private val configProvider: () -> FileConfiguration): 
             val normalizedKey = key.trim().lowercase(Locale.ROOT)
             val normalizedValue = section.getString(key)?.trim()?.lowercase(Locale.ROOT) ?: continue
             if (normalizedKey.isBlank() || normalizedValue.isBlank()) continue
-            if (!PERMISSION_NODE.matches(normalizedValue)) {
+            if (normalizedValue.length > MAX_EMOJI_PERMISSION_LENGTH || !PERMISSION_NODE.matches(normalizedValue)) {
                 logger.warn("Ignoring invalid guild emoji permission mapping for '$key'")
                 continue
             }

--- a/src/main/kotlin/net/lumalyte/lg/infrastructure/services/GuildEmojiGrantService.kt
+++ b/src/main/kotlin/net/lumalyte/lg/infrastructure/services/GuildEmojiGrantService.kt
@@ -1,125 +1,34 @@
 package net.lumalyte.lg.infrastructure.services
 
-import net.lumalyte.lg.application.services.GuildService
-import net.lumalyte.lg.application.services.MemberService
 import net.lumalyte.lg.application.services.ConfigService
-import org.bukkit.Bukkit
-import org.bukkit.plugin.Plugin
-import org.slf4j.LoggerFactory
+import net.lumalyte.lg.application.services.EmojiGrantReconciliationResult
+import net.lumalyte.lg.application.services.GuildEmojiGrantReconciler
+import net.lumalyte.lg.application.services.GuildService
+import java.util.Locale
 import java.util.UUID
 
-/**
- * Manages automatic emoji permission grants for guild members based on
- * the [guild.emoji_grants] config section.
- *
- * When a guild name is mapped to a permission node, all current and future
- * members of that guild are granted the permission via LuckPerms console
- * commands. The permission is revoked when a member leaves or the guild is
- * disbanded.
- */
 class GuildEmojiGrantService(
     private val guildService: GuildService,
-    private val memberService: MemberService,
     private val configService: ConfigService,
-    private val plugin: Plugin
+    private val reconciler: GuildEmojiGrantReconciler,
 ) {
-    private val logger = LoggerFactory.getLogger(GuildEmojiGrantService::class.java)
+    fun reconcileAll(): EmojiGrantReconciliationResult =
+        reconciler.reconcileAll(configService.loadConfig().guild.emojiGrants)
 
-    /**
-     * Returns the emoji permission node configured for a guild by its ID.
-     * Loads the guild from the repository; returns null if the guild no longer exists.
-     */
-    fun resolveEmojiGrant(guildId: UUID): String? {
-        val guild = guildService.getGuild(guildId) ?: return null
-        return resolveEmojiGrantByName(guild.name)
-    }
+    fun reconcileMember(playerId: UUID, guildId: UUID): EmojiGrantReconciliationResult =
+        reconciler.reconcileMembership(playerId, guildId, resolveEmojiGrant(guildId))
 
-    /**
-     * Returns the emoji permission node configured for a guild by its name.
-     * Case-insensitive matching. Does not require the guild to exist in the repository,
-     * so it can be called after a guild has been deleted (e.g. on disband).
-     */
-    fun resolveEmojiGrantByName(guildName: String): String? {
-        val grants = configService.loadConfig().guild.emojiGrants
-        return grants[guildName.lowercase()]
-    }
+    fun removeMember(playerId: UUID, guildId: UUID): EmojiGrantReconciliationResult =
+        reconciler.removeMembership(playerId, guildId)
 
-    /**
-     * Grants emoji permissions to all current members of every guild that
-     * has a configured emoji grant. Called on plugin enable.
-     */
-    fun grantAll() {
-        val grants = configService.loadConfig().guild.emojiGrants
-        if (grants.isEmpty()) return
+    fun reconcileGuild(guildId: UUID): EmojiGrantReconciliationResult =
+        reconciler.reconcileGuild(guildId, resolveEmojiGrant(guildId))
 
-        val allGuilds = guildService.getAllGuilds()
-        for (guild in allGuilds) {
-            val permission = grants[guild.name.lowercase()] ?: continue
-            val members = memberService.getGuildMembers(guild.id)
-            for (member in members) {
-                grantPermission(member.playerId, permission)
-            }
-        }
-        logger.info("Processed emoji grants for ${allGuilds.count { grants.containsKey(it.name.lowercase()) }} guild(s)")
-    }
+    fun removeGuild(guildId: UUID): EmojiGrantReconciliationResult = reconciler.removeGuild(guildId)
 
-    /**
-     * Grants the configured emoji permission to all current members of a guild.
-     */
-    fun grantForGuild(guildId: UUID) {
-        val permission = resolveEmojiGrant(guildId) ?: return
-        val members = memberService.getGuildMembers(guildId)
-        for (member in members) {
-            grantPermission(member.playerId, permission)
-        }
-    }
+    fun resolveEmojiGrant(guildId: UUID): String? =
+        guildService.getGuild(guildId)?.let { resolveEmojiGrantByName(it.name) }
 
-    /**
-     * Revokes the configured emoji permission from all current members of a guild.
-     */
-    fun revokeForGuild(guildId: UUID) {
-        val permission = resolveEmojiGrant(guildId) ?: return
-        val members = memberService.getGuildMembers(guildId)
-        for (member in members) {
-            revokePermission(member.playerId, permission)
-        }
-    }
-
-    /**
-     * Grants the configured emoji permission to a specific player for their guild.
-     */
-    fun grantForPlayer(playerId: UUID, guildId: UUID) {
-        val permission = resolveEmojiGrant(guildId) ?: return
-        grantPermission(playerId, permission)
-    }
-
-    /**
-     * Revokes the configured emoji permission from a specific player for their guild.
-     */
-    fun revokeForPlayer(playerId: UUID, guildId: UUID) {
-        val permission = resolveEmojiGrant(guildId) ?: return
-        revokePermission(playerId, permission)
-    }
-
-    /**
-     * Grants a raw permission node to a player via LuckPerms console command.
-     * Runs on the server's main thread because Bukkit.dispatchCommand is not thread-safe.
-     */
-    fun grantPermission(playerId: UUID, permission: String) {
-        Bukkit.getScheduler().runTask(plugin, Runnable {
-            val cmd = "lp user $playerId permission set $permission true"
-            Bukkit.dispatchCommand(Bukkit.getConsoleSender(), cmd)
-        })
-    }
-
-    /**
-     * Revokes a raw permission node from a player via LuckPerms console command.
-     * Runs on the server's main thread because Bukkit.dispatchCommand is not thread-safe.
-     */
-    fun revokePermission(playerId: UUID, permission: String) {
-        Bukkit.getScheduler().runTask(plugin, Runnable {
-            val cmd = "lp user $playerId permission unset $permission"
-            Bukkit.dispatchCommand(Bukkit.getConsoleSender(), cmd)
-        })
-    }
+    fun resolveEmojiGrantByName(guildName: String): String? =
+        configService.loadConfig().guild.emojiGrants[guildName.lowercase(Locale.ROOT)]
 }

--- a/src/main/kotlin/net/lumalyte/lg/infrastructure/services/GuildEmojiGrantService.kt
+++ b/src/main/kotlin/net/lumalyte/lg/infrastructure/services/GuildEmojiGrantService.kt
@@ -30,5 +30,5 @@ class GuildEmojiGrantService(
         guildService.getGuild(guildId)?.let { resolveEmojiGrantByName(it.name) }
 
     fun resolveEmojiGrantByName(guildName: String): String? =
-        configService.loadConfig().guild.emojiGrants[guildName.lowercase(Locale.ROOT)]
+        configService.loadConfig().guild.emojiGrants[guildName.trim().lowercase(Locale.ROOT)]
 }

--- a/src/main/kotlin/net/lumalyte/lg/infrastructure/services/GuildServiceBukkit.kt
+++ b/src/main/kotlin/net/lumalyte/lg/infrastructure/services/GuildServiceBukkit.kt
@@ -203,7 +203,7 @@ class GuildServiceBukkit(
         val result = guildRepository.update(updatedGuild)
         if (result) {
             logger.info("Guild $guildId renamed to '$newName' by $actorId")
-            Bukkit.getPluginManager().callEvent(GuildRenamedEvent(guild, updatedGuild, actorId))
+            Bukkit.getPluginManager().callEvent(GuildRenamedEvent(guildId, guild.name, newName))
         }
         return result
     }

--- a/src/main/kotlin/net/lumalyte/lg/infrastructure/services/GuildServiceBukkit.kt
+++ b/src/main/kotlin/net/lumalyte/lg/infrastructure/services/GuildServiceBukkit.kt
@@ -18,6 +18,7 @@ import net.lumalyte.lg.api.events.GuildBannerSetEvent
 import net.lumalyte.lg.api.events.GuildBannerChangedEvent
 import net.lumalyte.lg.api.events.GuildCreatedEvent
 import net.lumalyte.lg.api.events.GuildDisbandedEvent
+import net.lumalyte.lg.api.events.GuildRenamedEvent
 import net.lumalyte.lg.api.events.GuildHomeSetEvent
 import net.lumalyte.lg.api.events.GuildTrackingChangedEvent
 import net.lumalyte.lg.utils.serializeToString
@@ -202,6 +203,7 @@ class GuildServiceBukkit(
         val result = guildRepository.update(updatedGuild)
         if (result) {
             logger.info("Guild $guildId renamed to '$newName' by $actorId")
+            Bukkit.getPluginManager().callEvent(GuildRenamedEvent(guild, updatedGuild, actorId))
         }
         return result
     }

--- a/src/main/kotlin/net/lumalyte/lg/infrastructure/services/LuckPermsEmojiPermissionGateway.kt
+++ b/src/main/kotlin/net/lumalyte/lg/infrastructure/services/LuckPermsEmojiPermissionGateway.kt
@@ -1,0 +1,45 @@
+package net.lumalyte.lg.infrastructure.services
+
+import net.lumalyte.lg.application.services.EmojiPermissionGateway
+import org.bukkit.Bukkit
+import org.bukkit.plugin.Plugin
+import org.slf4j.LoggerFactory
+import java.util.UUID
+import java.util.concurrent.Callable
+import java.util.concurrent.TimeUnit
+
+class LuckPermsEmojiPermissionGateway(
+    private val plugin: Plugin,
+) : EmojiPermissionGateway {
+    private val logger = LoggerFactory.getLogger(LuckPermsEmojiPermissionGateway::class.java)
+
+    override fun grant(playerId: UUID, permission: String): Boolean =
+        dispatch(playerId, permission, "set $permission true")
+
+    override fun revoke(playerId: UUID, permission: String): Boolean =
+        dispatch(playerId, permission, "unset $permission")
+
+    private fun dispatch(playerId: UUID, permission: String, operation: String): Boolean {
+        if (!PERMISSION_NODE.matches(permission)) {
+            logger.warn("Rejected invalid managed emoji permission for player $playerId")
+            return false
+        }
+        val command = "lp user $playerId permission $operation"
+        return try {
+            if (Bukkit.isPrimaryThread()) {
+                Bukkit.dispatchCommand(Bukkit.getConsoleSender(), command)
+            } else {
+                Bukkit.getScheduler()
+                    .callSyncMethod(plugin, Callable { Bukkit.dispatchCommand(Bukkit.getConsoleSender(), command) })
+                    .get(5, TimeUnit.SECONDS)
+            }
+        } catch (exception: Exception) {
+            logger.error("Failed to dispatch managed emoji permission operation for player $playerId", exception)
+            false
+        }
+    }
+
+    companion object {
+        private val PERMISSION_NODE = Regex("^[a-z0-9][a-z0-9_.-]*$")
+    }
+}

--- a/src/main/kotlin/net/lumalyte/lg/infrastructure/services/LuckPermsEmojiPermissionGateway.kt
+++ b/src/main/kotlin/net/lumalyte/lg/infrastructure/services/LuckPermsEmojiPermissionGateway.kt
@@ -2,15 +2,10 @@ package net.lumalyte.lg.infrastructure.services
 
 import net.lumalyte.lg.application.services.EmojiPermissionGateway
 import org.bukkit.Bukkit
-import org.bukkit.plugin.Plugin
 import org.slf4j.LoggerFactory
 import java.util.UUID
-import java.util.concurrent.Callable
-import java.util.concurrent.TimeUnit
 
-class LuckPermsEmojiPermissionGateway(
-    private val plugin: Plugin,
-) : EmojiPermissionGateway {
+class LuckPermsEmojiPermissionGateway : EmojiPermissionGateway {
     private val logger = LoggerFactory.getLogger(LuckPermsEmojiPermissionGateway::class.java)
 
     override fun grant(playerId: UUID, permission: String): Boolean =
@@ -25,14 +20,12 @@ class LuckPermsEmojiPermissionGateway(
             return false
         }
         val command = "lp user $playerId permission $operation"
+        if (!Bukkit.isPrimaryThread()) {
+            logger.error("Refusing off-thread LuckPerms emoji command for player $playerId; reconciliation must run on the server thread")
+            return false
+        }
         return try {
-            if (Bukkit.isPrimaryThread()) {
-                Bukkit.dispatchCommand(Bukkit.getConsoleSender(), command)
-            } else {
-                Bukkit.getScheduler()
-                    .callSyncMethod(plugin, Callable { Bukkit.dispatchCommand(Bukkit.getConsoleSender(), command) })
-                    .get(5, TimeUnit.SECONDS)
-            }
+            Bukkit.dispatchCommand(Bukkit.getConsoleSender(), command)
         } catch (exception: Exception) {
             logger.error("Failed to dispatch managed emoji permission operation for player $playerId", exception)
             false

--- a/src/main/kotlin/net/lumalyte/lg/interaction/commands/LumaGuildsCommand.kt
+++ b/src/main/kotlin/net/lumalyte/lg/interaction/commands/LumaGuildsCommand.kt
@@ -139,6 +139,13 @@ class LumaGuildsCommand : CommandExecutor, TabCompleter, KoinComponent {
             // Reinitialize config and services
             plugin.initConfig()
 
+            val emojiResult = org.koin.core.context.GlobalContext.get()
+                .get<net.lumalyte.lg.infrastructure.services.GuildEmojiGrantService>()
+                .reconcileAll()
+            if (!emojiResult.successful) {
+                sender.sendMessage("LumaGuilds emoji permissions reconciled with ${emojiResult.failed} failure(s); check console.")
+            }
+
             // Refresh cached configs in listeners
             plugin.vaultProtectionListener.refreshConfig()
             org.koin.core.context.GlobalContext.get()

--- a/src/main/kotlin/net/lumalyte/lg/interaction/commands/LumaGuildsCommand.kt
+++ b/src/main/kotlin/net/lumalyte/lg/interaction/commands/LumaGuildsCommand.kt
@@ -156,8 +156,10 @@ class LumaGuildsCommand : CommandExecutor, TabCompleter, KoinComponent {
             // stopping and restarting schedulers, recreating Koin context, etc.
             // For development, config reload should be sufficient.
 
-            sender.sendMessage(lang.msg("admin.migrated.luma_guilds.handlereload.lumaguilds_configuration_reloaded_successfully"))
-            sender.sendMessage(lang.msg("admin.migrated.luma_guilds.handlereload.some_changes_may_require_a_full_server"))
+            if (emojiResult.successful) {
+                sender.sendMessage(lang.msg("admin.migrated.luma_guilds.handlereload.lumaguilds_configuration_reloaded_successfully"))
+                sender.sendMessage(lang.msg("admin.migrated.luma_guilds.handlereload.some_changes_may_require_a_full_server"))
+            }
 
         } catch (e: Exception) {
             // Command handler - catching all exceptions to prevent command crash

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -164,8 +164,9 @@ guild:
   # Emoji Grants — map guild names to Nexo emoji permission nodes
   # Members of the listed guild are automatically granted the permission to use
   # the corresponding emoji in chat and guild emoji selection. Guild names are
-  # matched case-insensitively; permission nodes are normalized to lowercase and
-  # must contain only letters, numbers, dots, underscores, and hyphens.
+  # matched case-insensitively; permission nodes are normalized to lowercase,
+  # must begin with a letter or number, and may then contain only letters,
+  # numbers, dots, underscores, or hyphens (maximum 255 characters).
   # One permission may be configured per guild. Changes are applied by
   # /lumaguilds reload, including removal or replacement of old grants.
   # Example:

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -163,7 +163,11 @@ guild:
 
   # Emoji Grants — map guild names to Nexo emoji permission nodes
   # Members of the listed guild are automatically granted the permission to use
-  # the corresponding emoji in chat.
+  # the corresponding emoji in chat and guild emoji selection. Guild names are
+  # matched case-insensitively; permission nodes are normalized to lowercase and
+  # must contain only letters, numbers, dots, underscores, and hyphens.
+  # One permission may be configured per guild. Changes are applied by
+  # /lumaguilds reload, including removal or replacement of old grants.
   # Example:
   #   emoji_grants:
   #     MyGuild: lumaguilds.emoji.crown

--- a/src/test/kotlin/net/lumalyte/lg/api/events/GuildRenamedEventTest.kt
+++ b/src/test/kotlin/net/lumalyte/lg/api/events/GuildRenamedEventTest.kt
@@ -1,0 +1,24 @@
+package net.lumalyte.lg.api.events
+
+import net.lumalyte.lg.domain.entities.Guild
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertSame
+import org.junit.jupiter.api.Test
+import java.time.Instant
+import java.util.UUID
+
+class GuildRenamedEventTest {
+    @Test
+    fun `exposes old and updated guild state with actor`() {
+        val oldGuild = Guild(UUID.randomUUID(), "Old", createdAt = Instant.EPOCH)
+        val updatedGuild = oldGuild.copy(name = "New")
+        val actorId = UUID.randomUUID()
+
+        val event = GuildRenamedEvent(oldGuild, updatedGuild, actorId)
+
+        assertSame(oldGuild, event.oldGuild)
+        assertSame(updatedGuild, event.guild)
+        assertEquals(actorId, event.actorId)
+        assertSame(event.handlers, GuildRenamedEvent.getHandlerList())
+    }
+}

--- a/src/test/kotlin/net/lumalyte/lg/api/events/GuildRenamedEventTest.kt
+++ b/src/test/kotlin/net/lumalyte/lg/api/events/GuildRenamedEventTest.kt
@@ -1,24 +1,19 @@
 package net.lumalyte.lg.api.events
 
-import net.lumalyte.lg.domain.entities.Guild
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Assertions.assertSame
 import org.junit.jupiter.api.Test
-import java.time.Instant
 import java.util.UUID
 
 class GuildRenamedEventTest {
     @Test
-    fun `exposes old and updated guild state with actor`() {
-        val oldGuild = Guild(UUID.randomUUID(), "Old", createdAt = Instant.EPOCH)
-        val updatedGuild = oldGuild.copy(name = "New")
-        val actorId = UUID.randomUUID()
+    fun `exposes guild id and old and new names`() {
+        val guildId = UUID.randomUUID()
+        val event = GuildRenamedEvent(guildId, "Old", "New")
 
-        val event = GuildRenamedEvent(oldGuild, updatedGuild, actorId)
-
-        assertSame(oldGuild, event.oldGuild)
-        assertSame(updatedGuild, event.guild)
-        assertEquals(actorId, event.actorId)
+        assertEquals(guildId, event.guildId)
+        assertEquals("Old", event.oldName)
+        assertEquals("New", event.newName)
         assertSame(event.handlers, GuildRenamedEvent.getHandlerList())
     }
 }

--- a/src/test/kotlin/net/lumalyte/lg/application/services/GuildEmojiGrantReconcilerTest.kt
+++ b/src/test/kotlin/net/lumalyte/lg/application/services/GuildEmojiGrantReconcilerTest.kt
@@ -135,6 +135,20 @@ class GuildEmojiGrantReconcilerTest {
     }
 
     @Test
+    fun `member leave preserves permission required by another guild membership`() {
+        val otherGuildId = UUID.randomUUID()
+        val permission = "enthusia.emoji.shared"
+        ledger.upsert(EmojiPermissionGrant(playerOne, guildId, permission))
+        ledger.upsert(EmojiPermissionGrant(playerOne, otherGuildId, permission))
+
+        reconciler.removeMembership(playerOne, guildId)
+
+        assertEquals(emptyList(), gateway.operations)
+        assertNull(ledger.getForPlayerAndGuild(playerOne, guildId))
+        assertEquals(permission, ledger.getForPlayerAndGuild(playerOne, otherGuildId)?.permission)
+    }
+
+    @Test
     fun `guild reconciliation replaces members and removes former member grants`() {
         val formerMember = UUID.randomUUID()
         ledger.upsert(EmojiPermissionGrant(playerOne, guildId, "enthusia.emoji.old"))

--- a/src/test/kotlin/net/lumalyte/lg/application/services/GuildEmojiGrantReconcilerTest.kt
+++ b/src/test/kotlin/net/lumalyte/lg/application/services/GuildEmojiGrantReconcilerTest.kt
@@ -43,6 +43,15 @@ class GuildEmojiGrantReconcilerTest {
     }
 
     @Test
+    fun `guild names with surrounding spaces use normalized mapping`() {
+        every { guildService.getAllGuilds() } returns setOf(guild.copy(name = " Badgers "))
+
+        val result = reconciler.reconcileAll(mapOf("badgers" to "enthusia.emoji.badger"))
+
+        assertEquals(2, result.granted)
+    }
+
+    @Test
     fun `unrecorded matching permission is never revoked`() {
         gateway.externallyOwned += playerOne to "enthusia.emoji.badger"
 

--- a/src/test/kotlin/net/lumalyte/lg/application/services/GuildEmojiGrantReconcilerTest.kt
+++ b/src/test/kotlin/net/lumalyte/lg/application/services/GuildEmojiGrantReconcilerTest.kt
@@ -1,0 +1,212 @@
+package net.lumalyte.lg.application.services
+
+import io.mockk.every
+import io.mockk.mockk
+import net.lumalyte.lg.application.persistence.EmojiGrantRepository
+import net.lumalyte.lg.domain.entities.EmojiPermissionGrant
+import net.lumalyte.lg.domain.entities.Guild
+import net.lumalyte.lg.domain.entities.Member
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import java.time.Instant
+import java.util.UUID
+import kotlin.test.assertEquals
+import kotlin.test.assertNull
+
+class GuildEmojiGrantReconcilerTest {
+    private val guildId = UUID.randomUUID()
+    private val playerOne = UUID.randomUUID()
+    private val playerTwo = UUID.randomUUID()
+    private val guild = Guild(id = guildId, name = "Badgers", createdAt = Instant.EPOCH)
+    private val guildService = mockk<GuildService>()
+    private val memberService = mockk<MemberService>()
+    private lateinit var ledger: InMemoryEmojiGrantRepository
+    private lateinit var gateway: RecordingEmojiPermissionGateway
+    private lateinit var reconciler: GuildEmojiGrantReconciler
+
+    @BeforeEach
+    fun setUp() {
+        ledger = InMemoryEmojiGrantRepository()
+        gateway = RecordingEmojiPermissionGateway()
+        every { guildService.getAllGuilds() } returns setOf(guild)
+        every { memberService.getGuildMembers(guildId) } returns setOf(member(playerOne), member(playerTwo))
+        reconciler = GuildEmojiGrantReconciler(guildService, memberService, ledger, gateway)
+    }
+
+    @Test
+    fun `initial mapping grants every current member and records ownership`() {
+        val result = reconciler.reconcileAll(mapOf("badgers" to "enthusia.emoji.badger"))
+
+        assertEquals(setOf(playerOne, playerTwo), ledger.getForGuild(guildId).map { it.playerId }.toSet())
+        assertEquals(2, result.granted)
+        assertEquals(0, result.failed)
+    }
+
+    @Test
+    fun `unrecorded matching permission is never revoked`() {
+        gateway.externallyOwned += playerOne to "enthusia.emoji.badger"
+
+        reconciler.reconcileAll(emptyMap())
+
+        assertEquals(emptyList(), gateway.operations)
+    }
+
+    @Test
+    fun `replacement revokes old permission before granting new`() {
+        ledger.upsert(EmojiPermissionGrant(playerOne, guildId, "enthusia.emoji.old"))
+        every { memberService.getGuildMembers(guildId) } returns setOf(member(playerOne))
+
+        reconciler.reconcileAll(mapOf("badgers" to "enthusia.emoji.new"))
+
+        assertEquals(
+            listOf(
+                "revoke:$playerOne:enthusia.emoji.old",
+                "grant:$playerOne:enthusia.emoji.new",
+            ),
+            gateway.operations,
+        )
+        assertEquals("enthusia.emoji.new", ledger.getForPlayerAndGuild(playerOne, guildId)?.permission)
+    }
+
+    @Test
+    fun `config removal revokes and deletes recorded ownership`() {
+        ledger.upsert(EmojiPermissionGrant(playerOne, guildId, "enthusia.emoji.badger"))
+
+        reconciler.reconcileAll(emptyMap())
+
+        assertEquals(listOf("revoke:$playerOne:enthusia.emoji.badger"), gateway.operations)
+        assertNull(ledger.getForPlayerAndGuild(playerOne, guildId))
+    }
+
+    @Test
+    fun `failed revoke retains ownership for retry`() {
+        ledger.upsert(EmojiPermissionGrant(playerOne, guildId, "enthusia.emoji.badger"))
+        gateway.failRevokes += "enthusia.emoji.badger"
+
+        val result = reconciler.reconcileAll(emptyMap())
+
+        assertEquals(1, result.failed)
+        assertEquals("enthusia.emoji.badger", ledger.getForPlayerAndGuild(playerOne, guildId)?.permission)
+    }
+
+    @Test
+    fun `failed grant creates no ownership row`() {
+        every { memberService.getGuildMembers(guildId) } returns setOf(member(playerOne))
+        gateway.failGrants += "enthusia.emoji.badger"
+
+        val result = reconciler.reconcileAll(mapOf("badgers" to "enthusia.emoji.badger"))
+
+        assertEquals(1, result.failed)
+        assertNull(ledger.getForPlayerAndGuild(playerOne, guildId))
+    }
+
+    @Test
+    fun `ledger write failure compensates successful external grant`() {
+        every { memberService.getGuildMembers(guildId) } returns setOf(member(playerOne))
+        ledger.failNextUpsert = true
+
+        reconciler.reconcileAll(mapOf("badgers" to "enthusia.emoji.badger"))
+
+        assertEquals(
+            listOf(
+                "grant:$playerOne:enthusia.emoji.badger",
+                "revoke:$playerOne:enthusia.emoji.badger",
+            ),
+            gateway.operations,
+        )
+        assertNull(ledger.getForPlayerAndGuild(playerOne, guildId))
+    }
+
+    @Test
+    fun `member join grants current mapping`() {
+        reconciler.reconcileMembership(playerOne, guildId, "enthusia.emoji.badger")
+
+        assertEquals("enthusia.emoji.badger", ledger.getForPlayerAndGuild(playerOne, guildId)?.permission)
+    }
+
+    @Test
+    fun `member leave revokes recorded grant without current config`() {
+        ledger.upsert(EmojiPermissionGrant(playerOne, guildId, "enthusia.emoji.removed"))
+
+        reconciler.removeMembership(playerOne, guildId)
+
+        assertEquals(listOf("revoke:$playerOne:enthusia.emoji.removed"), gateway.operations)
+        assertNull(ledger.getForPlayerAndGuild(playerOne, guildId))
+    }
+
+    @Test
+    fun `guild reconciliation replaces members and removes former member grants`() {
+        val formerMember = UUID.randomUUID()
+        ledger.upsert(EmojiPermissionGrant(playerOne, guildId, "enthusia.emoji.old"))
+        ledger.upsert(EmojiPermissionGrant(formerMember, guildId, "enthusia.emoji.old"))
+
+        reconciler.reconcileGuild(guildId, "enthusia.emoji.new")
+
+        assertEquals(
+            setOf(
+                EmojiPermissionGrant(playerOne, guildId, "enthusia.emoji.new"),
+                EmojiPermissionGrant(playerTwo, guildId, "enthusia.emoji.new"),
+            ),
+            ledger.getForGuild(guildId).toSet(),
+        )
+        val playerOperations = gateway.operations.filter { it.contains(playerOne.toString()) }
+        assertEquals(
+            listOf(
+                "revoke:$playerOne:enthusia.emoji.old",
+                "grant:$playerOne:enthusia.emoji.new",
+            ),
+            playerOperations,
+        )
+    }
+
+    @Test
+    fun `guild removal revokes ledger after guild record is gone`() {
+        ledger.upsert(EmojiPermissionGrant(playerOne, guildId, "enthusia.emoji.badger"))
+        ledger.upsert(EmojiPermissionGrant(playerTwo, guildId, "enthusia.emoji.badger"))
+
+        reconciler.removeGuild(guildId)
+
+        assertEquals(emptyList(), ledger.getForGuild(guildId))
+        assertEquals(2, gateway.operations.count { it.startsWith("revoke:") })
+    }
+
+    private fun member(playerId: UUID) = Member(playerId, guildId, UUID.randomUUID(), Instant.EPOCH)
+}
+
+private class InMemoryEmojiGrantRepository : EmojiGrantRepository {
+    private val values = linkedMapOf<Pair<UUID, UUID>, EmojiPermissionGrant>()
+    var failNextUpsert = false
+
+    override fun getAll(): List<EmojiPermissionGrant> = values.values.toList()
+    override fun getForGuild(guildId: UUID): List<EmojiPermissionGrant> = values.values.filter { it.guildId == guildId }
+    override fun getForPlayerAndGuild(playerId: UUID, guildId: UUID): EmojiPermissionGrant? = values[playerId to guildId]
+    override fun upsert(grant: EmojiPermissionGrant): Boolean {
+        if (failNextUpsert) {
+            failNextUpsert = false
+            return false
+        }
+        values[grant.playerId to grant.guildId] = grant
+        return true
+    }
+    override fun delete(playerId: UUID, guildId: UUID): Boolean {
+        values.remove(playerId to guildId)
+        return true
+    }
+}
+
+private class RecordingEmojiPermissionGateway : EmojiPermissionGateway {
+    val operations = mutableListOf<String>()
+    val externallyOwned = mutableSetOf<Pair<UUID, String>>()
+    val failGrants = mutableSetOf<String>()
+    val failRevokes = mutableSetOf<String>()
+
+    override fun grant(playerId: UUID, permission: String): Boolean {
+        operations += "grant:$playerId:$permission"
+        return permission !in failGrants
+    }
+
+    override fun revoke(playerId: UUID, permission: String): Boolean {
+        operations += "revoke:$playerId:$permission"
+        return permission !in failRevokes
+    }
+}

--- a/src/test/kotlin/net/lumalyte/lg/config/ConfigLoaderConsistencyTest.kt
+++ b/src/test/kotlin/net/lumalyte/lg/config/ConfigLoaderConsistencyTest.kt
@@ -1,6 +1,7 @@
 package net.lumalyte.lg.config
 
 import net.lumalyte.lg.infrastructure.services.ConfigServiceBukkit
+import net.lumalyte.lg.domain.entities.MAX_EMOJI_PERMISSION_LENGTH
 import org.bukkit.configuration.file.YamlConfiguration
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Assertions.assertFalse
@@ -90,6 +91,15 @@ class ConfigLoaderConsistencyTest {
         assertEquals("enthusia.emoji.badger", grants["badgers"])
         assertFalse(grants.containsKey("blank"))
         assertFalse(grants.containsKey("injected"))
+    }
+
+    @Test
+    fun `emoji grants reject nodes longer than durable storage limit`() {
+        val cfg = YamlConfiguration().apply {
+            set("guild.emoji_grants.Badgers", "a".repeat(MAX_EMOJI_PERMISSION_LENGTH + 1))
+        }
+
+        assertFalse(load(cfg).guild.emojiGrants.containsKey("badgers"))
     }
 
     @Test

--- a/src/test/kotlin/net/lumalyte/lg/config/ConfigLoaderConsistencyTest.kt
+++ b/src/test/kotlin/net/lumalyte/lg/config/ConfigLoaderConsistencyTest.kt
@@ -3,6 +3,7 @@ package net.lumalyte.lg.config
 import net.lumalyte.lg.infrastructure.services.ConfigServiceBukkit
 import org.bukkit.configuration.file.YamlConfiguration
 import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertFalse
 import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.Test
 import java.io.File
@@ -74,6 +75,21 @@ class ConfigLoaderConsistencyTest {
     fun `banner copy physical cost is loaded`() {
         val cfg = YamlConfiguration().apply { set("guild.banner_copy_physical_cost", 99) }
         assertEquals(99, load(cfg).guild.bannerCopyPhysicalCost)
+    }
+
+    @Test
+    fun `emoji grants normalize safe nodes and reject unsafe values`() {
+        val cfg = YamlConfiguration().apply {
+            set("guild.emoji_grants.Badgers", "  Enthusia.Emoji.Badger  ")
+            set("guild.emoji_grants.Blank", "   ")
+            set("guild.emoji_grants.Injected", "permission true\nlp user attacker permission set * true")
+        }
+
+        val grants = load(cfg).guild.emojiGrants
+
+        assertEquals("enthusia.emoji.badger", grants["badgers"])
+        assertFalse(grants.containsKey("blank"))
+        assertFalse(grants.containsKey("injected"))
     }
 
     @Test

--- a/src/test/kotlin/net/lumalyte/lg/config/ConfigLoaderConsistencyTest.kt
+++ b/src/test/kotlin/net/lumalyte/lg/config/ConfigLoaderConsistencyTest.kt
@@ -93,6 +93,20 @@ class ConfigLoaderConsistencyTest {
     }
 
     @Test
+    fun `config provider is dereferenced for each load`() {
+        var cfg = YamlConfiguration().apply {
+            set("guild.emoji_grants.Badgers", "enthusia.emoji.old")
+        }
+        val service = ConfigServiceBukkit { cfg }
+        assertEquals("enthusia.emoji.old", service.loadConfig().guild.emojiGrants["badgers"])
+
+        cfg = YamlConfiguration().apply {
+            set("guild.emoji_grants.Badgers", "enthusia.emoji.new")
+        }
+        assertEquals("enthusia.emoji.new", service.loadConfig().guild.emojiGrants["badgers"])
+    }
+
+    @Test
     fun `shipped config yml documents all newly-wired keys`() {
         val yml = File("src/main/resources/config.yml").readText()
         listOf(

--- a/src/test/kotlin/net/lumalyte/lg/infrastructure/persistence/guilds/EmojiGrantRepositorySQLiteTest.kt
+++ b/src/test/kotlin/net/lumalyte/lg/infrastructure/persistence/guilds/EmojiGrantRepositorySQLiteTest.kt
@@ -1,0 +1,85 @@
+package net.lumalyte.lg.infrastructure.persistence.guilds
+
+import net.lumalyte.lg.domain.entities.EmojiPermissionGrant
+import net.lumalyte.lg.infrastructure.persistence.storage.VirtualThreadSQLiteStorage
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.io.TempDir
+import java.nio.file.Path
+import java.util.UUID
+import kotlin.test.assertEquals
+import kotlin.test.assertNotNull
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+
+class EmojiGrantRepositorySQLiteTest {
+    @TempDir
+    lateinit var tempDir: Path
+
+    private lateinit var storage: VirtualThreadSQLiteStorage
+    private lateinit var repository: EmojiGrantRepositorySQLite
+
+    private val playerId = UUID.randomUUID()
+    private val otherPlayerId = UUID.randomUUID()
+    private val guildId = UUID.randomUUID()
+
+    @BeforeEach
+    fun setUp() {
+        storage = VirtualThreadSQLiteStorage(tempDir.toFile())
+        repository = EmojiGrantRepositorySQLite(storage)
+    }
+
+    @AfterEach
+    fun tearDown() {
+        storage.connection.close()
+    }
+
+    @Test
+    fun `owned grant survives repository restart`() {
+        val grant = EmojiPermissionGrant(playerId, guildId, "enthusia.emoji.badger")
+        assertTrue(repository.upsert(grant))
+
+        val secondStorage = VirtualThreadSQLiteStorage(tempDir.toFile())
+        try {
+            assertEquals(
+                grant,
+                EmojiGrantRepositorySQLite(secondStorage).getForPlayerAndGuild(playerId, guildId),
+            )
+        } finally {
+            secondStorage.connection.close()
+        }
+    }
+
+    @Test
+    fun `upsert replaces one memberships permission`() {
+        repository.upsert(EmojiPermissionGrant(playerId, guildId, "enthusia.emoji.old"))
+        repository.upsert(EmojiPermissionGrant(playerId, guildId, "enthusia.emoji.new"))
+
+        assertEquals("enthusia.emoji.new", repository.getForPlayerAndGuild(playerId, guildId)?.permission)
+        assertEquals(1, repository.getAll().size)
+    }
+
+    @Test
+    fun `delete preserves other guild members`() {
+        repository.upsert(EmojiPermissionGrant(playerId, guildId, "enthusia.emoji.badger"))
+        repository.upsert(EmojiPermissionGrant(otherPlayerId, guildId, "enthusia.emoji.badger"))
+
+        assertTrue(repository.delete(playerId, guildId))
+
+        assertNull(repository.getForPlayerAndGuild(playerId, guildId))
+        assertNotNull(repository.getForPlayerAndGuild(otherPlayerId, guildId))
+    }
+
+    @Test
+    fun `guild lookup returns only that guilds owned grants`() {
+        val otherGuildId = UUID.randomUUID()
+        repository.upsert(EmojiPermissionGrant(playerId, guildId, "enthusia.emoji.badger"))
+        repository.upsert(EmojiPermissionGrant(playerId, otherGuildId, "enthusia.emoji.dragon"))
+
+        assertEquals(
+            listOf(EmojiPermissionGrant(playerId, guildId, "enthusia.emoji.badger")),
+            repository.getForGuild(guildId),
+        )
+    }
+}

--- a/src/test/kotlin/net/lumalyte/lg/infrastructure/persistence/guilds/EmojiGrantRepositorySQLiteTest.kt
+++ b/src/test/kotlin/net/lumalyte/lg/infrastructure/persistence/guilds/EmojiGrantRepositorySQLiteTest.kt
@@ -1,6 +1,7 @@
 package net.lumalyte.lg.infrastructure.persistence.guilds
 
 import net.lumalyte.lg.domain.entities.EmojiPermissionGrant
+import net.lumalyte.lg.application.errors.DatabaseOperationException
 import net.lumalyte.lg.infrastructure.persistence.storage.VirtualThreadSQLiteStorage
 import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.BeforeEach
@@ -12,6 +13,7 @@ import kotlin.test.assertEquals
 import kotlin.test.assertNotNull
 import kotlin.test.assertNull
 import kotlin.test.assertTrue
+import kotlin.test.assertFailsWith
 
 class EmojiGrantRepositorySQLiteTest {
     @TempDir
@@ -81,5 +83,15 @@ class EmojiGrantRepositorySQLiteTest {
             listOf(EmojiPermissionGrant(playerId, guildId, "enthusia.emoji.badger")),
             repository.getForGuild(guildId),
         )
+    }
+
+    @Test
+    fun `malformed persisted UUID is reported as database operation failure`() {
+        storage.connection.executeUpdate(
+            "INSERT INTO guild_emoji_grants_applied (player_id, guild_id, permission) VALUES (?, ?, ?)",
+            "not-a-uuid", guildId.toString(), "enthusia.emoji.badger",
+        )
+
+        assertFailsWith<DatabaseOperationException> { EmojiGrantRepositorySQLite(storage) }
     }
 }

--- a/src/test/kotlin/net/lumalyte/lg/infrastructure/services/LuckPermsEmojiPermissionGatewayTest.kt
+++ b/src/test/kotlin/net/lumalyte/lg/infrastructure/services/LuckPermsEmojiPermissionGatewayTest.kt
@@ -1,0 +1,60 @@
+package net.lumalyte.lg.infrastructure.services
+
+import org.bukkit.command.Command
+import org.bukkit.command.CommandSender
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.mockbukkit.mockbukkit.MockBukkit
+import org.mockbukkit.mockbukkit.ServerMock
+import java.util.UUID
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+class LuckPermsEmojiPermissionGatewayTest {
+    private lateinit var server: ServerMock
+    private val commands = mutableListOf<String>()
+
+    @BeforeEach
+    fun setUp() {
+        server = MockBukkit.mock()
+        server.commandMap.register("lp", object : Command("lp") {
+            override fun execute(sender: CommandSender, commandLabel: String, args: Array<out String>): Boolean {
+                commands += "$commandLabel ${args.joinToString(" ")}"
+                return true
+            }
+        })
+    }
+
+    @AfterEach
+    fun tearDown() {
+        MockBukkit.unmock()
+    }
+
+    @Test
+    fun `valid grant and revoke dispatch exact LuckPerms commands`() {
+        val playerId = UUID.randomUUID()
+        val gateway = LuckPermsEmojiPermissionGateway(MockBukkit.createMockPlugin())
+
+        assertTrue(gateway.grant(playerId, "enthusia.emoji.badger"))
+        assertTrue(gateway.revoke(playerId, "enthusia.emoji.badger"))
+
+        assertEquals(
+            listOf(
+                "lp user $playerId permission set enthusia.emoji.badger true",
+                "lp user $playerId permission unset enthusia.emoji.badger",
+            ),
+            commands,
+        )
+    }
+
+    @Test
+    fun `invalid permission dispatches nothing`() {
+        val gateway = LuckPermsEmojiPermissionGateway(MockBukkit.createMockPlugin())
+
+        assertFalse(gateway.grant(UUID.randomUUID(), "permission true\nlp user attacker permission set * true"))
+
+        assertEquals(emptyList(), commands)
+    }
+}

--- a/src/test/kotlin/net/lumalyte/lg/infrastructure/services/LuckPermsEmojiPermissionGatewayTest.kt
+++ b/src/test/kotlin/net/lumalyte/lg/infrastructure/services/LuckPermsEmojiPermissionGatewayTest.kt
@@ -35,7 +35,7 @@ class LuckPermsEmojiPermissionGatewayTest {
     @Test
     fun `valid grant and revoke dispatch exact LuckPerms commands`() {
         val playerId = UUID.randomUUID()
-        val gateway = LuckPermsEmojiPermissionGateway(MockBukkit.createMockPlugin())
+        val gateway = LuckPermsEmojiPermissionGateway()
 
         assertTrue(gateway.grant(playerId, "enthusia.emoji.badger"))
         assertTrue(gateway.revoke(playerId, "enthusia.emoji.badger"))
@@ -51,7 +51,7 @@ class LuckPermsEmojiPermissionGatewayTest {
 
     @Test
     fun `invalid permission dispatches nothing`() {
-        val gateway = LuckPermsEmojiPermissionGateway(MockBukkit.createMockPlugin())
+        val gateway = LuckPermsEmojiPermissionGateway()
 
         assertFalse(gateway.grant(UUID.randomUUID(), "permission true\nlp user attacker permission set * true"))
 


### PR DESCRIPTION
## Summary
- persist LumaGuilds-managed guild emoji grants in a durable SQLite/MariaDB-compatible ownership ledger
- reconcile grants on startup, reload, membership changes, guild creation, rename, disband, config removal, and mapping replacement
- validate configured permission nodes and dispatch exact LuckPerms commands only on the server thread
- preserve externally-owned permissions and shared permission nodes across multiple guild memberships
- document automatic guild grants and complete LG-1104

## Verification
- `.\\gradlew.bat clean test`
- 682 tests passed
- architecture and Koin graph checks passed
- independent review completed with no remaining actionable findings

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Breaking
- Update integrations to use `GuildEmojiGrantService` reconciliation methods and its new constructor.

## Fixes
- Preserve and reconcile managed guild emoji permission grants across restarts, membership changes, renames, disbands, and configuration changes.

## Features
- Configure normalized, validated `emoji_grants` mappings and dispatch exact LuckPerms commands on the server thread.
- Use `GuildRenamedEvent` to reconcile grants after guild renames.
- Persist managed grants with SQLite/MariaDB-compatible ownership tracking.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->